### PR TITLE
Distinguish schema node namespace/prefix from namespace/prefix yang statements. E.g. for belongs-to { prefix }

### DIFF
--- a/schema-header.act
+++ b/schema-header.act
@@ -230,7 +230,6 @@ class DNode(object):
     parent: ?DNode
     dname: str
     namespace: str
-    prefix: str
     name: str
     config: bool
     description: ?str
@@ -532,9 +531,8 @@ class DContainer(DNodeInner):
     must: list[Must]
     presence: bool
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "Container"
         self.config = config
@@ -548,6 +546,7 @@ class DContainer(DNodeInner):
         self.children = children
 
 class DModule(DNodeInner):
+    prefix: str
     augment: list[Augment]
     contact: ?str
     deviation: list[str]
@@ -595,9 +594,8 @@ class DList(DNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "List"
         self.key = key
@@ -619,9 +617,8 @@ class DLeaf(DNodeLeaf):
     default: ?str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "Leaf"
         self.config = config
@@ -651,9 +648,8 @@ class DLeafList(DNodeLeaf):
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=[], if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=[], if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "LeafList"
         self.config = config
@@ -673,9 +669,8 @@ class DLeafList(DNodeLeaf):
 
 class DNotification(DNodeInner):
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "Notification"
         self.description = description
@@ -686,7 +681,6 @@ class DNotification(DNodeInner):
 class DRoot(DNodeInner):
     def __init__(self, modules: list[DNode]=[]):
         self.namespace = ""
-        self.prefix = ""
         self.name = "root"
         self.dname = "Root"
         self.config = True
@@ -779,8 +773,7 @@ class Context(object):
 
 class SchemaNode(object):
     parent: ?SchemaNode
-    namespace: ?str
-    prefix: ?str
+    ns: ?str
     exts: list[Ext]
 
     def _get_argname(self) -> ?str:
@@ -819,7 +812,7 @@ class SchemaNode(object):
     def get_namespace(self) -> str:
         n = self
         for i in range(RECURSION_LIMIT+1):
-            nnamespace = n.namespace
+            nnamespace = n.ns
             if nnamespace is not None:
                 return nnamespace
             nparent = n.parent
@@ -828,20 +821,6 @@ class SchemaNode(object):
                 continue
             else:
                 raise ValueError("Unable to find namespace")
-            if i > RECURSION_LIMIT:
-                raise ValueError("Recursion limit reached")
-        raise ValueError("Unable to find namespace")
-
-    def get_prefix(self) -> str:
-        n = self
-        for i in range(RECURSION_LIMIT+1):
-            nprefix = n.prefix
-            if nprefix is not None:
-                return nprefix
-            nparent = n.parent
-            if nparent is not None:
-                n = nparent
-                continue
             if i > RECURSION_LIMIT:
                 raise ValueError("Recursion limit reached")
         raise ValueError("Unable to find namespace")
@@ -922,7 +901,7 @@ class SchemaNode(object):
         #tns = ns if ns is not None else self.get_namespace()
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
-                child_namespace = child.namespace
+                #child_namespace = child.ns
                 # TODO:
                 if isinstance(child, Anydata) and child.name == name:
                     return child
@@ -1033,7 +1012,7 @@ class SchemaNode(object):
                         new_children = aug.expand_children(context)
                         target.children.extend(new_children)
                         for new_child in new_children:
-                            new_child.namespace = aug.get_namespace()
+                            new_child.ns = aug.get_namespace()
                             new_child.parent = target
                     else:
                         raise ValueError("Augment target is not an inner node")

--- a/src/rfcgen.act
+++ b/src/rfcgen.act
@@ -225,7 +225,7 @@ def _attr_type(name, stmt, stmts) -> str:
 
     # TODO: change namespace and prefix cardinality to 1
     #if cardinality == "0..1":
-    if cardinality == "0..1" or name in {"namespace", "prefix"}:
+    if cardinality == "0..1":
         return "?" + t
     elif cardinality == "1":
         return t
@@ -258,7 +258,7 @@ def _attr_taker(name, stmt, stmts) -> str:
     elif name in {"fraction-digits", "length", "position"}:
         t = "int"
 
-    if cardinality == "0..1" or name in {"namespace", "prefix"}:
+    if cardinality == "0..1":
         if name in stmts:
             return "take_opt_%s(ss)" % t
         return "take_opt_%s(ss, \"%s\")" % (t, name)
@@ -277,7 +277,7 @@ def _attr_defval(name, stmt, stms) -> str:
     if name == stmt.argument_name:
         return ""
     cardinality = stmt.substmts[name].cardinality
-    if cardinality == "0..1" or name in {"namespace", "prefix"}:
+    if cardinality == "0..1":
         return "=None"
     elif name == "yang-version":
         return "=1.1"
@@ -321,7 +321,6 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DContainer:
         new_dnode = DContainer(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -355,17 +354,13 @@ snode_methods = {
 
 """,
         "get_namespace": """    def get_namespace(self) -> str:
+        self_ns = self.ns
+        if self_ns is not None:
+            return self_ns
         selfnamespace = self.namespace
         if selfnamespace is not None:
             return selfnamespace
         raise ValueError("Module %s has no namespace" % self.name)
-
-""",
-        "get_prefix": """    def get_prefix(self) -> str:
-        selfprefix = self.prefix
-        if selfprefix is not None:
-            return selfprefix
-        raise ValueError("Module %s has no prefix" % self.name)
 
 """,
         "get_revision": """    def get_revision(self) -> ?Revision:
@@ -379,7 +374,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DModule:
         new_dnode = DModule(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
+            prefix=self.prefix,
             name=self.name,
             description=self.description,
             revision=self.revision,
@@ -397,7 +392,6 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
@@ -437,7 +431,6 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DList:
         new_dnode = DList(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             key=self.keys(),
             config=self.is_config(),
@@ -472,7 +465,6 @@ snode_methods = {
             new_units = base_typedef.units
 
         new = Leaf(self.name,
-                   namespace=self.namespace,
                    config=self.config,
                    default=new_default,
                    description=self.description,
@@ -484,14 +476,14 @@ snode_methods = {
                    type_=base_typedef.type_,
                    units=new_units,
                    when=self.when,
-                   exts=self.exts)
+                   exts=self.exts,
+                   ns=self.ns)
         return new
 
 """,
         "to_dnode": """    def to_dnode(self) -> DLeaf:
         return DLeaf(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -518,7 +510,6 @@ snode_methods = {
             new_units = base_typedef.units
 
         new = LeafList(self.name,
-                       namespace=self.namespace,
                        config=self.config,
                        default=self.default,
                        description=self.description,
@@ -532,7 +523,8 @@ snode_methods = {
                        type_=base_typedef.type_,
                        units=new_units,
                        when=self.when,
-                       exts=self.exts)
+                       exts=self.exts,
+                       ns=self.ns)
         return new
 
 """,
@@ -553,7 +545,6 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DLeafList:
         return DLeafList(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -725,8 +716,6 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         res.append("    \"\"\"")
 
         for attr in cattrs:
-            if attr in {"namespace", "prefix"}:
-                continue
             res.append("    %s: %s" % (_attr_name(attr), _attr_type(attr, stmt, stmts)))
 
 
@@ -750,19 +739,20 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         init_attrs.append("exts=[]")
         if have_children:
             init_attrs.append("children=[]")
-        if "namespace" not in set(cattrs):
-            init_attrs.append("namespace=None")
-        if "prefix" not in set(cattrs):
-            init_attrs.append("prefix=None")
         if "parent" not in set(cattrs):
             init_attrs.append("parent=None")
+        if "ns" not in set(cattrs):
+            init_attrs.append("ns=None")
         res.append("    def __init__(" + ", ".join(init_attrs) + "):")
         res.append("        self.parent = parent")
-        res.append("        new_ns = namespace")
-        res.append("        if new_ns is None and parent is not None:")
-        res.append("            new_ns = parent.namespace")
-        res.append("        self.namespace = new_ns")
-        res.append("        self.prefix = prefix")
+        res.append("        new_ns = ns")
+        if stmt_name == "module":
+            res.append("        if new_ns is None:")
+            res.append("            new_ns = namespace")
+        else:
+            res.append("        if new_ns is None and parent is not None:")
+            res.append("            new_ns = parent.ns")
+        res.append("        self.ns = new_ns")
 #        res.append("        self.cname = \"%s\"" % _class_name(stmt_name))
 #        res.append("        self.yname = \"%s\"" % stmt_name)
 
@@ -775,35 +765,24 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                     if substmt.cardinality == "0..1":
                         res.append("        if %s is not None:" % _attr_name(substmt.name))
                         res.append("            %s.parent = self" % _attr_name(substmt.name))
-                        res.append("            n_namespace = %s.namespace" % _attr_name(substmt.name))
-                        res.append("            if n_namespace is None:")
-                        res.append("                %s.namespace = self.namespace" % _attr_name(substmt.name))
-                        res.append("            n_prefix = %s.prefix" % _attr_name(substmt.name))
-                        res.append("            if n_prefix is None:")
-                        res.append("                %s.prefix = self.prefix" % _attr_name(substmt.name))
+                        res.append("            n_ns = %s.ns" % _attr_name(substmt.name))
+                        res.append("            if n_ns is None:")
+                        res.append("                %s.ns = self.ns" % _attr_name(substmt.name))
                     elif substmt.cardinality == "1":
                         res.append("        %s.parent = self" % _attr_name(substmt.name))
-                        res.append("        n_namespace = %s.namespace" % _attr_name(substmt.name))
-                        res.append("        if n_namespace is None:")
-                        res.append("            %s.namespace = self.namespace" % _attr_name(substmt.name))
-                        res.append("        n_prefix = %s.prefix" % _attr_name(substmt.name))
-                        res.append("        if n_prefix is None:")
-                        res.append("            %s.prefix = self.prefix" % _attr_name(substmt.name))
+                        res.append("        n_ns = %s.ns" % _attr_name(substmt.name))
+                        res.append("        if n_ns is None:")
+                        res.append("            %s.ns = self.ns" % _attr_name(substmt.name))
                     elif substmt.cardinality == "0..n":
                         res.append("        for n in %s:" % _attr_name(substmt.name))
                         res.append("            n.parent = self")
-                        res.append("            n_namespace = n.namespace")
-                        res.append("            if n_namespace is None:")
-                        res.append("                n.namespace = self.namespace")
-                        res.append("            n_prefix = n.prefix")
-                        res.append("            if n_prefix is None:")
-                        res.append("                n.prefix = self.prefix")
+                        res.append("            n_ns = n.ns")
+                        res.append("            if n_ns is None:")
+                        res.append("                n.ns = self.ns")
                     else:
                         raise ValueError("Unknown cardinality: %s" % substmt.cardinality)
 
         for substmt in stmt.substmts.values():
-            if substmt.name in {"namespace", "prefix"}:
-                continue
             if substmt.name not in child_stmts: # Attribute
                 res.append("        self.%s = %s" % (_attr_name(substmt.name), _attr_name(substmt.name)))
 
@@ -812,12 +791,9 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         if have_children:
             res.append("        for n in children:")
             res.append("            n.parent = self")
-            res.append("            n_namespace = n.namespace")
-            res.append("            if n_namespace is None:")
-            res.append("                n.namespace = self.namespace")
-            res.append("            n_prefix = n.prefix")
-            res.append("            if n_prefix is None:")
-            res.append("                n.prefix = self.prefix")
+            res.append("            n_ns = n.ns")
+            res.append("            if n_ns is None:")
+            res.append("                n.ns = self.ns")
             res.append("        self.children = children")
         res.append("")
 
@@ -880,8 +856,8 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                 new_args += ["self." + _attr_name(arg_name)]
             new_args += list(map(lambda x: "%s=self.%s" % (_attr_name(x), _attr_name(x)), kwattrs))
             new_args.append("exts=self.exts")
-            if stmt_name != "module":
-                new_args.append("namespace=self.namespace")
+            if stmt_name not in {"module", "submodule"}:
+                new_args.append("ns=self.ns")
             if have_children:
                 new_args.append("children=self.expand_children(context)")
 
@@ -921,7 +897,7 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             res.append("    def __hash__(self):")
             res.append("        rev = self.get_revision()")
             res.append("        rev_str = rev.date if rev is not None else \"\"")
-            res.append("        return hash(self.get_namespace() + self.get_prefix() + rev_str)")
+            res.append("        return hash(self.get_namespace() + rev_str)")
             res.append("")
             res.append("    def __eq__(self, other: %s):" % _class_name(stmt_name))
             res.append("        return " + " and ".join(map(lambda x: "self.%s == other.%s" % (x, x), attributes_to_compare)))

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -546,6 +546,8 @@ def _test_prsrc_uses():
 def _test_is_config1():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   container c1 {
     container c2 {
       leaf l1 {
@@ -565,6 +567,8 @@ def _test_is_config1():
 def _test_is_config2():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   container c1 {
     container c2 {
       config false;
@@ -605,12 +609,14 @@ def _test_ns():
     else:
         testing.error("Expected Module instance")
     c1 = n.get("c1")
-    testing.assertEqual(c1.namespace, "http://example.com/foo")
+    testing.assertEqual(c1.ns, "http://example.com/foo")
 
 
 def _test_compile_type1():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   typedef domain-name {
     type string {
       length "1..253";
@@ -652,6 +658,8 @@ def _test_compile_type1():
 def _test_compile_type2():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   typedef td1 {
     type string {
       length "1..10";
@@ -698,6 +706,8 @@ def _test_compile_type2():
 def _test_compile_type3():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   typedef td1 {
     type string {
       length "1..10";
@@ -737,6 +747,8 @@ def _test_compile_type3():
 def _test_compile_type_in_imported_module():
     ys_foo = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   typedef td1 {
     type string {
       length "1..10";
@@ -745,6 +757,8 @@ def _test_compile_type_in_imported_module():
 }"""
     ys_bar = """module bar {
   yang-version "1.1";
+  namespace "http://example.com/bar";
+  prefix "bar";
   import foo {
     prefix "f";
   }
@@ -773,6 +787,8 @@ def _test_compile_type_in_imported_module():
 def _test_compile_uses():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   grouping g1 {
     container c1 {
       list li1 {
@@ -800,6 +816,8 @@ def _test_compile_uses():
 def _test_compile_imported_grouping():
     ys_foo = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   grouping g1 {
     container c1 {
       list li1 {
@@ -817,6 +835,8 @@ def _test_compile_imported_grouping():
 }"""
     ys_bar = """module bar {
   yang-version "1.1";
+  namespace "http://example.com/bar";
+  prefix "bar";
   import foo {
     prefix "f";
   }
@@ -963,6 +983,8 @@ def _test_compile_augment_absolute_path_under_uses():
     """Augmenting a grouping"""
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   grouping g1 {
     container c1 {
       leaf l1 {
@@ -994,6 +1016,8 @@ def _test_compile_augment_relative_path_under_module():
     """Augmenting a grouping"""
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   grouping g1 {
     container c1 {
       leaf l1 {
@@ -1044,6 +1068,8 @@ def _test_compile_refine():
 def _test_compile_choice():
     ys = """module foo {
   yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
   container c1 {
     choice ch1 {
       case cs1 {
@@ -1357,8 +1383,8 @@ def _test_compile_augment_on_augment_across_modules():
     nc_baz = yang.schema.stmt_to_smodule(yang.parser.parse(ys_baz))
     nc_baz_aug = nc_baz.augment[0]
     nc_baz_l3 = nc_baz.augment[0].get("l3")
-    print(nc_baz_aug, "namespace: ", nc_baz_aug.namespace, nc_baz_aug.parent)
-    print(nc_baz_l3, "namespace: ", nc_baz_l3.namespace, nc_baz_l3.parent)
+    print(nc_baz_aug, "namespace: ", nc_baz_aug.ns, nc_baz_aug.parent)
+    print(nc_baz_l3, "namespace: ", nc_baz_l3.ns, nc_baz_l3.parent)
     print("---")
 
     nc_bar = yang.schema.stmt_to_smodule(yang.parser.parse(ys_bar))

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -227,7 +227,6 @@ class DNode(object):
     parent: ?DNode
     dname: str
     namespace: str
-    prefix: str
     name: str
     config: bool
     description: ?str
@@ -529,9 +528,8 @@ class DContainer(DNodeInner):
     must: list[Must]
     presence: bool
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "Container"
         self.config = config
@@ -545,6 +543,7 @@ class DContainer(DNodeInner):
         self.children = children
 
 class DModule(DNodeInner):
+    prefix: str
     augment: list[Augment]
     contact: ?str
     deviation: list[str]
@@ -592,9 +591,8 @@ class DList(DNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "List"
         self.key = key
@@ -616,9 +614,8 @@ class DLeaf(DNodeLeaf):
     default: ?str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "Leaf"
         self.config = config
@@ -648,9 +645,8 @@ class DLeafList(DNodeLeaf):
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=[], if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=[], if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "LeafList"
         self.config = config
@@ -670,9 +666,8 @@ class DLeafList(DNodeLeaf):
 
 class DNotification(DNodeInner):
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
-        self.prefix = prefix
         self.name = name
         self.dname = "Notification"
         self.description = description
@@ -683,7 +678,6 @@ class DNotification(DNodeInner):
 class DRoot(DNodeInner):
     def __init__(self, modules: list[DNode]=[]):
         self.namespace = ""
-        self.prefix = ""
         self.name = "root"
         self.dname = "Root"
         self.config = True
@@ -776,8 +770,7 @@ class Context(object):
 
 class SchemaNode(object):
     parent: ?SchemaNode
-    namespace: ?str
-    prefix: ?str
+    ns: ?str
     exts: list[Ext]
 
     def _get_argname(self) -> ?str:
@@ -816,7 +809,7 @@ class SchemaNode(object):
     def get_namespace(self) -> str:
         n = self
         for i in range(RECURSION_LIMIT+1):
-            nnamespace = n.namespace
+            nnamespace = n.ns
             if nnamespace is not None:
                 return nnamespace
             nparent = n.parent
@@ -825,20 +818,6 @@ class SchemaNode(object):
                 continue
             else:
                 raise ValueError("Unable to find namespace")
-            if i > RECURSION_LIMIT:
-                raise ValueError("Recursion limit reached")
-        raise ValueError("Unable to find namespace")
-
-    def get_prefix(self) -> str:
-        n = self
-        for i in range(RECURSION_LIMIT+1):
-            nprefix = n.prefix
-            if nprefix is not None:
-                return nprefix
-            nparent = n.parent
-            if nparent is not None:
-                n = nparent
-                continue
             if i > RECURSION_LIMIT:
                 raise ValueError("Recursion limit reached")
         raise ValueError("Unable to find namespace")
@@ -919,7 +898,7 @@ class SchemaNode(object):
         #tns = ns if ns is not None else self.get_namespace()
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
-                child_namespace = child.namespace
+                #child_namespace = child.ns
                 # TODO:
                 if isinstance(child, Anydata) and child.name == name:
                     return child
@@ -1030,7 +1009,7 @@ class SchemaNode(object):
                         new_children = aug.expand_children(context)
                         target.children.extend(new_children)
                         for new_child in new_children:
-                            new_child.namespace = aug.get_namespace()
+                            new_child.ns = aug.get_namespace()
                             new_child.parent = target
                     else:
                         raise ValueError("Augment target is not an inner node")
@@ -1757,29 +1736,22 @@ class Action(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         if input is not None:
             input.parent = self
-            n_namespace = input.namespace
-            if n_namespace is None:
-                input.namespace = self.namespace
-            n_prefix = input.prefix
-            if n_prefix is None:
-                input.prefix = self.prefix
+            n_ns = input.ns
+            if n_ns is None:
+                input.ns = self.ns
         if output is not None:
             output.parent = self
-            n_namespace = output.namespace
-            if n_namespace is None:
-                output.namespace = self.namespace
-            n_prefix = output.prefix
-            if n_prefix is None:
-                output.prefix = self.prefix
+            n_ns = output.ns
+            if n_ns is None:
+                output.ns = self.ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -1790,12 +1762,9 @@ class Action(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -1838,7 +1807,7 @@ class Action(SchemaNodeInner):
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
-                     namespace=self.namespace,
+                     ns=self.ns,
                      children=self.expand_children(context))
         return new
 
@@ -1873,21 +1842,17 @@ class Anydata(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.config = config
         self.description = description
@@ -1933,7 +1898,7 @@ class Anydata(SchemaNodeOuter):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
-                      namespace=self.namespace)
+                      ns=self.ns)
         return new
 
     def __str__(self):
@@ -1967,21 +1932,17 @@ class Anyxml(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.config = config
         self.description = description
@@ -2027,7 +1988,7 @@ class Anyxml(SchemaNodeOuter):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
-                     namespace=self.namespace)
+                     ns=self.ns)
         return new
 
     def __str__(self):
@@ -2058,13 +2019,12 @@ class Augment(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, target_node: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, target_node: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.target_node = target_node
         self.description = description
         self.if_feature = if_feature
@@ -2074,12 +2034,9 @@ class Augment(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -2120,7 +2077,7 @@ class Augment(SchemaNodeInner):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
-                      namespace=self.namespace,
+                      ns=self.ns,
                       children=self.expand_children(context))
         return new
 
@@ -2146,15 +2103,16 @@ class BelongsTo(SchemaNodeOuter):
     https://tools.ietf.org/html/rfc7950#section-7.2.2
     """
     module: str
+    prefix: str
 
-    def __init__(self, module: str, prefix: ?str=None, exts=[], namespace=None, parent=None):
+    def __init__(self, module: str, prefix: str, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.module = module
+        self.prefix = prefix
         self.exts = exts
 
     def prsrc(self, indent=0):
@@ -2177,7 +2135,7 @@ class BelongsTo(SchemaNodeOuter):
         new = BelongsTo(self.module,
                         prefix=self.prefix,
                         exts=self.exts,
-                        namespace=self.namespace)
+                        ns=self.ns)
         return new
 
     def __str__(self):
@@ -2208,13 +2166,12 @@ class Bit(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], position: ?int=None, reference: ?str=None, status: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], position: ?int=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -2251,7 +2208,7 @@ class Bit(SchemaNodeOuter):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  namespace=self.namespace)
+                  ns=self.ns)
         return new
 
     def __str__(self):
@@ -2282,13 +2239,12 @@ class Case(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -2298,12 +2254,9 @@ class Case(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -2344,7 +2297,7 @@ class Case(SchemaNodeInner):
                    status=self.status,
                    when=self.when,
                    exts=self.exts,
-                   namespace=self.namespace,
+                   ns=self.ns,
                    children=self.expand_children(context))
         return new
 
@@ -2379,13 +2332,12 @@ class Choice(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.config = config
         self.default = default
@@ -2398,12 +2350,9 @@ class Choice(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -2450,7 +2399,7 @@ class Choice(SchemaNodeInner):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
-                     namespace=self.namespace,
+                     ns=self.ns,
                      children=self.expand_children(context))
         return new
 
@@ -2485,21 +2434,17 @@ class Container(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], presence: ?str=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], presence: ?str=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.config = config
         self.description = description
@@ -2512,12 +2457,9 @@ class Container(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -2562,7 +2504,6 @@ class Container(SchemaNodeInner):
     def to_dnode(self) -> DContainer:
         new_dnode = DContainer(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -2590,7 +2531,7 @@ class Container(SchemaNodeInner):
                         status=self.status,
                         when=self.when,
                         exts=self.exts,
-                        namespace=self.namespace,
+                        ns=self.ns,
                         children=self.expand_children(context))
         return new
 
@@ -2622,13 +2563,12 @@ class Enum(SchemaNodeOuter):
     status: ?str
     value: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, value: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, value: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -2665,7 +2605,7 @@ class Enum(SchemaNodeOuter):
                    status=self.status,
                    value=self.value,
                    exts=self.exts,
-                   namespace=self.namespace)
+                   ns=self.ns)
         return new
 
     def __str__(self):
@@ -2695,13 +2635,12 @@ class Extension(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, argument: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, argument: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.argument = argument
         self.description = description
@@ -2735,7 +2674,7 @@ class Extension(SchemaNodeOuter):
                         reference=self.reference,
                         status=self.status,
                         exts=self.exts,
-                        namespace=self.namespace)
+                        ns=self.ns)
         return new
 
     def __str__(self):
@@ -2765,13 +2704,12 @@ class Feature(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -2805,7 +2743,7 @@ class Feature(SchemaNodeOuter):
                       reference=self.reference,
                       status=self.status,
                       exts=self.exts,
-                      namespace=self.namespace)
+                      ns=self.ns)
         return new
 
     def __str__(self):
@@ -2834,13 +2772,12 @@ class Grouping(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.description = description
         self.reference = reference
@@ -2848,12 +2785,9 @@ class Grouping(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -2890,7 +2824,7 @@ class Grouping(SchemaNodeInner):
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
-                       namespace=self.namespace,
+                       ns=self.ns,
                        children=self.expand_children(context))
         return new
 
@@ -2922,13 +2856,12 @@ class Identity(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, base: list[str]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, base: list[str]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.name = name
         self.base = base
         self.description = description
@@ -2965,7 +2898,7 @@ class Identity(SchemaNodeOuter):
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
-                       namespace=self.namespace)
+                       ns=self.ns)
         return new
 
     def __str__(self):
@@ -2991,18 +2924,19 @@ class Import(SchemaNodeOuter):
     """
     module: str
     description: ?str
+    prefix: str
     reference: ?str
     revision_date: ?str
 
-    def __init__(self, module: str, prefix: ?str=None, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], namespace=None, parent=None):
+    def __init__(self, module: str, prefix: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.module = module
         self.description = description
+        self.prefix = prefix
         self.reference = reference
         self.revision_date = revision_date
         self.exts = exts
@@ -3033,7 +2967,7 @@ class Import(SchemaNodeOuter):
                      reference=self.reference,
                      revision_date=self.revision_date,
                      exts=self.exts,
-                     namespace=self.namespace)
+                     ns=self.ns)
         return new
 
     def __str__(self):
@@ -3062,13 +2996,12 @@ class Include(SchemaNodeOuter):
     reference: ?str
     revision_date: ?str
 
-    def __init__(self, module: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, module: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.module = module
         self.description = description
         self.reference = reference
@@ -3099,7 +3032,7 @@ class Include(SchemaNodeOuter):
                       reference=self.reference,
                       revision_date=self.revision_date,
                       exts=self.exts,
-                      namespace=self.namespace)
+                      ns=self.ns)
         return new
 
     def __str__(self):
@@ -3125,31 +3058,24 @@ class Input(SchemaNodeInner):
     """
     must: list[Must]
 
-    def __init__(self, must: list[Must]=[], exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.must = must
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -3181,7 +3107,7 @@ class Input(SchemaNodeInner):
     def compile(self, context: Context):
         new = Input(must=self.must,
                     exts=self.exts,
-                    namespace=self.namespace,
+                    ns=self.ns,
                     children=self.expand_children(context))
         return new
 
@@ -3219,28 +3145,21 @@ class Leaf(SchemaNodeOuter):
     units: ?str
     when: ?str
 
-    def __init__(self, name: str, type_: Type, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, type_: Type, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         type_.parent = self
-        n_namespace = type_.namespace
-        if n_namespace is None:
-            type_.namespace = self.namespace
-        n_prefix = type_.prefix
-        if n_prefix is None:
-            type_.prefix = self.prefix
+        n_ns = type_.ns
+        if n_ns is None:
+            type_.ns = self.ns
         self.name = name
         self.config = config
         self.default = default
@@ -3293,7 +3212,6 @@ class Leaf(SchemaNodeOuter):
             new_units = base_typedef.units
 
         new = Leaf(self.name,
-                   namespace=self.namespace,
                    config=self.config,
                    default=new_default,
                    description=self.description,
@@ -3305,13 +3223,13 @@ class Leaf(SchemaNodeOuter):
                    type_=base_typedef.type_,
                    units=new_units,
                    when=self.when,
-                   exts=self.exts)
+                   exts=self.exts,
+                   ns=self.ns)
         return new
 
     def to_dnode(self) -> DLeaf:
         return DLeaf(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -3362,28 +3280,21 @@ class LeafList(SchemaNodeOuter):
     units: ?str
     when: ?str
 
-    def __init__(self, name: str, type_: Type, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, type_: Type, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         type_.parent = self
-        n_namespace = type_.namespace
-        if n_namespace is None:
-            type_.namespace = self.namespace
-        n_prefix = type_.prefix
-        if n_prefix is None:
-            type_.prefix = self.prefix
+        n_ns = type_.ns
+        if n_ns is None:
+            type_.ns = self.ns
         self.name = name
         self.config = config
         self.default = default
@@ -3436,7 +3347,6 @@ class LeafList(SchemaNodeOuter):
             new_units = base_typedef.units
 
         new = LeafList(self.name,
-                       namespace=self.namespace,
                        config=self.config,
                        default=self.default,
                        description=self.description,
@@ -3450,7 +3360,8 @@ class LeafList(SchemaNodeOuter):
                        type_=base_typedef.type_,
                        units=new_units,
                        when=self.when,
-                       exts=self.exts)
+                       exts=self.exts,
+                       ns=self.ns)
         return new
 
     def get_max_elements(self) -> ?int:
@@ -3468,7 +3379,6 @@ class LeafList(SchemaNodeOuter):
     def to_dnode(self) -> DLeafList:
         return DLeafList(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -3511,13 +3421,12 @@ class Length(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.value = value
         self.description = description
         self.error_app_tag = error_app_tag
@@ -3551,7 +3460,7 @@ class Length(SchemaNodeOuter):
                      error_message=self.error_message,
                      reference=self.reference,
                      exts=self.exts,
-                     namespace=self.namespace)
+                     ns=self.ns)
         return new
 
     def __str__(self):
@@ -3589,21 +3498,17 @@ class List(SchemaNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], key: ?str=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, unique: list[str]=[], when: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], key: ?str=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, unique: list[str]=[], when: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.config = config
         self.description = description
@@ -3620,12 +3525,9 @@ class List(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -3686,7 +3588,6 @@ class List(SchemaNodeInner):
     def to_dnode(self) -> DList:
         new_dnode = DList(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             key=self.keys(),
             config=self.is_config(),
@@ -3720,7 +3621,7 @@ class List(SchemaNodeInner):
                    unique=self.unique,
                    when=self.when,
                    exts=self.exts,
-                   namespace=self.namespace,
+                   ns=self.ns,
                    children=self.expand_children(context))
         return new
 
@@ -3754,66 +3655,49 @@ class Module(SchemaNodeInner):
     feature: list[Feature]
     import_: list[Import]
     include: list[Include]
+    namespace: str
     organization: ?str
+    prefix: str
     reference: ?str
     revision: list[Revision]
     yang_version: float
 
-    def __init__(self, name: str, namespace: ?str=None, prefix: ?str=None, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None):
+    def __init__(self, name: str, namespace: str, prefix: str, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
-        if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+        new_ns = ns
+        if new_ns is None:
+            new_ns = namespace
+        self.ns = new_ns
         for n in augment:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in extension_:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in feature:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in import_:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in include:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in revision:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.augment = augment
         self.contact = contact
@@ -3823,19 +3707,18 @@ class Module(SchemaNodeInner):
         self.feature = feature
         self.import_ = import_
         self.include = include
+        self.namespace = namespace
         self.organization = organization
+        self.prefix = prefix
         self.reference = reference
         self.revision = revision
         self.yang_version = yang_version
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -3889,16 +3772,13 @@ class Module(SchemaNodeInner):
         return ModRev(self.name, rev_date)
 
     def get_namespace(self) -> str:
+        self_ns = self.ns
+        if self_ns is not None:
+            return self_ns
         selfnamespace = self.namespace
         if selfnamespace is not None:
             return selfnamespace
         raise ValueError("Module %s has no namespace" % self.name)
-
-    def get_prefix(self) -> str:
-        selfprefix = self.prefix
-        if selfprefix is not None:
-            return selfprefix
-        raise ValueError("Module %s has no prefix" % self.name)
 
     def get_revision(self) -> ?Revision:
         latest = None
@@ -3910,7 +3790,7 @@ class Module(SchemaNodeInner):
     def to_dnode(self) -> DModule:
         new_dnode = DModule(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
+            prefix=self.prefix,
             name=self.name,
             description=self.description,
             revision=self.revision,
@@ -3956,7 +3836,7 @@ extension Module (Hashable):
     def __hash__(self):
         rev = self.get_revision()
         rev_str = rev.date if rev is not None else ""
-        return hash(self.get_namespace() + self.get_prefix() + rev_str)
+        return hash(self.get_namespace() + rev_str)
 
     def __eq__(self, other: Module):
         return self.name == other.name and self.augment == other.augment and self.contact == other.contact and self.description == other.description and self.deviation == other.deviation and self.extension_ == other.extension_ and self.feature == other.feature and self.import_ == other.import_ and self.include == other.include and self.namespace == other.namespace and self.organization == other.organization and self.prefix == other.prefix and self.reference == other.reference and self.revision == other.revision and self.yang_version == other.yang_version
@@ -3976,13 +3856,12 @@ class Must(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, condition: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, condition: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.condition = condition
         self.description = description
         self.error_app_tag = error_app_tag
@@ -4016,7 +3895,7 @@ class Must(SchemaNodeOuter):
                    error_message=self.error_message,
                    reference=self.reference,
                    exts=self.exts,
-                   namespace=self.namespace)
+                   ns=self.ns)
         return new
 
     def __str__(self):
@@ -4047,21 +3926,17 @@ class Notification(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -4071,12 +3946,9 @@ class Notification(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -4112,7 +3984,6 @@ class Notification(SchemaNodeInner):
     def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
             namespace=self.get_namespace(),
-            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
@@ -4133,7 +4004,7 @@ class Notification(SchemaNodeInner):
                            reference=self.reference,
                            status=self.status,
                            exts=self.exts,
-                           namespace=self.namespace,
+                           ns=self.ns,
                            children=self.expand_children(context))
         return new
 
@@ -4160,31 +4031,24 @@ class Output(SchemaNodeInner):
     """
     must: list[Must]
 
-    def __init__(self, must: list[Must]=[], exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.must = must
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -4216,7 +4080,7 @@ class Output(SchemaNodeInner):
     def compile(self, context: Context):
         new = Output(must=self.must,
                      exts=self.exts,
-                     namespace=self.namespace,
+                     ns=self.ns,
                      children=self.expand_children(context))
         return new
 
@@ -4248,13 +4112,12 @@ class Pattern(SchemaNodeOuter):
     modifier: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, modifier: ?str=None, reference: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, modifier: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.value = value
         self.description = description
         self.error_app_tag = error_app_tag
@@ -4291,7 +4154,7 @@ class Pattern(SchemaNodeOuter):
                       modifier=self.modifier,
                       reference=self.reference,
                       exts=self.exts,
-                      namespace=self.namespace)
+                      ns=self.ns)
         return new
 
     def __str__(self):
@@ -4321,13 +4184,12 @@ class Range(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.value = value
         self.description = description
         self.error_app_tag = error_app_tag
@@ -4361,7 +4223,7 @@ class Range(SchemaNodeOuter):
                     error_message=self.error_message,
                     reference=self.reference,
                     exts=self.exts,
-                    namespace=self.namespace)
+                    ns=self.ns)
         return new
 
     def __str__(self):
@@ -4397,21 +4259,17 @@ class Refine(SchemaNodeOuter):
     presence: ?str
     reference: ?str
 
-    def __init__(self, target_node: str, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], presence: ?str=None, reference: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, target_node: str, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], presence: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in must:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.target_node = target_node
         self.config = config
         self.default = default
@@ -4463,7 +4321,7 @@ class Refine(SchemaNodeOuter):
                      presence=self.presence,
                      reference=self.reference,
                      exts=self.exts,
-                     namespace=self.namespace)
+                     ns=self.ns)
         return new
 
     def __str__(self):
@@ -4491,13 +4349,12 @@ class Revision(SchemaNodeOuter):
     description: ?str
     reference: ?str
 
-    def __init__(self, date: str, description: ?str=None, reference: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, date: str, description: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         self.date = date
         self.description = description
         self.reference = reference
@@ -4525,7 +4382,7 @@ class Revision(SchemaNodeOuter):
                        description=self.description,
                        reference=self.reference,
                        exts=self.exts,
-                       namespace=self.namespace)
+                       ns=self.ns)
         return new
 
     def __str__(self):
@@ -4557,29 +4414,22 @@ class Rpc(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         if input is not None:
             input.parent = self
-            n_namespace = input.namespace
-            if n_namespace is None:
-                input.namespace = self.namespace
-            n_prefix = input.prefix
-            if n_prefix is None:
-                input.prefix = self.prefix
+            n_ns = input.ns
+            if n_ns is None:
+                input.ns = self.ns
         if output is not None:
             output.parent = self
-            n_namespace = output.namespace
-            if n_namespace is None:
-                output.namespace = self.namespace
-            n_prefix = output.prefix
-            if n_prefix is None:
-                output.prefix = self.prefix
+            n_ns = output.ns
+            if n_ns is None:
+                output.ns = self.ns
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -4590,12 +4440,9 @@ class Rpc(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -4638,7 +4485,7 @@ class Rpc(SchemaNodeInner):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  namespace=self.namespace,
+                  ns=self.ns,
                   children=self.expand_children(context))
         return new
 
@@ -4678,68 +4525,46 @@ class Submodule(SchemaNodeInner):
     revision: list[Revision]
     yang_version: float
 
-    def __init__(self, name: str, belongs_to: BelongsTo, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, belongs_to: BelongsTo, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in augment:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         belongs_to.parent = self
-        n_namespace = belongs_to.namespace
-        if n_namespace is None:
-            belongs_to.namespace = self.namespace
-        n_prefix = belongs_to.prefix
-        if n_prefix is None:
-            belongs_to.prefix = self.prefix
+        n_ns = belongs_to.ns
+        if n_ns is None:
+            belongs_to.ns = self.ns
         for n in extension_:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in feature:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in import_:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in include:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in revision:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.augment = augment
         self.belongs_to = belongs_to
@@ -4757,12 +4582,9 @@ class Submodule(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.children = children
 
     def prsrc(self, indent=0):
@@ -4831,7 +4653,6 @@ class Submodule(SchemaNodeInner):
                         revision=self.revision,
                         yang_version=self.yang_version,
                         exts=self.exts,
-                        namespace=self.namespace,
                         children=self.expand_children(context))
         new.expand_augments(context)
         return new
@@ -4869,61 +4690,42 @@ class Type(SchemaNodeOuter):
     require_instance: ?bool
     type_: list[Type]
 
-    def __init__(self, name: str, base: list[str]=[], bit: list[Bit]=[], enum: list[Enum]=[], fraction_digits: ?int=None, length: ?Length=None, path: ?str=None, pattern: list[Pattern]=[], range_: ?Range=None, require_instance: ?bool=None, type_: list[Type]=[], exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, base: list[str]=[], bit: list[Bit]=[], enum: list[Enum]=[], fraction_digits: ?int=None, length: ?Length=None, path: ?str=None, pattern: list[Pattern]=[], range_: ?Range=None, require_instance: ?bool=None, type_: list[Type]=[], exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in bit:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in enum:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         if length is not None:
             length.parent = self
-            n_namespace = length.namespace
-            if n_namespace is None:
-                length.namespace = self.namespace
-            n_prefix = length.prefix
-            if n_prefix is None:
-                length.prefix = self.prefix
+            n_ns = length.ns
+            if n_ns is None:
+                length.ns = self.ns
         for n in pattern:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         if range_ is not None:
             range_.parent = self
-            n_namespace = range_.namespace
-            if n_namespace is None:
-                range_.namespace = self.namespace
-            n_prefix = range_.prefix
-            if n_prefix is None:
-                range_.prefix = self.prefix
+            n_ns = range_.ns
+            if n_ns is None:
+                range_.ns = self.ns
         for n in type_:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.base = base
         self.bit = bit
@@ -5011,7 +4813,7 @@ class Type(SchemaNodeOuter):
                    require_instance=self.require_instance,
                    type_=self.type_,
                    exts=self.exts,
-                   namespace=self.namespace)
+                   ns=self.ns)
         return new
 
     def __str__(self):
@@ -5043,20 +4845,16 @@ class Typedef(SchemaNodeOuter):
     type_: Type
     units: ?str
 
-    def __init__(self, name: str, type_: Type, default: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, type_: Type, default: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         type_.parent = self
-        n_namespace = type_.namespace
-        if n_namespace is None:
-            type_.namespace = self.namespace
-        n_prefix = type_.prefix
-        if n_prefix is None:
-            type_.prefix = self.prefix
+        n_ns = type_.ns
+        if n_ns is None:
+            type_.ns = self.ns
         self.name = name
         self.default = default
         self.description = description
@@ -5138,29 +4936,22 @@ class Uses(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, augment: list[Augment]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, refine: list[Refine]=[], status: ?str=None, when: ?str=None, exts=[], namespace=None, prefix=None, parent=None):
+    def __init__(self, name: str, augment: list[Augment]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, refine: list[Refine]=[], status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
         self.parent = parent
-        new_ns = namespace
+        new_ns = ns
         if new_ns is None and parent is not None:
-            new_ns = parent.namespace
-        self.namespace = new_ns
-        self.prefix = prefix
+            new_ns = parent.ns
+        self.ns = new_ns
         for n in augment:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         for n in refine:
             n.parent = self
-            n_namespace = n.namespace
-            if n_namespace is None:
-                n.namespace = self.namespace
-            n_prefix = n.prefix
-            if n_prefix is None:
-                n.prefix = self.prefix
+            n_ns = n.ns
+            if n_ns is None:
+                n.ns = self.ns
         self.name = name
         self.augment = augment
         self.description = description
@@ -5903,7 +5694,7 @@ def stmt_to_snode(stmt: Statement, parent: ?SchemaNode=None) -> SchemaNode:
     if stmt.kw == "belongs-to":
         if arg is not None:
             n = BelongsTo(arg,
-                          prefix=take_opt_str(ss, "prefix"),
+                          prefix=take_str(ss, "prefix"),
                           exts=take_exts(ss),
                           parent=parent
                           )
@@ -6066,7 +5857,7 @@ def stmt_to_snode(stmt: Statement, parent: ?SchemaNode=None) -> SchemaNode:
         if arg is not None:
             n = Import(arg,
                        description=take_opt_str(ss, "description"),
-                       prefix=take_opt_str(ss, "prefix"),
+                       prefix=take_str(ss, "prefix"),
                        reference=take_opt_str(ss, "reference"),
                        revision_date=take_opt_str(ss, "revision-date"),
                        exts=take_exts(ss),
@@ -6199,9 +5990,9 @@ def stmt_to_snode(stmt: Statement, parent: ?SchemaNode=None) -> SchemaNode:
                        feature=take_features(ss),
                        import_=take_imports(ss),
                        include=take_includes(ss),
-                       namespace=take_opt_str(ss, "namespace"),
+                       namespace=take_str(ss, "namespace"),
                        organization=take_opt_str(ss, "organization"),
-                       prefix=take_opt_str(ss, "prefix"),
+                       prefix=take_str(ss, "prefix"),
                        reference=take_opt_str(ss, "reference"),
                        revision=take_revisions(ss),
                        yang_version=take_yang_version(ss),


### PR DESCRIPTION
Separate the prefix/namespace attributes of each schema-node inherited through origin module _from_  prefix/namespace yang sub-statement attributes, e.g. import { prefix } and belongs-to { prefix }.