### PR TITLE
Propagate leaf(list) ns in to_gdata()

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -432,11 +432,11 @@ class DNodeInner(DNode):
                 res.append("        _%s = self.%s" % (_safe_name(child.name), _safe_name(child.name)))
         for child in self.children:
             if isinstance(child, DLeafList):
-                res.append("        res.children['%s'] = yang.gdata.LeafList('%s', self.%s, ns=self._ns)" % (child.name, child.name, _safe_name(child.name)))
+                res.append("        res.children['%s'] = yang.gdata.LeafList('%s', self.%s, ns='%s')" % (child.name, child.name, _safe_name(child.name), child.namespace))
             else:
                 res.append("        if _%s is not None:" % _safe_name(child.name))
                 if isinstance(child, DLeaf):
-                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', _%s, ns=self._ns)" % (child.name, child.name, _safe_name(child.name)))
+                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', _%s, ns='%s')" % (child.name, child.name, _safe_name(child.name), child.namespace))
                 elif isinstance(child, DContainer):
                     res.append("            res.children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
                 elif isinstance(child, DList):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -358,6 +358,10 @@ class DNodeInner(DNode):
         res.append("    def __init__(%s):" % init_args_str)
         # Set namespace from us
         res.append("        self._ns = \"%s\"" % self.namespace)
+        res.append("        self._children_ns = {")
+        for child in self.children:
+            res.append("            \"%s\": \"%s\"," % (_safe_name(child.name), child.namespace))
+        res.append("        }")
 
         for child in self.children:
             if isinstance(child, DContainer):
@@ -428,11 +432,11 @@ class DNodeInner(DNode):
                 res.append("        _%s = self.%s" % (_safe_name(child.name), _safe_name(child.name)))
         for child in self.children:
             if isinstance(child, DLeafList):
-                res.append("        res.children['%s'] = yang.gdata.LeafList('%s', self.%s, ns=self._ns)" % (child.name, child.name, _safe_name(child.name)))
+                res.append("        res.children['%s'] = yang.gdata.LeafList('%s', self.%s, ns='%s')" % (child.name, child.name, _safe_name(child.name), child.namespace))
             else:
                 res.append("        if _%s is not None:" % _safe_name(child.name))
                 if isinstance(child, DLeaf):
-                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', _%s, ns=self._ns)" % (child.name, child.name, _safe_name(child.name)))
+                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', _%s, ns='%s')" % (child.name, child.name, _safe_name(child.name), child.namespace))
                 elif isinstance(child, DContainer):
                     res.append("            res.children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
                 elif isinstance(child, DList):

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -4,6 +4,10 @@ class base__c1(yang.adata.MNode):
 
     def __init__(self, foo: ?str, foo: ?str):
         self._ns = "http://example.com/base"
+        self._children_ns = {
+            "foo": "http://example.com/bar",
+            "foo": "http://example.com/foo",
+        }
         self.foo = foo
         self.foo = foo
 
@@ -12,9 +16,9 @@ class base__c1(yang.adata.MNode):
         _foo = self.foo
         _foo = self.foo
         if _foo is not None:
-            res.children['foo'] = yang.gdata.Leaf('foo', _foo, ns=self._ns)
+            res.children['foo'] = yang.gdata.Leaf('foo', _foo, ns='http://example.com/bar')
         if _foo is not None:
-            res.children['foo'] = yang.gdata.Leaf('foo', _foo, ns=self._ns)
+            res.children['foo'] = yang.gdata.Leaf('foo', _foo, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -7,6 +7,13 @@ class foo__c1(yang.adata.MNode):
 
     def __init__(self, as_: ?str, for_: ?str, import_: ?str, in_: ?str, with_: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "as_": "http://example.com/foo",
+            "for_": "http://example.com/foo",
+            "import_": "http://example.com/foo",
+            "in_": "http://example.com/foo",
+            "with_": "http://example.com/foo",
+        }
         self.as_ = as_
         self.for_ = for_
         self.import_ = import_
@@ -21,15 +28,15 @@ class foo__c1(yang.adata.MNode):
         _in_ = self.in_
         _with_ = self.with_
         if _as_ is not None:
-            res.children['as'] = yang.gdata.Leaf('as', _as_, ns=self._ns)
+            res.children['as'] = yang.gdata.Leaf('as', _as_, ns='http://example.com/foo')
         if _for_ is not None:
-            res.children['for'] = yang.gdata.Leaf('for', _for_, ns=self._ns)
+            res.children['for'] = yang.gdata.Leaf('for', _for_, ns='http://example.com/foo')
         if _import_ is not None:
-            res.children['import'] = yang.gdata.Leaf('import', _import_, ns=self._ns)
+            res.children['import'] = yang.gdata.Leaf('import', _import_, ns='http://example.com/foo')
         if _in_ is not None:
-            res.children['in'] = yang.gdata.Leaf('in', _in_, ns=self._ns)
+            res.children['in'] = yang.gdata.Leaf('in', _in_, ns='http://example.com/foo')
         if _with_ is not None:
-            res.children['with'] = yang.gdata.Leaf('with', _with_, ns=self._ns)
+            res.children['with'] = yang.gdata.Leaf('with', _with_, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -3,13 +3,16 @@ class foo__l1_entry(yang.adata.MNode):
 
     def __init__(self, name: str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "name": "http://example.com/foo",
+        }
         self.name = name
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.ListElement([str(self.name)], ns=self._ns)
         _name = self.name
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns=self._ns)
+            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -3,13 +3,16 @@ class foo__foo__bar(yang.adata.MNode):
 
     def __init__(self, l1: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+        }
         self.l1 = l1
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('bar', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns=self._ns)
+            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -32,6 +35,9 @@ class foo__foo(yang.adata.MNode):
 
     def __init__(self, bar: ?foo__foo__bar=None):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "bar": "http://example.com/foo",
+        }
         if bar is not None:
             self.bar = bar
         else:

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -3,13 +3,16 @@ class foo__foo__bar(yang.adata.MNode):
 
     def __init__(self, l1: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+        }
         self.l1 = l1
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('bar', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns=self._ns)
+            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -32,6 +35,9 @@ class foo__foo(yang.adata.MNode):
 
     def __init__(self, bar: ?foo__foo__bar=None):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "bar": "http://example.com/foo",
+        }
         if bar is not None:
             self.bar = bar
         else:

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -10,13 +10,16 @@ class foo__l1__bar(yang.adata.MNode):
 
     def __init__(self, hi: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "hi": "http://example.com/foo",
+        }
         self.hi = hi
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('bar', ns=self._ns)
         _hi = self.hi
         if _hi is not None:
-            res.children['hi'] = yang.gdata.Leaf('hi', _hi, ns=self._ns)
+            res.children['hi'] = yang.gdata.Leaf('hi', _hi, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -41,6 +44,11 @@ class foo__l1_entry(yang.adata.MNode):
 
     def __init__(self, name: str, id: ?str, bar: ?foo__l1__bar=None):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "name": "http://example.com/foo",
+            "id": "http://example.com/foo",
+            "bar": "http://example.com/foo",
+        }
         self.name = name
         self.id = id
         if bar is not None:
@@ -57,9 +65,9 @@ class foo__l1_entry(yang.adata.MNode):
         _id = self.id
         _bar = self.bar
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns=self._ns)
+            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
         if _id is not None:
-            res.children['id'] = yang.gdata.Leaf('id', _id, ns=self._ns)
+            res.children['id'] = yang.gdata.Leaf('id', _id, ns='http://example.com/foo')
         if _bar is not None:
             res.children['bar'] = _bar.to_gdata()
         for child in res.children.values():
@@ -114,6 +122,9 @@ class root(yang.adata.MNode):
 
     def __init__(self, l1: list[foo__l1_entry]=[]):
         self._ns = ""
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+        }
         self.l1 = foo__l1(elements=l1)
         self.l1._parent = self
 

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -4,6 +4,10 @@ class foo__l1_entry(yang.adata.MNode):
 
     def __init__(self, name: str, id: str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "name": "http://example.com/foo",
+            "id": "http://example.com/foo",
+        }
         self.name = name
         self.id = id
 
@@ -12,9 +16,9 @@ class foo__l1_entry(yang.adata.MNode):
         _name = self.name
         _id = self.id
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns=self._ns)
+            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
         if _id is not None:
-            res.children['id'] = yang.gdata.Leaf('id', _id, ns=self._ns)
+            res.children['id'] = yang.gdata.Leaf('id', _id, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -3,13 +3,16 @@ class foo__l1__bar(yang.adata.MNode):
 
     def __init__(self, hi: str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "hi": "http://example.com/foo",
+        }
         self.hi = hi
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('bar', ns=self._ns)
         _hi = self.hi
         if _hi is not None:
-            res.children['hi'] = yang.gdata.Leaf('hi', _hi, ns=self._ns)
+            res.children['hi'] = yang.gdata.Leaf('hi', _hi, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -33,6 +36,10 @@ class foo__l1_entry(yang.adata.MNode):
 
     def __init__(self, name: str, bar: ?foo__l1__bar=None):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "name": "http://example.com/foo",
+            "bar": "http://example.com/foo",
+        }
         self.name = name
         self.bar = bar
         self_bar = self.bar
@@ -49,7 +56,7 @@ class foo__l1_entry(yang.adata.MNode):
         _name = self.name
         _bar = self.bar
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns=self._ns)
+            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
         if _bar is not None:
             res.children['bar'] = _bar.to_gdata()
         for child in res.children.values():

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -10,13 +10,16 @@ class foo__c1(yang.adata.MNode):
 
     def __init__(self, l1: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+        }
         self.l1 = l1
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('c1', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns=self._ns)
+            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -39,13 +42,16 @@ class foo__pc1__foo(yang.adata.MNode):
 
     def __init__(self, l1: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+        }
         self.l1 = l1
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('foo', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns=self._ns)
+            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -68,6 +74,9 @@ class foo__pc1(yang.adata.MNode):
 
     def __init__(self, foo: ?foo__pc1__foo=None):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "foo": "http://example.com/foo",
+        }
         if foo is not None:
             self.foo = foo
         else:
@@ -104,6 +113,10 @@ class root(yang.adata.MNode):
 
     def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None):
         self._ns = ""
+        self._children_ns = {
+            "c1": "http://example.com/foo",
+            "pc1": "http://example.com/foo",
+        }
         if c1 is not None:
             self.c1 = c1
         else:

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -73,3 +73,17 @@ def _test_foo_from_xml2():
     xml_out_text = d.to_gdata().to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
+
+def _test_foo_from_xml_leaf_ns():
+    xml_text = """<data>
+<c1 xmlns="http://example.com/foo">
+  <l1>foo</l1>
+  <l2 xmlns="http://example.com/bar">bar</l2>
+</c1>
+</data>"""
+    xml_in = xml.decode(xml_text)
+    d = yang_foo_root.from_xml(xml_in)
+    xml_out_text = d.to_gdata().to_xmlstr()
+    xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
+    #testing.assertEqual(xml_in.encode(), xml_out.encode())
+    return xml_out_text

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -7,16 +7,25 @@ import yang.gdata
 
 class foo__c1(yang.adata.MNode):
     l1: ?str
+    l2: ?str
 
-    def __init__(self, l1: ?str):
+    def __init__(self, l1: ?str, l2: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+            "l2": "http://example.com/bar",
+        }
         self.l1 = l1
+        self.l2 = l2
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('c1', ns=self._ns)
         _l1 = self.l1
+        _l2 = self.l2
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns=self._ns)
+            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+        if _l2 is not None:
+            res.children['l2'] = yang.gdata.Leaf('l2', _l2, ns='http://example.com/bar')
         for child in res.children.values():
             child.parent = res
         return res
@@ -24,13 +33,13 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=n.get_opt_str("l1"))
+            return foo__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
         return foo__c1()
 
     @staticmethod
     def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
         return foo__c1()
 
 
@@ -39,13 +48,16 @@ class foo__pc1__foo(yang.adata.MNode):
 
     def __init__(self, l1: ?str):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "l1": "http://example.com/foo",
+        }
         self.l1 = l1
 
     def to_gdata(self) -> yang.gdata.Node:
         res = yang.gdata.Container('foo', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns=self._ns)
+            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -68,6 +80,9 @@ class foo__pc1(yang.adata.MNode):
 
     def __init__(self, foo: ?foo__pc1__foo=None):
         self._ns = "http://example.com/foo"
+        self._children_ns = {
+            "foo": "http://example.com/foo",
+        }
         if foo is not None:
             self.foo = foo
         else:
@@ -104,6 +119,10 @@ class root(yang.adata.MNode):
 
     def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None):
         self._ns = ""
+        self._children_ns = {
+            "c1": "http://example.com/foo",
+            "pc1": "http://example.com/foo",
+        }
         if c1 is not None:
             self.c1 = c1
         else:

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_leaf_ns
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_leaf_ns
@@ -1,0 +1,4 @@
+<c1 xmlns="http://example.com/foo">
+  <l1>foo</l1>
+  <l2 xmlns="http://example.com/bar">bar</l2>
+</c1>

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -29,7 +29,21 @@ ys_foo = """module foo {
     }
 }"""
 
+ys_bar = """module bar {
+    yang-version "1.1";
+    namespace "http://example.com/bar";
+    prefix "bar";
+    import foo {
+        prefix "foo";
+    }
+    augment /foo:c1 {
+        leaf l2 {
+            type string;
+        }
+    }
+}"""
+
 actor main(env: Env):
     wfcap = file.WriteFileCap(file.FileCap(env.cap))
-    yang_to_act(wfcap, yangs=[ys_foo], filename="../test_data_classes/src/yang_foo.act")
+    yang_to_act(wfcap, yangs=[ys_foo, ys_bar], filename="../test_data_classes/src/yang_foo.act")
     env.exit(0)


### PR DESCRIPTION
We previously, rather naively, just propagated the namespace of the inner node when creating gdata leaf and leaflists. We now use the correct namespace of the leaf!

Fixes #25