### PR TITLE
Support delete of type empty

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -436,7 +436,7 @@ class DNodeInner(DNode):
             else:
                 res.append("        if _%s is not None:" % _safe_name(child.name))
                 if isinstance(child, DLeaf):
-                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', _%s, ns='%s')" % (child.name, child.name, _safe_name(child.name), child.namespace))
+                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', '%s', _%s, ns='%s')" % (child.name, child.name, child.type_.name, _safe_name(child.name), child.namespace))
                 elif isinstance(child, DContainer):
                     res.append("            res.children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
                 elif isinstance(child, DList):

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -275,12 +275,15 @@ class Node(object):
         if self._ns == None:
             self._ns = ns
 
-    def fmt_tag(self, cns, close=False):
+    def fmt_tag(self, cns, attrs: list[(str, str)]=[], close=False, end=False):
         ns_str = ""
         ns = self.ns()
         if cns != ns:
             ns_str = " xmlns=\"" + ns + "\""
-        return "<" + ("/" if close else "") + self.get_name() + ("" if close else ns_str) + ">"
+        attr_str = " ".join(map(lambda x: x.0 + "=" + x.1, attrs))
+        if attr_str != "":
+            attr_str = " " + attr_str
+        return "<" + ("/" if close else "") + self.get_name() + ("" if close else ns_str) + attr_str + ("/" if end else "") + ">"
 
     def to_xmlstr(self, pretty=True, indent=0, cns="") -> str:
         def _indent():
@@ -340,7 +343,19 @@ class Node(object):
                 cns = self.ns()
             return xml
         elif isinstance(self, Leaf):
-            xml = _indent() + self.fmt_tag(cns) + str(self.val) + self.fmt_tag(cns, close=True) + _nl()
+            xml = _indent()
+            if self.t == "empty":
+                v = self.val
+                if v == None:
+                    return ""
+                if isinstance(v, bool):
+                    if v == True:
+                        xml += self.fmt_tag(cns, end=True)
+                    else:
+                        xml += self.fmt_tag(cns, attrs=[("xmlns:xc", '"urn:ietf:params:xml:ns:netconf:base:1.0"'), ("xc:operation", '"remove"')], end=True)
+            else:
+                xml += self.fmt_tag(cns) + str(self.val) + self.fmt_tag(cns, close=True)
+            xml += _nl()
             if cns == "":
                 cns = self.ns()
             return xml
@@ -664,10 +679,12 @@ class ListElement(Inner):
 
 class Leaf(Node):
     name: str
+    t: str
     val: value
 
-    def __init__(self, name: str, val: value, ns: ?str=None, prefix: ?str=None):
+    def __init__(self, name: str, t: str, val: value, ns: ?str=None, prefix: ?str=None):
         self.name = name
+        self.t = t
         self.val = val
         self._ns = ns
         self.prefix = prefix
@@ -716,8 +733,12 @@ def merge(a: Node, b: Node) -> Node:
     elif isinstance(a, Leaf) and isinstance(b, Leaf):
         if a.name != b.name:
             raise ValueError("Cannot merge leaves with different names")
+        if a.t != b.t:
+            raise ValueError("Cannot merge leaves with different types")
         aval = a.val
         bval = b.val
+        if aval == None and bval == None:
+            return a
         if isinstance(aval, int) and isinstance(bval, int):
             if aval == bval:
                 return a
@@ -1009,25 +1030,25 @@ def from_xml_opt_values(n: xml.Node, name: str) -> list[value]:
 
 def _test_merge1():
     y1 = Container("foo", {
-        "a": Leaf("a", 1),
+        "a": Leaf("a", "int", 1),
         "l1": List("l1", ["name"], [
             ListElement(["k1"], {
-                "n1": Leaf("n1", 1),
-                "n2": Leaf("n2", 2)
+                "n1": Leaf("n1", "int", 1),
+                "n2": Leaf("n2", "int", 2)
             }),
             ListElement(["k4"], {
-                "n4": Leaf("n4", 4),
+                "n4": Leaf("n4", "int", 4),
             }),
         ])
     }, ns="http://example.com/acme")
 
     y2 = Container("foo", {
-        "b": Leaf("b", 2),
-        "c": Leaf("c", 3),
+        "b": Leaf("b", "int", 2),
+        "c": Leaf("c", "int", 3),
         "l1": List("l1", ["name"], [
             ListElement(["k2"], {
-                "n1": Leaf("n1", 1),
-                "n3": Leaf("n3", 3)
+                "n1": Leaf("n1", "int", 1),
+                "n3": Leaf("n3", "int", 3)
             }),
         ]),
         "d": LeafList("d", ["a", "b", "c"])
@@ -1038,20 +1059,20 @@ def _test_merge1():
     exp = Container("foo", {
         "l1": List("l1", ["name"], [
             ListElement(["k1"], {
-                "n1": Leaf("n1", 1),
-                "n2": Leaf("n2", 2)
+                "n1": Leaf("n1", "int", 1),
+                "n2": Leaf("n2", "int", 2)
             }),
             ListElement(["k2"], {
-                "n1": Leaf("n1", 1),
-                "n3": Leaf("n3", 3)
+                "n1": Leaf("n1", "int", 1),
+                "n3": Leaf("n3", "int", 3)
             }),
             ListElement(["k4"], {
-                "n4": Leaf("n4", 4),
+                "n4": Leaf("n4", "int", 4),
             }),
         ]),
-        "a": Leaf("a", 1),
-        "b": Leaf("b", 2),
-        "c": Leaf("c", 3),
+        "a": Leaf("a", "int", 1),
+        "b": Leaf("b", "int", 2),
+        "c": Leaf("c", "int", 3),
         "d": LeafList("d", ["a", "b", "c"])
     }, ns="http://example.com/acme")
 
@@ -1060,57 +1081,57 @@ def _test_merge1():
 def _test_merge_list1():
     y1 = List("l1", ["name"], [
         ListElement(["first"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["breaker"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["fourth"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["common"], {
-            "n2": Leaf("n2", 2)
+            "n2": Leaf("n2", "int", 2)
         }),
         ListElement(["last"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
     ], user_order=True, ns="http://example.com/acme")
 
     y2 = List("l1", ["name"], [
         ListElement(["breaker"]),
         ListElement(["second"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["third"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["common"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["last"])
     ], user_order=True)
 
     exp = List("l1", ["name"], [
         ListElement(["first"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["breaker"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["third"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["second"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["fourth"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
         ListElement(["common"], {
-            "n2": Leaf("n2", 2)
+            "n2": Leaf("n2", "int", 2)
         }),
         ListElement(["last"], {
-            "n1": Leaf("n1", 1)
+            "n1": Leaf("n1", "int", 1)
         }),
     ])
     print(merge(y1, y2).to_xmlstr())
@@ -1169,14 +1190,14 @@ def _test_yang_data():
 def _test_prsrc():
     y1 = Module("moo", {
         "foo": Container("foo", {
-            "a": Leaf("a", 1),
+            "a": Leaf("a", "int", 1),
             "l1": List("l1", ["name"], [
                 ListElement(["k1"], {
-                    "n1": Leaf("n1", 1),
-                    "n2": Leaf("n2", 2)
+                    "n1": Leaf("n1", "int", 1),
+                    "n2": Leaf("n2", "int", 2)
                 }),
                 ListElement(["k4"], {
-                    "n4": Leaf("n4", 4),
+                    "n4": Leaf("n4", "int", 4),
                 }),
             ])
         })
@@ -1187,7 +1208,7 @@ def _test_prsrc():
 def _test_prsrc_root():
     y1 = Root({
         "foo": Container("foo", {
-            "a": Leaf("a", 1),
+            "a": Leaf("a", "int", 1),
             "b": LeafList("b", ["a", "b", "c"]),
         }, ns="http://example.com/acme")
     })
@@ -1197,14 +1218,14 @@ def _test_prsrc_root():
 def _test_to_xmlstr():
     y1 = Module("moo", {
         "foo": Container("foo", {
-            "a": Leaf("a", 1),
+            "a": Leaf("a", "int", 1),
             "l1": List("l1", ["name"], [
                 ListElement(["k1"], {
-                    "n1": Leaf("n1", 1),
-                    "n2": Leaf("n2", 2)
+                    "n1": Leaf("n1", "int", 1),
+                    "n2": Leaf("n2", "int", 2)
                 }),
                 ListElement(["k4"], {
-                    "n4": Leaf("n4", 4),
+                    "n4": Leaf("n4", "int", 4),
                 }),
             ])
         })
@@ -1215,7 +1236,7 @@ def _test_to_xmlstr():
 def _test_to_xmlstr_root():
     y1 = Root({
         "foo": Container("foo", {
-            "a": Leaf("a", 1),
+            "a": Leaf("a", "int", 1),
             "b": LeafList("b", ["a", "b", "c"]),
         }, ns="http://example.com/acme")
     })
@@ -1225,8 +1246,8 @@ def _test_to_xmlstr_root():
 def _test_to_xmlstr_leaf_ns():
     y1 = Root({
         "foo": Container("foo", {
-            "a": Leaf("a", 1, ns="http://example.com/foo"),
-            "b": Leaf("b", 2)
+            "a": Leaf("a", "int", 1, ns="http://example.com/foo"),
+            "b": Leaf("b", "int", 2)
         }, ns="http://example.com/acme")
     })
 
@@ -1238,14 +1259,14 @@ def _test_to_xmlstr_mixed():
             ListElement(["dev1"], {
                 "config": Container("config", {
                     "hostname": Container("hostname", {
-                        "system-network-name": Leaf("system-network-name", "dev1")
+                        "system-network-name": Leaf("system-network-name", "str", "dev1")
                     }, ns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg")
                 }),
             }),
             ListElement(["dev2"], {
                 "config": Container("config", {
                     "hostname": Container("hostname", {
-                        "system-network-name": Leaf("system-network-name", "dev2")
+                        "system-network-name": Leaf("system-network-name", "str", "dev2")
                     }, ns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg")
                 }),
             }),
@@ -1257,13 +1278,13 @@ def _test_to_xmlstr_mixed():
 def _test_to_xmlstr_root_merge():
     y1 = Root({
         "foo": Container("foo", {
-            "a": Leaf("a", 1),
+            "a": Leaf("a", "int", 1),
             "b": LeafList("b", ["a", "b", "c"]),
         }, ns="http://example.com/acme")
     })
     y2 = Root({
         "bar": Container("bar", {
-            "b": Leaf("b", 42),
+            "b": Leaf("b", "int", 42),
         }, ns="http://example.com/bar")
     })
     ym = merge(y1, y2)

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -432,7 +432,7 @@ class DNodeInner(DNode):
             else:
                 res.append("        if _%s is not None:" % _safe_name(child.name))
                 if isinstance(child, DLeaf):
-                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', _%s, ns='%s')" % (child.name, child.name, _safe_name(child.name), child.namespace))
+                    res.append("            res.children['%s'] = yang.gdata.Leaf('%s', '%s', _%s, ns='%s')" % (child.name, child.name, child.type_.name, _safe_name(child.name), child.namespace))
                 elif isinstance(child, DContainer):
                     res.append("            res.children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
                 elif isinstance(child, DList):

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -12,9 +12,9 @@ class base__c1(yang.adata.MNode):
         _foo = self.foo
         _foo = self.foo
         if _foo is not None:
-            res.children['foo'] = yang.gdata.Leaf('foo', _foo, ns='http://example.com/bar')
+            res.children['foo'] = yang.gdata.Leaf('foo', 'string', _foo, ns='http://example.com/bar')
         if _foo is not None:
-            res.children['foo'] = yang.gdata.Leaf('foo', _foo, ns='http://example.com/foo')
+            res.children['foo'] = yang.gdata.Leaf('foo', 'string', _foo, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -21,15 +21,15 @@ class foo__c1(yang.adata.MNode):
         _in_ = self.in_
         _with_ = self.with_
         if _as_ is not None:
-            res.children['as'] = yang.gdata.Leaf('as', _as_, ns='http://example.com/foo')
+            res.children['as'] = yang.gdata.Leaf('as', 'string', _as_, ns='http://example.com/foo')
         if _for_ is not None:
-            res.children['for'] = yang.gdata.Leaf('for', _for_, ns='http://example.com/foo')
+            res.children['for'] = yang.gdata.Leaf('for', 'string', _for_, ns='http://example.com/foo')
         if _import_ is not None:
-            res.children['import'] = yang.gdata.Leaf('import', _import_, ns='http://example.com/foo')
+            res.children['import'] = yang.gdata.Leaf('import', 'string', _import_, ns='http://example.com/foo')
         if _in_ is not None:
-            res.children['in'] = yang.gdata.Leaf('in', _in_, ns='http://example.com/foo')
+            res.children['in'] = yang.gdata.Leaf('in', 'string', _in_, ns='http://example.com/foo')
         if _with_ is not None:
-            res.children['with'] = yang.gdata.Leaf('with', _with_, ns='http://example.com/foo')
+            res.children['with'] = yang.gdata.Leaf('with', 'string', _with_, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -9,7 +9,7 @@ class foo__l1_entry(yang.adata.MNode):
         res = yang.gdata.ListElement([str(self.name)], ns=self._ns)
         _name = self.name
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
+            res.children['name'] = yang.gdata.Leaf('name', 'string', _name, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -9,7 +9,7 @@ class foo__foo__bar(yang.adata.MNode):
         res = yang.gdata.Container('bar', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+            res.children['l1'] = yang.gdata.Leaf('l1', 'string', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -9,7 +9,7 @@ class foo__foo__bar(yang.adata.MNode):
         res = yang.gdata.Container('bar', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+            res.children['l1'] = yang.gdata.Leaf('l1', 'string', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -16,7 +16,7 @@ class foo__l1__bar(yang.adata.MNode):
         res = yang.gdata.Container('bar', ns=self._ns)
         _hi = self.hi
         if _hi is not None:
-            res.children['hi'] = yang.gdata.Leaf('hi', _hi, ns='http://example.com/foo')
+            res.children['hi'] = yang.gdata.Leaf('hi', 'string', _hi, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -57,9 +57,9 @@ class foo__l1_entry(yang.adata.MNode):
         _id = self.id
         _bar = self.bar
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
+            res.children['name'] = yang.gdata.Leaf('name', 'string', _name, ns='http://example.com/foo')
         if _id is not None:
-            res.children['id'] = yang.gdata.Leaf('id', _id, ns='http://example.com/foo')
+            res.children['id'] = yang.gdata.Leaf('id', 'string', _id, ns='http://example.com/foo')
         if _bar is not None:
             res.children['bar'] = _bar.to_gdata()
         for child in res.children.values():

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -12,9 +12,9 @@ class foo__l1_entry(yang.adata.MNode):
         _name = self.name
         _id = self.id
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
+            res.children['name'] = yang.gdata.Leaf('name', 'string', _name, ns='http://example.com/foo')
         if _id is not None:
-            res.children['id'] = yang.gdata.Leaf('id', _id, ns='http://example.com/foo')
+            res.children['id'] = yang.gdata.Leaf('id', 'string', _id, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -9,7 +9,7 @@ class foo__l1__bar(yang.adata.MNode):
         res = yang.gdata.Container('bar', ns=self._ns)
         _hi = self.hi
         if _hi is not None:
-            res.children['hi'] = yang.gdata.Leaf('hi', _hi, ns='http://example.com/foo')
+            res.children['hi'] = yang.gdata.Leaf('hi', 'string', _hi, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -49,7 +49,7 @@ class foo__l1_entry(yang.adata.MNode):
         _name = self.name
         _bar = self.bar
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
+            res.children['name'] = yang.gdata.Leaf('name', 'string', _name, ns='http://example.com/foo')
         if _bar is not None:
             res.children['bar'] = _bar.to_gdata()
         for child in res.children.values():

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -16,7 +16,7 @@ class foo__c1(yang.adata.MNode):
         res = yang.gdata.Container('c1', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+            res.children['l1'] = yang.gdata.Leaf('l1', 'string', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -45,7 +45,7 @@ class foo__pc1__foo(yang.adata.MNode):
         res = yang.gdata.Container('foo', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+            res.children['l1'] = yang.gdata.Leaf('l1', 'string', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -97,7 +97,7 @@ def _test_list_create_idempotency():
     # TODO: fix this!!!
     return r.to_gdata().to_xmlstr()
 
-def _test_foo_from_xml_int():
+def _test_foo_from_gdata_int():
     xml_text = """<data>
 <c1 xmlns="http://example.com/foo">
   <l3>1337</l3>
@@ -109,3 +109,14 @@ def _test_foo_from_xml_int():
     gd = d.to_gdata()
     nr = yang_foo_root.from_gdata(gd)
     testing.assertEqual(nr.c1.l3, 1337)
+
+
+def _test_empty_true():
+    r = yang_foo_root()
+    r.c1.l_empty = True
+    return r.to_gdata().to_xmlstr()
+
+def _test_empty_false():
+    r = yang_foo_root()
+    r.c1.l_empty = False
+    return r.to_gdata().to_xmlstr()

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -19,9 +19,9 @@ class foo__c1__li_entry(yang.adata.MNode):
         _name = self.name
         _val = self.val
         if _name is not None:
-            res.children['name'] = yang.gdata.Leaf('name', _name, ns='http://example.com/foo')
+            res.children['name'] = yang.gdata.Leaf('name', 'string', _name, ns='http://example.com/foo')
         if _val is not None:
-            res.children['val'] = yang.gdata.Leaf('val', _val, ns='http://example.com/foo')
+            res.children['val'] = yang.gdata.Leaf('val', 'string', _val, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res
@@ -80,13 +80,15 @@ class foo__c1__li(yang.adata.MNode):
 class foo__c1(yang.adata.MNode):
     l1: ?str
     l3: ?int
+    l_empty: ?bool
     li: foo__c1__li
     l2: ?str
 
-    def __init__(self, l1: ?str, l3: ?int, li: list[foo__c1__li_entry]=[], l2: ?str):
+    def __init__(self, l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], l2: ?str):
         self._ns = "http://example.com/foo"
         self.l1 = l1
         self.l3 = l3
+        self.l_empty = l_empty
         self.li = foo__c1__li(elements=li)
         self.li._parent = self
         self.l2 = l2
@@ -95,16 +97,19 @@ class foo__c1(yang.adata.MNode):
         res = yang.gdata.Container('c1', ns=self._ns)
         _l1 = self.l1
         _l3 = self.l3
+        _l_empty = self.l_empty
         _li = self.li
         _l2 = self.l2
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+            res.children['l1'] = yang.gdata.Leaf('l1', 'string', _l1, ns='http://example.com/foo')
         if _l3 is not None:
-            res.children['l3'] = yang.gdata.Leaf('l3', _l3, ns='http://example.com/foo')
+            res.children['l3'] = yang.gdata.Leaf('l3', 'uint64', _l3, ns='http://example.com/foo')
+        if _l_empty is not None:
+            res.children['l_empty'] = yang.gdata.Leaf('l_empty', 'empty', _l_empty, ns='http://example.com/foo')
         if _li is not None:
             res.children['li'] = _li.to_gdata()
         if _l2 is not None:
-            res.children['l2'] = yang.gdata.Leaf('l2', _l2, ns='http://example.com/bar')
+            res.children['l2'] = yang.gdata.Leaf('l2', 'string', _l2, ns='http://example.com/bar')
         for child in res.children.values():
             child.parent = res
         return res
@@ -112,13 +117,13 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=n.get_opt_str("l1"), l3=n.get_opt_int("l3"), li=foo__c1__li.from_gdata(n.get_list("li")), l2=n.get_opt_str("l2"))
+            return foo__c1(l1=n.get_opt_str("l1"), l3=n.get_opt_int("l3"), l_empty=n.get_opt_bool("l_empty"), li=foo__c1__li.from_gdata(n.get_list("li")), l2=n.get_opt_str("l2"))
         return foo__c1()
 
     @staticmethod
     def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l3=yang.gdata.from_xml_opt_int(n, "l3"), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, "li")), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l3=yang.gdata.from_xml_opt_int(n, "l3"), l_empty=yang.gdata.from_xml_opt_bool(n, "l_empty"), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, "li")), l2=yang.gdata.from_xml_opt_str(n, "l2"))
         return foo__c1()
 
 
@@ -133,7 +138,7 @@ class foo__pc1__foo(yang.adata.MNode):
         res = yang.gdata.Container('foo', ns=self._ns)
         _l1 = self.l1
         if _l1 is not None:
-            res.children['l1'] = yang.gdata.Leaf('l1', _l1, ns='http://example.com/foo')
+            res.children['l1'] = yang.gdata.Leaf('l1', 'string', _l1, ns='http://example.com/foo')
         for child in res.children.values():
             child.parent = res
         return res

--- a/test/test_data_classes_gen/.build/sys
+++ b/test/test_data_classes_gen/.build/sys
@@ -1,1 +1,0 @@
-/home/kll/dt/acton/dist

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -21,6 +21,9 @@ ys_foo = """module foo {
         leaf l3 {
             type uint64;
         }
+        leaf l_empty {
+            type empty;
+        }
         list li {
             key name;
             leaf name {


### PR DESCRIPTION
We map type empty to a bool, so for False, we remove the type empty.

Had to pass down the type of Leaf as an argument, so that adds quite a bit of code but I don't see how we can otherwise disambiguate between type empty and type boolean in YANG since they both map to Acton bool