### PR TITLE
Add back get(_opt)_value

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -480,12 +480,20 @@ class Node(object):
                         return cvals
         raise ValueError("Cannot find leaf-list child with name " + name)
 
-    # plural opts
     def get_opt_strs(self, name) -> list[str]:
         try:
             return self.get_strs(name)
         except ValueError:
             return []
+
+    def get_value(self, name) -> value:
+        child = self.get_leaf(name)
+        return child.val
+
+    def get_opt_value(self, name) -> ?value:
+        child = self.get_opt_leaf(name)
+        if child != None:
+            return child.val
 
 extension Node(Eq):
     def __eq__(self, other: Node) -> bool:


### PR DESCRIPTION
I mistakenly removed these, thinking that they were only used by other get_X functions but we have some yang types, like a yang union, mapped directly to the acton 'value' type.