### PR TITLE
Handle YANG default values

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -348,7 +348,11 @@ class DNodeInner(DNode):
                 else:
                     req_args.append("%s: %s" % (_safe_name(child.name), get_path_name(child)))
             elif isinstance(child, DLeaf):
-                child_arg = "%s: %s" % (_safe_name(child.name), yang_leaf_to_acton_type(child, loose))
+                defval = ""
+                child_default = child.default
+                if child_default != None:
+                    defval = "=None"
+                child_arg = "%s: %s%s" % (_safe_name(child.name), yang_leaf_to_acton_arg_type(child, loose), defval)
                 if is_optional_yang_leaf(child, loose):
                     opt_args.append(child_arg)
                 else:
@@ -381,7 +385,14 @@ class DNodeInner(DNode):
                 else:
                     res.append("        self.%s._parent = self" % (_safe_name(child.name)))
             elif isinstance(child, DLeaf):
-                res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                child_default = child.default
+                if child_default != None:
+                    res.append("        if %s != None:" % (_safe_name(child.name)))
+                    res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        else:")
+                    res.append("            self.%s = %s" % (_safe_name(child.name), prsrc_literal(child.type_.name, child_default)))
+                else:
+                    res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
             elif isinstance(child, DLeafList):
                 #res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
                 res.append("        if %s is not None:" % (_safe_name(child.name)))
@@ -785,13 +796,13 @@ class DLeaf(DNodeLeaf):
         return False
 
 class DLeafList(DNodeLeaf):
-    default: list[str]
+    default: ?list[str]
     max_elements: ?int
     min_elements: int
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=[], if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
         self.name = name
         self.gname = "LeafList"
@@ -1538,10 +1549,19 @@ def _prsrc_attrs(indent, attrs):
 
 def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     optional = True
+
     # Mandatory leaf in YANG model are non-optional in Acton
+    mandatory = False
     leafmandatory = leaf.mandatory
-    if leafmandatory is not None:
-        optional = not leafmandatory
+    if leafmandatory != None:
+        mandatory = leafmandatory
+
+    has_default = False
+    if isinstance(leaf, DLeaf):
+        if leaf.default != None:
+            has_default = True
+
+    optional = not (mandatory or has_default)
     # But with loose validation, even mandatory YANG leaves are optional!
     if loose:
         optional = True
@@ -1553,35 +1573,23 @@ def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     return optional
 
 def yang_leaf_to_acton_type(leaf: DNodeLeaf, loose: bool=False) -> str:
-    # TODO: use is_optiona_yang_leaf
-    optional = True
-    # Mandatory leaf in YANG model are non-optional in Acton
-    leafmandatory = leaf.mandatory
-    if leafmandatory is not None:
-        optional = not leafmandatory
-    # But with loose validation, even mandatory YANG leaves are optional!
-    if loose:
-        optional = True
-    # ... although being part of a key always makes it non-optional
-    parent = leaf.parent
-    if isinstance(parent, DList):
-        if leaf.name in parent.key:
-            optional = False
+    optional = is_optional_yang_leaf(leaf, loose)
+    optional_str = "?" if optional else ""
+    t = yang_type_to_acton_type(leaf.type_)
+    return optional_str + t
+
+def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, loose: bool=False) -> str:
+    optional = is_optional_yang_leaf(leaf, loose)
+    if isinstance(leaf, DLeaf):
+        if leaf.default != None:
+            optional = True
     optional_str = "?" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
 
 def yang_leaf_to_getval(leaf: DNodeLeaf) -> str:
     # TODO: uh, do we need loose arg?
-    # TODO: use is_optiona_yang_leaf
-    optional = True
-    leafmandatory = leaf.mandatory
-    if leafmandatory is not None:
-        optional = not leafmandatory
-    parent = leaf.parent
-    if isinstance(parent, DList):
-        if leaf.name in parent.key:
-            optional = False
+    optional = is_optional_yang_leaf(leaf)
     optional_str = "opt_" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
@@ -1702,6 +1710,10 @@ def yang_type_to_acton_type(t: ?Type) -> str:
             return yang_typename_to_acton_type(t.name)
     raise ValueError("type not defined")
 
+def prsrc_literal(ytype: str, value: str) -> str:
+    if ytype == "string":
+        return '"' + value + '"'
+    return value
 
 def _safe_name(name: str) -> str:
     new = name.replace("-", "_")

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -605,6 +605,7 @@ snode_methods = {
             namespace=self.get_namespace(),
             name=self.name,
             config=self.is_config(),
+            default=self.default,
             description=self.description,
             if_feature=self.if_feature,
             mandatory=self.mandatory,

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1719,3 +1719,24 @@ def _test_prdaclass_top_container_from_xml_opt():
     root = yang.compile([ys_base])
     src = root.prdaclass()
     return src
+
+
+def _test_leaf_defaults():
+    ys_base = """module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    container c {
+        leaf l_str_def {
+            type string;
+            default "foo";
+        }
+    }
+}"""
+    root = yang.compile([ys_base])
+
+    l_str_def = root.get("c").get("l_str_def")
+    if isinstance(l_str_def, yang.schema.DLeaf):
+        testing.assertEqual(l_str_def.default, "foo")
+    else:
+        testing.error("Expected Leaf instance")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -344,7 +344,11 @@ class DNodeInner(DNode):
                 else:
                     req_args.append("%s: %s" % (_safe_name(child.name), get_path_name(child)))
             elif isinstance(child, DLeaf):
-                child_arg = "%s: %s" % (_safe_name(child.name), yang_leaf_to_acton_type(child, loose))
+                defval = ""
+                child_default = child.default
+                if child_default != None:
+                    defval = "=None"
+                child_arg = "%s: %s%s" % (_safe_name(child.name), yang_leaf_to_acton_arg_type(child, loose), defval)
                 if is_optional_yang_leaf(child, loose):
                     opt_args.append(child_arg)
                 else:
@@ -377,7 +381,14 @@ class DNodeInner(DNode):
                 else:
                     res.append("        self.%s._parent = self" % (_safe_name(child.name)))
             elif isinstance(child, DLeaf):
-                res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                child_default = child.default
+                if child_default != None:
+                    res.append("        if %s != None:" % (_safe_name(child.name)))
+                    res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        else:")
+                    res.append("            self.%s = %s" % (_safe_name(child.name), prsrc_literal(child.type_.name, child_default)))
+                else:
+                    res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
             elif isinstance(child, DLeafList):
                 #res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
                 res.append("        if %s is not None:" % (_safe_name(child.name)))
@@ -781,13 +792,13 @@ class DLeaf(DNodeLeaf):
         return False
 
 class DLeafList(DNodeLeaf):
-    default: list[str]
+    default: ?list[str]
     max_elements: ?int
     min_elements: int
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=[], if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
         self.name = name
         self.gname = "LeafList"
@@ -1534,10 +1545,19 @@ def _prsrc_attrs(indent, attrs):
 
 def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     optional = True
+
     # Mandatory leaf in YANG model are non-optional in Acton
+    mandatory = False
     leafmandatory = leaf.mandatory
-    if leafmandatory is not None:
-        optional = not leafmandatory
+    if leafmandatory != None:
+        mandatory = leafmandatory
+
+    has_default = False
+    if isinstance(leaf, DLeaf):
+        if leaf.default != None:
+            has_default = True
+
+    optional = not (mandatory or has_default)
     # But with loose validation, even mandatory YANG leaves are optional!
     if loose:
         optional = True
@@ -1549,35 +1569,23 @@ def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     return optional
 
 def yang_leaf_to_acton_type(leaf: DNodeLeaf, loose: bool=False) -> str:
-    # TODO: use is_optiona_yang_leaf
-    optional = True
-    # Mandatory leaf in YANG model are non-optional in Acton
-    leafmandatory = leaf.mandatory
-    if leafmandatory is not None:
-        optional = not leafmandatory
-    # But with loose validation, even mandatory YANG leaves are optional!
-    if loose:
-        optional = True
-    # ... although being part of a key always makes it non-optional
-    parent = leaf.parent
-    if isinstance(parent, DList):
-        if leaf.name in parent.key:
-            optional = False
+    optional = is_optional_yang_leaf(leaf, loose)
+    optional_str = "?" if optional else ""
+    t = yang_type_to_acton_type(leaf.type_)
+    return optional_str + t
+
+def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, loose: bool=False) -> str:
+    optional = is_optional_yang_leaf(leaf, loose)
+    if isinstance(leaf, DLeaf):
+        if leaf.default != None:
+            optional = True
     optional_str = "?" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
 
 def yang_leaf_to_getval(leaf: DNodeLeaf) -> str:
     # TODO: uh, do we need loose arg?
-    # TODO: use is_optiona_yang_leaf
-    optional = True
-    leafmandatory = leaf.mandatory
-    if leafmandatory is not None:
-        optional = not leafmandatory
-    parent = leaf.parent
-    if isinstance(parent, DList):
-        if leaf.name in parent.key:
-            optional = False
+    optional = is_optional_yang_leaf(leaf)
     optional_str = "opt_" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
@@ -1698,6 +1706,10 @@ def yang_type_to_acton_type(t: ?Type) -> str:
             return yang_typename_to_acton_type(t.name)
     raise ValueError("type not defined")
 
+def prsrc_literal(ytype: str, value: str) -> str:
+    if ytype == "string":
+        return '"' + value + '"'
+    return value
 
 def _safe_name(name: str) -> str:
     new = name.replace("-", "_")
@@ -3532,6 +3544,7 @@ class Leaf(SchemaNodeOuter):
             namespace=self.get_namespace(),
             name=self.name,
             config=self.is_config(),
+            default=self.default,
             description=self.description,
             if_feature=self.if_feature,
             mandatory=self.mandatory,

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -6,6 +6,7 @@ import yang.adata
 import yang.gdata
 
 from yang_foo import root as yang_foo_root
+import yang_basics
 
 # YANG model used to generate yang_foo
 #
@@ -120,3 +121,9 @@ def _test_empty_false():
     r = yang_foo_root()
     r.c1.l_empty = False
     return r.to_gdata().to_xmlstr()
+
+
+def _test_leaf_defaults():
+    r = yang_basics.root()
+    testing.assertEqual(r.c.l_str_def, "foo")
+    testing.assertEqual(r.c.l_uint64_def, 1234567890)

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -1,0 +1,81 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class basics__c(yang.adata.MNode):
+    l_str_def: str
+    l_uint64_def: int
+
+    def __init__(self, l_str_def: ?str=None, l_uint64_def: ?int=None):
+        self._ns = "http://example.com/basics"
+        if l_str_def != None:
+            self.l_str_def = l_str_def
+        else:
+            self.l_str_def = "foo"
+        if l_uint64_def != None:
+            self.l_uint64_def = l_uint64_def
+        else:
+            self.l_uint64_def = 1234567890
+
+    def to_gdata(self) -> yang.gdata.Node:
+        res = yang.gdata.Container('c', ns=self._ns)
+        _l_str_def = self.l_str_def
+        _l_uint64_def = self.l_uint64_def
+        if _l_str_def is not None:
+            res.children['l_str_def'] = yang.gdata.Leaf('l_str_def', 'string', _l_str_def, ns='http://example.com/basics')
+        if _l_uint64_def is not None:
+            res.children['l_uint64_def'] = yang.gdata.Leaf('l_uint64_def', 'uint64', _l_uint64_def, ns='http://example.com/basics')
+        for child in res.children.values():
+            child.parent = res
+        return res
+
+    @staticmethod
+    def from_gdata(n: ?yang.gdata.Node) -> basics__c:
+        if n != None:
+            return basics__c(l_str_def=n.get_str("l_str_def"), l_uint64_def=n.get_int("l_uint64_def"))
+        return basics__c()
+
+    @staticmethod
+    def from_xml(n: ?xml.Node) -> basics__c:
+        if n != None:
+            return basics__c(l_str_def=yang.gdata.from_xml_str(n, "l_str_def"), l_uint64_def=yang.gdata.from_xml_int(n, "l_uint64_def"))
+        return basics__c()
+
+
+class root(yang.adata.MNode):
+    c: basics__c
+
+    def __init__(self, c: ?basics__c=None):
+        self._ns = ""
+        if c is not None:
+            self.c = c
+        else:
+            self.c = basics__c()
+        self_c = self.c
+        if self_c is not None:
+            self_c._parent = self
+
+    def to_gdata(self) -> yang.gdata.Node:
+        res = yang.gdata.Root()
+        _c = self.c
+        if _c is not None:
+            res.children['c'] = _c.to_gdata()
+        for child in res.children.values():
+            child.parent = res
+        return res
+
+    @staticmethod
+    def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c=basics__c.from_gdata(n.get_opt_container("c")))
+        return root()
+
+    @staticmethod
+    def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, "c")))
+        return root()
+

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -58,7 +58,25 @@ ys_bar = """module bar {
     }
 }"""
 
+ys_basics = """module basics {
+    yang-version "1.1";
+    namespace "http://example.com/basics";
+    prefix "b";
+    container c {
+        leaf l_str_def {
+            type string;
+            default "foo";
+        }
+        leaf l_uint64_def {
+            type uint64;
+            default 1234567890;
+        }
+    }
+}"""
+
+
 actor main(env: Env):
     wfcap = file.WriteFileCap(file.FileCap(env.cap))
     yang_to_act(wfcap, yangs=[ys_foo, ys_bar], filename="../test_data_classes/src/yang_foo.act")
+    yang_to_act(wfcap, yangs=[ys_basics], filename="../test_data_classes/src/yang_basics.act")
     env.exit(0)


### PR DESCRIPTION
Leaf with default values are now mapped to non-optional types in Acton and we inject the default value unless another value is provided. We can't keep track of if a value is explicitly set or is using the default value, not sure how important that is.

Fixes #30 