### PR TITLE
ayangc

### DIFF
--- a/src/ayangc.act
+++ b/src/ayangc.act
@@ -1,0 +1,100 @@
+import argparse
+import file
+import yang
+import yang.parser
+import yang.schema
+import transform_unions
+import testing
+
+
+actor main(env):
+    """ayangc: Acton YANG Compiler
+
+    This is an experimental tool that exposes some functions from the acton-yang
+    library in a command-line interface. The interface is likely to change in
+    future as the needs evolve. Right now, it parses a YANG file into low-level
+    Statement tree. Then it optionally applies transforms to the SchemaNode tree
+    and prints out the resulting YANG after converting it back to Statement
+    tree.
+
+    As a side effect, the comments in YANG are removed entirely, some YANG
+    statements may be reordered or have their arguments quoted. But from the
+    modeling point of view, the resulting YANG should be equivalent to the input
+    YANG (less the changes made by transform).
+    """
+    p = argparse.Parser()
+    p.add_arg("infile", "input yang file")
+    p.add_option("transform", "strlist", "+", [], "transforms to apply")
+    args = p.parse(env.argv)
+    file_cap = file.FileCap(env.cap)
+
+    infile = file.ReadFile(
+        file.ReadFileCap(file_cap),
+        args.get_str("infile")).read().decode()
+
+    y = yang.parser.parse(infile)
+    transforms = args.get_strlist("transform")
+    if len(transforms) > 0:
+        n = yang.schema.stmt_to_snode(y)
+        for transform in args.get_strlist("transform"):
+            if transform == "unions":
+                print("Applying transform: " + transform, err=True)
+                transform_unions.rewrite_unions(n)
+                print("Done", err=True)
+            else:
+                print("Unknown transform: " + transform, err=True)
+                env.exit(1)
+        y = n.to_statement()
+
+    yang_out = y.pryang()
+    print(yang_out)
+
+    env.exit(0)
+
+
+test_yang = """module test_ayangc {
+  // This comment will be removed
+  yang-version "1.1";
+  namespace "http://example.com/test_ayangc";
+  prefix "test_ayangc";
+  description "test yang module";
+  revision 2019-01-01 {
+    description "test revision";
+    reference "ref1";
+  }
+  import ietf-inet-types {
+    prefix "inet";
+    revision-date 2013-07-15;
+  }
+  typedef t1 {
+    type string;
+  }
+  extension ext1 {
+    description "extension 1";
+    argument "arg1";
+  }
+  container c1 {
+    description "container 1";
+    leaf l1 {
+      type string;
+      description "leaf 1";
+      if-feature "fe1 or fe2";
+    }
+    leaf l2 {
+      type union {
+        /* rewrite this union */
+        type string {
+          pattern "<.*>|^.*$";
+        }
+        type uint32;
+      }
+      description "leaf 2";
+    }
+  }
+}
+"""
+
+def _test_ayangc_transform_unions():
+    n = yang.schema_from_src(test_yang)
+    transform_unions.rewrite_unions(n)
+    return n.to_statement().pryang()

--- a/src/transform_unions.act
+++ b/src/transform_unions.act
@@ -1,0 +1,133 @@
+import testing
+
+import yang
+import yang.schema
+import yang.parser
+
+mut def rewrite_unions(node: yang.schema.SchemaNode) -> None:
+    """Rewrite stupid union types to sane types
+
+    This modifies the schema in place.
+
+    JUNOS YANG models have weird construct where normal leaf with seemingly
+    normal values instead are of a union type, where one of the types is a
+    string with the pattern "<.*>|^.*$". The first sub-pattern is probably to
+    allow for wildcards for apply-group templating, but the second sub-pattern
+    matches anything, so it's not clear why it's there. Sometimes the string
+    part is the first member of the union, which is horribly wrong since it will
+    always match and thus the uint32 part (or whatever it might be) will never
+    be used. Utterly broken.
+
+    If we don't care about apply-template and want reasonable types in our YANG
+    model, we can just rewrite such leaf types. This function does that.
+    """
+    def rewrite_type(tn: yang.schema.Type) -> yang.schema.Type:
+        """Rewrite a type node, if it's a union of two, where one type is a
+        string with the pattern "<.*>|^.*$"
+        """
+        def is_weird_pattern(t):
+            if t.name == "string":
+                if len(t.pattern) == 1:
+                    p = t.pattern[0]
+                    if p.value == "<.*>|^.*$" or p.value == "<.*>|$.*":
+                        return True
+            return False
+
+        def has_weird_pattern(types):
+            for t in types:
+                if is_weird_pattern(t):
+                    return True
+            return False
+
+        if tn.name == "union":
+            if len(tn.type_) == 2 and has_weird_pattern(tn.type_):
+                for t in tn.type_:
+                    if not is_weird_pattern(t):
+                        return t
+        return tn
+
+
+    if isinstance(node, yang.schema.Leaf):
+        node.type_ = rewrite_type(node.type_)
+    elif isinstance(node, yang.schema.LeafList):
+        node.type_ = rewrite_type(node.type_)
+    elif isinstance(node, yang.schema.SchemaNodeInner):
+        for child in node.children:
+            rewrite_unions(child)
+
+test_yang = """module test_yang {
+  yang-version "1.1";
+  namespace "http://example.com/test_yang";
+  prefix "test_yang";
+  description "test yang module";
+  revision 2019-01-01 {
+    description "test revision";
+    reference "ref1";
+  }
+  import ietf-inet-types {
+    prefix "inet";
+    revision-date 2013-07-15;
+  }
+  container c1 {
+    description "container 1";
+    leaf l1 {
+      description "keep type";
+      type string;
+    }
+    leaf l2 {
+      description "rewrite union";
+      type union {
+        type string {
+          pattern "<.*>|^.*$";
+        }
+        type uint32;
+      }
+    }
+    leaf l3 {
+      description "rewrite union";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|^.*$";
+        }
+      }
+    }
+    leaf-list l4 {
+      description "rewrite union";
+      type union {
+        type uint32;
+        type string {
+          pattern "<.*>|^.*$";
+        }
+      }
+    }
+    leaf l5 {
+      description "rewrite union";
+      type union {
+        type string {
+          // Other weird pattern
+          pattern "<.*>|$.*";
+        }
+        type uint32;
+      }
+    }
+  }
+}
+"""
+
+
+def _test_rewrite_unions():
+    y = yang.parser.parse(test_yang)
+    n = yang.schema.stmt_to_snode(y)
+    rewrite_unions(n)
+    l1 = n.get("c1").get("l1")
+    l2 = n.get("c1").get("l2")
+    l3 = n.get("c1").get("l3")
+    l4 = n.get("c1").get("l4")
+    l5 = n.get("c1").get("l5")
+    if isinstance(l1, yang.schema.Leaf) and isinstance(l2, yang.schema.Leaf) and isinstance(l3, yang.schema.Leaf) and isinstance(l4, yang.schema.LeafList) and isinstance(l5, yang.schema.Leaf):
+        testing.assertEqual(l1.type_.name, "string")
+        testing.assertEqual(l2.type_.name, "uint32")
+        testing.assertEqual(l3.type_.name, "uint32")
+        testing.assertEqual(l4.type_.name, "uint32")
+        testing.assertEqual(l5.type_.name, "uint32")

--- a/test/golden/ayangc/ayangc_transform_unions
+++ b/test/golden/ayangc/ayangc_transform_unions
@@ -1,0 +1,33 @@
+module test_ayangc {
+  yang-version "1.1";
+  namespace "http://example.com/test_ayangc";
+  prefix "test_ayangc";
+  import ietf-inet-types {
+    prefix "inet";
+    revision-date 2013-07-15;
+  }
+  description "test yang module";
+  revision 2019-01-01 {
+    description "test revision";
+    reference "ref1";
+  }
+  extension ext1 {
+    argument "arg1";
+    description "extension 1";
+  }
+  typedef t1 {
+    type string;
+  }
+  container c1 {
+    description "container 1";
+    leaf l1 {
+      type string;
+      description "leaf 1";
+      if-feature "fe1 or fe2";
+    }
+    leaf l2 {
+      type uint32;
+      description "leaf 2";
+    }
+  }
+}


### PR DESCRIPTION
ayangc - Acton YANG Compiler currently supports two use cases:
1. Processing a YANG file to remove comments (like commented out sections) and printing the output YANG
2. Processing a YANG file to transform Junos union types of pattern match for apply-group and target data type to only keep the target data type.