### PR TITLE
Make direct descendants of choice (+case) optional

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1000,15 +1000,32 @@ class SchemaNode(object):
     mut def to_dnode(self) -> DNode:
         raise NotImplementedError('SchemaNode to_dschema not implemented for %s' % type(self))
 
-    def get_dnode_children(self):
+    def get_dnode_children(self, in_choice: bool=False):
+        mut def unset_mandatory(node):
+            """Unset the mandatory attribute if present
+            """
+            if isinstance(node, DLeaf):
+                print("Unset mandatory on %s" % node.name, err=True)
+                node.mandatory = False
+            elif isinstance(node, DAnydata):
+                node.mandatory = None
+            elif isinstance(node, DAnyxml):
+                node.mandatory = None
+
         if isinstance(self, SchemaNodeInner):
             new_children = []
             for child in self.children:
                 if isinstance(child, Case):
-                    new_children.extend(child.get_dnode_children())
+                    # Direct descendants of case are data nodes, where we must
+                    # unset mandatory
+                    new_children.extend(child.get_dnode_children(in_choice=True))
                     continue
                 if isinstance(child, Choice):
-                    new_children.extend(child.get_dnode_children())
+                    # Direct descendants of choice are either case or data node,
+                    # like leaf, container, etc. We unset mandatory on these to
+                    # avoid ending up with invalid mutually exclusive
+                    # constraints in the data tree. Of course we then have no constraints ...
+                    new_children.extend(child.get_dnode_children(in_choice=True))
                     continue
                 if isinstance(child, Grouping):
                     continue
@@ -1018,7 +1035,10 @@ class SchemaNode(object):
                     continue
                 if isinstance(child, Uses):
                     continue
-                new_children.append(child.to_dnode())
+                dnode_child = child.to_dnode()
+                if in_choice:
+                    unset_mandatory(dnode_child)
+                new_children.append(dnode_child)
             return new_children
         raise ValueError("get_dnode_children() called on non-inner node %s" % type(self))
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -996,15 +996,32 @@ class SchemaNode(object):
     mut def to_dnode(self) -> DNode:
         raise NotImplementedError('SchemaNode to_dschema not implemented for %s' % type(self))
 
-    def get_dnode_children(self):
+    def get_dnode_children(self, in_choice: bool=False):
+        mut def unset_mandatory(node):
+            """Unset the mandatory attribute if present
+            """
+            if isinstance(node, DLeaf):
+                print("Unset mandatory on %s" % node.name, err=True)
+                node.mandatory = False
+            elif isinstance(node, DAnydata):
+                node.mandatory = None
+            elif isinstance(node, DAnyxml):
+                node.mandatory = None
+
         if isinstance(self, SchemaNodeInner):
             new_children = []
             for child in self.children:
                 if isinstance(child, Case):
-                    new_children.extend(child.get_dnode_children())
+                    # Direct descendants of case are data nodes, where we must
+                    # unset mandatory
+                    new_children.extend(child.get_dnode_children(in_choice=True))
                     continue
                 if isinstance(child, Choice):
-                    new_children.extend(child.get_dnode_children())
+                    # Direct descendants of choice are either case or data node,
+                    # like leaf, container, etc. We unset mandatory on these to
+                    # avoid ending up with invalid mutually exclusive
+                    # constraints in the data tree. Of course we then have no constraints ...
+                    new_children.extend(child.get_dnode_children(in_choice=True))
                     continue
                 if isinstance(child, Grouping):
                     continue
@@ -1014,7 +1031,10 @@ class SchemaNode(object):
                     continue
                 if isinstance(child, Uses):
                     continue
-                new_children.append(child.to_dnode())
+                dnode_child = child.to_dnode()
+                if in_choice:
+                    unset_mandatory(dnode_child)
+                new_children.append(dnode_child)
             return new_children
         raise ValueError("get_dnode_children() called on non-inner node %s" % type(self))
 

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -99,6 +99,9 @@ def _test_foo_from_xml_full():
 <c.dot xmlns="http://example.com/foo">
   <l.dot1>who put that here?!</l.dot1>
 </c.dot>
+<cc xmlns="http://example.com/foo">
+  <cake>cake</cake>
+</cc>
 </data>"""
     xml_in = xml.decode(xml_text)
     d = yang_foo_root.from_xml(xml_in)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -307,10 +307,10 @@ class foo__cc__death(yang.adata.MNode):
 
 
 class foo__cc(yang.adata.MNode):
-    cake: str
+    cake: ?str
     death: foo__cc__death
 
-    mut def __init__(self, cake: str, death: list[foo__cc__death_entry]=[]):
+    mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]):
         self._ns = "http://example.com/foo"
         self.cake = cake
         self.death = foo__cc__death(elements=death)
@@ -331,14 +331,14 @@ class foo__cc(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__cc:
         if n != None:
-            return foo__cc(cake=n.get_str("cake"), death=foo__cc__death.from_gdata(n.get_list("death")))
-        raise ValueError("Missing required subtree foo__cc")
+            return foo__cc(cake=n.get_opt_str("cake"), death=foo__cc__death.from_gdata(n.get_list("death")))
+        return foo__cc()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__cc:
         if n != None:
-            return foo__cc(cake=yang.gdata.from_xml_str(n, "cake"), death=foo__cc__death.from_xml(yang.gdata.get_xml_children(n, "death")))
-        raise ValueError("Missing required subtree foo__cc")
+            return foo__cc(cake=yang.gdata.from_xml_opt_str(n, "cake"), death=foo__cc__death.from_xml(yang.gdata.get_xml_children(n, "death")))
+        return foo__cc()
 
 
 class root(yang.adata.MNode):
@@ -347,7 +347,7 @@ class root(yang.adata.MNode):
     c_dot: foo__c_dot
     cc: foo__cc
 
-    mut def __init__(self, cc: foo__cc, c1: ?foo__c1=None, pc1: ?foo__pc1=None, c_dot: ?foo__c_dot=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None):
         self._ns = ""
         if c1 is not None:
             self.c1 = c1
@@ -370,8 +370,13 @@ class root(yang.adata.MNode):
         self_c_dot = self.c_dot
         if self_c_dot is not None:
             self_c_dot._parent = self
-        self.cc = cc
-        self.cc._parent = self
+        if cc is not None:
+            self.cc = cc
+        else:
+            self.cc = foo__cc()
+        self_cc = self.cc
+        if self_cc is not None:
+            self_cc._parent = self
 
     mut def create_pc1(self):
         res = foo__pc1()
@@ -399,12 +404,12 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_container("cc")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")), cc=foo__cc.from_xml(yang.gdata.get_xml_child(n, "cc")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc")))
         return root()
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -238,12 +238,116 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot()
 
 
+class foo__cc__death_entry(yang.adata.MNode):
+    name: str
+
+    mut def __init__(self, name: str):
+        self._ns = "http://example.com/foo"
+        self.name = name
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        res = yang.gdata.ListElement([str(self.name)], ns=self._ns)
+        _name = self.name
+        if _name is not None:
+            res.children['name'] = yang.gdata.Leaf('name', 'string', _name, ns='http://example.com/foo')
+        for child in res.children.values():
+            child.parent = res
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
+        return foo__cc__death_entry(name=n.get_str("name"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> foo__cc__death_entry:
+        return foo__cc__death_entry(name=yang.gdata.from_xml_str(n, "name"))
+
+class foo__cc__death(yang.adata.MNode):
+    elements: list[foo__cc__death_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/foo"
+        self._name = 'death'
+        self.elements = elements
+
+    mut def create(self, name):
+        for e in self.elements:
+            match = True
+            if e.name != name:
+                match = False
+                break
+            if match:
+                return e
+
+        res = foo__cc__death_entry(name)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        res = yang.gdata.List('death', ['name'], ns=self._ns)
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            e_gdata.parent = res
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                res.elements.append(e_gdata)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.List) -> list[foo__cc__death_entry]:
+        res = []
+        for e in n.elements:
+            res.append(foo__cc__death_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[foo__cc__death_entry]:
+        res = []
+        for node in nodes:
+            res.append(foo__cc__death_entry.from_xml(node))
+        return res
+
+
+class foo__cc(yang.adata.MNode):
+    cake: str
+    death: foo__cc__death
+
+    mut def __init__(self, cake: str, death: list[foo__cc__death_entry]=[]):
+        self._ns = "http://example.com/foo"
+        self.cake = cake
+        self.death = foo__cc__death(elements=death)
+        self.death._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        res = yang.gdata.Container('cc', ns=self._ns)
+        _cake = self.cake
+        _death = self.death
+        if _cake is not None:
+            res.children['cake'] = yang.gdata.Leaf('cake', 'string', _cake, ns='http://example.com/foo')
+        if _death is not None:
+            res.children['death'] = _death.to_gdata()
+        for child in res.children.values():
+            child.parent = res
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__cc:
+        if n != None:
+            return foo__cc(cake=n.get_str("cake"), death=foo__cc__death.from_gdata(n.get_list("death")))
+        raise ValueError("Missing required subtree foo__cc")
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__cc:
+        if n != None:
+            return foo__cc(cake=yang.gdata.from_xml_str(n, "cake"), death=foo__cc__death.from_xml(yang.gdata.get_xml_children(n, "death")))
+        raise ValueError("Missing required subtree foo__cc")
+
+
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1
     c_dot: foo__c_dot
+    cc: foo__cc
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, c_dot: ?foo__c_dot=None):
+    mut def __init__(self, cc: foo__cc, c1: ?foo__c1=None, pc1: ?foo__pc1=None, c_dot: ?foo__c_dot=None):
         self._ns = ""
         if c1 is not None:
             self.c1 = c1
@@ -266,6 +370,8 @@ class root(yang.adata.MNode):
         self_c_dot = self.c_dot
         if self_c_dot is not None:
             self_c_dot._parent = self
+        self.cc = cc
+        self.cc._parent = self
 
     mut def create_pc1(self):
         res = foo__pc1()
@@ -277,12 +383,15 @@ class root(yang.adata.MNode):
         _c1 = self.c1
         _pc1 = self.pc1
         _c_dot = self.c_dot
+        _cc = self.cc
         if _c1 is not None:
             res.children['c1'] = _c1.to_gdata()
         if _pc1 is not None:
             res.children['pc1'] = _pc1.to_gdata()
         if _c_dot is not None:
             res.children['c.dot'] = _c_dot.to_gdata()
+        if _cc is not None:
+            res.children['cc'] = _cc.to_gdata()
         for child in res.children.values():
             child.parent = res
         return res
@@ -290,12 +399,12 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_container("cc")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")), cc=foo__cc.from_xml(yang.gdata.get_xml_child(n, "cc")))
         return root()
 

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -84,6 +84,25 @@ ys_foo = """module foo {
             type string;
         }
     }
+    container cc {
+        choice cake-or-death {
+            case cake {
+                leaf cake {
+                    type string;
+                    mandatory true;
+                }
+            }
+            case death {
+                list death {
+                    key name;
+                    leaf name {
+                        type string;
+                    }
+                }
+            }
+            mandatory true;
+        }
+    }
 }"""
 
 ys_bar = """module bar {


### PR DESCRIPTION
The data nodes (DLeaf, DAnydata, DAnyxml) that are direct descendants of
choice/case and are marked as mandatory in the schema are made optional
as DNode's. We don't currently have a way of defining (mutually
exclusive) groups of constraints on DNode's and then validating the data, 
so we just disable the mandatory requirements for the time being.