### PR TITLE
Handle empty presence containers

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -387,7 +387,7 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if isinstance(child, DContainer):
-                if loose or optional_subtree(child):
+                if loose or optional_subtree(child) and not child.presence:
                     res.append("        if %s is not None:" % (_safe_name(child.name)))
                     res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
                     res.append("        else:")
@@ -473,9 +473,15 @@ class DNodeInner(DNode):
         elif isinstance(self, DRoot):
             res.append("        return yang.gdata.%s(children)" % (self.gname))
         elif set_ns:
-            res.append("        return yang.gdata.%s(children, ns='%s')" % (self.gname, self.namespace))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("        return yang.gdata.%s(children, presence=True, ns='%s')" % (self.gname, self.namespace))
+            else:
+                res.append("        return yang.gdata.%s(children, ns='%s')" % (self.gname, self.namespace))
         else:
-            res.append("        return yang.gdata.%s(children)" % (self.gname))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("        return yang.gdata.%s(children, presence=True)" % (self.gname))
+            else:
+                res.append("        return yang.gdata.%s(children)" % (self.gname))
         res.append("")
 #
         # .from_gdata()
@@ -506,11 +512,17 @@ class DNodeInner(DNode):
             res.append("    mut def from_gdata(n: yang.gdata.Node) -> %s_entry:" % get_path_name(self))
             res.append("        return %s_entry(%s)" % (get_path_name(self), from_gdata_args))
         else:
-            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> %s:" % get_path_name(self))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> ?%s:" % get_path_name(self))
+            else:
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> %s:" % get_path_name(self))
             res.append("        if n != None:")
             res.append("            return %s(%s)" % (get_path_name(self), from_gdata_args))
             if optional_subtree(self):
-                res.append("        return %s()" % (get_path_name(self)))
+                if isinstance(self, DContainer) and self.presence:
+                    res.append("        return None")
+                else:
+                    res.append("        return %s()" % (get_path_name(self)))
             else:
                 res.append("        raise ValueError(\"Missing required subtree %s\")" % get_path_name(self))
         res.append("")
@@ -520,11 +532,17 @@ class DNodeInner(DNode):
             res.append("    mut def from_xml(n: xml.Node) -> %s_entry:" % get_path_name(self))
             res.append("        return %s_entry(%s)" % (get_path_name(self), from_xml_args))
         else:
-            res.append("    mut def from_xml(n: ?xml.Node) -> %s:" % get_path_name(self))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("    mut def from_xml(n: ?xml.Node) -> ?%s:" % get_path_name(self))
+            else:
+                res.append("    mut def from_xml(n: ?xml.Node) -> %s:" % get_path_name(self))
             res.append("        if n != None:")
             res.append("            return %s(%s)" % (get_path_name(self), from_xml_args))
             if optional_subtree(self):
-                res.append("        return %s()" % (get_path_name(self)))
+                if isinstance(self, DContainer) and self.presence:
+                    res.append("        return None")
+                else:
+                    res.append("        return %s()" % (get_path_name(self)))
             else:
                 res.append("        raise ValueError(\"Missing required subtree %s\")" % get_path_name(self))
         res.append("")

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -221,6 +221,8 @@ class Node(value):
             sname = ""
             if isinstance(self, Container):
                 sname = "Container"
+                if self.presence:
+                    args.insert(0, "presence=True")
             elif isinstance(self, AbsentListElement):
                 args.insert(0, str(self.key_vals))
                 sname = _ind(indent) + "AbsentListElement"
@@ -258,13 +260,14 @@ class Node(value):
             return ""
 
         if isinstance(self, Container):
-            if len(self.children) == 0:
-                return ""
             child_xml = ""
             for nm,child in self.children.items():
                 child_xml += child.to_xmlstr(nm, pretty, indent + 1)
             if child_xml == "":
-                return child_xml
+                if self.presence:
+                    return _indent() + fmt_tag(name, either(self.ns, cns), end=True) + _nl()
+                else:
+                    return ""
             xml = _indent() + fmt_tag(name, either(self.ns, cns)) + _nl()
             xml += child_xml
             xml += _indent() + fmt_tag(name, close=True) + _nl()
@@ -591,8 +594,9 @@ class Module(Inner):
 
 
 class Container(Inner):
-    def __init__(self, children: dict[str, Node]={}, ns: ?str=None, prefix: ?str=None):
+    def __init__(self, children: dict[str, Node]={}, presence: bool=False, ns: ?str=None, prefix: ?str=None):
         self.children = children
+        self.presence = presence
         self.ns = ns
         self.prefix = prefix
 
@@ -2117,3 +2121,19 @@ def _test_to_xmlstr_root_merge():
     ym = merge(y1, y2)
 
     return ym.to_xmlstr()
+
+def _test_to_xmlstr_presence():
+    y1 = Root({
+        "foo": Container({
+            "a": Leaf("int", 1)
+        }, presence=True, ns="http://example.com/acme")
+    })
+
+    return y1.to_xmlstr()
+
+def _test_to_xmlstr_presence_childless():
+    y1 = Root({
+        "foo": Container(presence=True, ns="http://example.com/acme")
+    })
+
+    return y1.to_xmlstr()

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -383,7 +383,7 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if isinstance(child, DContainer):
-                if loose or optional_subtree(child):
+                if loose or optional_subtree(child) and not child.presence:
                     res.append("        if %s is not None:" % (_safe_name(child.name)))
                     res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
                     res.append("        else:")
@@ -469,9 +469,15 @@ class DNodeInner(DNode):
         elif isinstance(self, DRoot):
             res.append("        return yang.gdata.%s(children)" % (self.gname))
         elif set_ns:
-            res.append("        return yang.gdata.%s(children, ns='%s')" % (self.gname, self.namespace))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("        return yang.gdata.%s(children, presence=True, ns='%s')" % (self.gname, self.namespace))
+            else:
+                res.append("        return yang.gdata.%s(children, ns='%s')" % (self.gname, self.namespace))
         else:
-            res.append("        return yang.gdata.%s(children)" % (self.gname))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("        return yang.gdata.%s(children, presence=True)" % (self.gname))
+            else:
+                res.append("        return yang.gdata.%s(children)" % (self.gname))
         res.append("")
 #
         # .from_gdata()
@@ -502,11 +508,17 @@ class DNodeInner(DNode):
             res.append("    mut def from_gdata(n: yang.gdata.Node) -> %s_entry:" % get_path_name(self))
             res.append("        return %s_entry(%s)" % (get_path_name(self), from_gdata_args))
         else:
-            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> %s:" % get_path_name(self))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> ?%s:" % get_path_name(self))
+            else:
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> %s:" % get_path_name(self))
             res.append("        if n != None:")
             res.append("            return %s(%s)" % (get_path_name(self), from_gdata_args))
             if optional_subtree(self):
-                res.append("        return %s()" % (get_path_name(self)))
+                if isinstance(self, DContainer) and self.presence:
+                    res.append("        return None")
+                else:
+                    res.append("        return %s()" % (get_path_name(self)))
             else:
                 res.append("        raise ValueError(\"Missing required subtree %s\")" % get_path_name(self))
         res.append("")
@@ -516,11 +528,17 @@ class DNodeInner(DNode):
             res.append("    mut def from_xml(n: xml.Node) -> %s_entry:" % get_path_name(self))
             res.append("        return %s_entry(%s)" % (get_path_name(self), from_xml_args))
         else:
-            res.append("    mut def from_xml(n: ?xml.Node) -> %s:" % get_path_name(self))
+            if isinstance(self, DContainer) and self.presence:
+                res.append("    mut def from_xml(n: ?xml.Node) -> ?%s:" % get_path_name(self))
+            else:
+                res.append("    mut def from_xml(n: ?xml.Node) -> %s:" % get_path_name(self))
             res.append("        if n != None:")
             res.append("            return %s(%s)" % (get_path_name(self), from_xml_args))
             if optional_subtree(self):
-                res.append("        return %s()" % (get_path_name(self)))
+                if isinstance(self, DContainer) and self.presence:
+                    res.append("        return None")
+                else:
+                    res.append("        return %s()" % (get_path_name(self)))
             else:
                 res.append("        raise ValueError(\"Missing required subtree %s\")" % get_path_name(self))
         res.append("")

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -10,16 +10,16 @@ class foo__foo__bar(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children)
+        return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo__bar:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo__bar:
         if n != None:
             return foo__foo__bar(l1=n.get_str("l1"))
         raise ValueError("Missing required subtree foo__foo__bar")
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo__bar:
+    mut def from_xml(n: ?xml.Node) -> ?foo__foo__bar:
         if n != None:
             return foo__foo__bar(l1=yang.gdata.from_xml_str(n, "l1"))
         raise ValueError("Missing required subtree foo__foo__bar")
@@ -48,17 +48,17 @@ class foo__foo(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, ns='http://example.com/foo')
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo:
         if n != None:
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container("bar")))
-        return foo__foo()
+        return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo:
+    mut def from_xml(n: ?xml.Node) -> ?foo__foo:
         if n != None:
             return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, "bar")))
-        return foo__foo()
+        return None
 

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -10,16 +10,16 @@ class foo__l1__bar(yang.adata.MNode):
         _hi = self.hi
         if _hi is not None:
             children['hi'] = yang.gdata.Leaf('string', _hi)
-        return yang.gdata.Container(children)
+        return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__l1__bar:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__l1__bar:
         if n != None:
             return foo__l1__bar(hi=n.get_str("hi"))
         raise ValueError("Missing required subtree foo__l1__bar")
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__l1__bar:
+    mut def from_xml(n: ?xml.Node) -> ?foo__l1__bar:
         if n != None:
             return foo__l1__bar(hi=yang.gdata.from_xml_str(n, "hi"))
         raise ValueError("Missing required subtree foo__l1__bar")

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -77,19 +77,19 @@ class foo__pc1(yang.adata.MNode):
         _foo = self.foo
         if _foo is not None:
             children['foo'] = _foo.to_gdata()
-        return yang.gdata.Container(children, ns='http://example.com/foo')
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc1:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container("foo")))
-        return foo__pc1()
+        return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc1:
+    mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, "foo")))
-        return foo__pc1()
+        return None
 
 
 class root(yang.adata.MNode):
@@ -105,10 +105,7 @@ class root(yang.adata.MNode):
         self_c1 = self.c1
         if self_c1 is not None:
             self_c1._parent = self
-        if pc1 is not None:
-            self.pc1 = pc1
-        else:
-            self.pc1 = foo__pc1()
+        self.pc1 = pc1
         self_pc1 = self.pc1
         if self_pc1 is not None:
             self_pc1._parent = self

--- a/test/golden/yang.gdata/to_xmlstr_presence
+++ b/test/golden/yang.gdata/to_xmlstr_presence
@@ -1,0 +1,3 @@
+<foo xmlns="http://example.com/acme">
+  <a>1</a>
+</foo>

--- a/test/golden/yang.gdata/to_xmlstr_presence_childless
+++ b/test/golden/yang.gdata/to_xmlstr_presence_childless
@@ -1,0 +1,1 @@
+<foo xmlns="http://example.com/acme"/>

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -124,6 +124,26 @@ def _test_foo_from_xml1():
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
+def _test_foo_from_xml_pc():
+    """"""
+    xml_text = """<data>
+<pc1 xmlns="http://example.com/foo"></pc1>
+</data>"""
+    xml_in = xml.decode(xml_text)
+    d = yang_foo_root.from_xml(xml_in)
+    pc1 = d.pc1
+    if pc1 is not None:
+        present = True
+    else:
+        present = False
+    testing.assertEqual(present, True)
+    g = d.to_gdata()
+    gc = g.prsrc()
+    print(gc, err=True)
+    xml_out_text = g.to_xmlstr()
+    xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
+    testing.assertEqual(xml_in.encode(), xml_out.encode())
+
 def _test_foo_from_xml2():
     """"""
     xml_text = """<data>
@@ -133,7 +153,16 @@ def _test_foo_from_xml2():
 </data>"""
     xml_in = xml.decode(xml_text)
     d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    pc1 = d.pc1
+    if pc1 is not None:
+        present = True
+    else:
+        present = False
+    testing.assertEqual(present, False)
+    g = d.to_gdata()
+    gc = g.prsrc()
+    print(gc, err=True)
+    xml_out_text = g.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
@@ -210,3 +239,12 @@ def _test_leaf_default_from_xml():
     testing.assertEqual(r.c.l_str_def, "foo")
     testing.assertEqual(r.c.l_str_def_quoted, '"foo"')
     testing.assertEqual(r.c.l_uint64_def, 1234567890)
+
+def _test_empty_presence():
+    xml_text = """<data><empty-presence xmlns="http://example.com/foo"/></data>"""
+    xml_in = xml.decode(xml_text)
+    d = yang_foo_root.from_xml(xml_in)
+    xml_out_text = d.to_gdata().to_xmlstr()
+    xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
+    # testing.assertEqual(xml_in.encode(), xml_out.encode())
+    return xml_out_text

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -180,19 +180,42 @@ class foo__pc1(yang.adata.MNode):
         _foo = self.foo
         if _foo is not None:
             children['foo'] = _foo.to_gdata()
-        return yang.gdata.Container(children, ns='http://example.com/foo')
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc1:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container("foo")))
-        return foo__pc1()
+        return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc1:
+    mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, "foo")))
-        return foo__pc1()
+        return None
+
+
+class foo__empty_presence(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = "http://example.com/foo"
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__empty_presence:
+        if n != None:
+            return foo__empty_presence()
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__empty_presence:
+        if n != None:
+            return foo__empty_presence()
+        return None
 
 
 class foo__c_dot(yang.adata.MNode):
@@ -328,10 +351,11 @@ class foo__cc(yang.adata.MNode):
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1
+    empty_presence: ?foo__empty_presence
     c_dot: foo__c_dot
     cc: foo__cc
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None):
         self._ns = ""
         if c1 is not None:
             self.c1 = c1
@@ -340,13 +364,14 @@ class root(yang.adata.MNode):
         self_c1 = self.c1
         if self_c1 is not None:
             self_c1._parent = self
-        if pc1 is not None:
-            self.pc1 = pc1
-        else:
-            self.pc1 = foo__pc1()
+        self.pc1 = pc1
         self_pc1 = self.pc1
         if self_pc1 is not None:
             self_pc1._parent = self
+        self.empty_presence = empty_presence
+        self_empty_presence = self.empty_presence
+        if self_empty_presence is not None:
+            self_empty_presence._parent = self
         if c_dot is not None:
             self.c_dot = c_dot
         else:
@@ -367,16 +392,24 @@ class root(yang.adata.MNode):
         self.pc1 = res
         return res
 
+    mut def create_empty_presence(self):
+        res = foo__empty_presence()
+        self.empty_presence = res
+        return res
+
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
         _c1 = self.c1
         _pc1 = self.pc1
+        _empty_presence = self.empty_presence
         _c_dot = self.c_dot
         _cc = self.cc
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
         if _pc1 is not None:
             children['pc1'] = _pc1.to_gdata()
+        if _empty_presence is not None:
+            children['empty-presence'] = _empty_presence.to_gdata()
         if _c_dot is not None:
             children['c.dot'] = _c_dot.to_gdata()
         if _cc is not None:
@@ -386,12 +419,12 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc")))
         return root()
 

--- a/test/test_data_classes/test/golden/test_data_classes/empty_presence
+++ b/test/test_data_classes/test/golden/test_data_classes/empty_presence
@@ -1,0 +1,1 @@
+<empty-presence xmlns="http://example.com/foo"/>

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -79,6 +79,9 @@ ys_foo = """module foo {
             }
         }
     }
+    container empty-presence {
+        presence "nothing else here";
+    }
     container c.dot {
         leaf l.dot1 {
             type string;


### PR DESCRIPTION
The current implementation does not produce XML configuration (dataclass -> to_gdata() -> to_xmlstr()) if we only create a *presence* container without setting any of its children.

```yang
container family {
  container inet {
    presence "inet;"
    leaf foo {
      type string;
    }
  }
}
```

This patch kind of works, but after reading it the next day it feels overly complex?!

In summary:
- add a `presence: bool=False` attribute to `yang.gdata.DContainer` gdata class and set it to True in `to_gdata()` when `yang.schema.Container` schemanode has *presence* and also the gdata instance has children.
  - maybe rename this to `present`, to not confuse with the `presence` attribute on schema node?
- output empty presence container in `yang.gdata.Node.to_xmlstr()` if the attribute added above is set
- the `from_gdata(n: ?yang.gdata.Node)` and `from_xml(n: ?xml.Node)` now return an optional dataclass instance for presence containers
  - [`mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1`](https://github.com/orchestron-orchestrator/acton-yang/compare/main...empty-presence#diff-c9751bf04caf40229dd0ea35ebcf144ac8e2e6931a7ab4ff14a6d39e0786f001R186)
  - [`mut def from_xml(n: ?xml.Node) -> ?foo__pc1`](https://github.com/orchestron-orchestrator/acton-yang/compare/main...empty-presence#diff-c9751bf04caf40229dd0ea35ebcf144ac8e2e6931a7ab4ff14a6d39e0786f001R192)