### PR TITLE
Fix uses expansion namespaces

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1220,7 +1220,7 @@ class SchemaNode(object):
             break
         raise ValueError("Unable to find Module")
 
-    def compile(self, context: Context) -> SchemaNode:
+    def compile(self, context: Context, new_ns: ?str=None) -> SchemaNode:
         """Compile an abstract YANG into a concrete one
         - expand uses / groupings
         - handle augments
@@ -1319,10 +1319,8 @@ class SchemaNode(object):
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
                 else:
-                    c_child = child.compile(context)
+                    c_child = child.compile(context, new_ns)
                     c_child.parent = target
-                    if new_ns is not None:
-                        c_child.ns = new_ns
                     target.children.append(c_child)
         else:
             raise ValueError("expand_children() called on non-inner node %s" % type(self))

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -326,17 +326,17 @@ snode_methods = {
         return SchemaNode.get(self, name, ns)
 
 """,
-        "compile": """    def compile(self, context: Context):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
         new_input = None
         if self_input is not None:
-            new_input = self_input.compile(context)
+            new_input = self_input.compile(context, new_ns)
         # new_output = self_output.compile(context) if self_output is not None else None # actonc codegen pre-evaluates before None-check
         new_output = None
         if self_output is not None:
-            new_output = self_output.compile(context)
+            new_output = self_output.compile(context, new_ns)
         new = Action(self.name,
                      description=self.description,
                      if_feature=self.if_feature,
@@ -345,8 +345,8 @@ snode_methods = {
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
-                     ns=self.ns)
-        self.expand_children(context, new)
+                     ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
 """,
@@ -572,7 +572,7 @@ snode_methods = {
     },
     "leaf": {
         # TODO: keep track of constraints in the derived type(s) that we resolve
-        "compile": """    def compile(self, context: Context):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -596,7 +596,7 @@ snode_methods = {
                    units=new_units,
                    when=self.when,
                    exts=self.exts,
-                   ns=self.ns)
+                   ns=new_ns if new_ns is not None else self.ns)
         return new
 
 """,
@@ -622,7 +622,7 @@ snode_methods = {
     },
     "leaf-list": {
         # TODO: keep track of constraints in the derived type(s) that we resolve
-        "compile": """    def compile(self, context: Context):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_units = self.units
@@ -644,7 +644,7 @@ snode_methods = {
                        units=new_units,
                        when=self.when,
                        exts=self.exts,
-                       ns=self.ns)
+                       ns=new_ns if new_ns is not None else self.ns)
         return new
 
 """,
@@ -716,7 +716,7 @@ snode_methods = {
         return SchemaNode.get(self, name, ns)
 
 """,
-        "compile": """    def compile(self, context: Context):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -735,8 +735,8 @@ snode_methods = {
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  ns=self.ns)
-        self.expand_children(context, new)
+                  ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
 """,
@@ -818,7 +818,7 @@ snode_methods = {
 """,
     },
     "typedef": {
-        "compile": """    def compile(self, context: Context):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -842,7 +842,7 @@ snode_methods = {
 """,
     },
     "uses": {
-        "compile": """    def compile(self, context: Context):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
         raise ValueError("Cannot compile 'uses'")
 
 """,
@@ -1174,18 +1174,18 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
 
         # -- compile
         if "compile" not in manual_methods:
-            res.append("    def compile(self, context: Context):")
+            res.append("    def compile(self, context: Context, new_ns: ?str=None):")
             new_args = []
             if arg_name is not None:
                 new_args += ["self." + _attr_name(arg_name)]
             new_args += list(map(lambda x: "%s=self.%s" % (_attr_name(x), _attr_name(x)), kwattrs))
             new_args.append("exts=self.exts")
             if stmt_name not in {"module", "submodule"}:
-                new_args.append("ns=self.ns")
+                new_args.append("ns=new_ns if new_ns is not None else self.ns")
 
             res.append("        new = %s(%s)" % (_class_name(stmt_name), (",\n               " + " " * len(_class_name(stmt_name))).join(new_args)))
             if have_children:
-                res.append("        self.expand_children(context, new)")
+                res.append("        self.expand_children(context, new, new_ns)")
             for substmt in stmt.substmts.values():
                 if substmt.name == "augment":
                     res.append("        new.expand_augments(context)")

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -844,7 +844,7 @@ def _test_compile_uses():
 }"""
     root = yang.compile([ys])
     testing.assertEqual(root.get("c1").get("li1").get("l1").config, True)
-
+    return root.prdaclass()
 
 def _test_compile_imported_grouping():
     ys_foo = """module foo {
@@ -881,7 +881,7 @@ def _test_compile_imported_grouping():
     root = yang.compile([ys_foo, ys_bar])
 
     testing.assertEqual(root.get("c1").get("li1").get("l1").config, True)
-
+    return root.prdaclass()
 
 def _test_compile_augment():
     ys = """module foo {
@@ -905,6 +905,7 @@ def _test_compile_augment():
 
     testing.assertEqual(root.get("c1").get("l1").config, True)
     testing.assertEqual(root.get("c1").get("l2").config, True)
+    return root.prdaclass()
 
 def _test_compile_augment_import():
     ys_foo = """module foo {
@@ -936,6 +937,7 @@ def _test_compile_augment_import():
 
     testing.assertEqual(root.get("c1").get("l1").config, True)
     testing.assertEqual(root.get("c1").get("l2").config, True)
+    return root.prdaclass()
 
 def _test_compile_uses_augment():
     """Augmenting a grouping"""
@@ -970,6 +972,7 @@ def _test_compile_uses_augment():
     testing.assertEqual(root.get("c1").get("l1").config, True)
     testing.assertEqual(root.get("c1").get("l2").config, True)
     testing.assertEqual(root.get("c1").exts, [yang.schema.Ext("some", "ext", "foo.bar")])
+    return root.prdaclass()
 
 def _test_compile_augment_uses():
     """Augmenting a grouping"""
@@ -1009,6 +1012,7 @@ def _test_compile_augment_uses():
         testing.assertEqual(l1.description, "leaf 1")
     else:
         testing.error("Expected Leaf instance")
+    return root.prdaclass()
 
 def _test_compile_augment_absolute_path_under_uses():
     """Augmenting a grouping"""
@@ -1114,6 +1118,7 @@ def _test_compile_augment_implicit_input_output():
   }
 }"""
     root = yang.compile([ys])
+    return root.prdaclass()
 
 def _test_compile_refine():
     """Refining a grouping"""
@@ -1145,6 +1150,7 @@ def _test_compile_refine():
         testing.assertEqual(l1.exts, [yang.schema.Ext("some", "ext", "foo.bar")])
     else:
         testing.error("Expected LeafList instance")
+    return root.prdaclass()
 
 def _test_compile_choice():
     ys = """module foo {
@@ -1225,7 +1231,7 @@ def _test_resolve_type_union_of_string():
     if isinstance(l1, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l1)
         testing.assertEqual(acton_type, "?str")
-
+    return root.prdaclass()
 
 def _test_resolve_type_union_of_intX():
     ys = """module foo {
@@ -1291,6 +1297,7 @@ def _test_resolve_type_union_of_intX():
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i64")
         testing.assertEqual(acton_type, "?int")
+    return root.prdaclass()
 
 def _test_compile_bundle1():
     ys_foo = """module foo {
@@ -1335,6 +1342,7 @@ def _test_compile_bundle1():
     src = root1.prdaclass()
     if not len(list(filter(lambda x: "    c1: foo__c1" == x, src.splitlines()))) == 1:
         testing.error("Expected exactly one 'c1: foo__c1'")
+    return src
 
 def _test_compile_extension():
     ys = """module foo {
@@ -1366,6 +1374,7 @@ def _test_compile_extension():
     root = yang.compile([ys])
     things_list = root.get("c1").get("things")
     testing.assertEqual(things_list.exts, [yang.schema.Ext("some", "exty", "foo.bar")])
+    return root.prdaclass()
 
 def _test_compile_augment_on_augment():
     ys_foo = """module foo {
@@ -1401,7 +1410,7 @@ def _test_compile_augment_on_augment():
     root = yang.compile([ys_foo])
     l3 = root.get("c1").get("c2").get("l3")
     testing.assertEqual(l3.config, True)
-
+    return root.prdaclass()
 
 def _test_compile_augment_on_augment_across_modules():
     ys_foo = """module foo {
@@ -1485,7 +1494,7 @@ def _test_compile_augment_on_augment_across_modules():
     testing.assertEqual(l1.namespace, "http://example.com/foo")
     testing.assertEqual(l2.namespace, "http://example.com/bar")
     testing.assertEqual(l3.namespace, "http://example.com/baz")
-
+    return root.prdaclass()
 
 def _test_compile_submodules1():
     ys_foo = """module foo {
@@ -1522,6 +1531,7 @@ def _test_compile_submodules1():
     l2 = root.get("c2").get("l2")
     testing.assertEqual(l1.config, True)
     testing.assertEqual(l2.config, True)
+    return root.prdaclass()
 
 def _test_compile_submodules2():
     ys_foo = """module foo {

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1216,7 +1216,7 @@ class SchemaNode(object):
             break
         raise ValueError("Unable to find Module")
 
-    def compile(self, context: Context) -> SchemaNode:
+    def compile(self, context: Context, new_ns: ?str=None) -> SchemaNode:
         """Compile an abstract YANG into a concrete one
         - expand uses / groupings
         - handle augments
@@ -1315,10 +1315,8 @@ class SchemaNode(object):
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
                 else:
-                    c_child = child.compile(context)
+                    c_child = child.compile(context, new_ns)
                     c_child.parent = target
-                    if new_ns is not None:
-                        c_child.ns = new_ns
                     target.children.append(c_child)
         else:
             raise ValueError("expand_children() called on non-inner node %s" % type(self))
@@ -2204,17 +2202,17 @@ class Action(SchemaNodeInner):
                 return _output
         return SchemaNode.get(self, name, ns)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
         new_input = None
         if self_input is not None:
-            new_input = self_input.compile(context)
+            new_input = self_input.compile(context, new_ns)
         # new_output = self_output.compile(context) if self_output is not None else None # actonc codegen pre-evaluates before None-check
         new_output = None
         if self_output is not None:
-            new_output = self_output.compile(context)
+            new_output = self_output.compile(context, new_ns)
         new = Action(self.name,
                      description=self.description,
                      if_feature=self.if_feature,
@@ -2223,8 +2221,8 @@ class Action(SchemaNodeInner):
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
-                     ns=self.ns)
-        self.expand_children(context, new)
+                     ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def to_dnode(self) -> DAction:
@@ -2371,7 +2369,7 @@ class Anydata(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Anydata(self.name,
                       config=self.config,
                       description=self.description,
@@ -2382,7 +2380,7 @@ class Anydata(SchemaNodeOuter):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
-                      ns=self.ns)
+                      ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -2511,7 +2509,7 @@ class Anyxml(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Anyxml(self.name,
                      config=self.config,
                      description=self.description,
@@ -2522,7 +2520,7 @@ class Anyxml(SchemaNodeOuter):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
-                     ns=self.ns)
+                     ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -2626,7 +2624,7 @@ class Augment(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Augment(self.target_node,
                       description=self.description,
                       if_feature=self.if_feature,
@@ -2634,8 +2632,8 @@ class Augment(SchemaNodeInner):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
-                      ns=self.ns)
-        self.expand_children(context, new)
+                      ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -2695,11 +2693,11 @@ class BelongsTo(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = BelongsTo(self.module,
                         prefix=self.prefix,
                         exts=self.exts,
-                        ns=self.ns)
+                        ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -2787,7 +2785,7 @@ class Bit(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Bit(self.name,
                   description=self.description,
                   if_feature=self.if_feature,
@@ -2795,7 +2793,7 @@ class Bit(SchemaNodeOuter):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  ns=self.ns)
+                  ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -2899,7 +2897,7 @@ class Case(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Case(self.name,
                    description=self.description,
                    if_feature=self.if_feature,
@@ -2907,8 +2905,8 @@ class Case(SchemaNodeInner):
                    status=self.status,
                    when=self.when,
                    exts=self.exts,
-                   ns=self.ns)
-        self.expand_children(context, new)
+                   ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -3034,7 +3032,7 @@ class Choice(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Choice(self.name,
                      config=self.config,
                      default=self.default,
@@ -3045,8 +3043,8 @@ class Choice(SchemaNodeInner):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
-                     ns=self.ns)
-        self.expand_children(context, new)
+                     ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -3201,7 +3199,7 @@ class Container(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Container(self.name,
                         config=self.config,
                         description=self.description,
@@ -3212,8 +3210,8 @@ class Container(SchemaNodeInner):
                         status=self.status,
                         when=self.when,
                         exts=self.exts,
-                        ns=self.ns)
-        self.expand_children(context, new)
+                        ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -3301,7 +3299,7 @@ class Enum(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Enum(self.name,
                    description=self.description,
                    if_feature=self.if_feature,
@@ -3309,7 +3307,7 @@ class Enum(SchemaNodeOuter):
                    status=self.status,
                    value=self.value,
                    exts=self.exts,
-                   ns=self.ns)
+                   ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -3390,14 +3388,14 @@ class Extension(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Extension(self.name,
                         argument=self.argument,
                         description=self.description,
                         reference=self.reference,
                         status=self.status,
                         exts=self.exts,
-                        ns=self.ns)
+                        ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -3481,14 +3479,14 @@ class Feature(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Feature(self.name,
                       description=self.description,
                       if_feature=self.if_feature,
                       reference=self.reference,
                       status=self.status,
                       exts=self.exts,
-                      ns=self.ns)
+                      ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -3581,14 +3579,14 @@ class Grouping(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Grouping(self.name,
                        description=self.description,
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
-                       ns=self.ns)
-        self.expand_children(context, new)
+                       ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -3676,7 +3674,7 @@ class Identity(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Identity(self.name,
                        base=self.base,
                        description=self.description,
@@ -3684,7 +3682,7 @@ class Identity(SchemaNodeOuter):
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
-                       ns=self.ns)
+                       ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -3765,14 +3763,14 @@ class Import(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Import(self.module,
                      prefix=self.prefix,
                      description=self.description,
                      reference=self.reference,
                      revision_date=self.revision_date,
                      exts=self.exts,
-                     ns=self.ns)
+                     ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -3849,13 +3847,13 @@ class Include(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Include(self.module,
                       description=self.description,
                       reference=self.reference,
                       revision_date=self.revision_date,
                       exts=self.exts,
-                      ns=self.ns)
+                      ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -3951,11 +3949,11 @@ class Input(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Input(must=self.must,
                     exts=self.exts,
-                    ns=self.ns)
-        self.expand_children(context, new)
+                    ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -4089,7 +4087,7 @@ class Leaf(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -4113,7 +4111,7 @@ class Leaf(SchemaNodeOuter):
                    units=new_units,
                    when=self.when,
                    exts=self.exts,
-                   ns=self.ns)
+                   ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def to_dnode(self) -> DLeaf:
@@ -4275,7 +4273,7 @@ class LeafList(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_units = self.units
@@ -4297,7 +4295,7 @@ class LeafList(SchemaNodeOuter):
                        units=new_units,
                        when=self.when,
                        exts=self.exts,
-                       ns=self.ns)
+                       ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def get_max_elements(self) -> ?int:
@@ -4409,14 +4407,14 @@ class Length(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Length(self.value,
                      description=self.description,
                      error_app_tag=self.error_app_tag,
                      error_message=self.error_message,
                      reference=self.reference,
                      exts=self.exts,
-                     ns=self.ns)
+                     ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -4604,7 +4602,7 @@ class List(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = List(self.name,
                    config=self.config,
                    description=self.description,
@@ -4619,8 +4617,8 @@ class List(SchemaNodeInner):
                    unique=self.unique,
                    when=self.when,
                    exts=self.exts,
-                   ns=self.ns)
-        self.expand_children(context, new)
+                   ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -4832,7 +4830,7 @@ class Module(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Module(self.name,
                      yang_version=self.yang_version,
                      namespace=self.namespace,
@@ -4849,7 +4847,7 @@ class Module(SchemaNodeInner):
                      extension_=self.extension_,
                      feature=self.feature,
                      exts=self.exts)
-        self.expand_children(context, new)
+        self.expand_children(context, new, new_ns)
         new.expand_augments(context)
         return new
 
@@ -4937,14 +4935,14 @@ class Must(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Must(self.condition,
                    description=self.description,
                    error_app_tag=self.error_app_tag,
                    error_message=self.error_message,
                    reference=self.reference,
                    exts=self.exts,
-                   ns=self.ns)
+                   ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -5074,7 +5072,7 @@ class Notification(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Notification(self.name,
                            description=self.description,
                            if_feature=self.if_feature,
@@ -5082,8 +5080,8 @@ class Notification(SchemaNodeInner):
                            reference=self.reference,
                            status=self.status,
                            exts=self.exts,
-                           ns=self.ns)
-        self.expand_children(context, new)
+                           ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -5182,11 +5180,11 @@ class Output(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Output(must=self.must,
                      exts=self.exts,
-                     ns=self.ns)
-        self.expand_children(context, new)
+                     ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def __str__(self):
@@ -5271,7 +5269,7 @@ class Pattern(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Pattern(self.value,
                       description=self.description,
                       error_app_tag=self.error_app_tag,
@@ -5279,7 +5277,7 @@ class Pattern(SchemaNodeOuter):
                       modifier=self.modifier,
                       reference=self.reference,
                       exts=self.exts,
-                      ns=self.ns)
+                      ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -5360,14 +5358,14 @@ class Range(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Range(self.value,
                     description=self.description,
                     error_app_tag=self.error_app_tag,
                     error_message=self.error_message,
                     reference=self.reference,
                     exts=self.exts,
-                    ns=self.ns)
+                    ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -5501,7 +5499,7 @@ class Refine(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Refine(self.target_node,
                      config=self.config,
                      default=self.default,
@@ -5514,7 +5512,7 @@ class Refine(SchemaNodeOuter):
                      presence=self.presence,
                      reference=self.reference,
                      exts=self.exts,
-                     ns=self.ns)
+                     ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -5587,12 +5585,12 @@ class Revision(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Revision(self.date,
                        description=self.description,
                        reference=self.reference,
                        exts=self.exts,
-                       ns=self.ns)
+                       ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -5723,7 +5721,7 @@ class Rpc(SchemaNodeInner):
                 return _output
         return SchemaNode.get(self, name, ns)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -5742,8 +5740,8 @@ class Rpc(SchemaNodeInner):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  ns=self.ns)
-        self.expand_children(context, new)
+                  ns=new_ns if new_ns is not None else self.ns)
+        self.expand_children(context, new, new_ns)
         return new
 
     def to_dnode(self) -> DRpc:
@@ -5940,7 +5938,7 @@ class Submodule(SchemaNodeInner):
                 latest = rev
         return latest
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Submodule(self.name,
                         yang_version=self.yang_version,
                         import_=self.import_,
@@ -5956,7 +5954,7 @@ class Submodule(SchemaNodeInner):
                         extension_=self.extension_,
                         feature=self.feature,
                         exts=self.exts)
-        self.expand_children(context, new)
+        self.expand_children(context, new, new_ns)
         new.expand_augments(context)
         return new
 
@@ -6119,7 +6117,7 @@ class Type(SchemaNodeOuter):
                 raise ValueError("Recursion limit reached for typedef %s" % self.name)
         raise ValueError("Unable to resolve typedef %s" % self.name)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         new = Type(self.name,
                    base=self.base,
                    bit=self.bit,
@@ -6132,7 +6130,7 @@ class Type(SchemaNodeOuter):
                    require_instance=self.require_instance,
                    type_=self.type_,
                    exts=self.exts,
-                   ns=self.ns)
+                   ns=new_ns if new_ns is not None else self.ns)
         return new
 
     def __str__(self):
@@ -6229,7 +6227,7 @@ class Typedef(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -6353,7 +6351,7 @@ class Uses(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context):
+    def compile(self, context: Context, new_ns: ?str=None):
         raise ValueError("Cannot compile 'uses'")
 
     mut def expand_refines(self, target_base: SchemaNode):

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -1,0 +1,71 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+    l2: ?str
+
+    mut def __init__(self, l1: ?str, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -1,0 +1,113 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1__a1(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = "http://example.com/foo"
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Action(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__a1:
+        if n != None:
+            return foo__c1__a1()
+        return foo__c1__a1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1__a1:
+        if n != None:
+            return foo__c1__a1()
+        return foo__c1__a1()
+
+
+class foo__c1(yang.adata.MNode):
+    a1: foo__c1__a1
+
+    mut def __init__(self):
+        self._ns = "http://example.com/foo"
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _a1 = self.a1
+        if _a1 is not None:
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1()
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1()
+        return foo__c1()
+
+
+class foo__r1(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = "http://example.com/foo"
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Rpc(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__r1:
+        if n != None:
+            return foo__r1()
+        return foo__r1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__r1:
+        if n != None:
+            return foo__r1()
+        return foo__r1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+    r1: foo__r1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        _r1 = self.r1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        if _r1 is not None:
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -1,0 +1,71 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+    l2: ?str
+
+    mut def __init__(self, l1: ?str, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2, ns='http://example.com/bar')
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -1,0 +1,109 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1__c2(yang.adata.MNode):
+    l2: ?str
+    l3: ?str
+
+    mut def __init__(self, l2: ?str, l3: ?str):
+        self._ns = "http://example.com/foo"
+        self.l2 = l2
+        self.l3 = l3
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l2 = self.l2
+        _l3 = self.l3
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        if _l3 is not None:
+            children['l3'] = yang.gdata.Leaf('string', _l3)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__c2:
+        if n != None:
+            return foo__c1__c2(l2=n.get_opt_str("l2"), l3=n.get_opt_str("l3"))
+        return foo__c1__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
+        if n != None:
+            return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, "l2"), l3=yang.gdata.from_xml_opt_str(n, "l3"))
+        return foo__c1__c2()
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+    c2: foo__c1__c2
+
+    mut def __init__(self, l1: ?str, c2: ?foo__c1__c2=None):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        if c2 is not None:
+            self.c2 = c2
+        else:
+            self.c2 = foo__c1__c2()
+        self_c2 = self.c2
+        if self_c2 is not None:
+            self_c2._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _c2 = self.c2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _c2 is not None:
+            children['c2'] = _c2.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"), c2=foo__c1__c2.from_gdata(n.get_opt_container("c2")))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -1,0 +1,109 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1__c2(yang.adata.MNode):
+    l2: ?str
+    l3: ?str
+
+    mut def __init__(self, l2: ?str, l3: ?str):
+        self._ns = "http://example.com/bar"
+        self.l2 = l2
+        self.l3 = l3
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l2 = self.l2
+        _l3 = self.l3
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        if _l3 is not None:
+            children['l3'] = yang.gdata.Leaf('string', _l3, ns='http://example.com/baz')
+        return yang.gdata.Container(children, ns='http://example.com/bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__c2:
+        if n != None:
+            return foo__c1__c2(l2=n.get_opt_str("l2"), l3=n.get_opt_str("l3"))
+        return foo__c1__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
+        if n != None:
+            return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, "l2"), l3=yang.gdata.from_xml_opt_str(n, "l3"))
+        return foo__c1__c2()
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+    c2: foo__c1__c2
+
+    mut def __init__(self, l1: ?str, c2: ?foo__c1__c2=None):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        if c2 is not None:
+            self.c2 = c2
+        else:
+            self.c2 = foo__c1__c2()
+        self_c2 = self.c2
+        if self_c2 is not None:
+            self_c2._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _c2 = self.c2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _c2 is not None:
+            children['c2'] = _c2.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"), c2=foo__c1__c2.from_gdata(n.get_opt_container("c2")))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -1,0 +1,99 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1__c2(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__c2:
+        if n != None:
+            return foo__c1__c2(l1=n.get_opt_str("l1"))
+        return foo__c1__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
+        if n != None:
+            return foo__c1__c2(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return foo__c1__c2()
+
+
+class foo__c1(yang.adata.MNode):
+    c2: foo__c1__c2
+
+    mut def __init__(self, c2: ?foo__c1__c2=None):
+        self._ns = "http://example.com/foo"
+        if c2 is not None:
+            self.c2 = c2
+        else:
+            self.c2 = foo__c1__c2()
+        self_c2 = self.c2
+        if self_c2 is not None:
+            self_c2._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c2 = self.c2
+        if _c2 is not None:
+            children['c2'] = _c2.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(c2=foo__c1__c2.from_gdata(n.get_opt_container("c2")))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -1,0 +1,71 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+    l2: ?str
+
+    mut def __init__(self, l1: ?str, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2, ns='http://example.com/bar')
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -1,0 +1,137 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1__things_entry(yang.adata.MNode):
+    name: str
+    id: ?str
+
+    mut def __init__(self, name: str, id: ?str):
+        self._ns = "http://example.com/foo"
+        self.name = name
+        self.id = id
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _name = self.name
+        _id = self.id
+        if _name is not None:
+            children['name'] = yang.gdata.Leaf('string', _name)
+        if _id is not None:
+            children['id'] = yang.gdata.Leaf('string', _id)
+        return yang.gdata.ListElement([str(self.name)], children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> foo__c1__things_entry:
+        return foo__c1__things_entry(name=n.get_str("name"), id=n.get_opt_str("id"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> foo__c1__things_entry:
+        return foo__c1__things_entry(name=yang.gdata.from_xml_str(n, "name"), id=yang.gdata.from_xml_opt_str(n, "id"))
+
+class foo__c1__things(yang.adata.MNode):
+    elements: list[foo__c1__things_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/foo"
+        self._name = 'things'
+        self.elements = elements
+
+    mut def create(self, name):
+        for e in self.elements:
+            match = True
+            if e.name != name:
+                match = False
+                break
+            if match:
+                return e
+
+        res = foo__c1__things_entry(name)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                elements.append(e_gdata)
+        return yang.gdata.List(['name'], elements)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.List) -> list[foo__c1__things_entry]:
+        res = []
+        for e in n.elements:
+            res.append(foo__c1__things_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__things_entry]:
+        res = []
+        for node in nodes:
+            res.append(foo__c1__things_entry.from_xml(node))
+        return res
+
+
+class foo__c1(yang.adata.MNode):
+    things: foo__c1__things
+
+    mut def __init__(self, things: list[foo__c1__things_entry]=[]):
+        self._ns = "http://example.com/foo"
+        self.things = foo__c1__things(elements=things)
+        self.things._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _things = self.things
+        if _things is not None:
+            children['things'] = _things.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(things=foo__c1__things.from_gdata(n.get_list("things")))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(things=foo__c1__things.from_xml(yang.gdata.get_xml_children(n, "things")))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -1,0 +1,132 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class bar__c1__li1_entry(yang.adata.MNode):
+    l1: str
+
+    mut def __init__(self, l1: str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.ListElement([str(self.l1)], children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> bar__c1__li1_entry:
+        return bar__c1__li1_entry(l1=n.get_str("l1"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> bar__c1__li1_entry:
+        return bar__c1__li1_entry(l1=yang.gdata.from_xml_str(n, "l1"))
+
+class bar__c1__li1(yang.adata.MNode):
+    elements: list[bar__c1__li1_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/foo"
+        self._name = 'li1'
+        self.elements = elements
+
+    mut def create(self, l1):
+        for e in self.elements:
+            match = True
+            if e.l1 != l1:
+                match = False
+                break
+            if match:
+                return e
+
+        res = bar__c1__li1_entry(l1)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                elements.append(e_gdata)
+        return yang.gdata.List(['l1'], elements, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.List) -> list[bar__c1__li1_entry]:
+        res = []
+        for e in n.elements:
+            res.append(bar__c1__li1_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[bar__c1__li1_entry]:
+        res = []
+        for node in nodes:
+            res.append(bar__c1__li1_entry.from_xml(node))
+        return res
+
+
+class bar__c1(yang.adata.MNode):
+    li1: bar__c1__li1
+
+    mut def __init__(self, li1: list[bar__c1__li1_entry]=[]):
+        self._ns = "http://example.com/bar"
+        self.li1 = bar__c1__li1(elements=li1)
+        self.li1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _li1 = self.li1
+        if _li1 is not None:
+            children['li1'] = _li1.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__c1:
+        if n != None:
+            return bar__c1(li1=bar__c1__li1.from_gdata(n.get_list("li1")))
+        return bar__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> bar__c1:
+        if n != None:
+            return bar__c1(li1=bar__c1__li1.from_xml(yang.gdata.get_xml_children(n, "li1")))
+        return bar__c1()
+
+
+class root(yang.adata.MNode):
+    c1: bar__c1
+
+    mut def __init__(self, c1: ?bar__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = bar__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=bar__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -9,7 +9,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
     l1: str
 
     mut def __init__(self, l1: str):
-        self._ns = "http://example.com/foo"
+        self._ns = "http://example.com/bar"
         self.l1 = l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -30,7 +30,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
     mut def __init__(self, elements=[]):
-        self._ns = "http://example.com/foo"
+        self._ns = "http://example.com/bar"
         self._name = 'li1'
         self.elements = elements
 
@@ -53,7 +53,7 @@ class bar__c1__li1(yang.adata.MNode):
             e_gdata = e.to_gdata()
             if isinstance(e_gdata, yang.gdata.ListElement):
                 elements.append(e_gdata)
-        return yang.gdata.List(['l1'], elements, ns='http://example.com/foo')
+        return yang.gdata.List(['l1'], elements)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.List) -> list[bar__c1__li1_entry]:

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -1,0 +1,67 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1(yang.adata.MNode):
+    l1: list[str]
+
+    mut def __init__(self, l1: ?list[str]=None):
+        self._ns = "http://example.com/foo"
+        if l1 is not None:
+            self.l1 = l1
+        else:
+            self.l1 = []
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        children['l1'] = yang.gdata.LeafList(self.l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_strs("l1"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_strs(n, "l1"))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -1,0 +1,104 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return foo__c1()
+
+
+class foo__c2(yang.adata.MNode):
+    l2: ?str
+
+    mut def __init__(self, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l2 = self.l2
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c2:
+        if n != None:
+            return foo__c2(l2=n.get_opt_str("l2"))
+        return foo__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c2:
+        if n != None:
+            return foo__c2(l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__c2()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+    c2: foo__c2
+
+    mut def __init__(self, c1: ?foo__c1=None, c2: ?foo__c2=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+        if c2 is not None:
+            self.c2 = c2
+        else:
+            self.c2 = foo__c2()
+        self_c2 = self.c2
+        if self_c2 is not None:
+            self_c2._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        _c2 = self.c2
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        if _c2 is not None:
+            children['c2'] = _c2.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), c2=foo__c2.from_gdata(n.get_opt_container("c2")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")))
+        return root()
+

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -1,0 +1,132 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1__li1_entry(yang.adata.MNode):
+    l1: str
+
+    mut def __init__(self, l1: str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.ListElement([str(self.l1)], children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li1_entry:
+        return foo__c1__li1_entry(l1=n.get_str("l1"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> foo__c1__li1_entry:
+        return foo__c1__li1_entry(l1=yang.gdata.from_xml_str(n, "l1"))
+
+class foo__c1__li1(yang.adata.MNode):
+    elements: list[foo__c1__li1_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/foo"
+        self._name = 'li1'
+        self.elements = elements
+
+    mut def create(self, l1):
+        for e in self.elements:
+            match = True
+            if e.l1 != l1:
+                match = False
+                break
+            if match:
+                return e
+
+        res = foo__c1__li1_entry(l1)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                elements.append(e_gdata)
+        return yang.gdata.List(['l1'], elements)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.List) -> list[foo__c1__li1_entry]:
+        res = []
+        for e in n.elements:
+            res.append(foo__c1__li1_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__li1_entry]:
+        res = []
+        for node in nodes:
+            res.append(foo__c1__li1_entry.from_xml(node))
+        return res
+
+
+class foo__c1(yang.adata.MNode):
+    li1: foo__c1__li1
+
+    mut def __init__(self, li1: list[foo__c1__li1_entry]=[]):
+        self._ns = "http://example.com/foo"
+        self.li1 = foo__c1__li1(elements=li1)
+        self.li1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _li1 = self.li1
+        if _li1 is not None:
+            children['li1'] = _li1.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(li1=foo__c1__li1.from_gdata(n.get_list("li1")))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(li1=foo__c1__li1.from_xml(yang.gdata.get_xml_children(n, "li1")))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -1,0 +1,71 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+    l2: ?str
+
+    mut def __init__(self, l1: ?str, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return root()
+

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -1,0 +1,48 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class root(yang.adata.MNode):
+    l1: ?int
+    l2: ?int
+    l3: ?int
+    l4: ?int
+
+    mut def __init__(self, l1: ?int, l2: ?int, l3: ?int, l4: ?int):
+        self._ns = ""
+        self.l1 = l1
+        self.l2 = l2
+        self.l3 = l3
+        self.l4 = l4
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        _l3 = self.l3
+        _l4 = self.l4
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('union', _l1, ns='http://example.com/foo')
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('union', _l2, ns='http://example.com/foo')
+        if _l3 is not None:
+            children['l3'] = yang.gdata.Leaf('union', _l3, ns='http://example.com/foo')
+        if _l4 is not None:
+            children['l4'] = yang.gdata.Leaf('union', _l4, ns='http://example.com/foo')
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(l1=n.get_opt_int("l1"), l2=n.get_opt_int("l2"), l3=n.get_opt_int("l3"), l4=n.get_opt_int("l4"))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(l1=yang.gdata.from_xml_opt_int(n, "l1"), l2=yang.gdata.from_xml_opt_int(n, "l2"), l3=yang.gdata.from_xml_opt_int(n, "l3"), l4=yang.gdata.from_xml_opt_int(n, "l4"))
+        return root()
+

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -1,0 +1,33 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class root(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = ""
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('union', _l1, ns='http://example.com/foo')
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(l1=n.get_opt_str("l1"))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return root()
+


### PR DESCRIPTION
When a grouping is used, the nodes expanded to the target must also "assume" the target namespace.

This PR adds a bunch out golden output for adata, to prove that everything except `test/golden/test_yang/compile_imported_grouping` where we use a grouping with nested children, remains unaffected.