### PR TITLE
Avoid collisions

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1025,6 +1025,7 @@ class Context(object):
 class SchemaNode(object):
     parent: ?SchemaNode
     ns: ?str
+    pfx: ?str
     exts: list[Ext]
     _yname: str
 
@@ -1111,8 +1112,9 @@ class SchemaNode(object):
     def get_prefix(self) -> str:
         n = self
         for i in range(RECURSION_LIMIT+1):
-            if isinstance(n, Module):
-                return n.prefix
+            nprefix = n.pfx
+            if nprefix is not None:
+                return nprefix
             nparent = n.parent
             if nparent is not None:
                 n = nparent
@@ -1262,7 +1264,7 @@ class SchemaNode(object):
             break
         raise ValueError("Unable to find Module")
 
-    def compile(self, context: Context, new_ns: ?str=None) -> SchemaNode:
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None) -> SchemaNode:
         """Compile an abstract YANG into a concrete one
         - expand uses / groupings
         - handle augments
@@ -1335,7 +1337,7 @@ class SchemaNode(object):
                     target = get_target(target_base, aug.target_node)
                     if isinstance(target, SchemaNodeInner):
                         # Just move the child to the target
-                        aug.expand_children(context, target, new_ns=aug.get_namespace())
+                        aug.expand_children(context, target, new_ns=aug.get_namespace(), new_pfx=aug.get_prefix())
                         target.exts.extend(aug.exts)
                     else:
                         raise ValueError("Augment target " + str(target) + " is not an inner node")
@@ -1350,18 +1352,18 @@ class SchemaNode(object):
         else:
             raise ValueError("Node type does not have augment substatements")
 
-    def expand_children(self, context: Context, target: SchemaNodeInner, new_ns: ?str = None):
+    def expand_children(self, context: Context, target: SchemaNodeInner, new_ns: ?str = None, new_pfx: ?str = None):
         """Expand abstract children into concrete nodes
         """
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
                 if isinstance(child, Uses):
                     grouping = child.get_grouping(_safe_name(child.name), context)
-                    grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns)
+                    grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
                 else:
-                    c_child = child.compile(context, new_ns)
+                    c_child = child.compile(context, new_ns, new_pfx)
                     c_child.parent = target
                     target.children.append(c_child)
         else:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -249,6 +249,7 @@ class DNode(object):
     parent: ?DNode
     gname: str       # The name of the GData class, e.g. "Container" for yang.gdata.Container
     namespace: str
+    prefix: str
     name: str
     config: bool
     description: ?str
@@ -309,13 +310,28 @@ class DNodeInner(DNode):
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
         pos_child_idx = 0
+        child_names = set()
+        child_name_conflicts = set()
         for child in self.children:
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
             else:
                 new_children.append(child)
-        self.children = new_children
+            if child.name in child_names:
+                child_name_conflicts.add(child.name)
+            else:
+                child_names.add(child.name)
+
+
+        def _unique_name(name: str, prefix: str) -> str:
+            if name not in child_name_conflicts:
+                return name
+            return "%s:%s" % (prefix, name)
+
+        def _unique_safe_name(name: str, prefix: str) -> str:
+            unique_name = _unique_name(name, prefix)
+            return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:
             if isinstance(child, DNodeInner):
@@ -332,16 +348,16 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if isinstance(child, DLeaf):
-                res.append("    %s: %s" % (_safe_name(child.name), yang_leaf_to_acton_type(child, loose)))
+                res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_acton_type(child, loose)))
             elif isinstance(child, DLeafList):
-                res.append("    %s: %s" % (_safe_name(child.name), yang_leaflist_to_acton_type(child)))
+                res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), yang_leaflist_to_acton_type(child)))
             elif isinstance(child, DContainer):
                 if child.presence:
-                    res.append("    %s: ?%s" % (_safe_name(child.name), get_path_name(child)))
+                    res.append("    %s: ?%s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
                 else:
-                    res.append("    %s: %s" % (_safe_name(child.name), get_path_name(child)))
+                    res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
             elif isinstance(child, DNodeInner):
-                res.append("    %s: %s" % (_safe_name(child.name), get_path_name(child)))
+                res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
             elif isinstance(child, DAnydata):
                 pass # TODO
             elif isinstance(child, DAnyxml):
@@ -362,23 +378,23 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
-                    opt_args.append("%s: ?%s=None" % (_safe_name(child.name), get_path_name(child)))
+                    opt_args.append("%s: ?%s=None" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
                 else:
-                    req_args.append("%s: %s" % (_safe_name(child.name), get_path_name(child)))
+                    req_args.append("%s: %s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
             elif isinstance(child, DLeaf):
                 defval = ""
                 child_default = child.default
                 if child_default != None:
                     defval = "=None"
-                child_arg = "%s: %s%s" % (_safe_name(child.name), yang_leaf_to_acton_arg_type(child, loose), defval)
+                child_arg = "%s: %s%s" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_acton_arg_type(child, loose), defval)
                 if is_optional_arg_yang_leaf(child, loose):
                     opt_args.append(child_arg)
                 else:
                     req_args.append(child_arg)
             elif isinstance(child, DLeafList):
-                opt_args.append("%s: ?%s=None" % (_safe_name(child.name), yang_leaflist_to_acton_type(child)))
+                opt_args.append("%s: ?%s=None" % (_unique_safe_name(child.name, child.prefix), yang_leaflist_to_acton_type(child)))
             elif isinstance(child, DList):
-                opt_args.append("%s: list[%s_entry]=[]" % (_safe_name(child.name), get_path_name(child)))
+                opt_args.append("%s: list[%s_entry]=[]" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
 
         init_args_str = ", ".join(["self"] + req_args + opt_args)
         res.append("    mut def __init__(%s):" % init_args_str)
@@ -388,39 +404,39 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DContainer):
                 if loose or optional_subtree(child) and not child.presence:
-                    res.append("        if %s is not None:" % (_safe_name(child.name)))
-                    res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        if %s is not None:" % (_unique_safe_name(child.name, child.prefix)))
+                    res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                     res.append("        else:")
-                    res.append("            self.%s = %s()" % (_safe_name(child.name), get_path_name(child)))
+                    res.append("            self.%s = %s()" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
                 else:
                     # NOTE: the default argument for P-container is None, so
                     # although unconditionally set here, it can be None
-                    res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                 if loose or child.presence or optional_subtree(child):
-                    res.append("        self_%s = self.%s" % (_safe_name(child.name), _safe_name(child.name)))
-                    res.append("        if self_%s is not None:" % (_safe_name(child.name)))
-                    res.append("            self_%s._parent = self" % (_safe_name(child.name)))
+                    res.append("        self_%s = self.%s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
+                    res.append("        if self_%s is not None:" % (_unique_safe_name(child.name, child.prefix)))
+                    res.append("            self_%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
                 else:
-                    res.append("        self.%s._parent = self" % (_safe_name(child.name)))
+                    res.append("        self.%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DLeaf):
                 child_default = child.default
                 if child_default != None:
-                    res.append("        if %s != None:" % (_safe_name(child.name)))
-                    res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        if %s != None:" % (_unique_safe_name(child.name, child.prefix)))
+                    res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                     res.append("        else:")
-                    res.append("            self.%s = %s" % (_safe_name(child.name), prsrc_literal(child.type_.name, child_default)))
+                    res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), prsrc_literal(child.type_.name, child_default)))
                 else:
-                    res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DLeafList):
-                #res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
-                res.append("        if %s is not None:" % (_safe_name(child.name)))
-                res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                #res.append("        self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
+                res.append("        if %s is not None:" % (_unique_safe_name(child.name, child.prefix)))
+                res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                 res.append("        else:")
                 # TODO: this is where we can set the leaf-list to a default value
-                res.append("            self.%s = []" % (_safe_name(child.name)))
+                res.append("            self.%s = []" % (_unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DList):
-                res.append("        self.%s = %s(elements=%s)" % (_safe_name(child.name), get_path_name(child), _safe_name(child.name)))
-                res.append("        self.%s._parent = self" % (_safe_name(child.name)))
+                res.append("        self.%s = %s(elements=%s)" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_safe_name(child.name, child.prefix)))
+                res.append("        self.%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
         if len(self.children) == 0:
             res.append("        pass")
         res.append("")
@@ -438,9 +454,9 @@ class DNodeInner(DNode):
                     elif isinstance(cchild, DContainer):
                         if not (loose or optional_subtree(cchild)):
                             pc_args.append(_safe_name(cchild.name))
-                res.append("    mut def create_%s(%s):" % (_safe_name(child.name), ", ".join(pc_args)))
+                res.append("    mut def create_%s(%s):" % (_unique_safe_name(child.name, child.prefix), ", ".join(pc_args)))
                 res.append("        res = %s(%s)" % (get_path_name(child), ", ".join(pc_args[1:])))
-                res.append("        self.%s = res" % (_safe_name(child.name)))
+                res.append("        self.%s = res" % (_unique_safe_name(child.name, child.prefix)))
                 res.append("        return res")
                 res.append("")
 
@@ -451,19 +467,19 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if not isinstance(child, DLeafList):
-                res.append("        _%s = self.%s" % (_safe_name(child.name), _safe_name(child.name)))
+                res.append("        _%s = self.%s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
         for child in self.children:
             child_ns = ", ns='" + child.namespace + "'" if child.namespace != self.namespace else ""
             if isinstance(child, DLeafList):
-                res.append("        children['%s'] = yang.gdata.LeafList(self.%s%s)" % (child.name, _safe_name(child.name), child_ns))
+                res.append("        children['%s'] = yang.gdata.LeafList(self.%s%s)" % (_unique_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix), child_ns))
             else:
-                res.append("        if _%s is not None:" % _safe_name(child.name))
+                res.append("        if _%s is not None:" % _unique_safe_name(child.name, child.prefix))
                 if isinstance(child, DLeaf):
-                    res.append("            children['%s'] = yang.gdata.Leaf('%s', _%s%s)" % (child.name, child.type_.name, _safe_name(child.name), child_ns))
+                    res.append("            children['%s'] = yang.gdata.Leaf('%s', _%s%s)" % (_unique_name(child.name, child.prefix), child.type_.name, _unique_safe_name(child.name, child.prefix), child_ns))
                 elif isinstance(child, DContainer):
-                    res.append("            children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
+                    res.append("            children['%s'] = _%s.to_gdata()" % (_unique_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                 elif isinstance(child, DList):
-                    res.append("            children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
+                    res.append("            children['%s'] = _%s.to_gdata()" % (_unique_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
 
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
@@ -490,21 +506,21 @@ class DNodeInner(DNode):
         from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
-                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
             elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
             elif isinstance(child, DContainer):
                 if loose or optional_subtree(child):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\", \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name, child.prefix))
                 else:
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
             elif isinstance(child, DList):
-                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
-                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
         from_gdata_args = ", ".join(from_gdata_args_list)
         from_xml_args = ", ".join(from_xml_args_list)
         res.append("    @staticmethod")
@@ -571,10 +587,10 @@ class DNodeInner(DNode):
                     if child.name in self.key:
                         continue
                     if child.mandatory:
-                        list_key_args.append(_safe_name(child.name))
+                        list_key_args.append(_unique_safe_name(child.name, child.prefix))
                 elif isinstance(child, DContainer):
                     if not (loose or optional_subtree(child)):
-                        list_key_args.append(_safe_name(child.name))
+                        list_key_args.append(_unique_safe_name(child.name, child.prefix))
             list_create_args = ["self"] + list_key_args
             res.append("    mut def create(%s):" % (", ".join(list_create_args)))
             res.append("        for e in self.elements:")
@@ -608,13 +624,13 @@ class DNodeInner(DNode):
             from_gdata_args_list = []
             for child in self.children:
                 if isinstance(child, DLeaf):
-                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
+                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
                 elif isinstance(child, DContainer):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
                 elif isinstance(child, DList):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
 #                elif isinstance(child, ListElement):
-#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
             from_gdata_args = ", ".join(from_gdata_args_list)
             res.append("    @staticmethod")
             res.append("    mut def from_gdata(n: yang.gdata.List) -> list[%s_entry]:" % get_path_name(self))
@@ -655,8 +671,9 @@ class DAction(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Action"
         self.config = False
@@ -674,8 +691,9 @@ class DAnydata(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Anydata"
         self.config = config
@@ -695,8 +713,9 @@ class DAnyxml(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Anyxml"
         self.config = config
@@ -715,8 +734,9 @@ class DContainer(DNodeInner):
     presence: bool
     status: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Container"
         self.config = config
@@ -732,8 +752,9 @@ class DContainer(DNodeInner):
 class DInput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, must=[], exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = "input"
         self.gname = "Input"
         self.config = False
@@ -742,7 +763,6 @@ class DInput(DNodeInner):
         self.children = children
 
 class DModule(DNodeInner):
-    prefix: str
     augment: list[Augment]
     contact: ?str
     deviation: list[str]
@@ -790,8 +810,9 @@ class DList(DNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, namespace: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "List"
         self.key = key
@@ -813,8 +834,9 @@ class DLeaf(DNodeLeaf):
     default: ?str
     units: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Leaf"
         self.config = config
@@ -844,8 +866,9 @@ class DLeafList(DNodeLeaf):
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "LeafList"
         self.config = config
@@ -866,8 +889,9 @@ class DLeafList(DNodeLeaf):
 class DNotification(DNodeInner):
     status: ?str
 
-    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Notification"
         self.description = description
@@ -879,8 +903,9 @@ class DNotification(DNodeInner):
 class DOutput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, must=[], exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = "output"
         self.gname = "Output"
         self.config = False
@@ -891,6 +916,7 @@ class DOutput(DNodeInner):
 class DRoot(DNodeInner):
     def __init__(self, modules: list[DNode]=[]):
         self.namespace = ""
+        self.prefix = ""
         self.name = "root"
         self.gname = "Root"
         self.config = True
@@ -907,8 +933,9 @@ class DRpc(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Rpc"
         self.config = False
@@ -1028,7 +1055,7 @@ class SchemaNode(object):
             """Unset the mandatory attribute if present
             """
             if isinstance(node, DLeaf):
-                print("Unset mandatory on %s" % node.name, err=True)
+                # print("Unset mandatory on %s" % node.name, err=True)
                 node.mandatory = False
             elif isinstance(node, DAnydata):
                 node.mandatory = None
@@ -1080,6 +1107,21 @@ class SchemaNode(object):
             if i > RECURSION_LIMIT:
                 raise ValueError("Recursion limit reached")
         raise ValueError("Unable to find namespace")
+
+    def get_prefix(self) -> str:
+        n = self
+        for i in range(RECURSION_LIMIT+1):
+            if isinstance(n, Module):
+                return n.prefix
+            nparent = n.parent
+            if nparent is not None:
+                n = nparent
+                continue
+            else:
+                raise ValueError("Unable to find prefix")
+            if i > RECURSION_LIMIT:
+                raise ValueError("Recursion limit reached")
+        raise ValueError("Unable to find prefix")
 
     def is_config(self) -> bool:
         n = self

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -500,27 +500,32 @@ class DNodeInner(DNode):
                 res.append("        return yang.gdata.%s(children)" % (self.gname))
         res.append("")
 #
+        def _maybe_ns(child: DNode) -> str:
+            if child.namespace != self.namespace:
+                return ", \"%s\"" % child.namespace
+            return ""
+
         # .from_gdata()
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
         from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
-                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
             elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
             elif isinstance(child, DContainer):
                 if loose or optional_subtree(child):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\", \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name, child.prefix))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\"%s))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), child.name, _maybe_ns(child)))
                 else:
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"%s))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), child.name, _maybe_ns(child)))
             elif isinstance(child, DList):
-                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
-                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"%s))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), child.name, _maybe_ns(child)))
         from_gdata_args = ", ".join(from_gdata_args_list)
         from_xml_args = ", ".join(from_xml_args_list)
         res.append("    @staticmethod")
@@ -624,13 +629,13 @@ class DNodeInner(DNode):
             from_gdata_args_list = []
             for child in self.children:
                 if isinstance(child, DLeaf):
-                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
                 elif isinstance(child, DContainer):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
                 elif isinstance(child, DList):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
 #                elif isinstance(child, ListElement):
-#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
             from_gdata_args = ", ".join(from_gdata_args_list)
             res.append("    @staticmethod")
             res.append("    mut def from_gdata(n: yang.gdata.List) -> list[%s_entry]:" % get_path_name(self))

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -353,6 +353,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DAction:
         new_dnode = DAction(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
@@ -375,6 +376,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DAnydata:
         return DAnydata(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -393,6 +395,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DAnyxml:
         return DAnyxml(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -418,6 +421,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DContainer:
         new_dnode = DContainer(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -440,6 +444,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DInput:
         new_dnode = DInput(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             must=self.must,
             exts=self.exts,
             children=self.get_dnode_children()
@@ -485,7 +490,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DModule:
         new_dnode = DModule(
             namespace=self.get_namespace(),
-            prefix=self.prefix,
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             revision=self.revision,
@@ -507,6 +512,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
@@ -550,6 +556,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DList:
         new_dnode = DList(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             key=self.keys(),
             config=self.is_config(),
@@ -603,6 +610,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DLeaf:
         return DLeaf(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             default=self.default,
@@ -665,6 +673,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DLeafList:
         return DLeafList(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             default=self.default,
@@ -687,6 +696,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DOutput:
         new_dnode = DOutput(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             must=self.must,
             exts=self.exts,
             children=self.get_dnode_children()
@@ -743,6 +753,7 @@ snode_methods = {
         "to_dnode": """    def to_dnode(self) -> DRpc:
         new_dnode = DRpc(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -326,7 +326,7 @@ snode_methods = {
         return SchemaNode.get(self, name, ns)
 
 """,
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -345,8 +345,9 @@ snode_methods = {
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
-        self.expand_children(context, new, new_ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
+        self.expand_children(context, new, new_ns, new_pfx)
         return new
 
 """,
@@ -479,6 +480,16 @@ snode_methods = {
         raise ValueError("Module %s has no namespace" % self.name)
 
 """,
+        "get_prefix": """    def get_prefix(self) -> str:
+        self_pfx = self.pfx
+        if self_pfx is not None:
+            return self_pfx
+        selfprefix = self.prefix
+        if selfprefix is not None:
+            return selfprefix
+        raise ValueError("Module %s has no prefix" % self.name)
+
+""",
         "get_revision": """    def get_revision(self) -> ?Revision:
         latest = None
         for rev in self.revision:
@@ -579,7 +590,7 @@ snode_methods = {
     },
     "leaf": {
         # TODO: keep track of constraints in the derived type(s) that we resolve
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -603,7 +614,9 @@ snode_methods = {
                    units=new_units,
                    when=self.when,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
+
         return new
 
 """,
@@ -630,7 +643,7 @@ snode_methods = {
     },
     "leaf-list": {
         # TODO: keep track of constraints in the derived type(s) that we resolve
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_units = self.units
@@ -652,7 +665,8 @@ snode_methods = {
                        units=new_units,
                        when=self.when,
                        exts=self.exts,
-                       ns=new_ns if new_ns is not None else self.ns)
+                       ns=new_ns if new_ns is not None else self.ns,
+                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
 """,
@@ -726,7 +740,7 @@ snode_methods = {
         return SchemaNode.get(self, name, ns)
 
 """,
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -745,8 +759,9 @@ snode_methods = {
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  ns=new_ns if new_ns is not None else self.ns)
-        self.expand_children(context, new, new_ns)
+                  ns=new_ns if new_ns is not None else self.ns,
+                  pfx=new_pfx if new_pfx is not None else self.pfx)
+        self.expand_children(context, new, new_ns, new_pfx)
         return new
 
 """,
@@ -829,7 +844,7 @@ snode_methods = {
 """,
     },
     "typedef": {
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -853,7 +868,7 @@ snode_methods = {
 """,
     },
     "uses": {
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None):
+        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         raise ValueError("Cannot compile 'uses'")
 
 """,
@@ -1035,16 +1050,24 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             init_attrs.append("parent=None")
         if "ns" not in set(cattrs):
             init_attrs.append("ns=None")
+        if "pfx" not in set(cattrs):
+            init_attrs.append("pfx=None")
         res.append("    def __init__(" + ", ".join(init_attrs) + "):")
         res.append("        self.parent = parent")
         res.append("        new_ns = ns")
+        res.append("        new_pfx = pfx")
         if stmt_name == "module":
             res.append("        if new_ns is None:")
             res.append("            new_ns = namespace")
+            res.append("        if new_pfx is None:")
+            res.append("            new_pfx = prefix")
         else:
             res.append("        if new_ns is None and parent is not None:")
             res.append("            new_ns = parent.ns")
+            res.append("        if new_pfx is None and parent is not None:")
+            res.append("            new_pfx = parent.pfx")
         res.append("        self.ns = new_ns")
+        res.append("        self.pfx = new_pfx")
 #        res.append("        self.cname = \"%s\"" % _class_name(stmt_name))
         res.append("        self._yname = \"%s\"" % stmt_name)
 
@@ -1060,17 +1083,26 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                         res.append("            n_ns = %s.ns" % _attr_name(substmt.name))
                         res.append("            if n_ns is None:")
                         res.append("                %s.ns = self.ns" % _attr_name(substmt.name))
+                        res.append("            n_pfx = %s.pfx" % _attr_name(substmt.name))
+                        res.append("            if n_pfx is None:")
+                        res.append("                %s.pfx = self.pfx" % _attr_name(substmt.name))
                     elif substmt.cardinality == "1":
                         res.append("        %s.parent = self" % _attr_name(substmt.name))
                         res.append("        n_ns = %s.ns" % _attr_name(substmt.name))
                         res.append("        if n_ns is None:")
                         res.append("            %s.ns = self.ns" % _attr_name(substmt.name))
+                        res.append("        n_pfx = %s.pfx" % _attr_name(substmt.name))
+                        res.append("        if n_pfx is None:")
+                        res.append("            %s.pfx = self.pfx" % _attr_name(substmt.name))
                     elif substmt.cardinality == "0..n":
                         res.append("        for n in %s:" % _attr_name(substmt.name))
                         res.append("            n.parent = self")
                         res.append("            n_ns = n.ns")
                         res.append("            if n_ns is None:")
                         res.append("                n.ns = self.ns")
+                        res.append("            n_pfx = n.pfx")
+                        res.append("            if n_pfx is None:")
+                        res.append("                n.pfx = self.pfx")
                     else:
                         raise ValueError("Unknown cardinality: %s" % substmt.cardinality)
 
@@ -1086,6 +1118,9 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             res.append("            n_ns = n.ns")
             res.append("            if n_ns is None:")
             res.append("                n.ns = self.ns")
+            res.append("            n_pfx = n.pfx")
+            res.append("            if n_pfx is None:")
+            res.append("                n.pfx = self.pfx")
             res.append("        self.children = children")
         res.append("")
 
@@ -1185,7 +1220,7 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
 
         # -- compile
         if "compile" not in manual_methods:
-            res.append("    def compile(self, context: Context, new_ns: ?str=None):")
+            res.append("    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):")
             new_args = []
             if arg_name is not None:
                 new_args += ["self." + _attr_name(arg_name)]
@@ -1193,6 +1228,7 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             new_args.append("exts=self.exts")
             if stmt_name not in {"module", "submodule"}:
                 new_args.append("ns=new_ns if new_ns is not None else self.ns")
+                new_args.append("pfx=new_pfx if new_pfx is not None else self.pfx")
 
             res.append("        new = %s(%s)" % (_class_name(stmt_name), (",\n               " + " " * len(_class_name(stmt_name))).join(new_args)))
             if have_children:

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1733,6 +1733,31 @@ def _test_prdaclass_list_key_mandatory():
     src = l1.prdaclass(top=False)
     return src
 
+def _test_prdaclass_top_conflict():
+    ys_foo = """module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    container c1 {
+        leaf l1 {
+            type string;
+        }
+    }
+}"""
+    ys_bar = """module bar {
+    yang-version "1.1";
+    namespace "http://example.com/bar";
+    prefix "bar";
+    container c1 {
+        leaf l1 {
+            type string;
+        }
+    }
+}"""
+    root = yang.compile([ys_foo, ys_bar])
+    src = root.prdaclass()
+    return src
+
 def _test_prdaclass_augment_name_conflict():
     ys_base = """module base {
     yang-version "1.1";
@@ -1770,7 +1795,6 @@ def _test_prdaclass_augment_name_conflict():
     }
 }"""
 
-    # TODO: sort out the resulting conflict by using a prefix
     root = yang.compile([ys_base, ys_foo, ys_bar])
     c1 = root.get("c1")
     src = c1.prdaclass(top=False)

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -185,7 +185,8 @@ def fmt_tag(name, ns=None, attrs: list[(str, str)]=[], close=False, end=False):
     attr_strs = list(map(lambda x: x.0 + "=" + x.1, ns_attr + attrs))
     left = "</" if close else "<"
     right = "/>" if end else ">"
-    return left + " ".join([name] + attr_strs) + right
+    name_without_prefix = name.split(":")[-1]
+    return left + " ".join([name_without_prefix] + attr_strs) + right
 
 
 class Node(value):
@@ -1349,13 +1350,13 @@ def patch(old: Node, p: ?Node) -> ?Node:
 
 
 
-def get_xml_child(n: xml.Node, name: str) -> xml.Node:
+def get_xml_child(n: xml.Node, name: str, ns: ?str) -> xml.Node:
     r = get_xml_opt_child(n, name)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
-def get_xml_opt_child(n: xml.Node, name: str) -> ?xml.Node:
+def get_xml_opt_child(n: xml.Node, name: str, ns: ?str) -> ?xml.Node:
     for child in n.children:
         if child.tag == name:
             return child

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1348,17 +1348,35 @@ def patch(old: Node, p: ?Node) -> ?Node:
         if p != None:
             raise ValueError("Unhandled node type in patch: %s" % str(type(p)))
 
+def _node_match(n: xml.Node, name: str, ns: ?str) -> bool:
+    """Check if an XML node matches the given name and namespace
 
+    It will match either on the default (nameless) namespace, or the node prefix
+    & a named namespace. For example:
+    <foo xmlns="urn:foo"> and <ns:foo xmlns:ns="urn:foo"> both match with name="foo", ns="urn:foo"
+    """
+    if n.tag == name:
+        if ns is not None:
+            for nsdef in n.nsdefs:
+                n0 = nsdef.0
+                n1 = nsdef.1
+                if n0 is not None and n0 == n.prefix and n1 == ns:
+                    return True
+                elif n0 is None and n1 == ns:
+                    return True
+        else:
+            return True
+    return False
 
 def get_xml_child(n: xml.Node, name: str, ns: ?str) -> xml.Node:
-    r = get_xml_opt_child(n, name)
+    r = get_xml_opt_child(n, name, ns)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
 def get_xml_opt_child(n: xml.Node, name: str, ns: ?str) -> ?xml.Node:
     for child in n.children:
-        if child.tag == name:
+        if _node_match(child, name, ns):
             return child
     return None
 
@@ -1371,98 +1389,98 @@ def get_xml_child_text(n: xml.Node, name: str) -> str:
             raise ValueError("Child text is None")
     raise ValueError("Cannot find xml child with name " + name)
 
-def get_xml_children(n: xml.Node, name: str) -> list[xml.Node]:
+def get_xml_children(n: xml.Node, name: str, ns: ?str) -> list[xml.Node]:
     res = []
     for child in n.children:
-        if child.tag == name:
+        if _node_match(child, name, ns):
             res.append(child)
     return res
 
-def from_xml_opt_bool(n: xml.Node, name: str) -> ?bool:
+def from_xml_opt_bool(n: xml.Node, name: str, ns: ?str) -> ?bool:
     try:
-        text = get_xml_child(n, name).text
+        text = get_xml_child(n, name, ns).text
         if text is not None:
             return bool(text)
     except ValueError:
         return None
 
-def from_xml_bool(n: xml.Node, name: str) -> bool:
-    r = from_xml_opt_bool(n, name)
+def from_xml_bool(n: xml.Node, name: str, ns: ?str) -> bool:
+    r = from_xml_opt_bool(n, name, ns)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
-def from_xml_float(n: xml.Node, name: str) -> float:
-    text = get_xml_child(n, name).text
+def from_xml_float(n: xml.Node, name: str, ns: ?str) -> float:
+    text = get_xml_child(n, name, ns).text
     if text is not None:
         res = float(text)
         return res
     raise ValueError("Cannot find xml child with name " + name)
     return 13.37 # bah, get C error otherwise
 
-def from_xml_opt_float(n: xml.Node, name: str) -> ?float:
+def from_xml_opt_float(n: xml.Node, name: str, ns: ?str) -> ?float:
     try:
-        text = get_xml_child(n, name).text
+        text = get_xml_child(n, name, ns).text
         if text is not None:
             res = float(text)
             return res
     except ValueError:
         return None
 
-def from_xml_opt_int(n: xml.Node, name: str) -> ?int:
+def from_xml_opt_int(n: xml.Node, name: str, ns: ?str) -> ?int:
     try:
-        text = get_xml_child(n, name).text
+        text = get_xml_child(n, name, ns).text
         if text is not None:
             return int(text)
     except ValueError:
         return None
 
-def from_xml_int(n: xml.Node, name: str) -> int:
-    r = from_xml_opt_int(n, name)
+def from_xml_int(n: xml.Node, name: str, ns: ?str) -> int:
+    r = from_xml_opt_int(n, name, ns)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
-def from_xml_opt_str(n: xml.Node, name: str) -> ?str:
+def from_xml_opt_str(n: xml.Node, name: str, ns: ?str) -> ?str:
     try:
-        return get_xml_child(n, name).text
+        return get_xml_child(n, name, ns).text
     except ValueError:
         return None
 
-def from_xml_str(n: xml.Node, name: str) -> str:
-    r = from_xml_opt_str(n, name)
+def from_xml_str(n: xml.Node, name: str, ns: ?str) -> str:
+    r = from_xml_opt_str(n, name, ns)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
-def from_xml_opt_value(n: xml.Node, name: str) -> ?value:
+def from_xml_opt_value(n: xml.Node, name: str, ns: ?str) -> ?value:
     try:
-        t = get_xml_child(n, name).text
+        t = get_xml_child(n, name, ns).text
         if isinstance(t, value):
             return t
     except ValueError:
         return None
 
 # plural
-def from_xml_opt_strs(n: xml.Node, name: str) -> list[str]:
+def from_xml_opt_strs(n: xml.Node, name: str, ns: ?str) -> list[str]:
     res = []
-    for child in get_xml_children(n, name):
+    for child in get_xml_children(n, name, ns):
         ctext = child.text
         if ctext is not None:
             res.append(ctext)
     return res
 
-def from_xml_opt_values(n: xml.Node, name: str) -> list[value]:
+def from_xml_opt_values(n: xml.Node, name: str, ns: ?str) -> list[value]:
     res = []
-    for child in get_xml_children(n, name):
+    for child in get_xml_children(n, name, ns):
         ctext = child.text
         if isinstance(ctext, value):
             res.append(ctext)
     return res
 
-def from_xml_opt_ints(n: xml.Node, name: str) -> list[int]:
+def from_xml_opt_ints(n: xml.Node, name: str, ns: ?str) -> list[int]:
     res = []
-    for child in get_xml_children(n, name):
+    for child in get_xml_children(n, name, ns):
         ctext = child.text
         if ctext is not None:
             res.append(int(ctext))

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -245,6 +245,7 @@ class DNode(object):
     parent: ?DNode
     gname: str       # The name of the GData class, e.g. "Container" for yang.gdata.Container
     namespace: str
+    prefix: str
     name: str
     config: bool
     description: ?str
@@ -305,13 +306,28 @@ class DNodeInner(DNode):
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
         pos_child_idx = 0
+        child_names = set()
+        child_name_conflicts = set()
         for child in self.children:
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
             else:
                 new_children.append(child)
-        self.children = new_children
+            if child.name in child_names:
+                child_name_conflicts.add(child.name)
+            else:
+                child_names.add(child.name)
+
+
+        def _unique_name(name: str, prefix: str) -> str:
+            if name not in child_name_conflicts:
+                return name
+            return "%s:%s" % (prefix, name)
+
+        def _unique_safe_name(name: str, prefix: str) -> str:
+            unique_name = _unique_name(name, prefix)
+            return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:
             if isinstance(child, DNodeInner):
@@ -328,16 +344,16 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if isinstance(child, DLeaf):
-                res.append("    %s: %s" % (_safe_name(child.name), yang_leaf_to_acton_type(child, loose)))
+                res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_acton_type(child, loose)))
             elif isinstance(child, DLeafList):
-                res.append("    %s: %s" % (_safe_name(child.name), yang_leaflist_to_acton_type(child)))
+                res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), yang_leaflist_to_acton_type(child)))
             elif isinstance(child, DContainer):
                 if child.presence:
-                    res.append("    %s: ?%s" % (_safe_name(child.name), get_path_name(child)))
+                    res.append("    %s: ?%s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
                 else:
-                    res.append("    %s: %s" % (_safe_name(child.name), get_path_name(child)))
+                    res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
             elif isinstance(child, DNodeInner):
-                res.append("    %s: %s" % (_safe_name(child.name), get_path_name(child)))
+                res.append("    %s: %s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
             elif isinstance(child, DAnydata):
                 pass # TODO
             elif isinstance(child, DAnyxml):
@@ -358,23 +374,23 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
-                    opt_args.append("%s: ?%s=None" % (_safe_name(child.name), get_path_name(child)))
+                    opt_args.append("%s: ?%s=None" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
                 else:
-                    req_args.append("%s: %s" % (_safe_name(child.name), get_path_name(child)))
+                    req_args.append("%s: %s" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
             elif isinstance(child, DLeaf):
                 defval = ""
                 child_default = child.default
                 if child_default != None:
                     defval = "=None"
-                child_arg = "%s: %s%s" % (_safe_name(child.name), yang_leaf_to_acton_arg_type(child, loose), defval)
+                child_arg = "%s: %s%s" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_acton_arg_type(child, loose), defval)
                 if is_optional_arg_yang_leaf(child, loose):
                     opt_args.append(child_arg)
                 else:
                     req_args.append(child_arg)
             elif isinstance(child, DLeafList):
-                opt_args.append("%s: ?%s=None" % (_safe_name(child.name), yang_leaflist_to_acton_type(child)))
+                opt_args.append("%s: ?%s=None" % (_unique_safe_name(child.name, child.prefix), yang_leaflist_to_acton_type(child)))
             elif isinstance(child, DList):
-                opt_args.append("%s: list[%s_entry]=[]" % (_safe_name(child.name), get_path_name(child)))
+                opt_args.append("%s: list[%s_entry]=[]" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
 
         init_args_str = ", ".join(["self"] + req_args + opt_args)
         res.append("    mut def __init__(%s):" % init_args_str)
@@ -384,39 +400,39 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DContainer):
                 if loose or optional_subtree(child) and not child.presence:
-                    res.append("        if %s is not None:" % (_safe_name(child.name)))
-                    res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        if %s is not None:" % (_unique_safe_name(child.name, child.prefix)))
+                    res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                     res.append("        else:")
-                    res.append("            self.%s = %s()" % (_safe_name(child.name), get_path_name(child)))
+                    res.append("            self.%s = %s()" % (_unique_safe_name(child.name, child.prefix), get_path_name(child)))
                 else:
                     # NOTE: the default argument for P-container is None, so
                     # although unconditionally set here, it can be None
-                    res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                 if loose or child.presence or optional_subtree(child):
-                    res.append("        self_%s = self.%s" % (_safe_name(child.name), _safe_name(child.name)))
-                    res.append("        if self_%s is not None:" % (_safe_name(child.name)))
-                    res.append("            self_%s._parent = self" % (_safe_name(child.name)))
+                    res.append("        self_%s = self.%s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
+                    res.append("        if self_%s is not None:" % (_unique_safe_name(child.name, child.prefix)))
+                    res.append("            self_%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
                 else:
-                    res.append("        self.%s._parent = self" % (_safe_name(child.name)))
+                    res.append("        self.%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DLeaf):
                 child_default = child.default
                 if child_default != None:
-                    res.append("        if %s != None:" % (_safe_name(child.name)))
-                    res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        if %s != None:" % (_unique_safe_name(child.name, child.prefix)))
+                    res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                     res.append("        else:")
-                    res.append("            self.%s = %s" % (_safe_name(child.name), prsrc_literal(child.type_.name, child_default)))
+                    res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), prsrc_literal(child.type_.name, child_default)))
                 else:
-                    res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                    res.append("        self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DLeafList):
-                #res.append("        self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
-                res.append("        if %s is not None:" % (_safe_name(child.name)))
-                res.append("            self.%s = %s" % (_safe_name(child.name), _safe_name(child.name)))
+                #res.append("        self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
+                res.append("        if %s is not None:" % (_unique_safe_name(child.name, child.prefix)))
+                res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                 res.append("        else:")
                 # TODO: this is where we can set the leaf-list to a default value
-                res.append("            self.%s = []" % (_safe_name(child.name)))
+                res.append("            self.%s = []" % (_unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DList):
-                res.append("        self.%s = %s(elements=%s)" % (_safe_name(child.name), get_path_name(child), _safe_name(child.name)))
-                res.append("        self.%s._parent = self" % (_safe_name(child.name)))
+                res.append("        self.%s = %s(elements=%s)" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_safe_name(child.name, child.prefix)))
+                res.append("        self.%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
         if len(self.children) == 0:
             res.append("        pass")
         res.append("")
@@ -434,9 +450,9 @@ class DNodeInner(DNode):
                     elif isinstance(cchild, DContainer):
                         if not (loose or optional_subtree(cchild)):
                             pc_args.append(_safe_name(cchild.name))
-                res.append("    mut def create_%s(%s):" % (_safe_name(child.name), ", ".join(pc_args)))
+                res.append("    mut def create_%s(%s):" % (_unique_safe_name(child.name, child.prefix), ", ".join(pc_args)))
                 res.append("        res = %s(%s)" % (get_path_name(child), ", ".join(pc_args[1:])))
-                res.append("        self.%s = res" % (_safe_name(child.name)))
+                res.append("        self.%s = res" % (_unique_safe_name(child.name, child.prefix)))
                 res.append("        return res")
                 res.append("")
 
@@ -447,19 +463,19 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if not isinstance(child, DLeafList):
-                res.append("        _%s = self.%s" % (_safe_name(child.name), _safe_name(child.name)))
+                res.append("        _%s = self.%s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
         for child in self.children:
             child_ns = ", ns='" + child.namespace + "'" if child.namespace != self.namespace else ""
             if isinstance(child, DLeafList):
-                res.append("        children['%s'] = yang.gdata.LeafList(self.%s%s)" % (child.name, _safe_name(child.name), child_ns))
+                res.append("        children['%s'] = yang.gdata.LeafList(self.%s%s)" % (_unique_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix), child_ns))
             else:
-                res.append("        if _%s is not None:" % _safe_name(child.name))
+                res.append("        if _%s is not None:" % _unique_safe_name(child.name, child.prefix))
                 if isinstance(child, DLeaf):
-                    res.append("            children['%s'] = yang.gdata.Leaf('%s', _%s%s)" % (child.name, child.type_.name, _safe_name(child.name), child_ns))
+                    res.append("            children['%s'] = yang.gdata.Leaf('%s', _%s%s)" % (_unique_name(child.name, child.prefix), child.type_.name, _unique_safe_name(child.name, child.prefix), child_ns))
                 elif isinstance(child, DContainer):
-                    res.append("            children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
+                    res.append("            children['%s'] = _%s.to_gdata()" % (_unique_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                 elif isinstance(child, DList):
-                    res.append("            children['%s'] = _%s.to_gdata()" % (child.name, _safe_name(child.name)))
+                    res.append("            children['%s'] = _%s.to_gdata()" % (_unique_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
 
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
@@ -486,21 +502,21 @@ class DNodeInner(DNode):
         from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
-                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
             elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
             elif isinstance(child, DContainer):
                 if loose or optional_subtree(child):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\", \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name, child.prefix))
                 else:
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
             elif isinstance(child, DList):
-                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
-                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
         from_gdata_args = ", ".join(from_gdata_args_list)
         from_xml_args = ", ".join(from_xml_args_list)
         res.append("    @staticmethod")
@@ -567,10 +583,10 @@ class DNodeInner(DNode):
                     if child.name in self.key:
                         continue
                     if child.mandatory:
-                        list_key_args.append(_safe_name(child.name))
+                        list_key_args.append(_unique_safe_name(child.name, child.prefix))
                 elif isinstance(child, DContainer):
                     if not (loose or optional_subtree(child)):
-                        list_key_args.append(_safe_name(child.name))
+                        list_key_args.append(_unique_safe_name(child.name, child.prefix))
             list_create_args = ["self"] + list_key_args
             res.append("    mut def create(%s):" % (", ".join(list_create_args)))
             res.append("        for e in self.elements:")
@@ -604,13 +620,13 @@ class DNodeInner(DNode):
             from_gdata_args_list = []
             for child in self.children:
                 if isinstance(child, DLeaf):
-                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_safe_name(child.name), yang_leaf_to_getval(child), child.name))
+                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
                 elif isinstance(child, DContainer):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
                 elif isinstance(child, DList):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
 #                elif isinstance(child, ListElement):
-#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_safe_name(child.name), get_path_name(child), child.name))
+#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
             from_gdata_args = ", ".join(from_gdata_args_list)
             res.append("    @staticmethod")
             res.append("    mut def from_gdata(n: yang.gdata.List) -> list[%s_entry]:" % get_path_name(self))
@@ -651,8 +667,9 @@ class DAction(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Action"
         self.config = False
@@ -670,8 +687,9 @@ class DAnydata(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Anydata"
         self.config = config
@@ -691,8 +709,9 @@ class DAnyxml(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Anyxml"
         self.config = config
@@ -711,8 +730,9 @@ class DContainer(DNodeInner):
     presence: bool
     status: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Container"
         self.config = config
@@ -728,8 +748,9 @@ class DContainer(DNodeInner):
 class DInput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, must=[], exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = "input"
         self.gname = "Input"
         self.config = False
@@ -738,7 +759,6 @@ class DInput(DNodeInner):
         self.children = children
 
 class DModule(DNodeInner):
-    prefix: str
     augment: list[Augment]
     contact: ?str
     deviation: list[str]
@@ -786,8 +806,9 @@ class DList(DNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, namespace: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "List"
         self.key = key
@@ -809,8 +830,9 @@ class DLeaf(DNodeLeaf):
     default: ?str
     units: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Leaf"
         self.config = config
@@ -840,8 +862,9 @@ class DLeafList(DNodeLeaf):
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "LeafList"
         self.config = config
@@ -862,8 +885,9 @@ class DLeafList(DNodeLeaf):
 class DNotification(DNodeInner):
     status: ?str
 
-    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Notification"
         self.description = description
@@ -875,8 +899,9 @@ class DNotification(DNodeInner):
 class DOutput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, must=[], exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = "output"
         self.gname = "Output"
         self.config = False
@@ -887,6 +912,7 @@ class DOutput(DNodeInner):
 class DRoot(DNodeInner):
     def __init__(self, modules: list[DNode]=[]):
         self.namespace = ""
+        self.prefix = ""
         self.name = "root"
         self.gname = "Root"
         self.config = True
@@ -903,8 +929,9 @@ class DRpc(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
         self.namespace = namespace
+        self.prefix = prefix
         self.name = name
         self.gname = "Rpc"
         self.config = False
@@ -1024,7 +1051,7 @@ class SchemaNode(object):
             """Unset the mandatory attribute if present
             """
             if isinstance(node, DLeaf):
-                print("Unset mandatory on %s" % node.name, err=True)
+                # print("Unset mandatory on %s" % node.name, err=True)
                 node.mandatory = False
             elif isinstance(node, DAnydata):
                 node.mandatory = None
@@ -1076,6 +1103,21 @@ class SchemaNode(object):
             if i > RECURSION_LIMIT:
                 raise ValueError("Recursion limit reached")
         raise ValueError("Unable to find namespace")
+
+    def get_prefix(self) -> str:
+        n = self
+        for i in range(RECURSION_LIMIT+1):
+            if isinstance(n, Module):
+                return n.prefix
+            nparent = n.parent
+            if nparent is not None:
+                n = nparent
+                continue
+            else:
+                raise ValueError("Unable to find prefix")
+            if i > RECURSION_LIMIT:
+                raise ValueError("Recursion limit reached")
+        raise ValueError("Unable to find prefix")
 
     def is_config(self) -> bool:
         n = self
@@ -2228,6 +2270,7 @@ class Action(SchemaNodeInner):
     def to_dnode(self) -> DAction:
         new_dnode = DAction(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
@@ -2357,6 +2400,7 @@ class Anydata(SchemaNodeOuter):
     def to_dnode(self) -> DAnydata:
         return DAnydata(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -2497,6 +2541,7 @@ class Anyxml(SchemaNodeOuter):
     def to_dnode(self) -> DAnyxml:
         return DAnyxml(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -3183,6 +3228,7 @@ class Container(SchemaNodeInner):
     def to_dnode(self) -> DContainer:
         new_dnode = DContainer(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             description=self.description,
@@ -3941,6 +3987,7 @@ class Input(SchemaNodeInner):
     def to_dnode(self) -> DInput:
         new_dnode = DInput(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             must=self.must,
             exts=self.exts,
             children=self.get_dnode_children()
@@ -4117,6 +4164,7 @@ class Leaf(SchemaNodeOuter):
     def to_dnode(self) -> DLeaf:
         return DLeaf(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             default=self.default,
@@ -4313,6 +4361,7 @@ class LeafList(SchemaNodeOuter):
     def to_dnode(self) -> DLeafList:
         return DLeafList(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             config=self.is_config(),
             default=self.default,
@@ -4584,6 +4633,7 @@ class List(SchemaNodeInner):
     def to_dnode(self) -> DList:
         new_dnode = DList(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             key=self.keys(),
             config=self.is_config(),
@@ -4815,7 +4865,7 @@ class Module(SchemaNodeInner):
     def to_dnode(self) -> DModule:
         new_dnode = DModule(
             namespace=self.get_namespace(),
-            prefix=self.prefix,
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             revision=self.revision,
@@ -5057,6 +5107,7 @@ class Notification(SchemaNodeInner):
     def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
@@ -5169,6 +5220,7 @@ class Output(SchemaNodeInner):
     def to_dnode(self) -> DOutput:
         new_dnode = DOutput(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             must=self.must,
             exts=self.exts,
             children=self.get_dnode_children()
@@ -5747,6 +5799,7 @@ class Rpc(SchemaNodeInner):
     def to_dnode(self) -> DRpc:
         new_dnode = DRpc(
             namespace=self.get_namespace(),
+            prefix=self.get_prefix(),
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1021,6 +1021,7 @@ class Context(object):
 class SchemaNode(object):
     parent: ?SchemaNode
     ns: ?str
+    pfx: ?str
     exts: list[Ext]
     _yname: str
 
@@ -1107,8 +1108,9 @@ class SchemaNode(object):
     def get_prefix(self) -> str:
         n = self
         for i in range(RECURSION_LIMIT+1):
-            if isinstance(n, Module):
-                return n.prefix
+            nprefix = n.pfx
+            if nprefix is not None:
+                return nprefix
             nparent = n.parent
             if nparent is not None:
                 n = nparent
@@ -1258,7 +1260,7 @@ class SchemaNode(object):
             break
         raise ValueError("Unable to find Module")
 
-    def compile(self, context: Context, new_ns: ?str=None) -> SchemaNode:
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None) -> SchemaNode:
         """Compile an abstract YANG into a concrete one
         - expand uses / groupings
         - handle augments
@@ -1331,7 +1333,7 @@ class SchemaNode(object):
                     target = get_target(target_base, aug.target_node)
                     if isinstance(target, SchemaNodeInner):
                         # Just move the child to the target
-                        aug.expand_children(context, target, new_ns=aug.get_namespace())
+                        aug.expand_children(context, target, new_ns=aug.get_namespace(), new_pfx=aug.get_prefix())
                         target.exts.extend(aug.exts)
                     else:
                         raise ValueError("Augment target " + str(target) + " is not an inner node")
@@ -1346,18 +1348,18 @@ class SchemaNode(object):
         else:
             raise ValueError("Node type does not have augment substatements")
 
-    def expand_children(self, context: Context, target: SchemaNodeInner, new_ns: ?str = None):
+    def expand_children(self, context: Context, target: SchemaNodeInner, new_ns: ?str = None, new_pfx: ?str = None):
         """Expand abstract children into concrete nodes
         """
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
                 if isinstance(child, Uses):
                     grouping = child.get_grouping(_safe_name(child.name), context)
-                    grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns)
+                    grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
                 else:
-                    c_child = child.compile(context, new_ns)
+                    c_child = child.compile(context, new_ns, new_pfx)
                     c_child.parent = target
                     target.children.append(c_child)
         else:
@@ -2145,23 +2147,33 @@ class Action(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "action"
         if input is not None:
             input.parent = self
             n_ns = input.ns
             if n_ns is None:
                 input.ns = self.ns
+            n_pfx = input.pfx
+            if n_pfx is None:
+                input.pfx = self.pfx
         if output is not None:
             output.parent = self
             n_ns = output.ns
             if n_ns is None:
                 output.ns = self.ns
+            n_pfx = output.pfx
+            if n_pfx is None:
+                output.pfx = self.pfx
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -2175,6 +2187,9 @@ class Action(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -2244,7 +2259,7 @@ class Action(SchemaNodeInner):
                 return _output
         return SchemaNode.get(self, name, ns)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -2263,8 +2278,9 @@ class Action(SchemaNodeInner):
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
-        self.expand_children(context, new, new_ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
+        self.expand_children(context, new, new_ns, new_pfx)
         return new
 
     def to_dnode(self) -> DAction:
@@ -2317,18 +2333,25 @@ class Anydata(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "anydata"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.config = config
         self.description = description
@@ -2413,7 +2436,7 @@ class Anydata(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Anydata(self.name,
                       config=self.config,
                       description=self.description,
@@ -2424,7 +2447,8 @@ class Anydata(SchemaNodeOuter):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
-                      ns=new_ns if new_ns is not None else self.ns)
+                      ns=new_ns if new_ns is not None else self.ns,
+                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -2458,18 +2482,25 @@ class Anyxml(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "anyxml"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.config = config
         self.description = description
@@ -2554,7 +2585,7 @@ class Anyxml(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Anyxml(self.name,
                      config=self.config,
                      description=self.description,
@@ -2565,7 +2596,8 @@ class Anyxml(SchemaNodeOuter):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -2596,12 +2628,16 @@ class Augment(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, target_node: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, target_node: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "augment"
         self.target_node = target_node
         self.description = description
@@ -2615,6 +2651,9 @@ class Augment(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -2669,7 +2708,7 @@ class Augment(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Augment(self.target_node,
                       description=self.description,
                       if_feature=self.if_feature,
@@ -2677,7 +2716,8 @@ class Augment(SchemaNodeInner):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
-                      ns=new_ns if new_ns is not None else self.ns)
+                      ns=new_ns if new_ns is not None else self.ns,
+                      pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -2705,12 +2745,16 @@ class BelongsTo(SchemaNodeOuter):
     module: str
     prefix: str
 
-    def __init__(self, module: str, prefix: str, exts=[], parent=None, ns=None):
+    def __init__(self, module: str, prefix: str, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "belongs-to"
         self.module = module
         self.prefix = prefix
@@ -2738,11 +2782,12 @@ class BelongsTo(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = BelongsTo(self.module,
                         prefix=self.prefix,
                         exts=self.exts,
-                        ns=new_ns if new_ns is not None else self.ns)
+                        ns=new_ns if new_ns is not None else self.ns,
+                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -2773,12 +2818,16 @@ class Bit(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], position: ?int=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], position: ?int=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "bit"
         self.name = name
         self.description = description
@@ -2830,7 +2879,7 @@ class Bit(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Bit(self.name,
                   description=self.description,
                   if_feature=self.if_feature,
@@ -2838,7 +2887,8 @@ class Bit(SchemaNodeOuter):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  ns=new_ns if new_ns is not None else self.ns)
+                  ns=new_ns if new_ns is not None else self.ns,
+                  pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -2869,12 +2919,16 @@ class Case(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "case"
         self.name = name
         self.description = description
@@ -2888,6 +2942,9 @@ class Case(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -2942,7 +2999,7 @@ class Case(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Case(self.name,
                    description=self.description,
                    if_feature=self.if_feature,
@@ -2950,7 +3007,8 @@ class Case(SchemaNodeInner):
                    status=self.status,
                    when=self.when,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -2985,12 +3043,16 @@ class Choice(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "choice"
         self.name = name
         self.config = config
@@ -3007,6 +3069,9 @@ class Choice(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -3077,7 +3142,7 @@ class Choice(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Choice(self.name,
                      config=self.config,
                      default=self.default,
@@ -3088,7 +3153,8 @@ class Choice(SchemaNodeInner):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -3123,18 +3189,25 @@ class Container(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], presence: ?str=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], presence: ?str=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "container"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.config = config
         self.description = description
@@ -3150,6 +3223,9 @@ class Container(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -3245,7 +3321,7 @@ class Container(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Container(self.name,
                         config=self.config,
                         description=self.description,
@@ -3256,7 +3332,8 @@ class Container(SchemaNodeInner):
                         status=self.status,
                         when=self.when,
                         exts=self.exts,
-                        ns=new_ns if new_ns is not None else self.ns)
+                        ns=new_ns if new_ns is not None else self.ns,
+                        pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -3288,12 +3365,16 @@ class Enum(SchemaNodeOuter):
     status: ?str
     value: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, value: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, value: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "enum"
         self.name = name
         self.description = description
@@ -3345,7 +3426,7 @@ class Enum(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Enum(self.name,
                    description=self.description,
                    if_feature=self.if_feature,
@@ -3353,7 +3434,8 @@ class Enum(SchemaNodeOuter):
                    status=self.status,
                    value=self.value,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -3383,12 +3465,16 @@ class Extension(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, argument: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, argument: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "extension"
         self.name = name
         self.argument = argument
@@ -3434,14 +3520,15 @@ class Extension(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Extension(self.name,
                         argument=self.argument,
                         description=self.description,
                         reference=self.reference,
                         status=self.status,
                         exts=self.exts,
-                        ns=new_ns if new_ns is not None else self.ns)
+                        ns=new_ns if new_ns is not None else self.ns,
+                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -3471,12 +3558,16 @@ class Feature(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "feature"
         self.name = name
         self.description = description
@@ -3525,14 +3616,15 @@ class Feature(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Feature(self.name,
                       description=self.description,
                       if_feature=self.if_feature,
                       reference=self.reference,
                       status=self.status,
                       exts=self.exts,
-                      ns=new_ns if new_ns is not None else self.ns)
+                      ns=new_ns if new_ns is not None else self.ns,
+                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -3561,12 +3653,16 @@ class Grouping(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "grouping"
         self.name = name
         self.description = description
@@ -3578,6 +3674,9 @@ class Grouping(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -3625,13 +3724,14 @@ class Grouping(SchemaNodeInner):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Grouping(self.name,
                        description=self.description,
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
-                       ns=new_ns if new_ns is not None else self.ns)
+                       ns=new_ns if new_ns is not None else self.ns,
+                       pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -3663,12 +3763,16 @@ class Identity(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, base: list[str]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, base: list[str]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "identity"
         self.name = name
         self.base = base
@@ -3720,7 +3824,7 @@ class Identity(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Identity(self.name,
                        base=self.base,
                        description=self.description,
@@ -3728,7 +3832,8 @@ class Identity(SchemaNodeOuter):
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
-                       ns=new_ns if new_ns is not None else self.ns)
+                       ns=new_ns if new_ns is not None else self.ns,
+                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -3758,12 +3863,16 @@ class Import(SchemaNodeOuter):
     reference: ?str
     revision_date: ?str
 
-    def __init__(self, module: str, prefix: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, module: str, prefix: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "import"
         self.module = module
         self.description = description
@@ -3809,14 +3918,15 @@ class Import(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Import(self.module,
                      prefix=self.prefix,
                      description=self.description,
                      reference=self.reference,
                      revision_date=self.revision_date,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -3845,12 +3955,16 @@ class Include(SchemaNodeOuter):
     reference: ?str
     revision_date: ?str
 
-    def __init__(self, module: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, module: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "include"
         self.module = module
         self.description = description
@@ -3893,13 +4007,14 @@ class Include(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Include(self.module,
                       description=self.description,
                       reference=self.reference,
                       revision_date=self.revision_date,
                       exts=self.exts,
-                      ns=new_ns if new_ns is not None else self.ns)
+                      ns=new_ns if new_ns is not None else self.ns,
+                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -3925,18 +4040,25 @@ class Input(SchemaNodeInner):
     """
     must: list[Must]
 
-    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None):
+    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "input"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.must = must
         self.exts = exts
         for n in children:
@@ -3944,6 +4066,9 @@ class Input(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -3996,10 +4121,11 @@ class Input(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Input(must=self.must,
                     exts=self.exts,
-                    ns=new_ns if new_ns is not None else self.ns)
+                    ns=new_ns if new_ns is not None else self.ns,
+                    pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -4037,22 +4163,32 @@ class Leaf(SchemaNodeOuter):
     units: ?str
     when: ?str
 
-    def __init__(self, name: str, type_: Type, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, type_: Type, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "leaf"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         type_.parent = self
         n_ns = type_.ns
         if n_ns is None:
             type_.ns = self.ns
+        n_pfx = type_.pfx
+        if n_pfx is None:
+            type_.pfx = self.pfx
         self.name = name
         self.config = config
         self.default = default
@@ -4134,7 +4270,7 @@ class Leaf(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -4158,7 +4294,9 @@ class Leaf(SchemaNodeOuter):
                    units=new_units,
                    when=self.when,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
+
         return new
 
     def to_dnode(self) -> DLeaf:
@@ -4216,22 +4354,32 @@ class LeafList(SchemaNodeOuter):
     units: ?str
     when: ?str
 
-    def __init__(self, name: str, type_: Type, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, type_: Type, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "leaf-list"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         type_.parent = self
         n_ns = type_.ns
         if n_ns is None:
             type_.ns = self.ns
+        n_pfx = type_.pfx
+        if n_pfx is None:
+            type_.pfx = self.pfx
         self.name = name
         self.config = config
         self.default = default
@@ -4321,7 +4469,7 @@ class LeafList(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_units = self.units
@@ -4343,7 +4491,8 @@ class LeafList(SchemaNodeOuter):
                        units=new_units,
                        when=self.when,
                        exts=self.exts,
-                       ns=new_ns if new_ns is not None else self.ns)
+                       ns=new_ns if new_ns is not None else self.ns,
+                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def get_max_elements(self) -> ?int:
@@ -4405,12 +4554,16 @@ class Length(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "length"
         self.value = value
         self.description = description
@@ -4456,14 +4609,15 @@ class Length(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Length(self.value,
                      description=self.description,
                      error_app_tag=self.error_app_tag,
                      error_message=self.error_message,
                      reference=self.reference,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -4501,18 +4655,25 @@ class List(SchemaNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], key: ?str=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, unique: list[str]=[], when: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], key: ?str=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, unique: list[str]=[], when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "list"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.config = config
         self.description = description
@@ -4532,6 +4693,9 @@ class List(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -4652,7 +4816,7 @@ class List(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = List(self.name,
                    config=self.config,
                    description=self.description,
@@ -4667,7 +4831,8 @@ class List(SchemaNodeInner):
                    unique=self.unique,
                    when=self.when,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -4708,43 +4873,65 @@ class Module(SchemaNodeInner):
     extension_: list[Extension]
     feature: list[Feature]
 
-    def __init__(self, name: str, namespace: str, prefix: str, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, namespace: str, prefix: str, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None:
             new_ns = namespace
+        if new_pfx is None:
+            new_pfx = prefix
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "module"
         for n in augment:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in extension_:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in feature:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in import_:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in include:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in revision:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.augment = augment
         self.contact = contact
@@ -4766,6 +4953,9 @@ class Module(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -4855,6 +5045,15 @@ class Module(SchemaNodeInner):
             return selfnamespace
         raise ValueError("Module %s has no namespace" % self.name)
 
+    def get_prefix(self) -> str:
+        self_pfx = self.pfx
+        if self_pfx is not None:
+            return self_pfx
+        selfprefix = self.prefix
+        if selfprefix is not None:
+            return selfprefix
+        raise ValueError("Module %s has no prefix" % self.name)
+
     def get_revision(self) -> ?Revision:
         latest = None
         for rev in self.revision:
@@ -4880,7 +5079,7 @@ class Module(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Module(self.name,
                      yang_version=self.yang_version,
                      namespace=self.namespace,
@@ -4934,12 +5133,16 @@ class Must(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, condition: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, condition: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "must"
         self.condition = condition
         self.description = description
@@ -4985,14 +5188,15 @@ class Must(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Must(self.condition,
                    description=self.description,
                    error_app_tag=self.error_app_tag,
                    error_message=self.error_message,
                    reference=self.reference,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -5023,18 +5227,25 @@ class Notification(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "notification"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -5047,6 +5258,9 @@ class Notification(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -5123,7 +5337,7 @@ class Notification(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Notification(self.name,
                            description=self.description,
                            if_feature=self.if_feature,
@@ -5131,7 +5345,8 @@ class Notification(SchemaNodeInner):
                            reference=self.reference,
                            status=self.status,
                            exts=self.exts,
-                           ns=new_ns if new_ns is not None else self.ns)
+                           ns=new_ns if new_ns is not None else self.ns,
+                           pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -5158,18 +5373,25 @@ class Output(SchemaNodeInner):
     """
     must: list[Must]
 
-    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None):
+    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "output"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.must = must
         self.exts = exts
         for n in children:
@@ -5177,6 +5399,9 @@ class Output(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -5232,10 +5457,11 @@ class Output(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Output(must=self.must,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns)
         return new
 
@@ -5267,12 +5493,16 @@ class Pattern(SchemaNodeOuter):
     modifier: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, modifier: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, modifier: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "pattern"
         self.value = value
         self.description = description
@@ -5321,7 +5551,7 @@ class Pattern(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Pattern(self.value,
                       description=self.description,
                       error_app_tag=self.error_app_tag,
@@ -5329,7 +5559,8 @@ class Pattern(SchemaNodeOuter):
                       modifier=self.modifier,
                       reference=self.reference,
                       exts=self.exts,
-                      ns=new_ns if new_ns is not None else self.ns)
+                      ns=new_ns if new_ns is not None else self.ns,
+                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -5359,12 +5590,16 @@ class Range(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "range"
         self.value = value
         self.description = description
@@ -5410,14 +5645,15 @@ class Range(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Range(self.value,
                     description=self.description,
                     error_app_tag=self.error_app_tag,
                     error_message=self.error_message,
                     reference=self.reference,
                     exts=self.exts,
-                    ns=new_ns if new_ns is not None else self.ns)
+                    ns=new_ns if new_ns is not None else self.ns,
+                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -5453,18 +5689,25 @@ class Refine(SchemaNodeOuter):
     presence: ?str
     reference: ?str
 
-    def __init__(self, target_node: str, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], presence: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, target_node: str, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], presence: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "refine"
         for n in must:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.target_node = target_node
         self.config = config
         self.default = default
@@ -5551,7 +5794,7 @@ class Refine(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Refine(self.target_node,
                      config=self.config,
                      default=self.default,
@@ -5564,7 +5807,8 @@ class Refine(SchemaNodeOuter):
                      presence=self.presence,
                      reference=self.reference,
                      exts=self.exts,
-                     ns=new_ns if new_ns is not None else self.ns)
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -5592,12 +5836,16 @@ class Revision(SchemaNodeOuter):
     description: ?str
     reference: ?str
 
-    def __init__(self, date: str, description: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, date: str, description: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "revision"
         self.date = date
         self.description = description
@@ -5637,12 +5885,13 @@ class Revision(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Revision(self.date,
                        description=self.description,
                        reference=self.reference,
                        exts=self.exts,
-                       ns=new_ns if new_ns is not None else self.ns)
+                       ns=new_ns if new_ns is not None else self.ns,
+                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -5674,23 +5923,33 @@ class Rpc(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "rpc"
         if input is not None:
             input.parent = self
             n_ns = input.ns
             if n_ns is None:
                 input.ns = self.ns
+            n_pfx = input.pfx
+            if n_pfx is None:
+                input.pfx = self.pfx
         if output is not None:
             output.parent = self
             n_ns = output.ns
             if n_ns is None:
                 output.ns = self.ns
+            n_pfx = output.pfx
+            if n_pfx is None:
+                output.pfx = self.pfx
         self.name = name
         self.description = description
         self.if_feature = if_feature
@@ -5704,6 +5963,9 @@ class Rpc(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -5773,7 +6035,7 @@ class Rpc(SchemaNodeInner):
                 return _output
         return SchemaNode.get(self, name, ns)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -5792,8 +6054,9 @@ class Rpc(SchemaNodeInner):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
-                  ns=new_ns if new_ns is not None else self.ns)
-        self.expand_children(context, new, new_ns)
+                  ns=new_ns if new_ns is not None else self.ns,
+                  pfx=new_pfx if new_pfx is not None else self.pfx)
+        self.expand_children(context, new, new_ns, new_pfx)
         return new
 
     def to_dnode(self) -> DRpc:
@@ -5851,47 +6114,72 @@ class Submodule(SchemaNodeInner):
     extension_: list[Extension]
     feature: list[Feature]
 
-    def __init__(self, name: str, belongs_to: BelongsTo, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None):
+    def __init__(self, name: str, belongs_to: BelongsTo, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "submodule"
         for n in augment:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         belongs_to.parent = self
         n_ns = belongs_to.ns
         if n_ns is None:
             belongs_to.ns = self.ns
+        n_pfx = belongs_to.pfx
+        if n_pfx is None:
+            belongs_to.pfx = self.pfx
         for n in extension_:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in feature:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in import_:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in include:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in revision:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.augment = augment
         self.belongs_to = belongs_to
@@ -5912,6 +6200,9 @@ class Submodule(SchemaNodeInner):
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.children = children
 
     def get_attrs(self) -> list[(str, ?value)]:
@@ -5991,7 +6282,7 @@ class Submodule(SchemaNodeInner):
                 latest = rev
         return latest
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Submodule(self.name,
                         yang_version=self.yang_version,
                         import_=self.import_,
@@ -6044,43 +6335,65 @@ class Type(SchemaNodeOuter):
     require_instance: ?bool
     type_: list[Type]
 
-    def __init__(self, name: str, base: list[str]=[], bit: list[Bit]=[], enum: list[Enum]=[], fraction_digits: ?int=None, length: ?Length=None, path: ?str=None, pattern: list[Pattern]=[], range_: ?Range=None, require_instance: ?bool=None, type_: list[Type]=[], exts=[], parent=None, ns=None):
+    def __init__(self, name: str, base: list[str]=[], bit: list[Bit]=[], enum: list[Enum]=[], fraction_digits: ?int=None, length: ?Length=None, path: ?str=None, pattern: list[Pattern]=[], range_: ?Range=None, require_instance: ?bool=None, type_: list[Type]=[], exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "type"
         for n in bit:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in enum:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         if length is not None:
             length.parent = self
             n_ns = length.ns
             if n_ns is None:
                 length.ns = self.ns
+            n_pfx = length.pfx
+            if n_pfx is None:
+                length.pfx = self.pfx
         for n in pattern:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         if range_ is not None:
             range_.parent = self
             n_ns = range_.ns
             if n_ns is None:
                 range_.ns = self.ns
+            n_pfx = range_.pfx
+            if n_pfx is None:
+                range_.pfx = self.pfx
         for n in type_:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.base = base
         self.bit = bit
@@ -6170,7 +6483,7 @@ class Type(SchemaNodeOuter):
                 raise ValueError("Recursion limit reached for typedef %s" % self.name)
         raise ValueError("Unable to resolve typedef %s" % self.name)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Type(self.name,
                    base=self.base,
                    bit=self.bit,
@@ -6183,7 +6496,8 @@ class Type(SchemaNodeOuter):
                    require_instance=self.require_instance,
                    type_=self.type_,
                    exts=self.exts,
-                   ns=new_ns if new_ns is not None else self.ns)
+                   ns=new_ns if new_ns is not None else self.ns,
+                   pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
     def __str__(self):
@@ -6215,17 +6529,24 @@ class Typedef(SchemaNodeOuter):
     status: ?str
     units: ?str
 
-    def __init__(self, name: str, type_: Type, default: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, type_: Type, default: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "typedef"
         type_.parent = self
         n_ns = type_.ns
         if n_ns is None:
             type_.ns = self.ns
+        n_pfx = type_.pfx
+        if n_pfx is None:
+            type_.pfx = self.pfx
         self.name = name
         self.default = default
         self.description = description
@@ -6280,7 +6601,7 @@ class Typedef(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -6331,23 +6652,33 @@ class Uses(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, augment: list[Augment]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, refine: list[Refine]=[], status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None):
+    def __init__(self, name: str, augment: list[Augment]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, refine: list[Refine]=[], status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
         self.parent = parent
         new_ns = ns
+        new_pfx = pfx
         if new_ns is None and parent is not None:
             new_ns = parent.ns
+        if new_pfx is None and parent is not None:
+            new_pfx = parent.pfx
         self.ns = new_ns
+        self.pfx = new_pfx
         self._yname = "uses"
         for n in augment:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         for n in refine:
             n.parent = self
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
+            n_pfx = n.pfx
+            if n_pfx is None:
+                n.pfx = self.pfx
         self.name = name
         self.augment = augment
         self.description = description
@@ -6404,7 +6735,7 @@ class Uses(SchemaNodeOuter):
         res.append(text_line)
         return "\n".join(res)
 
-    def compile(self, context: Context, new_ns: ?str=None):
+    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         raise ValueError("Cannot compile 'uses'")
 
     mut def expand_refines(self, target_base: SchemaNode):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -496,27 +496,32 @@ class DNodeInner(DNode):
                 res.append("        return yang.gdata.%s(children)" % (self.gname))
         res.append("")
 #
+        def _maybe_ns(child: DNode) -> str:
+            if child.namespace != self.namespace:
+                return ", \"%s\"" % child.namespace
+            return ""
+
         # .from_gdata()
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
         from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
-                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
             elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
             elif isinstance(child, DContainer):
                 if loose or optional_subtree(child):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\", \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name, child.prefix))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_opt_child(n, \"%s\"%s))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), child.name, _maybe_ns(child)))
                 else:
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), _unique_safe_name(child.name, child.prefix, child_name_conflicts)))
-                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
+                    from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_child(n, \"%s\"%s))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), child.name, _maybe_ns(child)))
             elif isinstance(child, DList):
-                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
-                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=%s.from_xml(yang.gdata.get_xml_children(n, \"%s\"%s))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), child.name, _maybe_ns(child)))
         from_gdata_args = ", ".join(from_gdata_args_list)
         from_xml_args = ", ".join(from_xml_args_list)
         res.append("    @staticmethod")
@@ -620,13 +625,13 @@ class DNodeInner(DNode):
             from_gdata_args_list = []
             for child in self.children:
                 if isinstance(child, DLeaf):
-                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), yang_leaf_to_getval(child), child.name))
+                    from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
                 elif isinstance(child, DContainer):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
                 elif isinstance(child, DList):
-                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
 #                elif isinstance(child, ListElement):
-#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix, child_name_conflicts), get_path_name(child), child.name))
+#                    from_gdata_args_list.append("%s=%s.from_gdata(n.get_list(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
             from_gdata_args = ", ".join(from_gdata_args_list)
             res.append("    @staticmethod")
             res.append("    mut def from_gdata(n: yang.gdata.List) -> list[%s_entry]:" % get_path_name(self))

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -66,6 +66,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -108,6 +108,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -33,7 +33,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2", "http://example.com/bar"))
         return foo__c1()
 
 
@@ -66,6 +66,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -104,6 +104,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -33,7 +33,7 @@ class foo__c1__c2(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
         if n != None:
-            return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, "l2"), l3=yang.gdata.from_xml_opt_str(n, "l3"))
+            return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, "l2"), l3=yang.gdata.from_xml_opt_str(n, "l3", "http://example.com/baz"))
         return foo__c1__c2()
 
 
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")))
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2", "http://example.com/bar")))
         return foo__c1()
 
 
@@ -104,6 +104,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -94,6 +94,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -33,7 +33,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2", "http://example.com/bar"))
         return foo__c1()
 
 
@@ -66,6 +66,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -132,6 +132,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -127,6 +127,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/bar")))
         return root()
 

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -62,6 +62,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -99,6 +99,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -127,6 +127,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -66,6 +66,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -1,31 +1,31 @@
 class base__c1(yang.adata.MNode):
-    foo: ?str
-    foo: ?str
+    bar_foo: ?str
+    foo_foo: ?str
 
-    mut def __init__(self, foo: ?str, foo: ?str):
+    mut def __init__(self, bar_foo: ?str, foo_foo: ?str):
         self._ns = "http://example.com/base"
-        self.foo = foo
-        self.foo = foo
+        self.bar_foo = bar_foo
+        self.foo_foo = foo_foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo = self.foo
-        _foo = self.foo
-        if _foo is not None:
-            children['foo'] = yang.gdata.Leaf('string', _foo, ns='http://example.com/bar')
-        if _foo is not None:
-            children['foo'] = yang.gdata.Leaf('string', _foo, ns='http://example.com/foo')
+        _bar_foo = self.bar_foo
+        _foo_foo = self.foo_foo
+        if _bar_foo is not None:
+            children['bar:foo'] = yang.gdata.Leaf('string', _bar_foo, ns='http://example.com/bar')
+        if _foo_foo is not None:
+            children['foo:foo'] = yang.gdata.Leaf('string', _foo_foo, ns='http://example.com/foo')
         return yang.gdata.Container(children, ns='http://example.com/base')
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__c1:
         if n != None:
-            return base__c1(foo=n.get_opt_str("foo"), foo=n.get_opt_str("foo"))
+            return base__c1(bar_foo=n.get_opt_str("bar:foo"), foo_foo=n.get_opt_str("foo:foo"))
         return base__c1()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> base__c1:
         if n != None:
-            return base__c1(foo=yang.gdata.from_xml_opt_str(n, "foo"), foo=yang.gdata.from_xml_opt_str(n, "foo"))
+            return base__c1(bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), foo_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/foo"))
         return base__c1()
 

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -61,6 +61,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(ieee_802_3=foo__ieee_802_3.from_xml(yang.gdata.get_xml_opt_child(n, "ieee-802.3")))
+            return root(ieee_802_3=foo__ieee_802_3.from_xml(yang.gdata.get_xml_opt_child(n, "ieee-802.3", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -100,6 +100,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(li1=foo__li1.from_xml(yang.gdata.get_xml_children(n, "li1")), ll1=yang.gdata.from_xml_opt_strs(n, "ll1"))
+            return root(li1=foo__li1.from_xml(yang.gdata.get_xml_children(n, "li1", "http://example.com/foo")), ll1=yang.gdata.from_xml_opt_strs(n, "ll1", "http://example.com/foo"))
         return root()
 

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -137,6 +137,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(l1=foo__l1.from_xml(yang.gdata.get_xml_children(n, "l1")))
+            return root(l1=foo__l1.from_xml(yang.gdata.get_xml_children(n, "l1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -93,12 +93,12 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(bar_c1=bar__c1.from_gdata(n.get_opt_container("bar_c1")), foo_c1=foo__c1.from_gdata(n.get_opt_container("foo_c1")))
+            return root(bar_c1=bar__c1.from_gdata(n.get_opt_container("bar:c1")), foo_c1=foo__c1.from_gdata(n.get_opt_container("foo:c1")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(bar_c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "bar")), foo_c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "foo")))
+            return root(bar_c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/bar")), foo_c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -1,0 +1,104 @@
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+class bar__c1(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = "http://example.com/bar"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__c1:
+        if n != None:
+            return bar__c1(l1=n.get_opt_str("l1"))
+        return bar__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> bar__c1:
+        if n != None:
+            return bar__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return bar__c1()
+
+
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=n.get_opt_str("l1"))
+        return foo__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c1:
+        if n != None:
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return foo__c1()
+
+
+class root(yang.adata.MNode):
+    bar_c1: bar__c1
+    foo_c1: foo__c1
+
+    mut def __init__(self, bar_c1: ?bar__c1=None, foo_c1: ?foo__c1=None):
+        self._ns = ""
+        if bar_c1 is not None:
+            self.bar_c1 = bar_c1
+        else:
+            self.bar_c1 = bar__c1()
+        self_bar_c1 = self.bar_c1
+        if self_bar_c1 is not None:
+            self_bar_c1._parent = self
+        if foo_c1 is not None:
+            self.foo_c1 = foo_c1
+        else:
+            self.foo_c1 = foo__c1()
+        self_foo_c1 = self.foo_c1
+        if self_foo_c1 is not None:
+            self_foo_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _bar_c1 = self.bar_c1
+        _foo_c1 = self.foo_c1
+        if _bar_c1 is not None:
+            children['bar:c1'] = _bar_c1.to_gdata()
+        if _foo_c1 is not None:
+            children['foo:c1'] = _foo_c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(bar_c1=bar__c1.from_gdata(n.get_opt_container("bar_c1")), foo_c1=foo__c1.from_gdata(n.get_opt_container("foo_c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(bar_c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "bar")), foo_c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "foo")))
+        return root()
+

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -134,6 +134,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "http://example.com/foo")))
         return root()
 

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -43,6 +43,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(l1=yang.gdata.from_xml_opt_int(n, "l1"), l2=yang.gdata.from_xml_opt_int(n, "l2"), l3=yang.gdata.from_xml_opt_int(n, "l3"), l4=yang.gdata.from_xml_opt_int(n, "l4"))
+            return root(l1=yang.gdata.from_xml_opt_int(n, "l1", "http://example.com/foo"), l2=yang.gdata.from_xml_opt_int(n, "l2", "http://example.com/foo"), l3=yang.gdata.from_xml_opt_int(n, "l3", "http://example.com/foo"), l4=yang.gdata.from_xml_opt_int(n, "l4", "http://example.com/foo"))
         return root()
 

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -28,6 +28,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+            return root(l1=yang.gdata.from_xml_opt_str(n, "l1", "http://example.com/foo"))
         return root()
 

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -10,7 +10,7 @@ from yang_foo import root as yang_foo_root
 import yang_basics
 
 def _test_mandatory1():
-    xml_text = """<data><tc1><l1>foo</l1></tc1></data>"""
+    xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1></data>"""
     # This should work, because we provide a value for the mandatory leaf l1
     r = yang_one.root.from_xml(xml.decode(xml_text))
     # This should not work
@@ -21,7 +21,7 @@ def _test_mandatory1():
 
 def _test_mandatory2():
     # This should work, because we provide a value for the mandatory leaf l1
-    xml_text = """<data><tc1><l1>foo</l1></tc1><li><name>foo</name><c1><l1>foo</l1></c1></li></data>"""
+    xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1><li xmlns="http://example.com/foo"><name>foo</name><c1><l1>foo</l1></c1></li></data>"""
     r = yang_one.root.from_xml(xml.decode(xml_text))
     # This should not work
     try:
@@ -179,6 +179,20 @@ def _test_foo_from_xml_leaf_ns():
 <c1 xmlns="http://example.com/foo">
   <l1>foo</l1>
   <l2 xmlns="http://example.com/bar">bar</l2>
+</c1>
+</data>"""
+    xml_in = xml.decode(xml_text)
+    d = yang_foo_root.from_xml(xml_in)
+    xml_out_text = d.to_gdata().to_xmlstr()
+    xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
+    #testing.assertEqual(xml_in.encode(), xml_out.encode())
+    return xml_out_text
+
+def _test_foo_from_xml_named_ns():
+    xml_text = """<data>
+<c1 xmlns="http://example.com/foo">
+  <l1>foo</l1>
+  <bar:l2 xmlns:bar="http://example.com/bar">bar</bar:l2>
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -102,6 +102,12 @@ def _test_foo_from_xml_full():
 <cc xmlns="http://example.com/foo">
   <cake>cake</cake>
 </cc>
+<conflict xmlns="http://example.com/foo">
+  <foo>foo-foo</foo>
+</conflict>
+<conflict xmlns="http://example.com/bar">
+  <foo>foo-bar</foo>
+</conflict>
 </data>"""
     xml_in = xml.decode(xml_text)
     d = yang_foo_root.from_xml(xml_in)

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -105,7 +105,9 @@ def _test_foo_from_xml_full():
 </data>"""
     xml_in = xml.decode(xml_text)
     d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    g = d.to_gdata()
+    print(g.prsrc(), err=True)
+    xml_out_text = g.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -80,6 +80,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, "c", "b")))
+            return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, "c", "http://example.com/basics")))
         return root()
 

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -80,6 +80,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, "c")))
+            return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, "c", "b")))
         return root()
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -131,7 +131,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l3=yang.gdata.from_xml_opt_int(n, "l3"), l_empty=yang.gdata.from_xml_opt_bool(n, "l_empty"), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, "li")), ll_uint64=yang.gdata.from_xml_opt_ints(n, "ll_uint64"), ll_str=yang.gdata.from_xml_opt_strs(n, "ll_str"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l3=yang.gdata.from_xml_opt_int(n, "l3"), l_empty=yang.gdata.from_xml_opt_bool(n, "l_empty"), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, "li")), ll_uint64=yang.gdata.from_xml_opt_ints(n, "ll_uint64"), ll_str=yang.gdata.from_xml_opt_strs(n, "ll_str"), l2=yang.gdata.from_xml_opt_str(n, "l2", "http://example.com/bar"))
         return foo__c1()
 
 
@@ -191,7 +191,7 @@ class foo__pc1(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
         if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, "foo", "foo")))
+            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, "foo")))
         return None
 
 
@@ -246,7 +246,7 @@ class foo__c_dot(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c_dot:
         if n != None:
-            return foo__c_dot(l_dot1=yang.gdata.from_xml_opt_str(n, "l.dot1"), l_dot2=yang.gdata.from_xml_opt_str(n, "l.dot2"))
+            return foo__c_dot(l_dot1=yang.gdata.from_xml_opt_str(n, "l.dot1"), l_dot2=yang.gdata.from_xml_opt_str(n, "l.dot2", "http://example.com/bar"))
         return foo__c_dot()
 
 
@@ -495,12 +495,12 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty_presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c_dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo_conflict")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar_conflict")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "bar")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "http://example.com/foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "http://example.com/foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "http://example.com/foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "http://example.com/foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/bar")))
         return root()
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -191,7 +191,7 @@ class foo__pc1(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
         if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, "foo")))
+            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, "foo", "foo")))
         return None
 
 
@@ -348,14 +348,70 @@ class foo__cc(yang.adata.MNode):
         return foo__cc()
 
 
+class foo__conflict(yang.adata.MNode):
+    foo: ?str
+
+    mut def __init__(self, foo: ?str):
+        self._ns = "http://example.com/foo"
+        self.foo = foo
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo = self.foo
+        if _foo is not None:
+            children['foo'] = yang.gdata.Leaf('string', _foo)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
+        if n != None:
+            return foo__conflict(foo=n.get_opt_str("foo"))
+        return foo__conflict()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__conflict:
+        if n != None:
+            return foo__conflict(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+        return foo__conflict()
+
+
+class bar__conflict(yang.adata.MNode):
+    foo: ?str
+
+    mut def __init__(self, foo: ?str):
+        self._ns = "http://example.com/bar"
+        self.foo = foo
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo = self.foo
+        if _foo is not None:
+            children['foo'] = yang.gdata.Leaf('string', _foo)
+        return yang.gdata.Container(children, ns='http://example.com/bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__conflict:
+        if n != None:
+            return bar__conflict(foo=n.get_opt_str("foo"))
+        return bar__conflict()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> bar__conflict:
+        if n != None:
+            return bar__conflict(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+        return bar__conflict()
+
+
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1
     empty_presence: ?foo__empty_presence
     c_dot: foo__c_dot
     cc: foo__cc
+    foo_conflict: foo__conflict
+    bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, bar_conflict: ?bar__conflict=None):
         self._ns = ""
         if c1 is not None:
             self.c1 = c1
@@ -386,6 +442,20 @@ class root(yang.adata.MNode):
         self_cc = self.cc
         if self_cc is not None:
             self_cc._parent = self
+        if foo_conflict is not None:
+            self.foo_conflict = foo_conflict
+        else:
+            self.foo_conflict = foo__conflict()
+        self_foo_conflict = self.foo_conflict
+        if self_foo_conflict is not None:
+            self_foo_conflict._parent = self
+        if bar_conflict is not None:
+            self.bar_conflict = bar_conflict
+        else:
+            self.bar_conflict = bar__conflict()
+        self_bar_conflict = self.bar_conflict
+        if self_bar_conflict is not None:
+            self_bar_conflict._parent = self
 
     mut def create_pc1(self):
         res = foo__pc1()
@@ -404,6 +474,8 @@ class root(yang.adata.MNode):
         _empty_presence = self.empty_presence
         _c_dot = self.c_dot
         _cc = self.cc
+        _foo_conflict = self.foo_conflict
+        _bar_conflict = self.bar_conflict
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
         if _pc1 is not None:
@@ -414,17 +486,21 @@ class root(yang.adata.MNode):
             children['c.dot'] = _c_dot.to_gdata()
         if _cc is not None:
             children['cc'] = _cc.to_gdata()
+        if _foo_conflict is not None:
+            children['foo:conflict'] = _foo_conflict.to_gdata()
+        if _bar_conflict is not None:
+            children['bar:conflict'] = _bar_conflict.to_gdata()
         return yang.gdata.Root(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty_presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c_dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo_conflict")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar_conflict")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "bar")))
         return root()
 

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -170,6 +170,6 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(tc1=foo__tc1.from_xml(yang.gdata.get_xml_child(n, "tc1")), li=foo__li.from_xml(yang.gdata.get_xml_children(n, "li")))
+            return root(tc1=foo__tc1.from_xml(yang.gdata.get_xml_child(n, "tc1", "http://example.com/foo")), li=foo__li.from_xml(yang.gdata.get_xml_children(n, "li", "http://example.com/foo")))
         raise ValueError("Missing required subtree root")
 

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_named_ns
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_named_ns
@@ -1,0 +1,4 @@
+<c1 xmlns="http://example.com/foo">
+  <l1>foo</l1>
+  <l2 xmlns="http://example.com/bar">bar</l2>
+</c1>

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -106,6 +106,11 @@ ys_foo = """module foo {
             mandatory true;
         }
     }
+    container conflict {
+        leaf foo {
+            type string;
+        }
+    }
 }"""
 
 ys_bar = """module bar {
@@ -122,6 +127,11 @@ ys_bar = """module bar {
     }
     augment /foo:c.dot {
         leaf l.dot2 {
+            type string;
+        }
+    }
+    container conflict {
+        leaf foo {
             type string;
         }
     }


### PR DESCRIPTION
Add module prefix where needed! As a side-effect of changing XML node lookup to include namespaces, we now require the input XML to include namespace on namespace change. This includes the top-level nodes, so some tests needed to be adjusted where the namespace was missing.