### PR TITLE
Restore (list key) child order in adata

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -322,7 +322,7 @@ class DNodeInner(DNode):
                 child_name_conflicts.add(child.name)
             else:
                 child_names.add(child.name)
-
+        self.children = new_children
 
         def _unique_name(name: str, prefix: str) -> str:
             if name not in child_name_conflicts:

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1733,6 +1733,26 @@ def _test_prdaclass_list_key_mandatory():
     src = l1.prdaclass(top=False)
     return src
 
+def _test_prdaclass_list_key_reorder():
+    ys = """module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    list l1 {
+        key name;
+        leaf id {
+            type string;
+        }
+        leaf name {
+            type string;
+        }
+    }
+}"""
+    root = yang.compile([ys])
+    l1 = root.get("l1")
+    src = l1.prdaclass(top=False)
+    return src
+
 def _test_prdaclass_top_conflict():
     ys_foo = """module foo {
     yang-version "1.1";

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -318,7 +318,7 @@ class DNodeInner(DNode):
                 child_name_conflicts.add(child.name)
             else:
                 child_names.add(child.name)
-
+        self.children = new_children
 
         def _unique_name(name: str, prefix: str) -> str:
             if name not in child_name_conflicts:

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -1,0 +1,70 @@
+class foo__l1_entry(yang.adata.MNode):
+    name: str
+    id: ?str
+
+    mut def __init__(self, name: str, id: ?str):
+        self._ns = "http://example.com/foo"
+        self.name = name
+        self.id = id
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _name = self.name
+        _id = self.id
+        if _name is not None:
+            children['name'] = yang.gdata.Leaf('string', _name)
+        if _id is not None:
+            children['id'] = yang.gdata.Leaf('string', _id)
+        return yang.gdata.ListElement([yang.gdata.yang_str(self.name)], children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
+        return foo__l1_entry(name=n.get_str("name"), id=n.get_opt_str("id"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> foo__l1_entry:
+        return foo__l1_entry(name=yang.gdata.from_xml_str(n, "name"), id=yang.gdata.from_xml_opt_str(n, "id"))
+
+class foo__l1(yang.adata.MNode):
+    elements: list[foo__l1_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/foo"
+        self._name = 'l1'
+        self.elements = elements
+
+    mut def create(self, name):
+        for e in self.elements:
+            match = True
+            if e.name != name:
+                match = False
+                break
+            if match:
+                return e
+
+        res = foo__l1_entry(name)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                elements.append(e_gdata)
+        return yang.gdata.List(['name'], elements, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__l1_entry]:
+        res = []
+        if n is not None:
+            for e in n.elements:
+                res.append(foo__l1_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[foo__l1_entry]:
+        res = []
+        for node in nodes:
+            res.append(foo__l1_entry.from_xml(node))
+        return res
+

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -569,7 +569,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), special=foo__special.from_gdata(n.get_list("special")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), special=foo__special.from_gdata(n.get_opt_list("special")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
         return root()
 
     @staticmethod


### PR DESCRIPTION
The child reordering "tweak" got lost in the avoid-collisions change, but it is now back, along with a test case to prove it works!