### PR TITLE
Fix conflicting augments

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2219,18 +2219,68 @@ def _safe_name(name: str) -> str:
     return new
 
 def get_path_name(dnode: DNode) -> str:
-    """
+    """Build the adata path name for a data node
+
+    For example, for the following YANG model:
+
+    module foo {
+      prefix foo;
+      container bar {
+        leaf baz {
+          type string;
+        }
+      }
+    }
+
+    the path name for the baz leaf is "foo__bar__baz".
+
+    This function detects conflicting names across sibling nodes. If we add
+    another module that augments a conflicting node like this:
+
+    module m2 {
+      import foo { prefix foo; }
+      augment /foo:bar {
+        leaf baz {
+          type string;
+        }
+      }
+    }
+
+    Then the path name for the baz leaves in the two modules is:
+    - foo__bar__foo_baz
+    - foo__bar__m2_baz
+
+    We do not rewrite the builtin keywords here (see _safe_name()) because it
+    is not necessary.
     """
     path = []
     while True:
-        path.append(dnode.name.replace("-", "_").replace(".", "_"))
+        self_unique_name = dnode.name
         parent = dnode.parent
+        # if parent is not None then of course it is DNodeInner (= has children
+        # attribute), but let's make that explicit for the compiler ...
         if parent is not None:
-            dnode = parent
-        else:
+            if isinstance(parent, DNodeInner):
+                sibling_names = set()
+                sibling_names_conflicts = set()
+                for sibling in parent.children:
+                    if sibling.name in sibling_names:
+                        sibling_names_conflicts.add(sibling.name)
+                    else:
+                        sibling_names.add(sibling.name)
+                if dnode.name not in sibling_names_conflicts:
+                    self_unique_name = dnode.name
+                else:
+                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
+                dnode = parent
+        path.append(self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_"))
+        if parent is None:
             break
+
+    # This never happens, we always get at least our name!
     if len(path) == 0:
         raise ValueError("No path for DNode" + str(dnode))
+
     return "__".join(reversed(path))
 
 

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1820,6 +1820,41 @@ def _test_prdaclass_augment_name_conflict():
     src = c1.prdaclass(top=False)
     return src
 
+def _test_prdaclass_augment_inner_name_conflict():
+    ys_base = """module base {
+    yang-version "1.1";
+    namespace "http://example.com/base";
+    prefix "base";
+    container c1 {
+        container c2 {
+            leaf foo {
+                type string;
+            }
+        }
+    }
+}"""
+
+    ys_foo = """module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    import base {
+      prefix "b";
+    }
+    augment "/b:c1" {
+        container c2 {
+            leaf foo {
+                type string;
+            }
+        }
+    }
+}"""
+
+    root = yang.compile([ys_base, ys_foo])
+    # c2 = root.get("c2")
+    src = root.prdaclass(top=False)
+    return src
+
 def _test_prdaclass_top_container_from_xml_opt():
     ys_base = """module foo {
     yang-version "1.1";

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1855,6 +1855,42 @@ def _test_prdaclass_augment_inner_name_conflict():
     src = root.prdaclass(top=False)
     return src
 
+def _test_prdaclass_augment_inner_list_conflict():
+    ys_base = """module base {
+    yang-version "1.1";
+    namespace "http://example.com/base";
+    prefix "base";
+    container c1 {
+        list l1 {
+            key k1;
+            leaf k1 {
+                type string;
+            }
+        }
+    }
+}"""
+
+    ys_foo = """module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    import base {
+      prefix "b";
+    }
+    augment "/b:c1" {
+        list l1 {
+            key k2;
+            leaf k2 {
+                type string;
+            }
+        }
+    }
+}"""
+
+    root = yang.compile([ys_base, ys_foo])
+    src = root.prdaclass(top=False)
+    return src
+
 def _test_prdaclass_top_container_from_xml_opt():
     ys_base = """module foo {
     yang-version "1.1";

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2215,18 +2215,68 @@ def _safe_name(name: str) -> str:
     return new
 
 def get_path_name(dnode: DNode) -> str:
-    """
+    """Build the adata path name for a data node
+
+    For example, for the following YANG model:
+
+    module foo {
+      prefix foo;
+      container bar {
+        leaf baz {
+          type string;
+        }
+      }
+    }
+
+    the path name for the baz leaf is "foo__bar__baz".
+
+    This function detects conflicting names across sibling nodes. If we add
+    another module that augments a conflicting node like this:
+
+    module m2 {
+      import foo { prefix foo; }
+      augment /foo:bar {
+        leaf baz {
+          type string;
+        }
+      }
+    }
+
+    Then the path name for the baz leaves in the two modules is:
+    - foo__bar__foo_baz
+    - foo__bar__m2_baz
+
+    We do not rewrite the builtin keywords here (see _safe_name()) because it
+    is not necessary.
     """
     path = []
     while True:
-        path.append(dnode.name.replace("-", "_").replace(".", "_"))
+        self_unique_name = dnode.name
         parent = dnode.parent
+        # if parent is not None then of course it is DNodeInner (= has children
+        # attribute), but let's make that explicit for the compiler ...
         if parent is not None:
-            dnode = parent
-        else:
+            if isinstance(parent, DNodeInner):
+                sibling_names = set()
+                sibling_names_conflicts = set()
+                for sibling in parent.children:
+                    if sibling.name in sibling_names:
+                        sibling_names_conflicts.add(sibling.name)
+                    else:
+                        sibling_names.add(sibling.name)
+                if dnode.name not in sibling_names_conflicts:
+                    self_unique_name = dnode.name
+                else:
+                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
+                dnode = parent
+        path.append(self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_"))
+        if parent is None:
             break
+
+    # This never happens, we always get at least our name!
     if len(path) == 0:
         raise ValueError("No path for DNode" + str(dnode))
+
     return "__".join(reversed(path))
 
 

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -1,4 +1,4 @@
-mut def from_json_base__c1__l1__k1(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__base_l1__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
 class base__c1__base_l1_entry(yang.adata.MNode):
@@ -118,7 +118,7 @@ mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata
     child_k1_full = jd.get('base:k1')
     child_k1 = child_k1_full if child_k1_full is not None else jd.get('k1')
     if child_k1 is not None:
-        children['k1'] = from_json_base__c1__l1__k1(child_k1)
+        children['k1'] = from_json_base__c1__base_l1__k1(child_k1)
     return yang.gdata.ListElement([str(child_k1 if child_k1 is not None else "")], children)
 
 mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
@@ -143,7 +143,7 @@ mut def to_json_base__c1__base_l1(n: yang.gdata.List) -> list[dict[str, ?value]]
     return elements
 
 
-mut def from_json_base__c1__l1__k2(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__foo_l1__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
 class base__c1__foo_l1_entry(yang.adata.MNode):
@@ -263,7 +263,7 @@ mut def from_json_base__c1__foo_l1_element(jd: dict[str, ?value]) -> yang.gdata.
     child_k2_full = jd.get('foo:k2')
     child_k2 = child_k2_full if child_k2_full is not None else jd.get('k2')
     if child_k2 is not None:
-        children['k2'] = from_json_base__c1__l1__k2(child_k2)
+        children['k2'] = from_json_base__c1__foo_l1__k2(child_k2)
     return yang.gdata.ListElement([str(child_k2 if child_k2 is not None else "")], children)
 
 mut def from_json_base__c1__foo_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -1,0 +1,433 @@
+mut def from_json_base__c1__l1__k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class base__c1__base_l1_entry(yang.adata.MNode):
+    k1: str
+
+    mut def __init__(self, k1: str):
+        self._ns = "http://example.com/base"
+        self.k1 = k1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _k1 = self.k1
+        if _k1 is not None:
+            children['k1'] = yang.gdata.Leaf('string', _k1)
+        return yang.gdata.ListElement([yang.gdata.yang_str(self.k1)], children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
+        return base__c1__base_l1_entry(k1=n.get_str("k1"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> base__c1__base_l1_entry:
+        return base__c1__base_l1_entry(k1=yang.gdata.from_xml_str(n, "k1"))
+
+class base__c1__base_l1(yang.adata.MNode):
+    elements: list[base__c1__base_l1_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/base"
+        self._name = 'l1'
+        self.elements = elements
+
+    mut def create(self, k1):
+        for e in self.elements:
+            match = True
+            if e.k1 != k1:
+                match = False
+                continue
+            if match:
+                return e
+
+        res = base__c1__base_l1_entry(k1)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                elements.append(e_gdata)
+        return yang.gdata.List(['k1'], elements)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[base__c1__base_l1_entry]:
+        res = []
+        if n is not None:
+            for e in n.elements:
+                res.append(base__c1__base_l1_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[base__c1__base_l1_entry]:
+        res = []
+        for node in nodes:
+            res.append(base__c1__base_l1_entry.from_xml(node))
+        return res
+
+
+mut def from_json_path_base__c1__base_l1_element(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.ListElement:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        val = from_json_base__c1__base_l1_element(jd_dict)
+        if op == "merge":
+            return val
+        elif op == "remove":
+            return yang.gdata.AbsentListElement(val.key_vals)
+        raise ValueError("Invalid operation")
+    elif len(path) > 1:
+        keys = path[0].split(",")
+        point = path[1]
+        rest_path = path[2:]
+        children: dict[str, yang.gdata.Node] = {}
+        for idx, key in enumerate(['k1']):
+            children[key] = yang.gdata.Leaf("str", keys[idx])
+        return yang.gdata.ListElement(keys, children)
+    raise ValueError("unreachable - no keys to list element")
+
+mut def from_json_path_base__c1__base_l1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.List:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        # Check that all keys are present in payload.
+        # If present, they must equal the keys in the path
+        # If not present, fill in from path
+        for key in ['k1']:
+            if key not in jd_dict:
+                jd_dict[key] = keys.pop(0)
+            else:
+                if str(jd_dict[key]) != keys.pop(0):
+                    raise ValueError("Key value mismatch between path and payload")
+        element = from_json_base__c1__base_l1_element(jd_dict)
+        elements = []
+        if op == "merge":
+            elements.append(element)
+        elif op == "remove":
+            elements.append(yang.gdata.AbsentListElement(element.key_vals))
+        return yang.gdata.List(['k1'], elements)
+    elif len(path) > 1:
+        return yang.gdata.List(['k1'], [from_json_path_base__c1__base_l1_element(jd, path, op)])
+    raise ValueError("Unable to resolve path, no keys provided")
+
+mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata.ListElement:
+    children = {}
+    child_k1_full = jd.get('base:k1')
+    child_k1 = child_k1_full if child_k1_full is not None else jd.get('k1')
+    if child_k1 is not None:
+        children['k1'] = from_json_base__c1__l1__k1(child_k1)
+    return yang.gdata.ListElement([str(child_k1 if child_k1 is not None else "")], children)
+
+mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
+    elements = []
+    for e in jd:
+        if isinstance(e, dict):
+            elements.append(from_json_base__c1__base_l1_element(e))
+    return yang.gdata.List(keys=['k1'], elements=elements, user_order=False, ns=None, prefix=None)
+
+mut def to_json_base__c1__base_l1_element(n: yang.gdata.ListElement) -> dict[str, ?value]:
+    children = {}
+    child_k1 = n.children.get('k1')
+    if child_k1 is not None:
+        if isinstance(child_k1, yang.gdata.Leaf):
+            children['k1'] = child_k1.val
+    return children
+
+mut def to_json_base__c1__base_l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
+    elements = []
+    for e in n.elements:
+        elements.append(to_json_base__c1__base_l1_element(e))
+    return elements
+
+
+mut def from_json_base__c1__l1__k2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class base__c1__foo_l1_entry(yang.adata.MNode):
+    k2: str
+
+    mut def __init__(self, k2: str):
+        self._ns = "http://example.com/foo"
+        self.k2 = k2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _k2 = self.k2
+        if _k2 is not None:
+            children['k2'] = yang.gdata.Leaf('string', _k2)
+        return yang.gdata.ListElement([yang.gdata.yang_str(self.k2)], children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> base__c1__foo_l1_entry:
+        return base__c1__foo_l1_entry(k2=n.get_str("k2"))
+
+    @staticmethod
+    mut def from_xml(n: xml.Node) -> base__c1__foo_l1_entry:
+        return base__c1__foo_l1_entry(k2=yang.gdata.from_xml_str(n, "k2"))
+
+class base__c1__foo_l1(yang.adata.MNode):
+    elements: list[base__c1__foo_l1_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = "http://example.com/foo"
+        self._name = 'l1'
+        self.elements = elements
+
+    mut def create(self, k2):
+        for e in self.elements:
+            match = True
+            if e.k2 != k2:
+                match = False
+                continue
+            if match:
+                return e
+
+        res = base__c1__foo_l1_entry(k2)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.ListElement):
+                elements.append(e_gdata)
+        return yang.gdata.List(['k2'], elements, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[base__c1__foo_l1_entry]:
+        res = []
+        if n is not None:
+            for e in n.elements:
+                res.append(base__c1__foo_l1_entry.from_gdata(e))
+        return res
+
+    @staticmethod
+    mut def from_xml(nodes: list[xml.Node]) -> list[base__c1__foo_l1_entry]:
+        res = []
+        for node in nodes:
+            res.append(base__c1__foo_l1_entry.from_xml(node))
+        return res
+
+
+mut def from_json_path_base__c1__foo_l1_element(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.ListElement:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        val = from_json_base__c1__foo_l1_element(jd_dict)
+        if op == "merge":
+            return val
+        elif op == "remove":
+            return yang.gdata.AbsentListElement(val.key_vals)
+        raise ValueError("Invalid operation")
+    elif len(path) > 1:
+        keys = path[0].split(",")
+        point = path[1]
+        rest_path = path[2:]
+        children: dict[str, yang.gdata.Node] = {}
+        for idx, key in enumerate(['k2']):
+            children[key] = yang.gdata.Leaf("str", keys[idx])
+        return yang.gdata.ListElement(keys, children)
+    raise ValueError("unreachable - no keys to list element")
+
+mut def from_json_path_base__c1__foo_l1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.List:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        # Check that all keys are present in payload.
+        # If present, they must equal the keys in the path
+        # If not present, fill in from path
+        for key in ['k2']:
+            if key not in jd_dict:
+                jd_dict[key] = keys.pop(0)
+            else:
+                if str(jd_dict[key]) != keys.pop(0):
+                    raise ValueError("Key value mismatch between path and payload")
+        element = from_json_base__c1__foo_l1_element(jd_dict)
+        elements = []
+        if op == "merge":
+            elements.append(element)
+        elif op == "remove":
+            elements.append(yang.gdata.AbsentListElement(element.key_vals))
+        return yang.gdata.List(['k2'], elements)
+    elif len(path) > 1:
+        return yang.gdata.List(['k2'], [from_json_path_base__c1__foo_l1_element(jd, path, op)])
+    raise ValueError("Unable to resolve path, no keys provided")
+
+mut def from_json_base__c1__foo_l1_element(jd: dict[str, ?value]) -> yang.gdata.ListElement:
+    children = {}
+    child_k2_full = jd.get('foo:k2')
+    child_k2 = child_k2_full if child_k2_full is not None else jd.get('k2')
+    if child_k2 is not None:
+        children['k2'] = from_json_base__c1__l1__k2(child_k2)
+    return yang.gdata.ListElement([str(child_k2 if child_k2 is not None else "")], children)
+
+mut def from_json_base__c1__foo_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
+    elements = []
+    for e in jd:
+        if isinstance(e, dict):
+            elements.append(from_json_base__c1__foo_l1_element(e))
+    return yang.gdata.List(keys=['k2'], elements=elements, user_order=False, ns=None, prefix=None)
+
+mut def to_json_base__c1__foo_l1_element(n: yang.gdata.ListElement) -> dict[str, ?value]:
+    children = {}
+    child_k2 = n.children.get('k2')
+    if child_k2 is not None:
+        if isinstance(child_k2, yang.gdata.Leaf):
+            children['k2'] = child_k2.val
+    return children
+
+mut def to_json_base__c1__foo_l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
+    elements = []
+    for e in n.elements:
+        elements.append(to_json_base__c1__foo_l1_element(e))
+    return elements
+
+
+class base__c1(yang.adata.MNode):
+    base_l1: base__c1__base_l1
+    foo_l1: base__c1__foo_l1
+
+    mut def __init__(self, base_l1: list[base__c1__base_l1_entry]=[], foo_l1: list[base__c1__foo_l1_entry]=[]):
+        self._ns = "http://example.com/base"
+        self.base_l1 = base__c1__base_l1(elements=base_l1)
+        self.base_l1._parent = self
+        self.foo_l1 = base__c1__foo_l1(elements=foo_l1)
+        self.foo_l1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _base_l1 = self.base_l1
+        _foo_l1 = self.foo_l1
+        if _base_l1 is not None:
+            children['base:l1'] = _base_l1.to_gdata()
+        if _foo_l1 is not None:
+            children['foo:l1'] = _foo_l1.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/base')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1:
+        if n != None:
+            return base__c1(base_l1=base__c1__base_l1.from_gdata(n.get_opt_list("base:l1")), foo_l1=base__c1__foo_l1.from_gdata(n.get_opt_list("foo:l1")))
+        return base__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> base__c1:
+        if n != None:
+            return base__c1(base_l1=base__c1__base_l1.from_xml(yang.gdata.get_xml_children(n, "l1")), foo_l1=base__c1__foo_l1.from_xml(yang.gdata.get_xml_children(n, "l1", "http://example.com/foo")))
+        return base__c1()
+
+
+mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:l1':
+            child = {'l1': from_json_path_base__c1__base_l1(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        if point == 'foo:l1':
+            child = {'l1': from_json_path_base__c1__foo_l1(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__c1(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_base_l1 = jd.get('base:l1')
+    if child_base_l1 is not None and isinstance(child_base_l1, list):
+        children['l1'] = from_json_base__c1__base_l1(child_base_l1)
+    child_foo_l1 = jd.get('foo:l1')
+    if child_foo_l1 is not None and isinstance(child_foo_l1, list):
+        children['l1'] = from_json_base__c1__foo_l1(child_foo_l1)
+    return yang.gdata.Container(children)
+
+mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_base_l1 = n.children.get('l1')
+    if child_base_l1 is not None:
+        if isinstance(child_base_l1, yang.gdata.List):
+            children['l1'] = to_json_base__c1__base_l1(child_base_l1)
+    child_foo_l1 = n.children.get('l1')
+    if child_foo_l1 is not None:
+        if isinstance(child_foo_l1, yang.gdata.List):
+            children['foo:l1'] = to_json_base__c1__foo_l1(child_foo_l1)
+    return children
+
+
+class root(yang.adata.MNode):
+    c1: base__c1
+
+    mut def __init__(self, c1: ?base__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = base__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=base__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=base__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/base")))
+        return root()
+
+
+mut def from_json_path_root(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:c1' or point == 'c1':
+            child = {'c1': from_json_path_base__c1(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_root(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_root(jd: dict[str, ?value]) -> yang.gdata.Root:
+    children = {}
+    child_c1_full = jd.get('base:c1')
+    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    if child_c1 is not None and isinstance(child_c1, dict):
+        children['c1'] = from_json_base__c1(child_c1)
+    return yang.gdata.Root(children)
+
+mut def to_json_root(n: yang.gdata.Root) -> dict[str, ?value]:
+    children = {}
+    child_c1 = n.children.get('c1')
+    if child_c1 is not None:
+        if isinstance(child_c1, yang.gdata.Container):
+            children['base:c1'] = to_json_base__c1(child_c1)
+    return children
+

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -1,7 +1,7 @@
-mut def from_json_base__c1__c2__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__base_c2__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class base__c1__c2(yang.adata.MNode):
+class base__c1__base_c2(yang.adata.MNode):
     foo: ?str
 
     mut def __init__(self, foo: ?str):
@@ -16,19 +16,19 @@ class base__c1__c2(yang.adata.MNode):
         return yang.gdata.Container(children)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1__c2:
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1__base_c2:
         if n != None:
-            return base__c1__c2(foo=n.get_opt_str("foo"))
-        return base__c1__c2()
+            return base__c1__base_c2(foo=n.get_opt_str("foo"))
+        return base__c1__base_c2()
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1__c2:
+    mut def from_xml(n: ?xml.Node) -> base__c1__base_c2:
         if n != None:
-            return base__c1__c2(foo=yang.gdata.from_xml_opt_str(n, "foo"))
-        return base__c1__c2()
+            return base__c1__base_c2(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+        return base__c1__base_c2()
 
 
-mut def from_json_path_base__c1__c2(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_base__c1__base_c2(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -38,21 +38,21 @@ mut def from_json_path_base__c1__c2(jd: value, path: list[str]=[], op: ?str="mer
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_base__c1__c2(yang.gdata.unwrap_dict(jd))
+            return from_json_base__c1__base_c2(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_base__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_base__c1__base_c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo_full = jd.get('base:foo')
     child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
     if child_foo is not None:
-        children['foo'] = from_json_base__c1__c2__foo(child_foo)
+        children['foo'] = from_json_base__c1__base_c2__foo(child_foo)
     return yang.gdata.Container(children)
 
-mut def to_json_base__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_base__c1__base_c2(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     child_foo = n.children.get('foo')
     if child_foo is not None:
@@ -61,10 +61,10 @@ mut def to_json_base__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
     return children
 
 
-mut def from_json_base__c1__c2__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__foo_c2__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class base__c1__c2(yang.adata.MNode):
+class base__c1__foo_c2(yang.adata.MNode):
     foo: ?str
 
     mut def __init__(self, foo: ?str):
@@ -79,19 +79,19 @@ class base__c1__c2(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1__c2:
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1__foo_c2:
         if n != None:
-            return base__c1__c2(foo=n.get_opt_str("foo"))
-        return base__c1__c2()
+            return base__c1__foo_c2(foo=n.get_opt_str("foo"))
+        return base__c1__foo_c2()
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1__c2:
+    mut def from_xml(n: ?xml.Node) -> base__c1__foo_c2:
         if n != None:
-            return base__c1__c2(foo=yang.gdata.from_xml_opt_str(n, "foo"))
-        return base__c1__c2()
+            return base__c1__foo_c2(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+        return base__c1__foo_c2()
 
 
-mut def from_json_path_base__c1__c2(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_base__c1__foo_c2(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -101,21 +101,21 @@ mut def from_json_path_base__c1__c2(jd: value, path: list[str]=[], op: ?str="mer
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_base__c1__c2(yang.gdata.unwrap_dict(jd))
+            return from_json_base__c1__foo_c2(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_base__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_base__c1__foo_c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo_full = jd.get('foo:foo')
     child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
     if child_foo is not None:
-        children['foo'] = from_json_base__c1__c2__foo(child_foo)
+        children['foo'] = from_json_base__c1__foo_c2__foo(child_foo)
     return yang.gdata.Container(children)
 
-mut def to_json_base__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_base__c1__foo_c2(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     child_foo = n.children.get('foo')
     if child_foo is not None:
@@ -125,22 +125,22 @@ mut def to_json_base__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
 
 
 class base__c1(yang.adata.MNode):
-    base_c2: base__c1__c2
-    foo_c2: base__c1__c2
+    base_c2: base__c1__base_c2
+    foo_c2: base__c1__foo_c2
 
-    mut def __init__(self, base_c2: ?base__c1__c2=None, foo_c2: ?base__c1__c2=None):
+    mut def __init__(self, base_c2: ?base__c1__base_c2=None, foo_c2: ?base__c1__foo_c2=None):
         self._ns = "http://example.com/base"
         if base_c2 is not None:
             self.base_c2 = base_c2
         else:
-            self.base_c2 = base__c1__c2()
+            self.base_c2 = base__c1__base_c2()
         self_base_c2 = self.base_c2
         if self_base_c2 is not None:
             self_base_c2._parent = self
         if foo_c2 is not None:
             self.foo_c2 = foo_c2
         else:
-            self.foo_c2 = base__c1__c2()
+            self.foo_c2 = base__c1__foo_c2()
         self_foo_c2 = self.foo_c2
         if self_foo_c2 is not None:
             self_foo_c2._parent = self
@@ -158,13 +158,13 @@ class base__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__c1:
         if n != None:
-            return base__c1(base_c2=base__c1__c2.from_gdata(n.get_opt_container("base:c2")), foo_c2=base__c1__c2.from_gdata(n.get_opt_container("foo:c2")))
+            return base__c1(base_c2=base__c1__base_c2.from_gdata(n.get_opt_container("base:c2")), foo_c2=base__c1__foo_c2.from_gdata(n.get_opt_container("foo:c2")))
         return base__c1()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> base__c1:
         if n != None:
-            return base__c1(base_c2=base__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")), foo_c2=base__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2", "http://example.com/foo")))
+            return base__c1(base_c2=base__c1__base_c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")), foo_c2=base__c1__foo_c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2", "http://example.com/foo")))
         return base__c1()
 
 
@@ -174,10 +174,10 @@ mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str="merge")
         point = path[0]
         rest_path = path[1:]
         if point == 'base:c2':
-            child = {'c2': from_json_path_base__c1__c2(jd, rest_path, op) }
+            child = {'c2': from_json_path_base__c1__base_c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:c2':
-            child = {'c2': from_json_path_base__c1__c2(jd, rest_path, op) }
+            child = {'c2': from_json_path_base__c1__foo_c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -192,10 +192,10 @@ mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_base_c2 = jd.get('base:c2')
     if child_base_c2 is not None and isinstance(child_base_c2, dict):
-        children['c2'] = from_json_base__c1__c2(child_base_c2)
+        children['c2'] = from_json_base__c1__base_c2(child_base_c2)
     child_foo_c2 = jd.get('foo:c2')
     if child_foo_c2 is not None and isinstance(child_foo_c2, dict):
-        children['c2'] = from_json_base__c1__c2(child_foo_c2)
+        children['c2'] = from_json_base__c1__foo_c2(child_foo_c2)
     return yang.gdata.Container(children)
 
 mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
@@ -203,11 +203,11 @@ mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
     child_base_c2 = n.children.get('c2')
     if child_base_c2 is not None:
         if isinstance(child_base_c2, yang.gdata.Container):
-            children['c2'] = to_json_base__c1__c2(child_base_c2)
+            children['c2'] = to_json_base__c1__base_c2(child_base_c2)
     child_foo_c2 = n.children.get('c2')
     if child_foo_c2 is not None:
         if isinstance(child_foo_c2, yang.gdata.Container):
-            children['foo:c2'] = to_json_base__c1__c2(child_foo_c2)
+            children['foo:c2'] = to_json_base__c1__foo_c2(child_foo_c2)
     return children
 
 

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -1,0 +1,279 @@
+mut def from_json_base__c1__c2__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class base__c1__c2(yang.adata.MNode):
+    foo: ?str
+
+    mut def __init__(self, foo: ?str):
+        self._ns = "http://example.com/base"
+        self.foo = foo
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo = self.foo
+        if _foo is not None:
+            children['foo'] = yang.gdata.Leaf('string', _foo)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1__c2:
+        if n != None:
+            return base__c1__c2(foo=n.get_opt_str("foo"))
+        return base__c1__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> base__c1__c2:
+        if n != None:
+            return base__c1__c2(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+        return base__c1__c2()
+
+
+mut def from_json_path_base__c1__c2(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:foo' or point == 'foo':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__c1__c2(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_full = jd.get('base:foo')
+    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    if child_foo is not None:
+        children['foo'] = from_json_base__c1__c2__foo(child_foo)
+    return yang.gdata.Container(children)
+
+mut def to_json_base__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_foo = n.children.get('foo')
+    if child_foo is not None:
+        if isinstance(child_foo, yang.gdata.Leaf):
+            children['foo'] = child_foo.val
+    return children
+
+
+mut def from_json_base__c1__c2__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class base__c1__c2(yang.adata.MNode):
+    foo: ?str
+
+    mut def __init__(self, foo: ?str):
+        self._ns = "http://example.com/foo"
+        self.foo = foo
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo = self.foo
+        if _foo is not None:
+            children['foo'] = yang.gdata.Leaf('string', _foo)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1__c2:
+        if n != None:
+            return base__c1__c2(foo=n.get_opt_str("foo"))
+        return base__c1__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> base__c1__c2:
+        if n != None:
+            return base__c1__c2(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+        return base__c1__c2()
+
+
+mut def from_json_path_base__c1__c2(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:foo' or point == 'foo':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__c1__c2(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_full = jd.get('foo:foo')
+    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    if child_foo is not None:
+        children['foo'] = from_json_base__c1__c2__foo(child_foo)
+    return yang.gdata.Container(children)
+
+mut def to_json_base__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_foo = n.children.get('foo')
+    if child_foo is not None:
+        if isinstance(child_foo, yang.gdata.Leaf):
+            children['foo'] = child_foo.val
+    return children
+
+
+class base__c1(yang.adata.MNode):
+    base_c2: base__c1__c2
+    foo_c2: base__c1__c2
+
+    mut def __init__(self, base_c2: ?base__c1__c2=None, foo_c2: ?base__c1__c2=None):
+        self._ns = "http://example.com/base"
+        if base_c2 is not None:
+            self.base_c2 = base_c2
+        else:
+            self.base_c2 = base__c1__c2()
+        self_base_c2 = self.base_c2
+        if self_base_c2 is not None:
+            self_base_c2._parent = self
+        if foo_c2 is not None:
+            self.foo_c2 = foo_c2
+        else:
+            self.foo_c2 = base__c1__c2()
+        self_foo_c2 = self.foo_c2
+        if self_foo_c2 is not None:
+            self_foo_c2._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _base_c2 = self.base_c2
+        _foo_c2 = self.foo_c2
+        if _base_c2 is not None:
+            children['base:c2'] = _base_c2.to_gdata()
+        if _foo_c2 is not None:
+            children['foo:c2'] = _foo_c2.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/base')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__c1:
+        if n != None:
+            return base__c1(base_c2=base__c1__c2.from_gdata(n.get_opt_container("base:c2")), foo_c2=base__c1__c2.from_gdata(n.get_opt_container("foo:c2")))
+        return base__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> base__c1:
+        if n != None:
+            return base__c1(base_c2=base__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2")), foo_c2=base__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, "c2", "http://example.com/foo")))
+        return base__c1()
+
+
+mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:c2':
+            child = {'c2': from_json_path_base__c1__c2(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        if point == 'foo:c2':
+            child = {'c2': from_json_path_base__c1__c2(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__c1(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_base_c2 = jd.get('base:c2')
+    if child_base_c2 is not None and isinstance(child_base_c2, dict):
+        children['c2'] = from_json_base__c1__c2(child_base_c2)
+    child_foo_c2 = jd.get('foo:c2')
+    if child_foo_c2 is not None and isinstance(child_foo_c2, dict):
+        children['c2'] = from_json_base__c1__c2(child_foo_c2)
+    return yang.gdata.Container(children)
+
+mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_base_c2 = n.children.get('c2')
+    if child_base_c2 is not None:
+        if isinstance(child_base_c2, yang.gdata.Container):
+            children['c2'] = to_json_base__c1__c2(child_base_c2)
+    child_foo_c2 = n.children.get('c2')
+    if child_foo_c2 is not None:
+        if isinstance(child_foo_c2, yang.gdata.Container):
+            children['foo:c2'] = to_json_base__c1__c2(child_foo_c2)
+    return children
+
+
+class root(yang.adata.MNode):
+    c1: base__c1
+
+    mut def __init__(self, c1: ?base__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = base__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=base__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=base__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/base")))
+        return root()
+
+
+mut def from_json_path_root(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:c1' or point == 'c1':
+            child = {'c1': from_json_path_base__c1(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_root(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_root(jd: dict[str, ?value]) -> yang.gdata.Root:
+    children = {}
+    child_c1_full = jd.get('base:c1')
+    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    if child_c1 is not None and isinstance(child_c1, dict):
+        children['c1'] = from_json_base__c1(child_c1)
+    return yang.gdata.Root(children)
+
+mut def to_json_root(n: yang.gdata.Root) -> dict[str, ?value]:
+    children = {}
+    child_c1 = n.children.get('c1')
+    if child_c1 is not None:
+        if isinstance(child_c1, yang.gdata.Container):
+            children['base:c1'] = to_json_base__c1(child_c1)
+    return children
+

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -1,7 +1,7 @@
-mut def from_json_base__c1__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-mut def from_json_base__c1__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__foo_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
 class base__c1(yang.adata.MNode):
@@ -58,10 +58,10 @@ mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_bar_foo = jd.get('bar:foo')
     if child_bar_foo is not None:
-        children['foo'] = from_json_base__c1__foo(child_bar_foo)
+        children['foo'] = from_json_base__c1__bar_foo(child_bar_foo)
     child_foo_foo = jd.get('foo:foo')
     if child_foo_foo is not None:
-        children['foo'] = from_json_base__c1__foo(child_foo_foo)
+        children['foo'] = from_json_base__c1__foo_foo(child_foo_foo)
     return yang.gdata.Container(children)
 
 mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -117,6 +117,9 @@ def _test_foo_from_xml_full():
 </cc>
 <conflict xmlns="http://example.com/foo">
   <foo>foo-foo</foo>
+  <inner></inner>
+  <foo xmlns="http://example.com/bar">foo-augmented-from-bar</foo>
+  <inner xmlns="http://example.com/bar"></inner>
 </conflict>
 <special xmlns="http://example.com/foo">
   <yes>true</yes>

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -951,30 +951,156 @@ mut def to_json_foo__cc(n: yang.gdata.Container) -> dict[str, ?value]:
 mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__conflict(yang.adata.MNode):
-    foo: ?str
+class foo__conflict__inner(yang.adata.MNode):
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self):
         self._ns = "http://example.com/foo"
-        self.foo = foo
+        pass
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo = self.foo
-        if _foo is not None:
-            children['foo'] = yang.gdata.Leaf('string', _foo)
+        return yang.gdata.Container(children, presence=True)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+
+mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    return children
+
+
+mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__conflict__inner(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = "http://example.com/bar"
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+
+mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    return children
+
+
+class foo__conflict(yang.adata.MNode):
+    foo_foo: ?str
+    foo_inner: ?foo__conflict__inner
+    bar_foo: ?str
+    bar_inner: ?foo__conflict__inner
+
+    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__inner=None):
+        self._ns = "http://example.com/foo"
+        self.foo_foo = foo_foo
+        self.foo_inner = foo_inner
+        self_foo_inner = self.foo_inner
+        if self_foo_inner is not None:
+            self_foo_inner._parent = self
+        self.bar_foo = bar_foo
+        self.bar_inner = bar_inner
+        self_bar_inner = self.bar_inner
+        if self_bar_inner is not None:
+            self_bar_inner._parent = self
+
+    mut def create_foo_inner(self):
+        res = foo__conflict__inner()
+        self.foo_inner = res
+        return res
+
+    mut def create_bar_inner(self):
+        res = foo__conflict__inner()
+        self.bar_inner = res
+        return res
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_foo = self.foo_foo
+        _foo_inner = self.foo_inner
+        _bar_foo = self.bar_foo
+        _bar_inner = self.bar_inner
+        if _foo_foo is not None:
+            children['foo:foo'] = yang.gdata.Leaf('string', _foo_foo)
+        if _foo_inner is not None:
+            children['foo:inner'] = _foo_inner.to_gdata()
+        if _bar_foo is not None:
+            children['bar:foo'] = yang.gdata.Leaf('string', _bar_foo, ns='http://example.com/bar')
+        if _bar_inner is not None:
+            children['bar:inner'] = _bar_inner.to_gdata()
         return yang.gdata.Container(children, ns='http://example.com/foo')
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo=n.get_opt_str("foo"))
+            return foo__conflict(foo_foo=n.get_opt_str("foo:foo"), foo_inner=foo__conflict__inner.from_gdata(n.get_opt_container("foo:inner")), bar_foo=n.get_opt_str("bar:foo"), bar_inner=foo__conflict__inner.from_gdata(n.get_opt_container("bar:inner")))
         return foo__conflict()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, "foo"), foo_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner")), bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), bar_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner", "http://example.com/bar")))
         return foo__conflict()
 
 
@@ -983,8 +1109,16 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str="me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo:foo':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'foo:inner':
+            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        if point == 'bar:foo':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'bar:inner':
+            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
@@ -996,18 +1130,38 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str="me
 
 mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
-    if child_foo is not None:
-        children['foo'] = from_json_foo__conflict__foo(child_foo)
+    child_foo_foo = jd.get('foo:foo')
+    if child_foo_foo is not None:
+        children['foo'] = from_json_foo__conflict__foo(child_foo_foo)
+    child_foo_inner = jd.get('foo:inner')
+    if child_foo_inner is not None and isinstance(child_foo_inner, dict):
+        children['inner'] = from_json_foo__conflict__inner(child_foo_inner)
+    child_bar_foo = jd.get('bar:foo')
+    if child_bar_foo is not None:
+        children['foo'] = from_json_foo__conflict__foo(child_bar_foo)
+    child_bar_inner = jd.get('bar:inner')
+    if child_bar_inner is not None and isinstance(child_bar_inner, dict):
+        children['inner'] = from_json_foo__conflict__inner(child_bar_inner)
     return yang.gdata.Container(children)
 
 mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
-    child_foo = n.children.get('foo')
-    if child_foo is not None:
-        if isinstance(child_foo, yang.gdata.Leaf):
-            children['foo'] = child_foo.val
+    child_foo_foo = n.children.get('foo')
+    if child_foo_foo is not None:
+        if isinstance(child_foo_foo, yang.gdata.Leaf):
+            children['foo'] = child_foo_foo.val
+    child_foo_inner = n.children.get('inner')
+    if child_foo_inner is not None:
+        if isinstance(child_foo_inner, yang.gdata.Container):
+            children['inner'] = to_json_foo__conflict__inner(child_foo_inner)
+    child_bar_foo = n.children.get('foo')
+    if child_bar_foo is not None:
+        if isinstance(child_bar_foo, yang.gdata.Leaf):
+            children['bar:foo'] = child_bar_foo.val
+    child_bar_inner = n.children.get('inner')
+    if child_bar_inner is not None:
+        if isinstance(child_bar_inner, yang.gdata.Container):
+            children['bar:inner'] = to_json_foo__conflict__inner(child_bar_inner)
     return children
 
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -948,10 +948,10 @@ mut def to_json_foo__cc(n: yang.gdata.Container) -> dict[str, ?value]:
     return children
 
 
-mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__conflict__foo_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__conflict__inner(yang.adata.MNode):
+class foo__conflict__foo_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = "http://example.com/foo"
@@ -962,19 +962,19 @@ class foo__conflict__inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__foo_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__foo_inner()
         return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__foo_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__foo_inner()
         return None
 
 
-mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_foo__conflict__foo_inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -982,25 +982,25 @@ mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__conflict__foo_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__conflict__foo_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_foo__conflict__foo_inner(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
 
 
-mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__conflict__inner(yang.adata.MNode):
+class foo__conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = "http://example.com/bar"
@@ -1011,19 +1011,19 @@ class foo__conflict__inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True, ns='http://example.com/bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__bar_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__bar_inner()
         return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__bar_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__bar_inner()
         return None
 
 
-mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -1031,28 +1031,28 @@ mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__conflict__bar_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_foo__conflict__bar_inner(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
 
 
 class foo__conflict(yang.adata.MNode):
     foo_foo: ?str
-    foo_inner: ?foo__conflict__inner
+    foo_inner: ?foo__conflict__foo_inner
     bar_foo: ?str
-    bar_inner: ?foo__conflict__inner
+    bar_inner: ?foo__conflict__bar_inner
 
-    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__inner=None):
+    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__foo_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
         self._ns = "http://example.com/foo"
         self.foo_foo = foo_foo
         self.foo_inner = foo_inner
@@ -1066,12 +1066,12 @@ class foo__conflict(yang.adata.MNode):
             self_bar_inner._parent = self
 
     mut def create_foo_inner(self):
-        res = foo__conflict__inner()
+        res = foo__conflict__foo_inner()
         self.foo_inner = res
         return res
 
     mut def create_bar_inner(self):
-        res = foo__conflict__inner()
+        res = foo__conflict__bar_inner()
         self.bar_inner = res
         return res
 
@@ -1094,13 +1094,13 @@ class foo__conflict(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=n.get_opt_str("foo:foo"), foo_inner=foo__conflict__inner.from_gdata(n.get_opt_container("foo:inner")), bar_foo=n.get_opt_str("bar:foo"), bar_inner=foo__conflict__inner.from_gdata(n.get_opt_container("bar:inner")))
+            return foo__conflict(foo_foo=n.get_opt_str("foo:foo"), foo_inner=foo__conflict__foo_inner.from_gdata(n.get_opt_container("foo:inner")), bar_foo=n.get_opt_str("bar:foo"), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container("bar:inner")))
         return foo__conflict()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, "foo"), foo_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner")), bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), bar_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner", "http://example.com/bar")))
+            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, "foo"), foo_inner=foo__conflict__foo_inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner")), bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner", "http://example.com/bar")))
         return foo__conflict()
 
 
@@ -1112,12 +1112,12 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str="me
         if point == 'foo:foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:inner':
-            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            child = {'inner': from_json_path_foo__conflict__foo_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:inner':
-            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            child = {'inner': from_json_path_foo__conflict__bar_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -1132,16 +1132,16 @@ mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo_foo = jd.get('foo:foo')
     if child_foo_foo is not None:
-        children['foo'] = from_json_foo__conflict__foo(child_foo_foo)
+        children['foo'] = from_json_foo__conflict__foo_foo(child_foo_foo)
     child_foo_inner = jd.get('foo:inner')
     if child_foo_inner is not None and isinstance(child_foo_inner, dict):
-        children['inner'] = from_json_foo__conflict__inner(child_foo_inner)
+        children['inner'] = from_json_foo__conflict__foo_inner(child_foo_inner)
     child_bar_foo = jd.get('bar:foo')
     if child_bar_foo is not None:
-        children['foo'] = from_json_foo__conflict__foo(child_bar_foo)
+        children['foo'] = from_json_foo__conflict__bar_foo(child_bar_foo)
     child_bar_inner = jd.get('bar:inner')
     if child_bar_inner is not None and isinstance(child_bar_inner, dict):
-        children['inner'] = from_json_foo__conflict__inner(child_bar_inner)
+        children['inner'] = from_json_foo__conflict__bar_inner(child_bar_inner)
     return yang.gdata.Container(children)
 
 mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
@@ -1153,7 +1153,7 @@ mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
     child_foo_inner = n.children.get('inner')
     if child_foo_inner is not None:
         if isinstance(child_foo_inner, yang.gdata.Container):
-            children['inner'] = to_json_foo__conflict__inner(child_foo_inner)
+            children['inner'] = to_json_foo__conflict__foo_inner(child_foo_inner)
     child_bar_foo = n.children.get('foo')
     if child_bar_foo is not None:
         if isinstance(child_bar_foo, yang.gdata.Leaf):
@@ -1161,7 +1161,7 @@ mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
     child_bar_inner = n.children.get('inner')
     if child_bar_inner is not None:
         if isinstance(child_bar_inner, yang.gdata.Container):
-            children['bar:inner'] = to_json_foo__conflict__inner(child_bar_inner)
+            children['bar:inner'] = to_json_foo__conflict__bar_inner(child_bar_inner)
     return children
 
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -953,10 +953,10 @@ mut def to_json_foo__cc(n: yang.gdata.Container) -> dict[str, ?value]:
     return children
 
 
-mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__conflict__foo_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__conflict__inner(yang.adata.MNode):
+class foo__conflict__foo_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = "http://example.com/foo"
@@ -967,19 +967,19 @@ class foo__conflict__inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__foo_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__foo_inner()
         return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__foo_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__foo_inner()
         return None
 
 
-mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_foo__conflict__foo_inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -987,25 +987,25 @@ mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__conflict__foo_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__conflict__foo_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_foo__conflict__foo_inner(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
 
 
-mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__conflict__inner(yang.adata.MNode):
+class foo__conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = "http://example.com/bar"
@@ -1016,19 +1016,19 @@ class foo__conflict__inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True, ns='http://example.com/bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__bar_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__bar_inner()
         return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__bar_inner:
         if n != None:
-            return foo__conflict__inner()
+            return foo__conflict__bar_inner()
         return None
 
 
-mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -1036,28 +1036,28 @@ mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__conflict__bar_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_foo__conflict__bar_inner(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
 
 
 class foo__conflict(yang.adata.MNode):
     foo_foo: ?str
-    foo_inner: ?foo__conflict__inner
+    foo_inner: ?foo__conflict__foo_inner
     bar_foo: ?str
-    bar_inner: ?foo__conflict__inner
+    bar_inner: ?foo__conflict__bar_inner
 
-    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__inner=None):
+    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__foo_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
         self._ns = "http://example.com/foo"
         self.foo_foo = foo_foo
         self.foo_inner = foo_inner
@@ -1071,12 +1071,12 @@ class foo__conflict(yang.adata.MNode):
             self_bar_inner._parent = self
 
     mut def create_foo_inner(self):
-        res = foo__conflict__inner()
+        res = foo__conflict__foo_inner()
         self.foo_inner = res
         return res
 
     mut def create_bar_inner(self):
-        res = foo__conflict__inner()
+        res = foo__conflict__bar_inner()
         self.bar_inner = res
         return res
 
@@ -1099,13 +1099,13 @@ class foo__conflict(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=n.get_opt_str("foo:foo"), foo_inner=foo__conflict__inner.from_gdata(n.get_opt_container("foo:inner")), bar_foo=n.get_opt_str("bar:foo"), bar_inner=foo__conflict__inner.from_gdata(n.get_opt_container("bar:inner")))
+            return foo__conflict(foo_foo=n.get_opt_str("foo:foo"), foo_inner=foo__conflict__foo_inner.from_gdata(n.get_opt_container("foo:inner")), bar_foo=n.get_opt_str("bar:foo"), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container("bar:inner")))
         return foo__conflict()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, "foo"), foo_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner")), bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), bar_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner", "http://example.com/bar")))
+            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, "foo"), foo_inner=foo__conflict__foo_inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner")), bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner", "http://example.com/bar")))
         return foo__conflict()
 
 
@@ -1117,12 +1117,12 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str="me
         if point == 'foo:foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:inner':
-            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            child = {'inner': from_json_path_foo__conflict__foo_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:inner':
-            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            child = {'inner': from_json_path_foo__conflict__bar_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -1137,16 +1137,16 @@ mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo_foo = jd.get('foo:foo')
     if child_foo_foo is not None:
-        children['foo'] = from_json_foo__conflict__foo(child_foo_foo)
+        children['foo'] = from_json_foo__conflict__foo_foo(child_foo_foo)
     child_foo_inner = jd.get('foo:inner')
     if child_foo_inner is not None and isinstance(child_foo_inner, dict):
-        children['inner'] = from_json_foo__conflict__inner(child_foo_inner)
+        children['inner'] = from_json_foo__conflict__foo_inner(child_foo_inner)
     child_bar_foo = jd.get('bar:foo')
     if child_bar_foo is not None:
-        children['foo'] = from_json_foo__conflict__foo(child_bar_foo)
+        children['foo'] = from_json_foo__conflict__bar_foo(child_bar_foo)
     child_bar_inner = jd.get('bar:inner')
     if child_bar_inner is not None and isinstance(child_bar_inner, dict):
-        children['inner'] = from_json_foo__conflict__inner(child_bar_inner)
+        children['inner'] = from_json_foo__conflict__bar_inner(child_bar_inner)
     return yang.gdata.Container(children)
 
 mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
@@ -1158,7 +1158,7 @@ mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
     child_foo_inner = n.children.get('inner')
     if child_foo_inner is not None:
         if isinstance(child_foo_inner, yang.gdata.Container):
-            children['inner'] = to_json_foo__conflict__inner(child_foo_inner)
+            children['inner'] = to_json_foo__conflict__foo_inner(child_foo_inner)
     child_bar_foo = n.children.get('foo')
     if child_bar_foo is not None:
         if isinstance(child_bar_foo, yang.gdata.Leaf):
@@ -1166,7 +1166,7 @@ mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
     child_bar_inner = n.children.get('inner')
     if child_bar_inner is not None:
         if isinstance(child_bar_inner, yang.gdata.Container):
-            children['bar:inner'] = to_json_foo__conflict__inner(child_bar_inner)
+            children['bar:inner'] = to_json_foo__conflict__bar_inner(child_bar_inner)
     return children
 
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -956,30 +956,156 @@ mut def to_json_foo__cc(n: yang.gdata.Container) -> dict[str, ?value]:
 mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__conflict(yang.adata.MNode):
-    foo: ?str
+class foo__conflict__inner(yang.adata.MNode):
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self):
         self._ns = "http://example.com/foo"
-        self.foo = foo
+        pass
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo = self.foo
-        if _foo is not None:
-            children['foo'] = yang.gdata.Leaf('string', _foo)
+        return yang.gdata.Container(children, presence=True)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+
+mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    return children
+
+
+mut def from_json_foo__conflict__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__conflict__inner(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = "http://example.com/bar"
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__inner:
+        if n != None:
+            return foo__conflict__inner()
+        return None
+
+
+mut def from_json_path_foo__conflict__inner(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__conflict__inner(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__conflict__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__conflict__inner(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    return children
+
+
+class foo__conflict(yang.adata.MNode):
+    foo_foo: ?str
+    foo_inner: ?foo__conflict__inner
+    bar_foo: ?str
+    bar_inner: ?foo__conflict__inner
+
+    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__inner=None):
+        self._ns = "http://example.com/foo"
+        self.foo_foo = foo_foo
+        self.foo_inner = foo_inner
+        self_foo_inner = self.foo_inner
+        if self_foo_inner is not None:
+            self_foo_inner._parent = self
+        self.bar_foo = bar_foo
+        self.bar_inner = bar_inner
+        self_bar_inner = self.bar_inner
+        if self_bar_inner is not None:
+            self_bar_inner._parent = self
+
+    mut def create_foo_inner(self):
+        res = foo__conflict__inner()
+        self.foo_inner = res
+        return res
+
+    mut def create_bar_inner(self):
+        res = foo__conflict__inner()
+        self.bar_inner = res
+        return res
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_foo = self.foo_foo
+        _foo_inner = self.foo_inner
+        _bar_foo = self.bar_foo
+        _bar_inner = self.bar_inner
+        if _foo_foo is not None:
+            children['foo:foo'] = yang.gdata.Leaf('string', _foo_foo)
+        if _foo_inner is not None:
+            children['foo:inner'] = _foo_inner.to_gdata()
+        if _bar_foo is not None:
+            children['bar:foo'] = yang.gdata.Leaf('string', _bar_foo, ns='http://example.com/bar')
+        if _bar_inner is not None:
+            children['bar:inner'] = _bar_inner.to_gdata()
         return yang.gdata.Container(children, ns='http://example.com/foo')
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo=n.get_opt_str("foo"))
+            return foo__conflict(foo_foo=n.get_opt_str("foo:foo"), foo_inner=foo__conflict__inner.from_gdata(n.get_opt_container("foo:inner")), bar_foo=n.get_opt_str("bar:foo"), bar_inner=foo__conflict__inner.from_gdata(n.get_opt_container("bar:inner")))
         return foo__conflict()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo=yang.gdata.from_xml_opt_str(n, "foo"))
+            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, "foo"), foo_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner")), bar_foo=yang.gdata.from_xml_opt_str(n, "foo", "http://example.com/bar"), bar_inner=foo__conflict__inner.from_xml(yang.gdata.get_xml_opt_child(n, "inner", "http://example.com/bar")))
         return foo__conflict()
 
 
@@ -988,8 +1114,16 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str="me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo:foo':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'foo:inner':
+            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        if point == 'bar:foo':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'bar:inner':
+            child = {'inner': from_json_path_foo__conflict__inner(jd, rest_path, op) }
+            return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
@@ -1001,18 +1135,38 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str="me
 
 mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
-    if child_foo is not None:
-        children['foo'] = from_json_foo__conflict__foo(child_foo)
+    child_foo_foo = jd.get('foo:foo')
+    if child_foo_foo is not None:
+        children['foo'] = from_json_foo__conflict__foo(child_foo_foo)
+    child_foo_inner = jd.get('foo:inner')
+    if child_foo_inner is not None and isinstance(child_foo_inner, dict):
+        children['inner'] = from_json_foo__conflict__inner(child_foo_inner)
+    child_bar_foo = jd.get('bar:foo')
+    if child_bar_foo is not None:
+        children['foo'] = from_json_foo__conflict__foo(child_bar_foo)
+    child_bar_inner = jd.get('bar:inner')
+    if child_bar_inner is not None and isinstance(child_bar_inner, dict):
+        children['inner'] = from_json_foo__conflict__inner(child_bar_inner)
     return yang.gdata.Container(children)
 
 mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
-    child_foo = n.children.get('foo')
-    if child_foo is not None:
-        if isinstance(child_foo, yang.gdata.Leaf):
-            children['foo'] = child_foo.val
+    child_foo_foo = n.children.get('foo')
+    if child_foo_foo is not None:
+        if isinstance(child_foo_foo, yang.gdata.Leaf):
+            children['foo'] = child_foo_foo.val
+    child_foo_inner = n.children.get('inner')
+    if child_foo_inner is not None:
+        if isinstance(child_foo_inner, yang.gdata.Container):
+            children['inner'] = to_json_foo__conflict__inner(child_foo_inner)
+    child_bar_foo = n.children.get('foo')
+    if child_bar_foo is not None:
+        if isinstance(child_bar_foo, yang.gdata.Leaf):
+            children['bar:foo'] = child_bar_foo.val
+    child_bar_inner = n.children.get('inner')
+    if child_bar_inner is not None:
+        if isinstance(child_bar_inner, yang.gdata.Container):
+            children['bar:inner'] = to_json_foo__conflict__inner(child_bar_inner)
     return children
 
 

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -29,7 +29,7 @@ Root(children={
     'death': List(['name'])
   }),
   'foo:conflict': Container(ns='http://example.com/foo', children={
-    'foo': Leaf(foo-foo)
+    'foo:foo': Leaf(foo-foo)
   }),
   'special': List(['yes'], ns='http://example.com/foo', elements=[
     ListElement(['true'], children={

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -29,7 +29,10 @@ Root(children={
     'death': List(['name'])
   }),
   'foo:conflict': Container(ns='http://example.com/foo', children={
-    'foo:foo': Leaf(foo-foo)
+    'foo:foo': Leaf(foo-foo),
+    'foo:inner': Container(presence=True),
+    'bar:foo': Leaf(foo-augmented-from-bar, ns='http://example.com/bar'),
+    'bar:inner': Container(presence=True, ns='http://example.com/bar')
   }),
   'special': List(['yes'], ns='http://example.com/foo', elements=[
     ListElement(['true'], children={

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -119,6 +119,9 @@ ys_foo = """module foo {
         leaf foo {
             type string;
         }
+        container inner {
+            presence "inner presence";
+        }
     }
     list special {
         key yes;
@@ -176,6 +179,14 @@ ys_bar = """module bar {
     container conflict {
         leaf foo {
             type string;
+        }
+    }
+    augment /foo:conflict {
+        leaf foo {
+            type string;
+        }
+        container inner {
+            presence "inner presence from bar";
         }
     }
 }"""


### PR DESCRIPTION
Fixes a case where an augmented inner node with a conflicting name resulted in adata class name conflicts:

```yang
module base {
    yang-version "1.1";
    namespace "http://example.com/base";
    prefix "base";
    container c1 {
        container c2 {
            leaf foo {
                type string;
            }
        }
    }
}
```

```yang
module foo {
    yang-version "1.1";
    namespace "http://example.com/foo";
    prefix "foo";
    import base {
      prefix "b";
    }
    augment "/b:c1" {
        container c2 {
            leaf foo {
                type string;
            }
        }
    }
}
```