### PR TITLE
Avoid safe node name conflicts in get_path_name()

### DIFF
--- a/README.org
+++ b/README.org
@@ -23,7 +23,7 @@ make
 - [x] TODO: support schema expansion of augments
 - [x] TODO: rewrite - to _ in names
 - [x] TODO: resolve union of various int types to largest (u)int
-- [ ] TODO: detect conflicts between a_b and a-b, and name in some deterministic fashion
+- [x] TODO: detect conflicts between a_b and a-b, and name in some deterministic fashion
 - [x] TODO: add simple compile() function to compile a bundle of YANG models and get a DNode tree
 - [x] TODO: fix bug, duplicating content when revision statement is present
 - [x] TODO: correctly map union base type, currently getting "string" and not "str" as it should be

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -350,19 +350,20 @@ class DNodeInner(DNode):
 
         child_names = set()
         child_name_conflicts = set()
-        child_safe_names = dict()
-        child_safe_name_conflicts = set()
+        child_safe_names: dict[str, dict[str, list[str]]] = dict()
+        child_safe_name_conflicts: dict[str, set[str]] = dict()
         for child in self.children:
             child_safe_name = _safe_name(child.name)
             if child.name in child_names:
                 child_name_conflicts.add(child.name)
             else:
                 child_names.add(child.name)
-            if child_safe_name in child_safe_names:
-                child_safe_name_conflicts.add(child_safe_name)
-                child_safe_names[child_safe_name].append(child.name)
+            if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
+                child_safe_name_conflicts.setdefault(child.prefix, set())
+                child_safe_name_conflicts[child.prefix].add(child_safe_name)
+                child_safe_names[child.prefix][child_safe_name].append(child.name)
             else:
-                child_safe_names[child_safe_name] = [child.name]
+                child_safe_names[child.prefix] = {child_safe_name: [child.name]}
 
         def _unique_name(name: str, prefix: str) -> str:
             if name not in child_name_conflicts:
@@ -373,9 +374,9 @@ class DNodeInner(DNode):
             # First get the non-ambiguous YANG name, possibly with prefix
             unique_name = _unique_name(name, prefix)
             safe_name = _safe_name(unique_name)
-            # Now check if the safe name is unique
-            if safe_name in child_safe_name_conflicts:
-                idx = child_safe_names[safe_name].index(name)
+            # Now check if the safe name is unique (within the confines of the module)
+            if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
+                idx = child_safe_names[prefix][safe_name].index(name)
                 return safe_name.replace(":", "_") + "_" + str(idx)
             return _safe_name(unique_name).replace(":", "_")
 

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -340,19 +340,29 @@ class DNodeInner(DNode):
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
         pos_child_idx = 0
-        child_names = set()
-        child_name_conflicts = set()
         for child in self.children:
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
             else:
                 new_children.append(child)
+        self.children = new_children
+
+        child_names = set()
+        child_name_conflicts = set()
+        child_safe_names = dict()
+        child_safe_name_conflicts = set()
+        for child in self.children:
+            child_safe_name = _safe_name(child.name)
             if child.name in child_names:
                 child_name_conflicts.add(child.name)
             else:
                 child_names.add(child.name)
-        self.children = new_children
+            if child_safe_name in child_safe_names:
+                child_safe_name_conflicts.add(child_safe_name)
+                child_safe_names[child_safe_name].append(child.name)
+            else:
+                child_safe_names[child_safe_name] = [child.name]
 
         def _unique_name(name: str, prefix: str) -> str:
             if name not in child_name_conflicts:
@@ -360,7 +370,13 @@ class DNodeInner(DNode):
             return "%s:%s" % (prefix, name)
 
         def _unique_safe_name(name: str, prefix: str) -> str:
+            # First get the non-ambiguous YANG name, possibly with prefix
             unique_name = _unique_name(name, prefix)
+            safe_name = _safe_name(unique_name)
+            # Now check if the safe name is unique
+            if safe_name in child_safe_name_conflicts:
+                idx = child_safe_names[safe_name].index(name)
+                return safe_name.replace(":", "_") + "_" + str(idx)
             return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2270,6 +2270,38 @@ def get_path_name(dnode: DNode) -> str:
     We do not rewrite the builtin keywords here (see _safe_name()) because it
     is not necessary.
     """
+
+        # child_names = set()
+        # child_name_conflicts = set()
+        # child_safe_names: dict[str, dict[str, list[str]]] = dict()
+        # child_safe_name_conflicts: dict[str, set[str]] = dict()
+        # for child in self.children:
+        #     child_safe_name = _safe_name(child.name)
+        #     if child.name in child_names:
+        #         child_name_conflicts.add(child.name)
+        #     else:
+        #         child_names.add(child.name)
+        #     if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
+        #         child_safe_name_conflicts.setdefault(child.prefix, set())
+        #         child_safe_name_conflicts[child.prefix].add(child_safe_name)
+        #         child_safe_names[child.prefix][child_safe_name].append(child.name)
+        #     else:
+        #         child_safe_names[child.prefix] = {child_safe_name: [child.name]}
+        # def _unique_name(name: str, prefix: str) -> str:
+        #     if name not in child_name_conflicts:
+        #         return name
+        #     return "%s:%s" % (prefix, name)
+
+        # def _unique_safe_name(name: str, prefix: str) -> str:
+        #     # First get the non-ambiguous YANG name, possibly with prefix
+        #     unique_name = _unique_name(name, prefix)
+        #     safe_name = _safe_name(unique_name)
+        #     # Now check if the safe name is unique (within the confines of the module)
+        #     if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
+        #         idx = child_safe_names[prefix][safe_name].index(name)
+        #         return safe_name.replace(":", "_") + "_" + str(idx)
+        #     return _safe_name(unique_name).replace(":", "_")
+
     path = []
     while True:
         self_unique_name = dnode.name
@@ -2280,15 +2312,32 @@ def get_path_name(dnode: DNode) -> str:
             if isinstance(parent, DNodeInner):
                 sibling_names = set()
                 sibling_names_conflicts = set()
+                sibling_safe_names: dict[str, dict[str, list[str]]] = dict()
+                sibling_safe_names_conflicts: dict[str, set[str]] = dict()
                 for sibling in parent.children:
                     if sibling.name in sibling_names:
                         sibling_names_conflicts.add(sibling.name)
                     else:
                         sibling_names.add(sibling.name)
-                if dnode.name not in sibling_names_conflicts:
-                    self_unique_name = dnode.name
-                else:
-                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
+                    sibling_safe_name = sibling.name.replace("-", "_").replace(".", "_")
+                    if sibling_safe_name in sibling_safe_names.get_def(sibling.prefix, dict()):
+                        sibling_safe_names_conflicts.setdefault(sibling.prefix, set())
+                        sibling_safe_names_conflicts[sibling.prefix].add(sibling_safe_name)
+                        sibling_safe_names[sibling.prefix][sibling_safe_name].append(sibling.name)
+                    else:
+                        sibling_safe_names[sibling.prefix] = {sibling_safe_name: [sibling.name]}
+
+                self_safe_name = dnode.name.replace("-", "_").replace(".", "_")
+                if self_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
+                    # If not, we need to add a number suffix to make it unique
+                    idx = sibling_safe_names[dnode.prefix][self_safe_name].index(dnode.name)
+                    self_safe_name = self_safe_name + "_" + str(idx)
+                
+                # Now get the non-ambiguous YANG name, possibly with prefix
+                self_unique_name = self_safe_name
+                if dnode.name in sibling_names_conflicts:
+                    self_unique_name = "%s_%s" % (dnode.prefix, self_safe_name)
+
                 dnode = parent
         path.append(self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_"))
         if parent is None:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -348,13 +348,12 @@ class DNodeInner(DNode):
                 new_children.append(child)
         self.children = new_children
 
-        child_name_conflicts, child_safe_names, child_safe_name_conflicts = _find_conflicting_names(self)
-
+        un = _UniqueNamer(self)
         def _unique_name(name: str, prefix: str) -> str:
-            return _g_unique_name(name, prefix, child_name_conflicts)
+            return un.unique_name(name, prefix)
 
         def _unique_safe_name(name: str, prefix: str) -> str:
-            return _g_unique_safe_name(name, prefix, child_name_conflicts, child_safe_names, child_safe_name_conflicts)
+            return un.unique_safe_name(name, prefix)
 
         for child in self.children:
             res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml))
@@ -760,7 +759,7 @@ class DNodeInner(DNode):
                 res.append("        point = path[0]")
                 res.append("        rest_path = path[1:]")
                 for child in self.children:
-                    if top == True or (child.name in child_name_conflicts):
+                    if top == True or (child.name in un.name_conflicts):
                         res.append("        if point == '%s:%s':" % (child.prefix, child.name))
                     else:
                         res.append("        if point == '%s:%s' or point == '%s':" % (child.prefix, child.name, child.name))
@@ -794,7 +793,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                if top == True or (child.name in child_name_conflicts):
+                if top == True or (child.name in un.name_conflicts):
                     res.append("    child_%s = jd.get('%s:%s')" % (_unique_safe_name(child.name, child.prefix), child.prefix, child.name))
                 else:
                     res.append("    child_%s_full = jd.get('%s:%s')" % (_unique_safe_name(child.name, child.prefix), child.prefix, child.name))
@@ -2212,39 +2211,43 @@ def _safe_name(name: str, safe_kw=True) -> str:
             new += "_"
     return new
 
-def _find_conflicting_names(node: DNodeInner):
-    child_names = set()
-    child_name_conflicts = set()
-    child_safe_names: dict[str, dict[str, list[str]]] = dict()
-    child_safe_name_conflicts: dict[str, set[str]] = dict()
-    for child in node.children:
-        child_safe_name = _safe_name(child.name)
-        if child.name in child_names:
-            child_name_conflicts.add(child.name)
-        else:
-            child_names.add(child.name)
-        if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
-            child_safe_name_conflicts.setdefault(child.prefix, set())
-            child_safe_name_conflicts[child.prefix].add(child_safe_name)
-            child_safe_names[child.prefix][child_safe_name].append(child.name)
-        else:
-            child_safe_names[child.prefix] = {child_safe_name: [child.name]}
-    return child_name_conflicts, child_safe_names, child_safe_name_conflicts
+class _UniqueNamer(object):
+    name_conflicts: set[str]
+    safe_names: dict[str, dict[str, list[str]]]
+    safe_name_conflicts: dict[str, set[str]]
 
-def _g_unique_name(name: str, prefix: str, child_name_conflicts) -> str:
-    if name not in child_name_conflicts:
-        return name
-    return "%s:%s" % (prefix, name)
-
-def _g_unique_safe_name(name: str, prefix: str, child_name_conflicts, child_safe_names, child_safe_name_conflicts, safe_kw=True) -> str:
-    # First get the non-ambiguous YANG name, possibly with prefix
-    unique_name = _g_unique_name(name, prefix, child_name_conflicts)
-    safe_name = _safe_name(unique_name, safe_kw)
-    # Now check if the safe name is unique (within the confines of the module)
-    if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
-        idx = child_safe_names[prefix][safe_name].index(name)
-        return safe_name.replace(":", "_") + "_" + str(idx)
-    return _safe_name(unique_name, safe_kw).replace(":", "_")
+    def __init__(self, node: DNodeInner):
+        names = set()
+        self.name_conflicts = set()
+        self.safe_names = dict()
+        self.safe_name_conflicts = dict()
+        for child in node.children:
+            child_safe_name = _safe_name(child.name)
+            if child.name in names:
+                self.name_conflicts.add(child.name)
+            else:
+                names.add(child.name)
+            if child_safe_name in self.safe_names.get_def(child.prefix, dict()):
+                self.safe_name_conflicts.setdefault(child.prefix, set())
+                self.safe_name_conflicts[child.prefix].add(child_safe_name)
+                self.safe_names[child.prefix][child_safe_name].append(child.name)
+            else:
+                self.safe_names[child.prefix] = {child_safe_name: [child.name]}
+    
+    def unique_name(self, name: str, prefix: str) -> str:
+        if name not in self.name_conflicts:
+            return name
+        return "%s:%s" % (prefix, name)
+    
+    def unique_safe_name(self, name: str, prefix: str, safe_kw=True) -> str:
+        # First get the non-ambiguous YANG name, possibly with prefix
+        unique_name = self.unique_name(name, prefix)
+        safe_name = _safe_name(unique_name, safe_kw)
+        # Now check if the safe name is unique (within the confines of the module)
+        if safe_name in self.safe_name_conflicts.get_def(prefix, set()):
+            idx = self.safe_names[prefix][safe_name].index(name)
+            return safe_name.replace(":", "_") + "_" + str(idx)
+        return _safe_name(unique_name, safe_kw).replace(":", "_")
 
 def get_path_name(dnode: DNode) -> str:
     """Build the adata path name for a data node
@@ -2290,11 +2293,8 @@ def get_path_name(dnode: DNode) -> str:
         # attribute), but let's make that explicit for the compiler ...
         if parent is not None:
             if isinstance(parent, DNodeInner):
-                sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts = _find_conflicting_names(parent)
-
-                # Now check if the safe name is unique (within the confines of the module)
-                self_unique_safe_name = _g_unique_safe_name(dnode.name, dnode.prefix, sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts, safe_kw=False)
-                
+                un = _UniqueNamer(parent)
+                self_unique_safe_name = un.unique_safe_name(dnode.name, dnode.prefix, safe_kw=False)
                 dnode = parent
         path.append(self_unique_safe_name)
         if parent is None:
@@ -2304,7 +2304,6 @@ def get_path_name(dnode: DNode) -> str:
     if len(path) == 0:
         raise ValueError("No path for DNode" + str(dnode))
 
-    print("path", path, err=True)
     return "__".join(reversed(path))
 
 

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2304,7 +2304,7 @@ def get_path_name(dnode: DNode) -> str:
 
     path = []
     while True:
-        self_unique_name = dnode.name
+        self_unique_safe_name = dnode.name
         parent = dnode.parent
         # if parent is not None then of course it is DNodeInner (= has children
         # attribute), but let's make that explicit for the compiler ...
@@ -2327,19 +2327,25 @@ def get_path_name(dnode: DNode) -> str:
                     else:
                         sibling_safe_names[sibling.prefix] = {sibling_safe_name: [sibling.name]}
 
-                self_safe_name = dnode.name.replace("-", "_").replace(".", "_")
-                if self_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
-                    # If not, we need to add a number suffix to make it unique
-                    idx = sibling_safe_names[dnode.prefix][self_safe_name].index(dnode.name)
-                    self_safe_name = self_safe_name + "_" + str(idx)
-                
-                # Now get the non-ambiguous YANG name, possibly with prefix
-                self_unique_name = self_safe_name
+                # First get the non-ambiguous YANG name, possibly with prefix
                 if dnode.name in sibling_names_conflicts:
-                    self_unique_name = "%s_%s" % (dnode.prefix, self_safe_name)
+                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
+                else:
+                    self_unique_name = dnode.name
 
+                # Now check if the safe name is unique (within the confines of the module)
+                self_unique_safe_name = self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_")
+                if self_unique_safe_name == "foo_bar":
+                    print(sibling_safe_names_conflicts, err=True)
+                    print(sibling_safe_names, err=True)
+                if self_unique_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
+                    print("in here", err=True)
+                    # If not, we need to add a number suffix to make it unique
+                    idx = sibling_safe_names[dnode.prefix][self_unique_safe_name].index(dnode.name)
+                    self_unique_safe_name = self_unique_safe_name + "_" + str(idx)
+                
                 dnode = parent
-        path.append(self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_"))
+        path.append(self_unique_safe_name.replace("-", "_").replace(".", "_").replace(":", "_"))
         if parent is None:
             break
 

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -348,37 +348,13 @@ class DNodeInner(DNode):
                 new_children.append(child)
         self.children = new_children
 
-        child_names = set()
-        child_name_conflicts = set()
-        child_safe_names: dict[str, dict[str, list[str]]] = dict()
-        child_safe_name_conflicts: dict[str, set[str]] = dict()
-        for child in self.children:
-            child_safe_name = _safe_name(child.name)
-            if child.name in child_names:
-                child_name_conflicts.add(child.name)
-            else:
-                child_names.add(child.name)
-            if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
-                child_safe_name_conflicts.setdefault(child.prefix, set())
-                child_safe_name_conflicts[child.prefix].add(child_safe_name)
-                child_safe_names[child.prefix][child_safe_name].append(child.name)
-            else:
-                child_safe_names[child.prefix] = {child_safe_name: [child.name]}
+        child_name_conflicts, child_safe_names, child_safe_name_conflicts = _find_conflicting_names(self)
 
         def _unique_name(name: str, prefix: str) -> str:
-            if name not in child_name_conflicts:
-                return name
-            return "%s:%s" % (prefix, name)
+            return _g_unique_name(name, prefix, child_name_conflicts)
 
         def _unique_safe_name(name: str, prefix: str) -> str:
-            # First get the non-ambiguous YANG name, possibly with prefix
-            unique_name = _unique_name(name, prefix)
-            safe_name = _safe_name(unique_name)
-            # Now check if the safe name is unique (within the confines of the module)
-            if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
-                idx = child_safe_names[prefix][safe_name].index(name)
-                return safe_name.replace(":", "_") + "_" + str(idx)
-            return _safe_name(unique_name).replace(":", "_")
+            return _g_unique_safe_name(name, prefix, child_name_conflicts, child_safe_names, child_safe_name_conflicts)
 
         for child in self.children:
             res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml))
@@ -2219,21 +2195,56 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return '"' + value.replace('"', '\\"') + '"'
     raise ValueError("Unhandled prsrc literal of type " + ytype)
 
-def _safe_name(name: str) -> str:
+def _safe_name(name: str, safe_kw=True) -> str:
     new = name.replace("-", "_").replace(".", "_")
-    if new in {"action",
-               "as",
-               "class",
-               "except",
-               "for",
-               "from",
-               "import",
-               "in",
-               "protocol",
-               "with",
-               }:
-        new += "_"
+    if safe_kw:
+        if new in {"action",
+                   "as",
+                   "class",
+                   "except",
+                   "for",
+                   "from",
+                   "import",
+                   "in",
+                   "protocol",
+                   "with",
+                   }:
+            new += "_"
     return new
+
+def _find_conflicting_names(node: DNodeInner):
+    child_names = set()
+    child_name_conflicts = set()
+    child_safe_names: dict[str, dict[str, list[str]]] = dict()
+    child_safe_name_conflicts: dict[str, set[str]] = dict()
+    for child in node.children:
+        child_safe_name = _safe_name(child.name)
+        if child.name in child_names:
+            child_name_conflicts.add(child.name)
+        else:
+            child_names.add(child.name)
+        if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
+            child_safe_name_conflicts.setdefault(child.prefix, set())
+            child_safe_name_conflicts[child.prefix].add(child_safe_name)
+            child_safe_names[child.prefix][child_safe_name].append(child.name)
+        else:
+            child_safe_names[child.prefix] = {child_safe_name: [child.name]}
+    return child_name_conflicts, child_safe_names, child_safe_name_conflicts
+
+def _g_unique_name(name: str, prefix: str, child_name_conflicts) -> str:
+    if name not in child_name_conflicts:
+        return name
+    return "%s:%s" % (prefix, name)
+
+def _g_unique_safe_name(name: str, prefix: str, child_name_conflicts, child_safe_names, child_safe_name_conflicts, safe_kw=True) -> str:
+    # First get the non-ambiguous YANG name, possibly with prefix
+    unique_name = _g_unique_name(name, prefix, child_name_conflicts)
+    safe_name = _safe_name(unique_name, safe_kw)
+    # Now check if the safe name is unique (within the confines of the module)
+    if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
+        idx = child_safe_names[prefix][safe_name].index(name)
+        return safe_name.replace(":", "_") + "_" + str(idx)
+    return _safe_name(unique_name, safe_kw).replace(":", "_")
 
 def get_path_name(dnode: DNode) -> str:
     """Build the adata path name for a data node
@@ -2271,81 +2282,21 @@ def get_path_name(dnode: DNode) -> str:
     is not necessary.
     """
 
-        # child_names = set()
-        # child_name_conflicts = set()
-        # child_safe_names: dict[str, dict[str, list[str]]] = dict()
-        # child_safe_name_conflicts: dict[str, set[str]] = dict()
-        # for child in self.children:
-        #     child_safe_name = _safe_name(child.name)
-        #     if child.name in child_names:
-        #         child_name_conflicts.add(child.name)
-        #     else:
-        #         child_names.add(child.name)
-        #     if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
-        #         child_safe_name_conflicts.setdefault(child.prefix, set())
-        #         child_safe_name_conflicts[child.prefix].add(child_safe_name)
-        #         child_safe_names[child.prefix][child_safe_name].append(child.name)
-        #     else:
-        #         child_safe_names[child.prefix] = {child_safe_name: [child.name]}
-        # def _unique_name(name: str, prefix: str) -> str:
-        #     if name not in child_name_conflicts:
-        #         return name
-        #     return "%s:%s" % (prefix, name)
-
-        # def _unique_safe_name(name: str, prefix: str) -> str:
-        #     # First get the non-ambiguous YANG name, possibly with prefix
-        #     unique_name = _unique_name(name, prefix)
-        #     safe_name = _safe_name(unique_name)
-        #     # Now check if the safe name is unique (within the confines of the module)
-        #     if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
-        #         idx = child_safe_names[prefix][safe_name].index(name)
-        #         return safe_name.replace(":", "_") + "_" + str(idx)
-        #     return _safe_name(unique_name).replace(":", "_")
-
     path = []
     while True:
-        self_unique_safe_name = dnode.name
+        self_unique_safe_name = _safe_name(dnode.name, safe_kw=False)
         parent = dnode.parent
         # if parent is not None then of course it is DNodeInner (= has children
         # attribute), but let's make that explicit for the compiler ...
         if parent is not None:
             if isinstance(parent, DNodeInner):
-                sibling_names = set()
-                sibling_names_conflicts = set()
-                sibling_safe_names: dict[str, dict[str, list[str]]] = dict()
-                sibling_safe_names_conflicts: dict[str, set[str]] = dict()
-                for sibling in parent.children:
-                    if sibling.name in sibling_names:
-                        sibling_names_conflicts.add(sibling.name)
-                    else:
-                        sibling_names.add(sibling.name)
-                    sibling_safe_name = sibling.name.replace("-", "_").replace(".", "_")
-                    if sibling_safe_name in sibling_safe_names.get_def(sibling.prefix, dict()):
-                        sibling_safe_names_conflicts.setdefault(sibling.prefix, set())
-                        sibling_safe_names_conflicts[sibling.prefix].add(sibling_safe_name)
-                        sibling_safe_names[sibling.prefix][sibling_safe_name].append(sibling.name)
-                    else:
-                        sibling_safe_names[sibling.prefix] = {sibling_safe_name: [sibling.name]}
-
-                # First get the non-ambiguous YANG name, possibly with prefix
-                if dnode.name in sibling_names_conflicts:
-                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
-                else:
-                    self_unique_name = dnode.name
+                sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts = _find_conflicting_names(parent)
 
                 # Now check if the safe name is unique (within the confines of the module)
-                self_unique_safe_name = self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_")
-                if self_unique_safe_name == "foo_bar":
-                    print(sibling_safe_names_conflicts, err=True)
-                    print(sibling_safe_names, err=True)
-                if self_unique_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
-                    print("in here", err=True)
-                    # If not, we need to add a number suffix to make it unique
-                    idx = sibling_safe_names[dnode.prefix][self_unique_safe_name].index(dnode.name)
-                    self_unique_safe_name = self_unique_safe_name + "_" + str(idx)
+                self_unique_safe_name = _g_unique_safe_name(dnode.name, dnode.prefix, sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts, safe_kw=False)
                 
                 dnode = parent
-        path.append(self_unique_safe_name.replace("-", "_").replace(".", "_").replace(":", "_"))
+        path.append(self_unique_safe_name)
         if parent is None:
             break
 
@@ -2353,6 +2304,7 @@ def get_path_name(dnode: DNode) -> str:
     if len(path) == 0:
         raise ValueError("No path for DNode" + str(dnode))
 
+    print("path", path, err=True)
     return "__".join(reversed(path))
 
 

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2013,3 +2013,47 @@ def _test_prdaclass_dot():
     root = yang.compile([ys_base])
     src = root.prdaclass()
     return src
+
+def _test_prdaclass_conflicting_safe_name():
+    ys_m1 = """module m1 {
+    yang-version "1.1";
+    namespace "http://example.com/m1";
+    prefix m1;
+    container foo-bar {
+        leaf foo-bar {
+            type string;
+        }
+    }
+    container foo_bar {
+        leaf foo_bar {
+            type string;
+        }
+    }
+    container foo.bar {
+        leaf foo.bar {
+            type string;
+        }
+    }
+}"""
+
+    ys_m2 = """module m2 {
+    yang-version "1.1";
+    namespace "http://example.com/m2";
+    prefix "m2";
+    import m1 {
+        prefix m1;
+    }
+    container foo-bar {
+        leaf foo-bar {
+            type string;
+        }
+    }
+    augment "/m1:foo-bar" {
+        leaf foo-bar {
+            type string;
+        }
+    }
+}"""
+    root = yang.compile([ys_m1, ys_m2])
+    src = root.prdaclass()
+    return src

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -344,13 +344,12 @@ class DNodeInner(DNode):
                 new_children.append(child)
         self.children = new_children
 
-        child_name_conflicts, child_safe_names, child_safe_name_conflicts = _find_conflicting_names(self)
-
+        un = _UniqueNamer(self)
         def _unique_name(name: str, prefix: str) -> str:
-            return _g_unique_name(name, prefix, child_name_conflicts)
+            return un.unique_name(name, prefix)
 
         def _unique_safe_name(name: str, prefix: str) -> str:
-            return _g_unique_safe_name(name, prefix, child_name_conflicts, child_safe_names, child_safe_name_conflicts)
+            return un.unique_safe_name(name, prefix)
 
         for child in self.children:
             res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml))
@@ -756,7 +755,7 @@ class DNodeInner(DNode):
                 res.append("        point = path[0]")
                 res.append("        rest_path = path[1:]")
                 for child in self.children:
-                    if top == True or (child.name in child_name_conflicts):
+                    if top == True or (child.name in un.name_conflicts):
                         res.append("        if point == '%s:%s':" % (child.prefix, child.name))
                     else:
                         res.append("        if point == '%s:%s' or point == '%s':" % (child.prefix, child.name, child.name))
@@ -790,7 +789,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                if top == True or (child.name in child_name_conflicts):
+                if top == True or (child.name in un.name_conflicts):
                     res.append("    child_%s = jd.get('%s:%s')" % (_unique_safe_name(child.name, child.prefix), child.prefix, child.name))
                 else:
                     res.append("    child_%s_full = jd.get('%s:%s')" % (_unique_safe_name(child.name, child.prefix), child.prefix, child.name))
@@ -2208,39 +2207,43 @@ def _safe_name(name: str, safe_kw=True) -> str:
             new += "_"
     return new
 
-def _find_conflicting_names(node: DNodeInner):
-    child_names = set()
-    child_name_conflicts = set()
-    child_safe_names: dict[str, dict[str, list[str]]] = dict()
-    child_safe_name_conflicts: dict[str, set[str]] = dict()
-    for child in node.children:
-        child_safe_name = _safe_name(child.name)
-        if child.name in child_names:
-            child_name_conflicts.add(child.name)
-        else:
-            child_names.add(child.name)
-        if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
-            child_safe_name_conflicts.setdefault(child.prefix, set())
-            child_safe_name_conflicts[child.prefix].add(child_safe_name)
-            child_safe_names[child.prefix][child_safe_name].append(child.name)
-        else:
-            child_safe_names[child.prefix] = {child_safe_name: [child.name]}
-    return child_name_conflicts, child_safe_names, child_safe_name_conflicts
+class _UniqueNamer(object):
+    name_conflicts: set[str]
+    safe_names: dict[str, dict[str, list[str]]]
+    safe_name_conflicts: dict[str, set[str]]
 
-def _g_unique_name(name: str, prefix: str, child_name_conflicts) -> str:
-    if name not in child_name_conflicts:
-        return name
-    return "%s:%s" % (prefix, name)
-
-def _g_unique_safe_name(name: str, prefix: str, child_name_conflicts, child_safe_names, child_safe_name_conflicts, safe_kw=True) -> str:
-    # First get the non-ambiguous YANG name, possibly with prefix
-    unique_name = _g_unique_name(name, prefix, child_name_conflicts)
-    safe_name = _safe_name(unique_name, safe_kw)
-    # Now check if the safe name is unique (within the confines of the module)
-    if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
-        idx = child_safe_names[prefix][safe_name].index(name)
-        return safe_name.replace(":", "_") + "_" + str(idx)
-    return _safe_name(unique_name, safe_kw).replace(":", "_")
+    def __init__(self, node: DNodeInner):
+        names = set()
+        self.name_conflicts = set()
+        self.safe_names = dict()
+        self.safe_name_conflicts = dict()
+        for child in node.children:
+            child_safe_name = _safe_name(child.name)
+            if child.name in names:
+                self.name_conflicts.add(child.name)
+            else:
+                names.add(child.name)
+            if child_safe_name in self.safe_names.get_def(child.prefix, dict()):
+                self.safe_name_conflicts.setdefault(child.prefix, set())
+                self.safe_name_conflicts[child.prefix].add(child_safe_name)
+                self.safe_names[child.prefix][child_safe_name].append(child.name)
+            else:
+                self.safe_names[child.prefix] = {child_safe_name: [child.name]}
+    
+    def unique_name(self, name: str, prefix: str) -> str:
+        if name not in self.name_conflicts:
+            return name
+        return "%s:%s" % (prefix, name)
+    
+    def unique_safe_name(self, name: str, prefix: str, safe_kw=True) -> str:
+        # First get the non-ambiguous YANG name, possibly with prefix
+        unique_name = self.unique_name(name, prefix)
+        safe_name = _safe_name(unique_name, safe_kw)
+        # Now check if the safe name is unique (within the confines of the module)
+        if safe_name in self.safe_name_conflicts.get_def(prefix, set()):
+            idx = self.safe_names[prefix][safe_name].index(name)
+            return safe_name.replace(":", "_") + "_" + str(idx)
+        return _safe_name(unique_name, safe_kw).replace(":", "_")
 
 def get_path_name(dnode: DNode) -> str:
     """Build the adata path name for a data node
@@ -2286,11 +2289,8 @@ def get_path_name(dnode: DNode) -> str:
         # attribute), but let's make that explicit for the compiler ...
         if parent is not None:
             if isinstance(parent, DNodeInner):
-                sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts = _find_conflicting_names(parent)
-
-                # Now check if the safe name is unique (within the confines of the module)
-                self_unique_safe_name = _g_unique_safe_name(dnode.name, dnode.prefix, sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts, safe_kw=False)
-                
+                un = _UniqueNamer(parent)
+                self_unique_safe_name = un.unique_safe_name(dnode.name, dnode.prefix, safe_kw=False)
                 dnode = parent
         path.append(self_unique_safe_name)
         if parent is None:
@@ -2300,7 +2300,6 @@ def get_path_name(dnode: DNode) -> str:
     if len(path) == 0:
         raise ValueError("No path for DNode" + str(dnode))
 
-    print("path", path, err=True)
     return "__".join(reversed(path))
 
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -336,19 +336,29 @@ class DNodeInner(DNode):
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
         pos_child_idx = 0
-        child_names = set()
-        child_name_conflicts = set()
         for child in self.children:
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
             else:
                 new_children.append(child)
+        self.children = new_children
+        
+        child_names = set()
+        child_name_conflicts = set()
+        child_safe_names = dict()
+        child_safe_name_conflicts = set()
+        for child in self.children:
+            child_safe_name = _safe_name(child.name)
             if child.name in child_names:
                 child_name_conflicts.add(child.name)
             else:
                 child_names.add(child.name)
-        self.children = new_children
+            if child_safe_name in child_safe_names:
+                child_safe_name_conflicts.add(child_safe_name)
+                child_safe_names[child_safe_name].append(child.name)
+            else:
+                child_safe_names[child_safe_name] = [child.name]
 
         def _unique_name(name: str, prefix: str) -> str:
             if name not in child_name_conflicts:
@@ -356,7 +366,13 @@ class DNodeInner(DNode):
             return "%s:%s" % (prefix, name)
 
         def _unique_safe_name(name: str, prefix: str) -> str:
+            # First get the non-ambiguous YANG name, possibly with prefix
             unique_name = _unique_name(name, prefix)
+            safe_name = _safe_name(unique_name)
+            # Now check if the safe name is unique
+            if safe_name in child_safe_name_conflicts:
+                idx = child_safe_names[safe_name].index(name)
+                return safe_name.replace(":", "_") + "_" + str(idx)
             return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -343,22 +343,23 @@ class DNodeInner(DNode):
             else:
                 new_children.append(child)
         self.children = new_children
-        
+
         child_names = set()
         child_name_conflicts = set()
-        child_safe_names = dict()
-        child_safe_name_conflicts = set()
+        child_safe_names: dict[str, dict[str, list[str]]] = dict()
+        child_safe_name_conflicts: dict[str, set[str]] = dict()
         for child in self.children:
             child_safe_name = _safe_name(child.name)
             if child.name in child_names:
                 child_name_conflicts.add(child.name)
             else:
                 child_names.add(child.name)
-            if child_safe_name in child_safe_names:
-                child_safe_name_conflicts.add(child_safe_name)
-                child_safe_names[child_safe_name].append(child.name)
+            if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
+                child_safe_name_conflicts.setdefault(child.prefix, set())
+                child_safe_name_conflicts[child.prefix].add(child_safe_name)
+                child_safe_names[child.prefix][child_safe_name].append(child.name)
             else:
-                child_safe_names[child_safe_name] = [child.name]
+                child_safe_names[child.prefix] = {child_safe_name: [child.name]}
 
         def _unique_name(name: str, prefix: str) -> str:
             if name not in child_name_conflicts:
@@ -369,9 +370,9 @@ class DNodeInner(DNode):
             # First get the non-ambiguous YANG name, possibly with prefix
             unique_name = _unique_name(name, prefix)
             safe_name = _safe_name(unique_name)
-            # Now check if the safe name is unique
-            if safe_name in child_safe_name_conflicts:
-                idx = child_safe_names[safe_name].index(name)
+            # Now check if the safe name is unique (within the confines of the module)
+            if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
+                idx = child_safe_names[prefix][safe_name].index(name)
                 return safe_name.replace(":", "_") + "_" + str(idx)
             return _safe_name(unique_name).replace(":", "_")
 
@@ -2265,6 +2266,38 @@ def get_path_name(dnode: DNode) -> str:
     We do not rewrite the builtin keywords here (see _safe_name()) because it
     is not necessary.
     """
+
+        # child_names = set()
+        # child_name_conflicts = set()
+        # child_safe_names: dict[str, dict[str, list[str]]] = dict()
+        # child_safe_name_conflicts: dict[str, set[str]] = dict()
+        # for child in self.children:
+        #     child_safe_name = _safe_name(child.name)
+        #     if child.name in child_names:
+        #         child_name_conflicts.add(child.name)
+        #     else:
+        #         child_names.add(child.name)
+        #     if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
+        #         child_safe_name_conflicts.setdefault(child.prefix, set())
+        #         child_safe_name_conflicts[child.prefix].add(child_safe_name)
+        #         child_safe_names[child.prefix][child_safe_name].append(child.name)
+        #     else:
+        #         child_safe_names[child.prefix] = {child_safe_name: [child.name]}
+        # def _unique_name(name: str, prefix: str) -> str:
+        #     if name not in child_name_conflicts:
+        #         return name
+        #     return "%s:%s" % (prefix, name)
+
+        # def _unique_safe_name(name: str, prefix: str) -> str:
+        #     # First get the non-ambiguous YANG name, possibly with prefix
+        #     unique_name = _unique_name(name, prefix)
+        #     safe_name = _safe_name(unique_name)
+        #     # Now check if the safe name is unique (within the confines of the module)
+        #     if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
+        #         idx = child_safe_names[prefix][safe_name].index(name)
+        #         return safe_name.replace(":", "_") + "_" + str(idx)
+        #     return _safe_name(unique_name).replace(":", "_")
+
     path = []
     while True:
         self_unique_name = dnode.name
@@ -2275,15 +2308,32 @@ def get_path_name(dnode: DNode) -> str:
             if isinstance(parent, DNodeInner):
                 sibling_names = set()
                 sibling_names_conflicts = set()
+                sibling_safe_names: dict[str, dict[str, list[str]]] = dict()
+                sibling_safe_names_conflicts: dict[str, set[str]] = dict()
                 for sibling in parent.children:
                     if sibling.name in sibling_names:
                         sibling_names_conflicts.add(sibling.name)
                     else:
                         sibling_names.add(sibling.name)
-                if dnode.name not in sibling_names_conflicts:
-                    self_unique_name = dnode.name
-                else:
-                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
+                    sibling_safe_name = sibling.name.replace("-", "_").replace(".", "_")
+                    if sibling_safe_name in sibling_safe_names.get_def(sibling.prefix, dict()):
+                        sibling_safe_names_conflicts.setdefault(sibling.prefix, set())
+                        sibling_safe_names_conflicts[sibling.prefix].add(sibling_safe_name)
+                        sibling_safe_names[sibling.prefix][sibling_safe_name].append(sibling.name)
+                    else:
+                        sibling_safe_names[sibling.prefix] = {sibling_safe_name: [sibling.name]}
+
+                self_safe_name = dnode.name.replace("-", "_").replace(".", "_")
+                if self_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
+                    # If not, we need to add a number suffix to make it unique
+                    idx = sibling_safe_names[dnode.prefix][self_safe_name].index(dnode.name)
+                    self_safe_name = self_safe_name + "_" + str(idx)
+                
+                # Now get the non-ambiguous YANG name, possibly with prefix
+                self_unique_name = self_safe_name
+                if dnode.name in sibling_names_conflicts:
+                    self_unique_name = "%s_%s" % (dnode.prefix, self_safe_name)
+
                 dnode = parent
         path.append(self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_"))
         if parent is None:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2300,7 +2300,7 @@ def get_path_name(dnode: DNode) -> str:
 
     path = []
     while True:
-        self_unique_name = dnode.name
+        self_unique_safe_name = dnode.name
         parent = dnode.parent
         # if parent is not None then of course it is DNodeInner (= has children
         # attribute), but let's make that explicit for the compiler ...
@@ -2323,19 +2323,25 @@ def get_path_name(dnode: DNode) -> str:
                     else:
                         sibling_safe_names[sibling.prefix] = {sibling_safe_name: [sibling.name]}
 
-                self_safe_name = dnode.name.replace("-", "_").replace(".", "_")
-                if self_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
-                    # If not, we need to add a number suffix to make it unique
-                    idx = sibling_safe_names[dnode.prefix][self_safe_name].index(dnode.name)
-                    self_safe_name = self_safe_name + "_" + str(idx)
-                
-                # Now get the non-ambiguous YANG name, possibly with prefix
-                self_unique_name = self_safe_name
+                # First get the non-ambiguous YANG name, possibly with prefix
                 if dnode.name in sibling_names_conflicts:
-                    self_unique_name = "%s_%s" % (dnode.prefix, self_safe_name)
+                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
+                else:
+                    self_unique_name = dnode.name
 
+                # Now check if the safe name is unique (within the confines of the module)
+                self_unique_safe_name = self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_")
+                if self_unique_safe_name == "foo_bar":
+                    print(sibling_safe_names_conflicts, err=True)
+                    print(sibling_safe_names, err=True)
+                if self_unique_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
+                    print("in here", err=True)
+                    # If not, we need to add a number suffix to make it unique
+                    idx = sibling_safe_names[dnode.prefix][self_unique_safe_name].index(dnode.name)
+                    self_unique_safe_name = self_unique_safe_name + "_" + str(idx)
+                
                 dnode = parent
-        path.append(self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_"))
+        path.append(self_unique_safe_name.replace("-", "_").replace(".", "_").replace(":", "_"))
         if parent is None:
             break
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -344,37 +344,13 @@ class DNodeInner(DNode):
                 new_children.append(child)
         self.children = new_children
 
-        child_names = set()
-        child_name_conflicts = set()
-        child_safe_names: dict[str, dict[str, list[str]]] = dict()
-        child_safe_name_conflicts: dict[str, set[str]] = dict()
-        for child in self.children:
-            child_safe_name = _safe_name(child.name)
-            if child.name in child_names:
-                child_name_conflicts.add(child.name)
-            else:
-                child_names.add(child.name)
-            if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
-                child_safe_name_conflicts.setdefault(child.prefix, set())
-                child_safe_name_conflicts[child.prefix].add(child_safe_name)
-                child_safe_names[child.prefix][child_safe_name].append(child.name)
-            else:
-                child_safe_names[child.prefix] = {child_safe_name: [child.name]}
+        child_name_conflicts, child_safe_names, child_safe_name_conflicts = _find_conflicting_names(self)
 
         def _unique_name(name: str, prefix: str) -> str:
-            if name not in child_name_conflicts:
-                return name
-            return "%s:%s" % (prefix, name)
+            return _g_unique_name(name, prefix, child_name_conflicts)
 
         def _unique_safe_name(name: str, prefix: str) -> str:
-            # First get the non-ambiguous YANG name, possibly with prefix
-            unique_name = _unique_name(name, prefix)
-            safe_name = _safe_name(unique_name)
-            # Now check if the safe name is unique (within the confines of the module)
-            if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
-                idx = child_safe_names[prefix][safe_name].index(name)
-                return safe_name.replace(":", "_") + "_" + str(idx)
-            return _safe_name(unique_name).replace(":", "_")
+            return _g_unique_safe_name(name, prefix, child_name_conflicts, child_safe_names, child_safe_name_conflicts)
 
         for child in self.children:
             res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml))
@@ -2215,21 +2191,56 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return '"' + value.replace('"', '\\"') + '"'
     raise ValueError("Unhandled prsrc literal of type " + ytype)
 
-def _safe_name(name: str) -> str:
+def _safe_name(name: str, safe_kw=True) -> str:
     new = name.replace("-", "_").replace(".", "_")
-    if new in {"action",
-               "as",
-               "class",
-               "except",
-               "for",
-               "from",
-               "import",
-               "in",
-               "protocol",
-               "with",
-               }:
-        new += "_"
+    if safe_kw:
+        if new in {"action",
+                   "as",
+                   "class",
+                   "except",
+                   "for",
+                   "from",
+                   "import",
+                   "in",
+                   "protocol",
+                   "with",
+                   }:
+            new += "_"
     return new
+
+def _find_conflicting_names(node: DNodeInner):
+    child_names = set()
+    child_name_conflicts = set()
+    child_safe_names: dict[str, dict[str, list[str]]] = dict()
+    child_safe_name_conflicts: dict[str, set[str]] = dict()
+    for child in node.children:
+        child_safe_name = _safe_name(child.name)
+        if child.name in child_names:
+            child_name_conflicts.add(child.name)
+        else:
+            child_names.add(child.name)
+        if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
+            child_safe_name_conflicts.setdefault(child.prefix, set())
+            child_safe_name_conflicts[child.prefix].add(child_safe_name)
+            child_safe_names[child.prefix][child_safe_name].append(child.name)
+        else:
+            child_safe_names[child.prefix] = {child_safe_name: [child.name]}
+    return child_name_conflicts, child_safe_names, child_safe_name_conflicts
+
+def _g_unique_name(name: str, prefix: str, child_name_conflicts) -> str:
+    if name not in child_name_conflicts:
+        return name
+    return "%s:%s" % (prefix, name)
+
+def _g_unique_safe_name(name: str, prefix: str, child_name_conflicts, child_safe_names, child_safe_name_conflicts, safe_kw=True) -> str:
+    # First get the non-ambiguous YANG name, possibly with prefix
+    unique_name = _g_unique_name(name, prefix, child_name_conflicts)
+    safe_name = _safe_name(unique_name, safe_kw)
+    # Now check if the safe name is unique (within the confines of the module)
+    if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
+        idx = child_safe_names[prefix][safe_name].index(name)
+        return safe_name.replace(":", "_") + "_" + str(idx)
+    return _safe_name(unique_name, safe_kw).replace(":", "_")
 
 def get_path_name(dnode: DNode) -> str:
     """Build the adata path name for a data node
@@ -2267,81 +2278,21 @@ def get_path_name(dnode: DNode) -> str:
     is not necessary.
     """
 
-        # child_names = set()
-        # child_name_conflicts = set()
-        # child_safe_names: dict[str, dict[str, list[str]]] = dict()
-        # child_safe_name_conflicts: dict[str, set[str]] = dict()
-        # for child in self.children:
-        #     child_safe_name = _safe_name(child.name)
-        #     if child.name in child_names:
-        #         child_name_conflicts.add(child.name)
-        #     else:
-        #         child_names.add(child.name)
-        #     if child_safe_name in child_safe_names.get_def(child.prefix, dict()):
-        #         child_safe_name_conflicts.setdefault(child.prefix, set())
-        #         child_safe_name_conflicts[child.prefix].add(child_safe_name)
-        #         child_safe_names[child.prefix][child_safe_name].append(child.name)
-        #     else:
-        #         child_safe_names[child.prefix] = {child_safe_name: [child.name]}
-        # def _unique_name(name: str, prefix: str) -> str:
-        #     if name not in child_name_conflicts:
-        #         return name
-        #     return "%s:%s" % (prefix, name)
-
-        # def _unique_safe_name(name: str, prefix: str) -> str:
-        #     # First get the non-ambiguous YANG name, possibly with prefix
-        #     unique_name = _unique_name(name, prefix)
-        #     safe_name = _safe_name(unique_name)
-        #     # Now check if the safe name is unique (within the confines of the module)
-        #     if safe_name in child_safe_name_conflicts.get_def(prefix, set()):
-        #         idx = child_safe_names[prefix][safe_name].index(name)
-        #         return safe_name.replace(":", "_") + "_" + str(idx)
-        #     return _safe_name(unique_name).replace(":", "_")
-
     path = []
     while True:
-        self_unique_safe_name = dnode.name
+        self_unique_safe_name = _safe_name(dnode.name, safe_kw=False)
         parent = dnode.parent
         # if parent is not None then of course it is DNodeInner (= has children
         # attribute), but let's make that explicit for the compiler ...
         if parent is not None:
             if isinstance(parent, DNodeInner):
-                sibling_names = set()
-                sibling_names_conflicts = set()
-                sibling_safe_names: dict[str, dict[str, list[str]]] = dict()
-                sibling_safe_names_conflicts: dict[str, set[str]] = dict()
-                for sibling in parent.children:
-                    if sibling.name in sibling_names:
-                        sibling_names_conflicts.add(sibling.name)
-                    else:
-                        sibling_names.add(sibling.name)
-                    sibling_safe_name = sibling.name.replace("-", "_").replace(".", "_")
-                    if sibling_safe_name in sibling_safe_names.get_def(sibling.prefix, dict()):
-                        sibling_safe_names_conflicts.setdefault(sibling.prefix, set())
-                        sibling_safe_names_conflicts[sibling.prefix].add(sibling_safe_name)
-                        sibling_safe_names[sibling.prefix][sibling_safe_name].append(sibling.name)
-                    else:
-                        sibling_safe_names[sibling.prefix] = {sibling_safe_name: [sibling.name]}
-
-                # First get the non-ambiguous YANG name, possibly with prefix
-                if dnode.name in sibling_names_conflicts:
-                    self_unique_name = "%s:%s" % (dnode.prefix, dnode.name)
-                else:
-                    self_unique_name = dnode.name
+                sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts = _find_conflicting_names(parent)
 
                 # Now check if the safe name is unique (within the confines of the module)
-                self_unique_safe_name = self_unique_name.replace("-", "_").replace(".", "_").replace(":", "_")
-                if self_unique_safe_name == "foo_bar":
-                    print(sibling_safe_names_conflicts, err=True)
-                    print(sibling_safe_names, err=True)
-                if self_unique_safe_name in sibling_safe_names_conflicts.get_def(dnode.prefix, set()):
-                    print("in here", err=True)
-                    # If not, we need to add a number suffix to make it unique
-                    idx = sibling_safe_names[dnode.prefix][self_unique_safe_name].index(dnode.name)
-                    self_unique_safe_name = self_unique_safe_name + "_" + str(idx)
+                self_unique_safe_name = _g_unique_safe_name(dnode.name, dnode.prefix, sibling_name_conflicts, sibling_safe_names, sibling_safe_names_conflicts, safe_kw=False)
                 
                 dnode = parent
-        path.append(self_unique_safe_name.replace("-", "_").replace(".", "_").replace(":", "_"))
+        path.append(self_unique_safe_name)
         if parent is None:
             break
 
@@ -2349,6 +2300,7 @@ def get_path_name(dnode: DNode) -> str:
     if len(path) == 0:
         raise ValueError("No path for DNode" + str(dnode))
 
+    print("path", path, err=True)
     return "__".join(reversed(path))
 
 

--- a/test/golden/test_yang/prdaclass_conflicting_safe_name
+++ b/test/golden/test_yang/prdaclass_conflicting_safe_name
@@ -1,0 +1,304 @@
+import json
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+mut def from_json_foo__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__foo_bar(yang.adata.MNode):
+    foo_bar: ?str
+
+    mut def __init__(self, foo_bar: ?str):
+        self._ns = "http://example.com/foo"
+        self.foo_bar = foo_bar
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_bar = self.foo_bar
+        if _foo_bar is not None:
+            children['foo-bar'] = yang.gdata.Leaf('string', _foo_bar)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_bar:
+        if n != None:
+            return foo__foo_bar(foo_bar=n.get_opt_str("foo-bar"))
+        return foo__foo_bar()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__foo_bar:
+        if n != None:
+            return foo__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar"))
+        return foo__foo_bar()
+
+
+mut def from_json_path_foo__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:foo-bar' or point == 'foo-bar':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__foo_bar(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_bar_full = jd.get('foo:foo-bar')
+    child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo-bar')
+    if child_foo_bar is not None:
+        children['foo-bar'] = from_json_foo__foo_bar__foo_bar(child_foo_bar)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_foo_bar = n.children.get('foo-bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Leaf):
+            children['foo-bar'] = child_foo_bar.val
+    return children
+
+
+mut def from_json_foo__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__foo_bar(yang.adata.MNode):
+    foo_bar: ?str
+
+    mut def __init__(self, foo_bar: ?str):
+        self._ns = "http://example.com/foo"
+        self.foo_bar = foo_bar
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_bar = self.foo_bar
+        if _foo_bar is not None:
+            children['foo_bar'] = yang.gdata.Leaf('string', _foo_bar)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_bar:
+        if n != None:
+            return foo__foo_bar(foo_bar=n.get_opt_str("foo_bar"))
+        return foo__foo_bar()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__foo_bar:
+        if n != None:
+            return foo__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo_bar"))
+        return foo__foo_bar()
+
+
+mut def from_json_path_foo__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:foo_bar' or point == 'foo_bar':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__foo_bar(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_bar_full = jd.get('foo:foo_bar')
+    child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo_bar')
+    if child_foo_bar is not None:
+        children['foo_bar'] = from_json_foo__foo_bar__foo_bar(child_foo_bar)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_foo_bar = n.children.get('foo_bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Leaf):
+            children['foo_bar'] = child_foo_bar.val
+    return children
+
+
+mut def from_json_foo__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__foo_bar(yang.adata.MNode):
+    foo_bar: ?str
+
+    mut def __init__(self, foo_bar: ?str):
+        self._ns = "http://example.com/foo"
+        self.foo_bar = foo_bar
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_bar = self.foo_bar
+        if _foo_bar is not None:
+            children['foo.bar'] = yang.gdata.Leaf('string', _foo_bar)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_bar:
+        if n != None:
+            return foo__foo_bar(foo_bar=n.get_opt_str("foo.bar"))
+        return foo__foo_bar()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__foo_bar:
+        if n != None:
+            return foo__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo.bar"))
+        return foo__foo_bar()
+
+
+mut def from_json_path_foo__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:foo.bar' or point == 'foo.bar':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__foo_bar(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_bar_full = jd.get('foo:foo.bar')
+    child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo.bar')
+    if child_foo_bar is not None:
+        children['foo.bar'] = from_json_foo__foo_bar__foo_bar(child_foo_bar)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_foo_bar = n.children.get('foo.bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Leaf):
+            children['foo.bar'] = child_foo_bar.val
+    return children
+
+
+class root(yang.adata.MNode):
+    foo_bar: foo__foo_bar
+    foo_bar: foo__foo_bar
+    foo_bar: foo__foo_bar
+
+    mut def __init__(self, foo_bar: ?foo__foo_bar=None, foo_bar: ?foo__foo_bar=None, foo_bar: ?foo__foo_bar=None):
+        self._ns = ""
+        if foo_bar is not None:
+            self.foo_bar = foo_bar
+        else:
+            self.foo_bar = foo__foo_bar()
+        self_foo_bar = self.foo_bar
+        if self_foo_bar is not None:
+            self_foo_bar._parent = self
+        if foo_bar is not None:
+            self.foo_bar = foo_bar
+        else:
+            self.foo_bar = foo__foo_bar()
+        self_foo_bar = self.foo_bar
+        if self_foo_bar is not None:
+            self_foo_bar._parent = self
+        if foo_bar is not None:
+            self.foo_bar = foo_bar
+        else:
+            self.foo_bar = foo__foo_bar()
+        self_foo_bar = self.foo_bar
+        if self_foo_bar is not None:
+            self_foo_bar._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_bar = self.foo_bar
+        _foo_bar = self.foo_bar
+        _foo_bar = self.foo_bar
+        if _foo_bar is not None:
+            children['foo-bar'] = _foo_bar.to_gdata()
+        if _foo_bar is not None:
+            children['foo_bar'] = _foo_bar.to_gdata()
+        if _foo_bar is not None:
+            children['foo.bar'] = _foo_bar.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(foo_bar=foo__foo_bar.from_gdata(n.get_opt_container("foo-bar")), foo_bar=foo__foo_bar.from_gdata(n.get_opt_container("foo_bar")), foo_bar=foo__foo_bar.from_gdata(n.get_opt_container("foo.bar")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(foo_bar=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo-bar", "http://example.com/foo")), foo_bar=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo_bar", "http://example.com/foo")), foo_bar=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo.bar", "http://example.com/foo")))
+        return root()
+
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:foo-bar':
+            child = {'foo-bar': from_json_path_foo__foo_bar(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        if point == 'foo:foo_bar':
+            child = {'foo_bar': from_json_path_foo__foo_bar(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        if point == 'foo:foo.bar':
+            child = {'foo.bar': from_json_path_foo__foo_bar(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
+    children = {}
+    child_foo_bar = jd.get('foo:foo-bar')
+    if child_foo_bar is not None and isinstance(child_foo_bar, dict):
+        children['foo-bar'] = from_json_foo__foo_bar(child_foo_bar)
+    child_foo_bar = jd.get('foo:foo_bar')
+    if child_foo_bar is not None and isinstance(child_foo_bar, dict):
+        children['foo_bar'] = from_json_foo__foo_bar(child_foo_bar)
+    child_foo_bar = jd.get('foo:foo.bar')
+    if child_foo_bar is not None and isinstance(child_foo_bar, dict):
+        children['foo.bar'] = from_json_foo__foo_bar(child_foo_bar)
+    return yang.gdata.Root(children)
+
+mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
+    children = {}
+    child_foo_bar = n.children.get('foo-bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Container):
+            children['foo:foo-bar'] = to_json_foo__foo_bar(child_foo_bar)
+    child_foo_bar = n.children.get('foo_bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Container):
+            children['foo:foo_bar'] = to_json_foo__foo_bar(child_foo_bar)
+    child_foo_bar = n.children.get('foo.bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Container):
+            children['foo:foo.bar'] = to_json_foo__foo_bar(child_foo_bar)
+    return children
+

--- a/test/golden/test_yang/prdaclass_conflicting_safe_name
+++ b/test/golden/test_yang/prdaclass_conflicting_safe_name
@@ -6,77 +6,93 @@ import yang.gdata
 # == This file is generated ==
 
 
-mut def from_json_foo__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+mut def from_json_m1__foo_bar__m1_foo_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__foo_bar(yang.adata.MNode):
-    foo_bar: ?str
+mut def from_json_m1__foo_bar__m2_foo_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
 
-    mut def __init__(self, foo_bar: ?str):
-        self._ns = "http://example.com/foo"
-        self.foo_bar = foo_bar
+class m1__foo_bar(yang.adata.MNode):
+    m1_foo_bar: ?str
+    m2_foo_bar: ?str
+
+    mut def __init__(self, m1_foo_bar: ?str, m2_foo_bar: ?str):
+        self._ns = "http://example.com/m1"
+        self.m1_foo_bar = m1_foo_bar
+        self.m2_foo_bar = m2_foo_bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_bar = self.foo_bar
-        if _foo_bar is not None:
-            children['foo-bar'] = yang.gdata.Leaf('string', _foo_bar)
-        return yang.gdata.Container(children, ns='http://example.com/foo')
+        _m1_foo_bar = self.m1_foo_bar
+        _m2_foo_bar = self.m2_foo_bar
+        if _m1_foo_bar is not None:
+            children['m1:foo-bar'] = yang.gdata.Leaf('string', _m1_foo_bar)
+        if _m2_foo_bar is not None:
+            children['m2:foo-bar'] = yang.gdata.Leaf('string', _m2_foo_bar, ns='http://example.com/m2')
+        return yang.gdata.Container(children, ns='http://example.com/m1')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_bar:
+    mut def from_gdata(n: ?yang.gdata.Node) -> m1__foo_bar:
         if n != None:
-            return foo__foo_bar(foo_bar=n.get_opt_str("foo-bar"))
-        return foo__foo_bar()
+            return m1__foo_bar(m1_foo_bar=n.get_opt_str("m1:foo-bar"), m2_foo_bar=n.get_opt_str("m2:foo-bar"))
+        return m1__foo_bar()
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo_bar:
+    mut def from_xml(n: ?xml.Node) -> m1__foo_bar:
         if n != None:
-            return foo__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar"))
-        return foo__foo_bar()
+            return m1__foo_bar(m1_foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar"), m2_foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar", "http://example.com/m2"))
+        return m1__foo_bar()
 
 
-mut def from_json_path_foo__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_m1__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo-bar' or point == 'foo-bar':
+        if point == 'm1:foo-bar':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'm2:foo-bar':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__foo_bar(yang.gdata.unwrap_dict(jd))
+            return from_json_m1__foo_bar(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_m1__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_bar_full = jd.get('foo:foo-bar')
-    child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo-bar')
-    if child_foo_bar is not None:
-        children['foo-bar'] = from_json_foo__foo_bar__foo_bar(child_foo_bar)
+    child_m1_foo_bar = jd.get('m1:foo-bar')
+    if child_m1_foo_bar is not None:
+        children['foo-bar'] = from_json_m1__foo_bar__m1_foo_bar(child_m1_foo_bar)
+    child_m2_foo_bar = jd.get('m2:foo-bar')
+    if child_m2_foo_bar is not None:
+        children['foo-bar'] = from_json_m1__foo_bar__m2_foo_bar(child_m2_foo_bar)
     return yang.gdata.Container(children)
 
-mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_m1__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
-    child_foo_bar = n.children.get('foo-bar')
-    if child_foo_bar is not None:
-        if isinstance(child_foo_bar, yang.gdata.Leaf):
-            children['foo-bar'] = child_foo_bar.val
+    child_m1_foo_bar = n.children.get('foo-bar')
+    if child_m1_foo_bar is not None:
+        if isinstance(child_m1_foo_bar, yang.gdata.Leaf):
+            children['foo-bar'] = child_m1_foo_bar.val
+    child_m2_foo_bar = n.children.get('foo-bar')
+    if child_m2_foo_bar is not None:
+        if isinstance(child_m2_foo_bar, yang.gdata.Leaf):
+            children['m2:foo-bar'] = child_m2_foo_bar.val
     return children
 
 
-mut def from_json_foo__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+mut def from_json_m1__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__foo_bar(yang.adata.MNode):
+class m1__foo_bar(yang.adata.MNode):
     foo_bar: ?str
 
     mut def __init__(self, foo_bar: ?str):
-        self._ns = "http://example.com/foo"
+        self._ns = "http://example.com/m1"
         self.foo_bar = foo_bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -84,46 +100,46 @@ class foo__foo_bar(yang.adata.MNode):
         _foo_bar = self.foo_bar
         if _foo_bar is not None:
             children['foo_bar'] = yang.gdata.Leaf('string', _foo_bar)
-        return yang.gdata.Container(children, ns='http://example.com/foo')
+        return yang.gdata.Container(children, ns='http://example.com/m1')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_bar:
+    mut def from_gdata(n: ?yang.gdata.Node) -> m1__foo_bar:
         if n != None:
-            return foo__foo_bar(foo_bar=n.get_opt_str("foo_bar"))
-        return foo__foo_bar()
+            return m1__foo_bar(foo_bar=n.get_opt_str("foo_bar"))
+        return m1__foo_bar()
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo_bar:
+    mut def from_xml(n: ?xml.Node) -> m1__foo_bar:
         if n != None:
-            return foo__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo_bar"))
-        return foo__foo_bar()
+            return m1__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo_bar"))
+        return m1__foo_bar()
 
 
-mut def from_json_path_foo__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_m1__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo_bar' or point == 'foo_bar':
+        if point == 'm1:foo_bar' or point == 'foo_bar':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__foo_bar(yang.gdata.unwrap_dict(jd))
+            return from_json_m1__foo_bar(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_m1__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_bar_full = jd.get('foo:foo_bar')
+    child_foo_bar_full = jd.get('m1:foo_bar')
     child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo_bar')
     if child_foo_bar is not None:
-        children['foo_bar'] = from_json_foo__foo_bar__foo_bar(child_foo_bar)
+        children['foo_bar'] = from_json_m1__foo_bar__foo_bar(child_foo_bar)
     return yang.gdata.Container(children)
 
-mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_m1__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     child_foo_bar = n.children.get('foo_bar')
     if child_foo_bar is not None:
@@ -132,14 +148,14 @@ mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
     return children
 
 
-mut def from_json_foo__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+mut def from_json_m1__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-class foo__foo_bar(yang.adata.MNode):
+class m1__foo_bar(yang.adata.MNode):
     foo_bar: ?str
 
     mut def __init__(self, foo_bar: ?str):
-        self._ns = "http://example.com/foo"
+        self._ns = "http://example.com/m1"
         self.foo_bar = foo_bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -147,46 +163,46 @@ class foo__foo_bar(yang.adata.MNode):
         _foo_bar = self.foo_bar
         if _foo_bar is not None:
             children['foo.bar'] = yang.gdata.Leaf('string', _foo_bar)
-        return yang.gdata.Container(children, ns='http://example.com/foo')
+        return yang.gdata.Container(children, ns='http://example.com/m1')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_bar:
+    mut def from_gdata(n: ?yang.gdata.Node) -> m1__foo_bar:
         if n != None:
-            return foo__foo_bar(foo_bar=n.get_opt_str("foo.bar"))
-        return foo__foo_bar()
+            return m1__foo_bar(foo_bar=n.get_opt_str("foo.bar"))
+        return m1__foo_bar()
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo_bar:
+    mut def from_xml(n: ?xml.Node) -> m1__foo_bar:
         if n != None:
-            return foo__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo.bar"))
-        return foo__foo_bar()
+            return m1__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo.bar"))
+        return m1__foo_bar()
 
 
-mut def from_json_path_foo__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+mut def from_json_path_m1__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo.bar' or point == 'foo.bar':
+        if point == 'm1:foo.bar' or point == 'foo.bar':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__foo_bar(yang.gdata.unwrap_dict(jd))
+            return from_json_m1__foo_bar(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_m1__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_bar_full = jd.get('foo:foo.bar')
+    child_foo_bar_full = jd.get('m1:foo.bar')
     child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo.bar')
     if child_foo_bar is not None:
-        children['foo.bar'] = from_json_foo__foo_bar__foo_bar(child_foo_bar)
+        children['foo.bar'] = from_json_m1__foo_bar__foo_bar(child_foo_bar)
     return yang.gdata.Container(children)
 
-mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+mut def to_json_m1__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     child_foo_bar = n.children.get('foo.bar')
     if child_foo_bar is not None:
@@ -195,58 +211,132 @@ mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
     return children
 
 
-class root(yang.adata.MNode):
-    foo_bar_0: foo__foo_bar
-    foo_bar_1: foo__foo_bar
-    foo_bar_2: foo__foo_bar
+mut def from_json_m2__foo_bar__foo_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
 
-    mut def __init__(self, foo_bar_0: ?foo__foo_bar=None, foo_bar_1: ?foo__foo_bar=None, foo_bar_2: ?foo__foo_bar=None):
+class m2__foo_bar(yang.adata.MNode):
+    foo_bar: ?str
+
+    mut def __init__(self, foo_bar: ?str):
+        self._ns = "http://example.com/m2"
+        self.foo_bar = foo_bar
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_bar = self.foo_bar
+        if _foo_bar is not None:
+            children['foo-bar'] = yang.gdata.Leaf('string', _foo_bar)
+        return yang.gdata.Container(children, ns='http://example.com/m2')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> m2__foo_bar:
+        if n != None:
+            return m2__foo_bar(foo_bar=n.get_opt_str("foo-bar"))
+        return m2__foo_bar()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> m2__foo_bar:
+        if n != None:
+            return m2__foo_bar(foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar"))
+        return m2__foo_bar()
+
+
+mut def from_json_path_m2__foo_bar(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'm2:foo-bar' or point == 'foo-bar':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_m2__foo_bar(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_m2__foo_bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_bar_full = jd.get('m2:foo-bar')
+    child_foo_bar = child_foo_bar_full if child_foo_bar_full is not None else jd.get('foo-bar')
+    if child_foo_bar is not None:
+        children['foo-bar'] = from_json_m2__foo_bar__foo_bar(child_foo_bar)
+    return yang.gdata.Container(children)
+
+mut def to_json_m2__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_foo_bar = n.children.get('foo-bar')
+    if child_foo_bar is not None:
+        if isinstance(child_foo_bar, yang.gdata.Leaf):
+            children['foo-bar'] = child_foo_bar.val
+    return children
+
+
+class root(yang.adata.MNode):
+    m1_foo_bar: m1__foo_bar
+    foo_bar_1: m1__foo_bar
+    foo_bar_2: m1__foo_bar
+    m2_foo_bar: m2__foo_bar
+
+    mut def __init__(self, m1_foo_bar: ?m1__foo_bar=None, foo_bar_1: ?m1__foo_bar=None, foo_bar_2: ?m1__foo_bar=None, m2_foo_bar: ?m2__foo_bar=None):
         self._ns = ""
-        if foo_bar_0 is not None:
-            self.foo_bar_0 = foo_bar_0
+        if m1_foo_bar is not None:
+            self.m1_foo_bar = m1_foo_bar
         else:
-            self.foo_bar_0 = foo__foo_bar()
-        self_foo_bar_0 = self.foo_bar_0
-        if self_foo_bar_0 is not None:
-            self_foo_bar_0._parent = self
+            self.m1_foo_bar = m1__foo_bar()
+        self_m1_foo_bar = self.m1_foo_bar
+        if self_m1_foo_bar is not None:
+            self_m1_foo_bar._parent = self
         if foo_bar_1 is not None:
             self.foo_bar_1 = foo_bar_1
         else:
-            self.foo_bar_1 = foo__foo_bar()
+            self.foo_bar_1 = m1__foo_bar()
         self_foo_bar_1 = self.foo_bar_1
         if self_foo_bar_1 is not None:
             self_foo_bar_1._parent = self
         if foo_bar_2 is not None:
             self.foo_bar_2 = foo_bar_2
         else:
-            self.foo_bar_2 = foo__foo_bar()
+            self.foo_bar_2 = m1__foo_bar()
         self_foo_bar_2 = self.foo_bar_2
         if self_foo_bar_2 is not None:
             self_foo_bar_2._parent = self
+        if m2_foo_bar is not None:
+            self.m2_foo_bar = m2_foo_bar
+        else:
+            self.m2_foo_bar = m2__foo_bar()
+        self_m2_foo_bar = self.m2_foo_bar
+        if self_m2_foo_bar is not None:
+            self_m2_foo_bar._parent = self
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_bar_0 = self.foo_bar_0
+        _m1_foo_bar = self.m1_foo_bar
         _foo_bar_1 = self.foo_bar_1
         _foo_bar_2 = self.foo_bar_2
-        if _foo_bar_0 is not None:
-            children['foo-bar'] = _foo_bar_0.to_gdata()
+        _m2_foo_bar = self.m2_foo_bar
+        if _m1_foo_bar is not None:
+            children['m1:foo-bar'] = _m1_foo_bar.to_gdata()
         if _foo_bar_1 is not None:
             children['foo_bar'] = _foo_bar_1.to_gdata()
         if _foo_bar_2 is not None:
             children['foo.bar'] = _foo_bar_2.to_gdata()
+        if _m2_foo_bar is not None:
+            children['m2:foo-bar'] = _m2_foo_bar.to_gdata()
         return yang.gdata.Root(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(foo_bar_0=foo__foo_bar.from_gdata(n.get_opt_container("foo-bar")), foo_bar_1=foo__foo_bar.from_gdata(n.get_opt_container("foo_bar")), foo_bar_2=foo__foo_bar.from_gdata(n.get_opt_container("foo.bar")))
+            return root(m1_foo_bar=m1__foo_bar.from_gdata(n.get_opt_container("m1:foo-bar")), foo_bar_1=m1__foo_bar.from_gdata(n.get_opt_container("foo_bar")), foo_bar_2=m1__foo_bar.from_gdata(n.get_opt_container("foo.bar")), m2_foo_bar=m2__foo_bar.from_gdata(n.get_opt_container("m2:foo-bar")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(foo_bar_0=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo-bar", "http://example.com/foo")), foo_bar_1=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo_bar", "http://example.com/foo")), foo_bar_2=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo.bar", "http://example.com/foo")))
+            return root(m1_foo_bar=m1__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo-bar", "http://example.com/m1")), foo_bar_1=m1__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo_bar", "http://example.com/m1")), foo_bar_2=m1__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo.bar", "http://example.com/m1")), m2_foo_bar=m2__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo-bar", "http://example.com/m2")))
         return root()
 
 
@@ -255,14 +345,17 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo-bar':
-            child = {'foo-bar': from_json_path_foo__foo_bar(jd, rest_path, op) }
+        if point == 'm1:foo-bar':
+            child = {'foo-bar': from_json_path_m1__foo_bar(jd, rest_path, op) }
             return yang.gdata.Root(child)
-        if point == 'foo:foo_bar':
-            child = {'foo_bar': from_json_path_foo__foo_bar(jd, rest_path, op) }
+        if point == 'm1:foo_bar':
+            child = {'foo_bar': from_json_path_m1__foo_bar(jd, rest_path, op) }
             return yang.gdata.Root(child)
-        if point == 'foo:foo.bar':
-            child = {'foo.bar': from_json_path_foo__foo_bar(jd, rest_path, op) }
+        if point == 'm1:foo.bar':
+            child = {'foo.bar': from_json_path_m1__foo_bar(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        if point == 'm2:foo-bar':
+            child = {'foo-bar': from_json_path_m2__foo_bar(jd, rest_path, op) }
             return yang.gdata.Root(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -275,30 +368,37 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.
 
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
     children = {}
-    child_foo_bar_0 = jd.get('foo:foo-bar')
-    if child_foo_bar_0 is not None and isinstance(child_foo_bar_0, dict):
-        children['foo-bar'] = from_json_foo__foo_bar(child_foo_bar_0)
-    child_foo_bar_1 = jd.get('foo:foo_bar')
+    child_m1_foo_bar = jd.get('m1:foo-bar')
+    if child_m1_foo_bar is not None and isinstance(child_m1_foo_bar, dict):
+        children['foo-bar'] = from_json_m1__foo_bar(child_m1_foo_bar)
+    child_foo_bar_1 = jd.get('m1:foo_bar')
     if child_foo_bar_1 is not None and isinstance(child_foo_bar_1, dict):
-        children['foo_bar'] = from_json_foo__foo_bar(child_foo_bar_1)
-    child_foo_bar_2 = jd.get('foo:foo.bar')
+        children['foo_bar'] = from_json_m1__foo_bar(child_foo_bar_1)
+    child_foo_bar_2 = jd.get('m1:foo.bar')
     if child_foo_bar_2 is not None and isinstance(child_foo_bar_2, dict):
-        children['foo.bar'] = from_json_foo__foo_bar(child_foo_bar_2)
+        children['foo.bar'] = from_json_m1__foo_bar(child_foo_bar_2)
+    child_m2_foo_bar = jd.get('m2:foo-bar')
+    if child_m2_foo_bar is not None and isinstance(child_m2_foo_bar, dict):
+        children['foo-bar'] = from_json_m2__foo_bar(child_m2_foo_bar)
     return yang.gdata.Root(children)
 
 mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
     children = {}
-    child_foo_bar_0 = n.children.get('foo-bar')
-    if child_foo_bar_0 is not None:
-        if isinstance(child_foo_bar_0, yang.gdata.Container):
-            children['foo:foo-bar'] = to_json_foo__foo_bar(child_foo_bar_0)
+    child_m1_foo_bar = n.children.get('foo-bar')
+    if child_m1_foo_bar is not None:
+        if isinstance(child_m1_foo_bar, yang.gdata.Container):
+            children['m1:foo-bar'] = to_json_m1__foo_bar(child_m1_foo_bar)
     child_foo_bar_1 = n.children.get('foo_bar')
     if child_foo_bar_1 is not None:
         if isinstance(child_foo_bar_1, yang.gdata.Container):
-            children['foo:foo_bar'] = to_json_foo__foo_bar(child_foo_bar_1)
+            children['m1:foo_bar'] = to_json_m1__foo_bar(child_foo_bar_1)
     child_foo_bar_2 = n.children.get('foo.bar')
     if child_foo_bar_2 is not None:
         if isinstance(child_foo_bar_2, yang.gdata.Container):
-            children['foo:foo.bar'] = to_json_foo__foo_bar(child_foo_bar_2)
+            children['m1:foo.bar'] = to_json_m1__foo_bar(child_foo_bar_2)
+    child_m2_foo_bar = n.children.get('foo-bar')
+    if child_m2_foo_bar is not None:
+        if isinstance(child_m2_foo_bar, yang.gdata.Container):
+            children['m2:foo-bar'] = to_json_m2__foo_bar(child_m2_foo_bar)
     return children
 

--- a/test/golden/test_yang/prdaclass_conflicting_safe_name
+++ b/test/golden/test_yang/prdaclass_conflicting_safe_name
@@ -196,57 +196,57 @@ mut def to_json_foo__foo_bar(n: yang.gdata.Container) -> dict[str, ?value]:
 
 
 class root(yang.adata.MNode):
-    foo_bar: foo__foo_bar
-    foo_bar: foo__foo_bar
-    foo_bar: foo__foo_bar
+    foo_bar_0: foo__foo_bar
+    foo_bar_1: foo__foo_bar
+    foo_bar_2: foo__foo_bar
 
-    mut def __init__(self, foo_bar: ?foo__foo_bar=None, foo_bar: ?foo__foo_bar=None, foo_bar: ?foo__foo_bar=None):
+    mut def __init__(self, foo_bar_0: ?foo__foo_bar=None, foo_bar_1: ?foo__foo_bar=None, foo_bar_2: ?foo__foo_bar=None):
         self._ns = ""
-        if foo_bar is not None:
-            self.foo_bar = foo_bar
+        if foo_bar_0 is not None:
+            self.foo_bar_0 = foo_bar_0
         else:
-            self.foo_bar = foo__foo_bar()
-        self_foo_bar = self.foo_bar
-        if self_foo_bar is not None:
-            self_foo_bar._parent = self
-        if foo_bar is not None:
-            self.foo_bar = foo_bar
+            self.foo_bar_0 = foo__foo_bar()
+        self_foo_bar_0 = self.foo_bar_0
+        if self_foo_bar_0 is not None:
+            self_foo_bar_0._parent = self
+        if foo_bar_1 is not None:
+            self.foo_bar_1 = foo_bar_1
         else:
-            self.foo_bar = foo__foo_bar()
-        self_foo_bar = self.foo_bar
-        if self_foo_bar is not None:
-            self_foo_bar._parent = self
-        if foo_bar is not None:
-            self.foo_bar = foo_bar
+            self.foo_bar_1 = foo__foo_bar()
+        self_foo_bar_1 = self.foo_bar_1
+        if self_foo_bar_1 is not None:
+            self_foo_bar_1._parent = self
+        if foo_bar_2 is not None:
+            self.foo_bar_2 = foo_bar_2
         else:
-            self.foo_bar = foo__foo_bar()
-        self_foo_bar = self.foo_bar
-        if self_foo_bar is not None:
-            self_foo_bar._parent = self
+            self.foo_bar_2 = foo__foo_bar()
+        self_foo_bar_2 = self.foo_bar_2
+        if self_foo_bar_2 is not None:
+            self_foo_bar_2._parent = self
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_bar = self.foo_bar
-        _foo_bar = self.foo_bar
-        _foo_bar = self.foo_bar
-        if _foo_bar is not None:
-            children['foo-bar'] = _foo_bar.to_gdata()
-        if _foo_bar is not None:
-            children['foo_bar'] = _foo_bar.to_gdata()
-        if _foo_bar is not None:
-            children['foo.bar'] = _foo_bar.to_gdata()
+        _foo_bar_0 = self.foo_bar_0
+        _foo_bar_1 = self.foo_bar_1
+        _foo_bar_2 = self.foo_bar_2
+        if _foo_bar_0 is not None:
+            children['foo-bar'] = _foo_bar_0.to_gdata()
+        if _foo_bar_1 is not None:
+            children['foo_bar'] = _foo_bar_1.to_gdata()
+        if _foo_bar_2 is not None:
+            children['foo.bar'] = _foo_bar_2.to_gdata()
         return yang.gdata.Root(children)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(foo_bar=foo__foo_bar.from_gdata(n.get_opt_container("foo-bar")), foo_bar=foo__foo_bar.from_gdata(n.get_opt_container("foo_bar")), foo_bar=foo__foo_bar.from_gdata(n.get_opt_container("foo.bar")))
+            return root(foo_bar_0=foo__foo_bar.from_gdata(n.get_opt_container("foo-bar")), foo_bar_1=foo__foo_bar.from_gdata(n.get_opt_container("foo_bar")), foo_bar_2=foo__foo_bar.from_gdata(n.get_opt_container("foo.bar")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(foo_bar=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo-bar", "http://example.com/foo")), foo_bar=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo_bar", "http://example.com/foo")), foo_bar=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo.bar", "http://example.com/foo")))
+            return root(foo_bar_0=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo-bar", "http://example.com/foo")), foo_bar_1=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo_bar", "http://example.com/foo")), foo_bar_2=foo__foo_bar.from_xml(yang.gdata.get_xml_opt_child(n, "foo.bar", "http://example.com/foo")))
         return root()
 
 
@@ -275,30 +275,30 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.
 
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
     children = {}
-    child_foo_bar = jd.get('foo:foo-bar')
-    if child_foo_bar is not None and isinstance(child_foo_bar, dict):
-        children['foo-bar'] = from_json_foo__foo_bar(child_foo_bar)
-    child_foo_bar = jd.get('foo:foo_bar')
-    if child_foo_bar is not None and isinstance(child_foo_bar, dict):
-        children['foo_bar'] = from_json_foo__foo_bar(child_foo_bar)
-    child_foo_bar = jd.get('foo:foo.bar')
-    if child_foo_bar is not None and isinstance(child_foo_bar, dict):
-        children['foo.bar'] = from_json_foo__foo_bar(child_foo_bar)
+    child_foo_bar_0 = jd.get('foo:foo-bar')
+    if child_foo_bar_0 is not None and isinstance(child_foo_bar_0, dict):
+        children['foo-bar'] = from_json_foo__foo_bar(child_foo_bar_0)
+    child_foo_bar_1 = jd.get('foo:foo_bar')
+    if child_foo_bar_1 is not None and isinstance(child_foo_bar_1, dict):
+        children['foo_bar'] = from_json_foo__foo_bar(child_foo_bar_1)
+    child_foo_bar_2 = jd.get('foo:foo.bar')
+    if child_foo_bar_2 is not None and isinstance(child_foo_bar_2, dict):
+        children['foo.bar'] = from_json_foo__foo_bar(child_foo_bar_2)
     return yang.gdata.Root(children)
 
 mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
     children = {}
-    child_foo_bar = n.children.get('foo-bar')
-    if child_foo_bar is not None:
-        if isinstance(child_foo_bar, yang.gdata.Container):
-            children['foo:foo-bar'] = to_json_foo__foo_bar(child_foo_bar)
-    child_foo_bar = n.children.get('foo_bar')
-    if child_foo_bar is not None:
-        if isinstance(child_foo_bar, yang.gdata.Container):
-            children['foo:foo_bar'] = to_json_foo__foo_bar(child_foo_bar)
-    child_foo_bar = n.children.get('foo.bar')
-    if child_foo_bar is not None:
-        if isinstance(child_foo_bar, yang.gdata.Container):
-            children['foo:foo.bar'] = to_json_foo__foo_bar(child_foo_bar)
+    child_foo_bar_0 = n.children.get('foo-bar')
+    if child_foo_bar_0 is not None:
+        if isinstance(child_foo_bar_0, yang.gdata.Container):
+            children['foo:foo-bar'] = to_json_foo__foo_bar(child_foo_bar_0)
+    child_foo_bar_1 = n.children.get('foo_bar')
+    if child_foo_bar_1 is not None:
+        if isinstance(child_foo_bar_1, yang.gdata.Container):
+            children['foo:foo_bar'] = to_json_foo__foo_bar(child_foo_bar_1)
+    child_foo_bar_2 = n.children.get('foo.bar')
+    if child_foo_bar_2 is not None:
+        if isinstance(child_foo_bar_2, yang.gdata.Container):
+            children['foo:foo.bar'] = to_json_foo__foo_bar(child_foo_bar_2)
     return children
 

--- a/test/test_data_classes/src/yang_mc.act
+++ b/test/test_data_classes/src/yang_mc.act
@@ -9,7 +9,7 @@ import yang.gdata
 mut def from_json_m1__foo_bar_0__m1_foo_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-mut def from_json_m1__foo_bar_0__m2_foo_bar_0(val: value) -> yang.gdata.Leaf:
+mut def from_json_m1__foo_bar_0__m2_foo_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
 mut def from_json_m1__foo_bar_0__foo_bar_1(val: value) -> yang.gdata.Leaf:
@@ -89,7 +89,7 @@ mut def from_json_m1__foo_bar_0(jd: dict[str, ?value]) -> yang.gdata.Container:
         children['foo-bar'] = from_json_m1__foo_bar_0__m1_foo_bar(child_m1_foo_bar)
     child_m2_foo_bar = jd.get('m2:foo-bar')
     if child_m2_foo_bar is not None:
-        children['foo-bar'] = from_json_m1__foo_bar_0__m2_foo_bar_0(child_m2_foo_bar)
+        children['foo-bar'] = from_json_m1__foo_bar_0__m2_foo_bar(child_m2_foo_bar)
     child_foo_bar_1_full = jd.get('m2:foo_bar')
     child_foo_bar_1 = child_foo_bar_1_full if child_foo_bar_1_full is not None else jd.get('foo_bar')
     if child_foo_bar_1 is not None:

--- a/test/test_data_classes/src/yang_mc.act
+++ b/test/test_data_classes/src/yang_mc.act
@@ -9,38 +9,54 @@ import yang.gdata
 mut def from_json_m1__foo_bar_0__m1_foo_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
-mut def from_json_m1__foo_bar_0__m2_foo_bar(val: value) -> yang.gdata.Leaf:
+mut def from_json_m1__foo_bar_0__m2_foo_bar_0(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+mut def from_json_m1__foo_bar_0__foo_bar_1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+mut def from_json_m1__foo_bar_0__foo_bar_2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
 class m1__foo_bar_0(yang.adata.MNode):
     m1_foo_bar: ?str
     m2_foo_bar: ?str
+    foo_bar_1: ?str
+    foo_bar_2: ?str
 
-    mut def __init__(self, m1_foo_bar: ?str, m2_foo_bar: ?str):
+    mut def __init__(self, m1_foo_bar: ?str, m2_foo_bar: ?str, foo_bar_1: ?str, foo_bar_2: ?str):
         self._ns = "http://example.com/m1"
         self.m1_foo_bar = m1_foo_bar
         self.m2_foo_bar = m2_foo_bar
+        self.foo_bar_1 = foo_bar_1
+        self.foo_bar_2 = foo_bar_2
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
         _m1_foo_bar = self.m1_foo_bar
         _m2_foo_bar = self.m2_foo_bar
+        _foo_bar_1 = self.foo_bar_1
+        _foo_bar_2 = self.foo_bar_2
         if _m1_foo_bar is not None:
             children['m1:foo-bar'] = yang.gdata.Leaf('string', _m1_foo_bar)
         if _m2_foo_bar is not None:
             children['m2:foo-bar'] = yang.gdata.Leaf('string', _m2_foo_bar, ns='http://example.com/m2')
+        if _foo_bar_1 is not None:
+            children['foo_bar'] = yang.gdata.Leaf('string', _foo_bar_1, ns='http://example.com/m2')
+        if _foo_bar_2 is not None:
+            children['foo.bar'] = yang.gdata.Leaf('string', _foo_bar_2, ns='http://example.com/m2')
         return yang.gdata.Container(children, ns='http://example.com/m1')
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> m1__foo_bar_0:
         if n != None:
-            return m1__foo_bar_0(m1_foo_bar=n.get_opt_str("m1:foo-bar"), m2_foo_bar=n.get_opt_str("m2:foo-bar"))
+            return m1__foo_bar_0(m1_foo_bar=n.get_opt_str("m1:foo-bar"), m2_foo_bar=n.get_opt_str("m2:foo-bar"), foo_bar_1=n.get_opt_str("foo_bar"), foo_bar_2=n.get_opt_str("foo.bar"))
         return m1__foo_bar_0()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> m1__foo_bar_0:
         if n != None:
-            return m1__foo_bar_0(m1_foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar"), m2_foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar", "http://example.com/m2"))
+            return m1__foo_bar_0(m1_foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar"), m2_foo_bar=yang.gdata.from_xml_opt_str(n, "foo-bar", "http://example.com/m2"), foo_bar_1=yang.gdata.from_xml_opt_str(n, "foo_bar", "http://example.com/m2"), foo_bar_2=yang.gdata.from_xml_opt_str(n, "foo.bar", "http://example.com/m2"))
         return m1__foo_bar_0()
 
 
@@ -52,6 +68,10 @@ mut def from_json_path_m1__foo_bar_0(jd: value, path: list[str]=[], op: ?str="me
         if point == 'm1:foo-bar':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'm2:foo-bar':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'm2:foo_bar' or point == 'foo_bar':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'm2:foo.bar' or point == 'foo.bar':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -69,7 +89,15 @@ mut def from_json_m1__foo_bar_0(jd: dict[str, ?value]) -> yang.gdata.Container:
         children['foo-bar'] = from_json_m1__foo_bar_0__m1_foo_bar(child_m1_foo_bar)
     child_m2_foo_bar = jd.get('m2:foo-bar')
     if child_m2_foo_bar is not None:
-        children['foo-bar'] = from_json_m1__foo_bar_0__m2_foo_bar(child_m2_foo_bar)
+        children['foo-bar'] = from_json_m1__foo_bar_0__m2_foo_bar_0(child_m2_foo_bar)
+    child_foo_bar_1_full = jd.get('m2:foo_bar')
+    child_foo_bar_1 = child_foo_bar_1_full if child_foo_bar_1_full is not None else jd.get('foo_bar')
+    if child_foo_bar_1 is not None:
+        children['foo_bar'] = from_json_m1__foo_bar_0__foo_bar_1(child_foo_bar_1)
+    child_foo_bar_2_full = jd.get('m2:foo.bar')
+    child_foo_bar_2 = child_foo_bar_2_full if child_foo_bar_2_full is not None else jd.get('foo.bar')
+    if child_foo_bar_2 is not None:
+        children['foo.bar'] = from_json_m1__foo_bar_0__foo_bar_2(child_foo_bar_2)
     return yang.gdata.Container(children)
 
 mut def to_json_m1__foo_bar_0(n: yang.gdata.Container) -> dict[str, ?value]:
@@ -82,6 +110,14 @@ mut def to_json_m1__foo_bar_0(n: yang.gdata.Container) -> dict[str, ?value]:
     if child_m2_foo_bar is not None:
         if isinstance(child_m2_foo_bar, yang.gdata.Leaf):
             children['m2:foo-bar'] = child_m2_foo_bar.val
+    child_foo_bar_1 = n.children.get('foo_bar')
+    if child_foo_bar_1 is not None:
+        if isinstance(child_foo_bar_1, yang.gdata.Leaf):
+            children['m2:foo_bar'] = child_foo_bar_1.val
+    child_foo_bar_2 = n.children.get('foo.bar')
+    if child_foo_bar_2 is not None:
+        if isinstance(child_foo_bar_2, yang.gdata.Leaf):
+            children['m2:foo.bar'] = child_foo_bar_2.val
     return children
 
 

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -211,6 +211,51 @@ ys_basics = """module basics {
     }
 }"""
 
+ys_m1 = """module m1 {
+    yang-version "1.1";
+    namespace "http://example.com/m1";
+    prefix m1;
+    container foo-bar {
+        leaf foo-bar {
+            type string;
+        }
+    }
+    container foo_bar {
+        leaf foo_bar {
+            type string;
+        }
+    }
+    container foo.bar {
+        leaf foo.bar {
+            type string;
+        }
+    }
+}"""
+
+ys_m2 = """module m2 {
+    yang-version "1.1";
+    namespace "http://example.com/m2";
+    prefix "m2";
+    import m1 {
+        prefix m1;
+    }
+    container foo-bar {
+        leaf foo-bar {
+            type string;
+        }
+    }
+    augment "/m1:foo-bar" {
+        leaf foo-bar {
+            type string;
+        }
+        leaf foo_bar {
+            type string;
+        }
+        leaf "foo.bar" {
+            type string;
+        }
+    }
+}"""
 
 actor main(env: Env):
     wfcap = file.WriteFileCap(file.FileCap(env.cap))
@@ -218,4 +263,5 @@ actor main(env: Env):
     yang_to_act(wfcap, yangs=[ys_foo, ys_bar], filename="../test_data_classes/src/yang_foo.act")
     yang_to_act(wfcap, yangs=[ys_foo, ys_bar], filename="../test_data_classes/src/yang_foo_loose.act", loose=True)
     yang_to_act(wfcap, yangs=[ys_basics], filename="../test_data_classes/src/yang_basics.act")
+    yang_to_act(wfcap, yangs=[ys_m1, ys_m2], filename="../test_data_classes/src/yang_mc.act")
     env.exit(0)


### PR DESCRIPTION
We already avoid conflicts when two YANG modules define a node with the same name in the same location in the schema tree by adding the module prefix, like `{pfx}_{name}`. But when generating Acton code for adata we must also make the node names and paths safe for Acton, meaning replacing dots, hyphens and colons with underscores. After this transform we must again ensure the safe Acton name does not conflict with another sibling. This PR proposes appending a numeric index to the end of the Acton name to make it unique.