### PR TITLE
Fix imports if module prefix contains hyphen

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -291,25 +291,25 @@ class DNode(object):
         """
         if isinstance(self, DNodeInner):
             for child in self.children:
-                if isinstance(child, DAction) and _safe_name(child.name) == name:
+                if isinstance(child, DAction) and child.name == name:
                     return child
-                elif isinstance(child, DAnydata) and _safe_name(child.name) == name:
+                elif isinstance(child, DAnydata) and child.name == name:
                     return child
-                elif isinstance(child, DAnyxml) and _safe_name(child.name) == name:
+                elif isinstance(child, DAnyxml) and child.name == name:
                     return child
-                elif isinstance(child, DContainer) and _safe_name(child.name) == name:
+                elif isinstance(child, DContainer) and child.name == name:
                     return child
                 elif isinstance(child, DInput) and name == 'input':
                     return child
-                elif isinstance(child, DLeaf) and _safe_name(child.name) == name:
+                elif isinstance(child, DLeaf) and child.name == name:
                     return child
-                elif isinstance(child, DLeafList) and _safe_name(child.name) == name:
+                elif isinstance(child, DLeafList) and child.name == name:
                     return child
-                elif isinstance(child, DList) and _safe_name(child.name) == name:
+                elif isinstance(child, DList) and child.name == name:
                     return child
                 elif isinstance(child, DOutput) and name == 'output':
                     return child
-                elif isinstance(child, DRpc) and _safe_name(child.name) == name:
+                elif isinstance(child, DRpc) and child.name == name:
                     return child
             raise ValueError("Child %s not found" % name)
 
@@ -1646,7 +1646,7 @@ class SchemaNode(object):
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
                 if isinstance(child, Uses):
-                    grouping = child.get_grouping(_safe_name(child.name), context)
+                    grouping = child.get_grouping(child.name, context)
                     grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
@@ -1686,7 +1686,7 @@ class SchemaNode(object):
         for i in range(RECURSION_LIMIT+1):
             if isinstance(n, SchemaNodeInner):
                 for child in n.children:
-                    if isinstance(child, Grouping) and _safe_name(child.name) == name:
+                    if isinstance(child, Grouping) and child.name == name:
                         return child
             nparent = n.parent
             if nparent is not None:

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1568,6 +1568,32 @@ def _test_compile_submodules2():
     # TODO: This conflict should be detected during compilation
     #testing.error("Expected ValueError")
 
+def _test_compile_import_hyphenated_prefix():
+    ys_foo = """module acme_foo-bar {
+  yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "acme_foo-bar";
+  import acme_qux-baz {
+    prefix "acme_qux-baz";
+  }
+  uses acme_qux-baz:g1;
+}"""
+    ys_qux = """module acme_qux-baz {
+  yang-version "1.1";
+  namespace "http://example.com/qux";
+  prefix "acme_qux-baz";
+  grouping g1 {
+    container c1 {
+      leaf l1 {
+        type string;
+      }
+    }
+  }
+}"""
+    root = yang.compile([ys_foo, ys_qux])
+
+    testing.assertEqual(root.get("c1").get("l1").config, True)
+    return root.prdaclass()
 
 def _test_prdaclass_req_arg():
     """Required arguments must come before optional arguments

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -287,25 +287,25 @@ class DNode(object):
         """
         if isinstance(self, DNodeInner):
             for child in self.children:
-                if isinstance(child, DAction) and _safe_name(child.name) == name:
+                if isinstance(child, DAction) and child.name == name:
                     return child
-                elif isinstance(child, DAnydata) and _safe_name(child.name) == name:
+                elif isinstance(child, DAnydata) and child.name == name:
                     return child
-                elif isinstance(child, DAnyxml) and _safe_name(child.name) == name:
+                elif isinstance(child, DAnyxml) and child.name == name:
                     return child
-                elif isinstance(child, DContainer) and _safe_name(child.name) == name:
+                elif isinstance(child, DContainer) and child.name == name:
                     return child
                 elif isinstance(child, DInput) and name == 'input':
                     return child
-                elif isinstance(child, DLeaf) and _safe_name(child.name) == name:
+                elif isinstance(child, DLeaf) and child.name == name:
                     return child
-                elif isinstance(child, DLeafList) and _safe_name(child.name) == name:
+                elif isinstance(child, DLeafList) and child.name == name:
                     return child
-                elif isinstance(child, DList) and _safe_name(child.name) == name:
+                elif isinstance(child, DList) and child.name == name:
                     return child
                 elif isinstance(child, DOutput) and name == 'output':
                     return child
-                elif isinstance(child, DRpc) and _safe_name(child.name) == name:
+                elif isinstance(child, DRpc) and child.name == name:
                     return child
             raise ValueError("Child %s not found" % name)
 
@@ -1642,7 +1642,7 @@ class SchemaNode(object):
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
                 if isinstance(child, Uses):
-                    grouping = child.get_grouping(_safe_name(child.name), context)
+                    grouping = child.get_grouping(child.name, context)
                     grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
@@ -1682,7 +1682,7 @@ class SchemaNode(object):
         for i in range(RECURSION_LIMIT+1):
             if isinstance(n, SchemaNodeInner):
                 for child in n.children:
-                    if isinstance(child, Grouping) and _safe_name(child.name) == name:
+                    if isinstance(child, Grouping) and child.name == name:
                         return child
             nparent = n.parent
             if nparent is not None:

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -1,0 +1,136 @@
+import json
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+mut def from_json_acme_foo_bar__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class acme_foo_bar__c1(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> acme_foo_bar__c1:
+        if n != None:
+            return acme_foo_bar__c1(l1=n.get_opt_str("l1"))
+        return acme_foo_bar__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> acme_foo_bar__c1:
+        if n != None:
+            return acme_foo_bar__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return acme_foo_bar__c1()
+
+
+mut def from_json_path_acme_foo_bar__c1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'acme_qux-baz:l1' or point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_acme_foo_bar__c1(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_acme_foo_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l1_full = jd.get('acme_qux-baz:l1')
+    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    if child_l1 is not None:
+        children['l1'] = from_json_acme_foo_bar__c1__l1(child_l1)
+    return yang.gdata.Container(children)
+
+mut def to_json_acme_foo_bar__c1(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_l1 = n.children.get('l1')
+    if child_l1 is not None:
+        if isinstance(child_l1, yang.gdata.Leaf):
+            children['l1'] = child_l1.val
+    return children
+
+
+class root(yang.adata.MNode):
+    c1: acme_foo_bar__c1
+
+    mut def __init__(self, c1: ?acme_foo_bar__c1=None):
+        self._ns = ""
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = acme_foo_bar__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Root(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(c1=acme_foo_bar__c1.from_gdata(n.get_opt_container("c1")))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(c1=acme_foo_bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")))
+        return root()
+
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'acme_foo-bar:c1':
+            child = {'c1': from_json_path_acme_foo_bar__c1(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
+    children = {}
+    child_c1 = jd.get('acme_foo-bar:c1')
+    if child_c1 is not None and isinstance(child_c1, dict):
+        children['c1'] = from_json_acme_foo_bar__c1(child_c1)
+    return yang.gdata.Root(children)
+
+mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
+    children = {}
+    child_c1 = n.children.get('c1')
+    if child_c1 is not None:
+        if isinstance(child_c1, yang.gdata.Container):
+            children['acme_foo-bar:c1'] = to_json_acme_foo_bar__c1(child_c1)
+    return children
+


### PR DESCRIPTION
We must not transform DNode prefix and names to "safe Acton" until absolutely necessary - in .prdaclass().