### PR TITLE
Stabilize order of type comparison for union type keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,3 +19,5 @@ jobs:
       - run: acton test
       - run: acton test perf
       - run: make test-daclass
+      # another diff check because test-daclass also generates code
+      - run: git diff --exit-code

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -1865,12 +1865,12 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, int) and isinstance(k2, int):
+            if isinstance(e_k2, str) and isinstance(k2, str):
                 if e_k2 != k2:
                     match = False
                     continue
             e_k2 = e.k2
-            if isinstance(e_k2, str) and isinstance(k2, str):
+            if isinstance(e_k2, int) and isinstance(k2, int):
                 if e_k2 != k2:
                     match = False
                     continue

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -1870,12 +1870,12 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, int) and isinstance(k2, int):
+            if isinstance(e_k2, str) and isinstance(k2, str):
                 if e_k2 != k2:
                     match = False
                     continue
             e_k2 = e.k2
-            if isinstance(e_k2, str) and isinstance(k2, str):
+            if isinstance(e_k2, int) and isinstance(k2, int):
                 if e_k2 != k2:
                     match = False
                     continue


### PR DESCRIPTION
It seems that the order of elements in an Acton set is not guaranteed to be stable :)