### PR TITLE
Quote keyword argument as per YANG 1.1 RFC

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -187,7 +187,7 @@ class Statement(object):
             m = re.match(r"[^A-Za-z0-9_-]", arg)
             quoted_arg = True if self.kw in _quoted_arg_keywords or m != None else False
             if quoted_arg:
-                res += '"' + arg.replace('"', '\\"') + '"'
+                res += '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"'
             else:
                 res += arg
         if len(self.substatements) == 0:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -180,11 +180,10 @@ class Statement(object):
         res += self.kw
         arg = self.arg
         if arg is not None:
-            # Always quote the argument if the keyword "looks better" with the
-            # argument quoted, or if the argument contains any character that
-            # require quoting to make it valid YANG:
+            # Always quote the argument if the argument contains any character
+            # that require quoting to make it valid YANG (RFC 7950, section 6.1.3):
             res += " "
-            m = re.match(r"[^A-Za-z0-9_-]", arg)
+            m = re.match(r"[\s'\\";{}]|//|/\\*|\\*/", arg)
             quoted_arg = True if self.kw in _quoted_arg_keywords or m != None else False
             if quoted_arg:
                 res += '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"'

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -102,7 +102,7 @@ test_yang = """module test_yang {
       presence "And you can quote me on that!";
     }
     leaf ql1 {
-      type string;
+      type inet:ipv4-address;
       description "some 'quotes'";
     }
     leaf ql2 {

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -248,6 +248,36 @@ def _test_parse_snode_pryang_twice():
     yy2 = ys2.pryang()
     testing.assertEqual(yy1, yy2, "YANG round trip^2 failed\n" + yy1 + "\n===\n" + yy2)
 
+def _test_parse_pryang_non_idempotent():
+    # YANG -> Statement -> SchemaNode -> Statement -> YANG -> Statement -> SchemaNode -> Statement -> YANG
+    # The single quoted keyword arguments will be converted to use double
+    # quotes after a single roundtrip, as we do not preserve the quotes used in
+    # our schema representation. This is fine, as long as the resulting YANG is
+    # still valid - \ is escaped as \\.
+    original = """module test_yang {
+    yang-version "1.1";
+    namespace "http://example.com/test_yang";
+    prefix "test_yang";
+    container c1 {
+        leaf l1 {
+            type string {
+                pattern 'example\\.com';
+            }
+            description 'leaf with single quote';
+        }
+    }
+}"""
+    n1 = yang.schema_from_src(original)
+    ys1 = n1.to_statement()
+    yy1 = ys1.pryang()
+    print(yy1, err=True)
+    testing.assertNotEqual(original, yy1, "YANG round trip not failed")
+    n2 = yang.schema_from_src(yy1)
+    ys2 = n2.to_statement()
+    yy2 = ys2.pryang()
+    testing.assertEqual(yy1, yy2, "YANG round trip^2 failed")
+    return yy1
+
 def _test_prsrc():
     s = yang.schema_from_src(test_yang)
     return s.prsrc()

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -176,11 +176,10 @@ class Statement(object):
         res += self.kw
         arg = self.arg
         if arg is not None:
-            # Always quote the argument if the keyword "looks better" with the
-            # argument quoted, or if the argument contains any character that
-            # require quoting to make it valid YANG:
+            # Always quote the argument if the argument contains any character
+            # that require quoting to make it valid YANG (RFC 7950, section 6.1.3):
             res += " "
-            m = re.match(r"[^A-Za-z0-9_-]", arg)
+            m = re.match(r"[\s'\\";{}]|//|/\\*|\\*/", arg)
             quoted_arg = True if self.kw in _quoted_arg_keywords or m != None else False
             if quoted_arg:
                 res += '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"'

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -183,7 +183,7 @@ class Statement(object):
             m = re.match(r"[^A-Za-z0-9_-]", arg)
             quoted_arg = True if self.kw in _quoted_arg_keywords or m != None else False
             if quoted_arg:
-                res += '"' + arg.replace('"', '\\"') + '"'
+                res += '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"'
             else:
                 res += arg
         if len(self.substatements) == 0:

--- a/test/golden/test_yang/parse_pryang_non_idempotent
+++ b/test/golden/test_yang/parse_pryang_non_idempotent
@@ -1,0 +1,13 @@
+module test_yang {
+  yang-version "1.1";
+  namespace "http://example.com/test_yang";
+  prefix "test_yang";
+  container c1 {
+    leaf l1 {
+      type string {
+        pattern "example\\.com";
+      }
+      description "leaf with single quote";
+    }
+  }
+}

--- a/test/golden/test_yang/prsrc
+++ b/test/golden/test_yang/prsrc
@@ -43,7 +43,7 @@ Module('test_yang', yang_version=1.1, namespace='http://example.com/test_yang', 
     ]),
     Container('c4', presence='single-unquoted-word', children=[
         Container('c5', presence='And you can quote me on that!'),
-        Leaf('ql1', type_=Type('string'), description="some 'quotes'"),
+        Leaf('ql1', type_=Type('inet:ipv4-address'), description="some 'quotes'"),
         Leaf('ql2', type_=Type('string'), description='contains "quotes"', must=[
                 Must('have "quotes"')
             ], when='does it "work"?'),

--- a/test/golden/test_yang/snode_to_statement
+++ b/test/golden/test_yang/snode_to_statement
@@ -95,7 +95,7 @@ module test_yang {
       presence "And you can quote me on that!";
     }
     leaf ql1 {
-      type string;
+      type inet:ipv4-address;
       description "some 'quotes'";
     }
     leaf ql2 {


### PR DESCRIPTION
RFC 7950, Section 6.1.3:

   An unquoted string is any sequence of characters that does not
   contain any space, tab, carriage return, or line feed characters, a
   single or double quote character, a semicolon (";"), braces ("{" or
   "}"), or comment sequences ("//", "/*", or "*/")

Also make sure when printing YANG (`SchemaNode.pryang()`) we escape `\` correctly because we always emit strings with double quotes.