### PR TITLE
Support binary leaf (with default value)

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -327,6 +327,7 @@ class DNodeInner(DNode):
         """
         res = []
         if top:
+            res.append("import base64")
             res.append("import json")
             res.append("import xml")
             res.append("import yang.adata")
@@ -2202,6 +2203,10 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return '"' + value + '"'
     elif ytype in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
         return value
+    elif ytype == "binary":
+        # Binary values are encoded as base64 strings in YANG and NETCONF, but
+        # stored as Acton bytes, so we need to decode it first
+        return "base64.decode(\"%s\".encode())" % value
     elif ytype == "string":
         return '"' + value.replace('"', '\\"') + '"'
     elif ytype == "union":

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1,3 +1,4 @@
+import base64
 import testing
 import xml
 
@@ -451,6 +452,37 @@ class Node(value):
     def get_opt_strs(self, name) -> list[str]:
         try:
             return self.get_strs(name)
+        except ValueError:
+            return []
+
+    def get_bytes(self, name) -> bytes:
+        child = self.get_leaf(name)
+        childval = child.val
+        if isinstance(childval, bytes):
+            return childval
+        raise ValueError("Leaf %s value is not type bytes" % name)
+
+    def get_opt_bytes(self, name) -> ?bytes:
+        child = self.get_opt_leaf(name)
+        if child != None:
+            childval = child.val
+            if isinstance(childval, bytes):
+                return childval
+
+    def get_bytess(self, name) -> list[bytes]:
+        if isinstance(self, Inner):
+            for nm,child in self.children.items():
+                if isinstance(child, LeafList) and nm == name:
+                    cvals = []
+                    for v in child.vals:
+                        if isinstance(v, bytes):
+                            cvals.append(v)
+                    return cvals
+        raise ValueError("Cannot find leaf-list child with name " + name)
+
+    def get_opt_bytess(self, name) -> list[bytes]:
+        try:
+            return self.get_bytess(name)
         except ValueError:
             return []
 
@@ -1406,6 +1438,20 @@ def from_xml_str(n: xml.Node, name: str, ns: ?str) -> str:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
+def from_xml_opt_bytes(n: xml.Node, name: str, ns: ?str) -> ?bytes:
+    try:
+        text = get_xml_child(n, name, ns).text
+        if text is not None:
+            return base64.decode(text.encode())
+    except ValueError:
+        return None
+
+def from_xml_bytes(n: xml.Node, name: str, ns: ?str) -> bytes:
+    r = from_xml_opt_bytes(n, name, ns)
+    if r is not None:
+        return r
+    raise ValueError("Cannot find xml child with name " + name)
+
 def from_xml_opt_value(n: xml.Node, name: str, ns: ?str) -> ?value:
     try:
         t = get_xml_child(n, name, ns).text
@@ -1427,6 +1473,14 @@ def from_xml_opt_strs(n: xml.Node, name: str, ns: ?str) -> list[str]:
         ctext = child.text
         if ctext is not None:
             res.append(ctext)
+    return res
+
+def from_xml_opt_bytess(n: xml.Node, name: str, ns: ?str) -> list[bytes]:
+    res = []
+    for child in get_xml_children(n, name, ns):
+        ctext = child.text
+        if ctext is not None:
+            res.append(base64.decode(ctext.encode()))
     return res
 
 def from_xml_opt_values(n: xml.Node, name: str, ns: ?str) -> list[value]:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -323,6 +323,7 @@ class DNodeInner(DNode):
         """
         res = []
         if top:
+            res.append("import base64")
             res.append("import json")
             res.append("import xml")
             res.append("import yang.adata")
@@ -2198,6 +2199,10 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return '"' + value + '"'
     elif ytype in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
         return value
+    elif ytype == "binary":
+        # Binary values are encoded as base64 strings in YANG and NETCONF, but
+        # stored as Acton bytes, so we need to decode it first
+        return "base64.decode(\"%s\".encode())" % value
     elif ytype == "string":
         return '"' + value.replace('"', '\\"') + '"'
     elif ytype == "union":

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -310,6 +310,9 @@ def _test_leaf_defaults():
     testing.assertEqual(r.c.l_str_def, "foo")
     testing.assertEqual(r.c.l_uint64_def, 1234567890)
     testing.assertEqual(r.c.l_str_def_quoted, '"foo"')
+    testing.assertEqual(r.c.l_binary_def, "Hello Acton 🫡".encode())
+
+    # union types
     uds = r.c.l_union_def_str
     if isinstance(uds, str):
         testing.assertEqual(uds, "foo")

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata
@@ -30,6 +31,9 @@ mut def from_json_basics__c__l_union_def_bool(val: value) -> yang.gdata.Leaf:
 mut def from_json_basics__c__l_union_def_enumeration(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("union", val)
 
+mut def from_json_basics__c__l_binary_def(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("binary", val)
+
 class basics__c(yang.adata.MNode):
     l_str_def: str
     l_str_def_quoted: str
@@ -39,8 +43,9 @@ class basics__c(yang.adata.MNode):
     l_union_def_float: value
     l_union_def_bool: value
     l_union_def_enumeration: value
+    l_binary_def: bytes
 
-    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?int=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None):
+    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?int=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None):
         self._ns = "http://example.com/basics"
         if l_str_def != None:
             self.l_str_def = l_str_def
@@ -74,6 +79,10 @@ class basics__c(yang.adata.MNode):
             self.l_union_def_enumeration = l_union_def_enumeration
         else:
             self.l_union_def_enumeration = "unlimited"
+        if l_binary_def != None:
+            self.l_binary_def = l_binary_def
+        else:
+            self.l_binary_def = base64.decode("SGVsbG8gQWN0b24g8J+roQ==".encode())
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -85,6 +94,7 @@ class basics__c(yang.adata.MNode):
         _l_union_def_float = self.l_union_def_float
         _l_union_def_bool = self.l_union_def_bool
         _l_union_def_enumeration = self.l_union_def_enumeration
+        _l_binary_def = self.l_binary_def
         if _l_str_def is not None:
             children['l_str_def'] = yang.gdata.Leaf('string', _l_str_def)
         if _l_str_def_quoted is not None:
@@ -101,18 +111,20 @@ class basics__c(yang.adata.MNode):
             children['l_union_def_bool'] = yang.gdata.Leaf('union', _l_union_def_bool)
         if _l_union_def_enumeration is not None:
             children['l_union_def_enumeration'] = yang.gdata.Leaf('union', _l_union_def_enumeration)
+        if _l_binary_def is not None:
+            children['l_binary_def'] = yang.gdata.Leaf('binary', _l_binary_def)
         return yang.gdata.Container(children, ns='http://example.com/basics')
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> basics__c:
         if n != None:
-            return basics__c(l_str_def=n.get_opt_str("l_str_def"), l_str_def_quoted=n.get_opt_str("l_str_def_quoted"), l_uint64_def=n.get_opt_int("l_uint64_def"), l_union_def_str=n.get_opt_value("l_union_def_str"), l_union_def_int=n.get_opt_value("l_union_def_int"), l_union_def_float=n.get_opt_value("l_union_def_float"), l_union_def_bool=n.get_opt_value("l_union_def_bool"), l_union_def_enumeration=n.get_opt_value("l_union_def_enumeration"))
+            return basics__c(l_str_def=n.get_opt_str("l_str_def"), l_str_def_quoted=n.get_opt_str("l_str_def_quoted"), l_uint64_def=n.get_opt_int("l_uint64_def"), l_union_def_str=n.get_opt_value("l_union_def_str"), l_union_def_int=n.get_opt_value("l_union_def_int"), l_union_def_float=n.get_opt_value("l_union_def_float"), l_union_def_bool=n.get_opt_value("l_union_def_bool"), l_union_def_enumeration=n.get_opt_value("l_union_def_enumeration"), l_binary_def=n.get_opt_bytes("l_binary_def"))
         return basics__c()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> basics__c:
         if n != None:
-            return basics__c(l_str_def=yang.gdata.from_xml_opt_str(n, "l_str_def"), l_str_def_quoted=yang.gdata.from_xml_opt_str(n, "l_str_def_quoted"), l_uint64_def=yang.gdata.from_xml_opt_int(n, "l_uint64_def"), l_union_def_str=yang.gdata.from_xml_opt_value(n, "l_union_def_str"), l_union_def_int=yang.gdata.from_xml_opt_value(n, "l_union_def_int"), l_union_def_float=yang.gdata.from_xml_opt_value(n, "l_union_def_float"), l_union_def_bool=yang.gdata.from_xml_opt_value(n, "l_union_def_bool"), l_union_def_enumeration=yang.gdata.from_xml_opt_value(n, "l_union_def_enumeration"))
+            return basics__c(l_str_def=yang.gdata.from_xml_opt_str(n, "l_str_def"), l_str_def_quoted=yang.gdata.from_xml_opt_str(n, "l_str_def_quoted"), l_uint64_def=yang.gdata.from_xml_opt_int(n, "l_uint64_def"), l_union_def_str=yang.gdata.from_xml_opt_value(n, "l_union_def_str"), l_union_def_int=yang.gdata.from_xml_opt_value(n, "l_union_def_int"), l_union_def_float=yang.gdata.from_xml_opt_value(n, "l_union_def_float"), l_union_def_bool=yang.gdata.from_xml_opt_value(n, "l_union_def_bool"), l_union_def_enumeration=yang.gdata.from_xml_opt_value(n, "l_union_def_enumeration"), l_binary_def=yang.gdata.from_xml_opt_bytes(n, "l_binary_def"))
         return basics__c()
 
 
@@ -136,6 +148,8 @@ mut def from_json_path_basics__c(jd: value, path: list[str]=[], op: ?str="merge"
         if point == 'b:l_union_def_bool' or point == 'l_union_def_bool':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'b:l_union_def_enumeration' or point == 'l_union_def_enumeration':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'b:l_binary_def' or point == 'l_binary_def':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -180,6 +194,10 @@ mut def from_json_basics__c(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_l_union_def_enumeration = child_l_union_def_enumeration_full if child_l_union_def_enumeration_full is not None else jd.get('l_union_def_enumeration')
     if child_l_union_def_enumeration is not None:
         children['l_union_def_enumeration'] = from_json_basics__c__l_union_def_enumeration(child_l_union_def_enumeration)
+    child_l_binary_def_full = jd.get('b:l_binary_def')
+    child_l_binary_def = child_l_binary_def_full if child_l_binary_def_full is not None else jd.get('l_binary_def')
+    if child_l_binary_def is not None:
+        children['l_binary_def'] = from_json_basics__c__l_binary_def(child_l_binary_def)
     return yang.gdata.Container(children)
 
 mut def to_json_basics__c(n: yang.gdata.Container) -> dict[str, ?value]:
@@ -216,6 +234,10 @@ mut def to_json_basics__c(n: yang.gdata.Container) -> dict[str, ?value]:
     if child_l_union_def_enumeration is not None:
         if isinstance(child_l_union_def_enumeration, yang.gdata.Leaf):
             children['l_union_def_enumeration'] = child_l_union_def_enumeration.val
+    child_l_binary_def = n.children.get('l_binary_def')
+    if child_l_binary_def is not None:
+        if isinstance(child_l_binary_def, yang.gdata.Leaf):
+            children['l_binary_def'] = child_l_binary_def.val
     return children
 
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -1,3 +1,4 @@
+import base64
 import json
 import xml
 import yang.adata

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -259,6 +259,10 @@ ys_basics = """module basics {
             }
             default unlimited;
         }
+        leaf l_binary_def {
+            type binary;
+            default "SGVsbG8gQWN0b24g8J+roQ==";
+        }
     }
 }"""
 


### PR DESCRIPTION
In YANG / NETCONF binary values are base64 encoded, while in Acton they are represented as bytes. Closes #99

This needs the compiler fix: https://github.com/actonlang/acton/pull/2194