### PR TITLE
Skip config=false by default when generating adata

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -314,7 +314,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')
@@ -322,7 +322,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         res = []
@@ -343,6 +343,8 @@ class DNodeInner(DNode):
         child_names = set()
         child_name_conflicts = set()
         for child in self.children:
+            if include_state == False and child.config == False:
+                continue
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
@@ -364,7 +366,7 @@ class DNodeInner(DNode):
             return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:
-            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml))
+            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -1135,7 +1137,9 @@ class DLeaf(DNodeLeaf):
                 return True
         return False
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+        if include_state == False and self.config == False:
+            return ""
         fname = "from_json_" + get_path_name(self)
         res = []
         res.append("mut def %s(val: value) -> yang.gdata.Leaf:" % fname)
@@ -1171,7 +1175,9 @@ class DLeafList(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+        if include_state == False and self.config == False:
+            return ""
         fname = "from_json_" + get_path_name(self)
         res = []
         res.append("mut def %s(val: list[value]) -> yang.gdata.LeafList:" % fname)
@@ -1337,7 +1343,7 @@ class SchemaNode(object):
         """
         raise NotImplementedError('SchemaNode prsrc')
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -81,6 +81,7 @@ test_yang = """module test_yang {
     }
   }
   container c3 {
+    config false;
     ext1:bob "Robert Johansson";
     action a1 {
       description "action 1";

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -310,7 +310,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')
@@ -318,7 +318,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         res = []
@@ -339,6 +339,8 @@ class DNodeInner(DNode):
         child_names = set()
         child_name_conflicts = set()
         for child in self.children:
+            if include_state == False and child.config == False:
+                continue
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
@@ -360,7 +362,7 @@ class DNodeInner(DNode):
             return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:
-            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml))
+            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -1131,7 +1133,9 @@ class DLeaf(DNodeLeaf):
                 return True
         return False
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+        if include_state == False and self.config == False:
+            return ""
         fname = "from_json_" + get_path_name(self)
         res = []
         res.append("mut def %s(val: value) -> yang.gdata.Leaf:" % fname)
@@ -1167,7 +1171,9 @@ class DLeafList(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+        if include_state == False and self.config == False:
+            return ""
         fname = "from_json_" + get_path_name(self)
         res = []
         res.append("mut def %s(val: list[value]) -> yang.gdata.LeafList:" % fname)
@@ -1333,7 +1339,7 @@ class SchemaNode(object):
         """
         raise NotImplementedError('SchemaNode prsrc')
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -7,7 +7,7 @@ import yang.gdata
 # == This file is generated ==
 
 
-class foo__c1__a1(yang.adata.MNode):
+class foo__c1(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = "http://example.com/foo"
@@ -15,52 +15,6 @@ class foo__c1__a1(yang.adata.MNode):
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        return yang.gdata.Action(children)
-
-    @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__a1:
-        if n != None:
-            return foo__c1__a1()
-        return foo__c1__a1()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1__a1:
-        if n != None:
-            return foo__c1__a1()
-        return foo__c1__a1()
-
-
-mut def from_json_path_foo__c1__a1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
-    # path handling
-    if len(path) > 0:
-        point = path[0]
-        rest_path = path[1:]
-        raise ValueError("Invalid path")
-    elif len(path) == 0:
-        if op == "merge":
-            return from_json_foo__c1__a1(yang.gdata.unwrap_dict(jd))
-        elif op == "remove":
-            return yang.gdata.Absent()
-        raise ValueError("Invalid operation")
-    raise ValueError("Unable to resolve path")
-
-mut def from_json_foo__c1__a1(jd: dict[str, ?value]) -> yang.gdata.Action:
-    children = {}
-    return yang.gdata.Action(children)
-
-    children = {}
-
-
-class foo__c1(yang.adata.MNode):
-    a1: foo__c1__a1
-
-    mut def __init__(self):
-        self._ns = "http://example.com/foo"
-
-    mut def to_gdata(self) -> yang.gdata.Node:
-        children = {}
-        _a1 = self.a1
-        if _a1 is not None:
         return yang.gdata.Container(children, ns='http://example.com/foo')
 
     @staticmethod
@@ -81,9 +35,6 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str="merge") 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:a1' or point == 'a1':
-            child = {'a1': from_json_path_foo__c1__a1(jd, rest_path, op) }
-            return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
@@ -95,67 +46,15 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str="merge") 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_a1_full = jd.get('foo:a1')
-    child_a1 = child_a1_full if child_a1_full is not None else jd.get('a1')
-    if child_a1 is not None:
-        children['a1'] = from_json_foo__c1__a1(child_a1)
     return yang.gdata.Container(children)
 
 mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
-    child_a1 = n.children.get('a1')
-    if child_a1 is not None:
-        pass
     return children
-
-
-class foo__r1(yang.adata.MNode):
-
-    mut def __init__(self):
-        self._ns = "http://example.com/foo"
-        pass
-
-    mut def to_gdata(self) -> yang.gdata.Node:
-        children = {}
-        return yang.gdata.Rpc(children, ns='http://example.com/foo')
-
-    @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__r1:
-        if n != None:
-            return foo__r1()
-        return foo__r1()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__r1:
-        if n != None:
-            return foo__r1()
-        return foo__r1()
-
-
-mut def from_json_path_foo__r1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
-    # path handling
-    if len(path) > 0:
-        point = path[0]
-        rest_path = path[1:]
-        raise ValueError("Invalid path")
-    elif len(path) == 0:
-        if op == "merge":
-            return from_json_foo__r1(yang.gdata.unwrap_dict(jd))
-        elif op == "remove":
-            return yang.gdata.Absent()
-        raise ValueError("Invalid operation")
-    raise ValueError("Unable to resolve path")
-
-mut def from_json_foo__r1(jd: dict[str, ?value]) -> yang.gdata.Rpc:
-    children = {}
-    return yang.gdata.Rpc(children)
-
-    children = {}
 
 
 class root(yang.adata.MNode):
     c1: foo__c1
-    r1: foo__r1
 
     mut def __init__(self, c1: ?foo__c1=None):
         self._ns = ""
@@ -170,10 +69,8 @@ class root(yang.adata.MNode):
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
         _c1 = self.c1
-        _r1 = self.r1
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
-        if _r1 is not None:
         return yang.gdata.Root(children)
 
     @staticmethod
@@ -197,9 +94,6 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.
         if point == 'foo:c1':
             child = {'c1': from_json_path_foo__c1(jd, rest_path, op) }
             return yang.gdata.Root(child)
-        if point == 'foo:r1':
-            child = {'r1': from_json_path_foo__r1(jd, rest_path, op) }
-            return yang.gdata.Root(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
@@ -214,9 +108,6 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
     child_c1 = jd.get('foo:c1')
     if child_c1 is not None and isinstance(child_c1, dict):
         children['c1'] = from_json_foo__c1(child_c1)
-    child_r1 = jd.get('foo:r1')
-    if child_r1 is not None:
-        children['r1'] = from_json_foo__r1(child_r1)
     return yang.gdata.Root(children)
 
 mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
@@ -225,8 +116,5 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
     if child_c1 is not None:
         if isinstance(child_c1, yang.gdata.Container):
             children['foo:c1'] = to_json_foo__c1(child_c1)
-    child_r1 = n.children.get('r1')
-    if child_r1 is not None:
-        pass
     return children
 

--- a/test/golden/test_yang/prsrc
+++ b/test/golden/test_yang/prsrc
@@ -33,7 +33,7 @@ Module('test_yang', yang_version=1.1, namespace='http://example.com/test_yang', 
                 ])
         ])
     ]),
-    Container('c3', exts=[
+    Container('c3', config=False, exts=[
             Ext('ext1', 'bob', arg='Robert Johansson')
         ], children=[
         Action('a1', description='action 1'),

--- a/test/golden/test_yang/snode_to_statement
+++ b/test/golden/test_yang/snode_to_statement
@@ -74,6 +74,7 @@ module test_yang {
     }
   }
   container c3 {
+    config false;
     ext1:bob "Robert Johansson";
     action a1 {
       description "action 1";

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -1990,6 +1990,154 @@ mut def to_json_foo__li_union(n: yang.gdata.List) -> list[dict[str, ?value]]:
     return elements
 
 
+mut def from_json_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+mut def from_json_foo__state__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__state__c1(yang.adata.MNode):
+    l1: ?str
+    l2: ?str
+
+    mut def __init__(self, l1: ?str, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state__c1:
+        if n != None:
+            return foo__state__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
+        return foo__state__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__state__c1:
+        if n != None:
+            return foo__state__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__state__c1()
+
+
+mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:l1' or point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'foo:l2' or point == 'l2':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__state__c1(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__state__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l1_full = jd.get('foo:l1')
+    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    if child_l1 is not None:
+        children['l1'] = from_json_foo__state__c1__l1(child_l1)
+    child_l2_full = jd.get('foo:l2')
+    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    if child_l2 is not None:
+        children['l2'] = from_json_foo__state__c1__l2(child_l2)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__state__c1(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_l1 = n.children.get('l1')
+    if child_l1 is not None:
+        if isinstance(child_l1, yang.gdata.Leaf):
+            children['l1'] = child_l1.val
+    child_l2 = n.children.get('l2')
+    if child_l2 is not None:
+        if isinstance(child_l2, yang.gdata.Leaf):
+            children['l2'] = child_l2.val
+    return children
+
+
+class foo__state(yang.adata.MNode):
+    c1: foo__state__c1
+
+    mut def __init__(self, c1: ?foo__state__c1=None):
+        self._ns = "http://example.com/foo"
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__state__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
+        if n != None:
+            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_container("c1")))
+        return foo__state()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__state:
+        if n != None:
+            return foo__state(c1=foo__state__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return foo__state()
+
+
+mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:c1' or point == 'c1':
+            child = {'c1': from_json_path_foo__state__c1(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__state(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_c1_full = jd.get('foo:c1')
+    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    if child_c1 is not None and isinstance(child_c1, dict):
+        children['c1'] = from_json_foo__state__c1(child_c1)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__state(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_c1 = n.children.get('c1')
+    if child_c1 is not None:
+        if isinstance(child_c1, yang.gdata.Container):
+            children['c1'] = to_json_foo__state__c1(child_c1)
+    return children
+
+
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -2064,9 +2212,10 @@ class root(yang.adata.MNode):
     special: foo__special
     nested: foo__nested
     li_union: foo__li_union
+    state: foo__state
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, bar_conflict: ?bar__conflict=None):
         self._ns = ""
         if c1 is not None:
             self.c1 = c1
@@ -2119,6 +2268,13 @@ class root(yang.adata.MNode):
             self_nested._parent = self
         self.li_union = foo__li_union(elements=li_union)
         self.li_union._parent = self
+        if state is not None:
+            self.state = state
+        else:
+            self.state = foo__state()
+        self_state = self.state
+        if self_state is not None:
+            self_state._parent = self
         if bar_conflict is not None:
             self.bar_conflict = bar_conflict
         else:
@@ -2154,6 +2310,7 @@ class root(yang.adata.MNode):
         _special = self.special
         _nested = self.nested
         _li_union = self.li_union
+        _state = self.state
         _bar_conflict = self.bar_conflict
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
@@ -2175,6 +2332,8 @@ class root(yang.adata.MNode):
             children['nested'] = _nested.to_gdata()
         if _li_union is not None:
             children['li-union'] = _li_union.to_gdata()
+        if _state is not None:
+            children['state'] = _state.to_gdata()
         if _bar_conflict is not None:
             children['bar:conflict'] = _bar_conflict.to_gdata()
         return yang.gdata.Root(children)
@@ -2182,13 +2341,13 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), pc2=foo__pc2.from_gdata(n.get_opt_container("pc2")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), special=foo__special.from_gdata(n.get_opt_list("special")), nested=foo__nested.from_gdata(n.get_opt_container("nested")), li_union=foo__li_union.from_gdata(n.get_opt_list("li-union")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), pc2=foo__pc2.from_gdata(n.get_opt_container("pc2")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), special=foo__special.from_gdata(n.get_opt_list("special")), nested=foo__nested.from_gdata(n.get_opt_container("nested")), li_union=foo__li_union.from_gdata(n.get_opt_list("li-union")), state=foo__state.from_gdata(n.get_opt_container("state")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "http://example.com/foo")), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, "pc2", "http://example.com/foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "http://example.com/foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "http://example.com/foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "http://example.com/foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/foo")), special=foo__special.from_xml(yang.gdata.get_xml_children(n, "special", "http://example.com/foo")), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, "nested", "http://example.com/foo")), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, "li-union", "http://example.com/foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/bar")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "http://example.com/foo")), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, "pc2", "http://example.com/foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "http://example.com/foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "http://example.com/foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "http://example.com/foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/foo")), special=foo__special.from_xml(yang.gdata.get_xml_children(n, "special", "http://example.com/foo")), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, "nested", "http://example.com/foo")), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, "li-union", "http://example.com/foo")), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, "state", "http://example.com/foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/bar")))
         return root()
 
 
@@ -2226,6 +2385,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.
             return yang.gdata.Root(child)
         if point == 'foo:li-union':
             child = {'li-union': from_json_path_foo__li_union(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        if point == 'foo:state':
+            child = {'state': from_json_path_foo__state(jd, rest_path, op) }
             return yang.gdata.Root(child)
         if point == 'bar:conflict':
             child = {'conflict': from_json_path_bar__conflict(jd, rest_path, op) }
@@ -2271,6 +2433,9 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
     child_li_union = jd.get('foo:li-union')
     if child_li_union is not None and isinstance(child_li_union, list):
         children['li-union'] = from_json_foo__li_union(child_li_union)
+    child_state = jd.get('foo:state')
+    if child_state is not None and isinstance(child_state, dict):
+        children['state'] = from_json_foo__state(child_state)
     child_bar_conflict = jd.get('bar:conflict')
     if child_bar_conflict is not None and isinstance(child_bar_conflict, dict):
         children['conflict'] = from_json_bar__conflict(child_bar_conflict)
@@ -2318,6 +2483,10 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
     if child_li_union is not None:
         if isinstance(child_li_union, yang.gdata.List):
             children['foo:li-union'] = to_json_foo__li_union(child_li_union)
+    child_state = n.children.get('state')
+    if child_state is not None:
+        if isinstance(child_state, yang.gdata.Container):
+            children['foo:state'] = to_json_foo__state(child_state)
     child_bar_conflict = n.children.get('conflict')
     if child_bar_conflict is not None:
         if isinstance(child_bar_conflict, yang.gdata.Container):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -1995,6 +1995,154 @@ mut def to_json_foo__li_union(n: yang.gdata.List) -> list[dict[str, ?value]]:
     return elements
 
 
+mut def from_json_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+mut def from_json_foo__state__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__state__c1(yang.adata.MNode):
+    l1: ?str
+    l2: ?str
+
+    mut def __init__(self, l1: ?str, l2: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        _l2 = self.l2
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state__c1:
+        if n != None:
+            return foo__state__c1(l1=n.get_opt_str("l1"), l2=n.get_opt_str("l2"))
+        return foo__state__c1()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__state__c1:
+        if n != None:
+            return foo__state__c1(l1=yang.gdata.from_xml_opt_str(n, "l1"), l2=yang.gdata.from_xml_opt_str(n, "l2"))
+        return foo__state__c1()
+
+
+mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:l1' or point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'foo:l2' or point == 'l2':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__state__c1(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__state__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l1_full = jd.get('foo:l1')
+    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    if child_l1 is not None:
+        children['l1'] = from_json_foo__state__c1__l1(child_l1)
+    child_l2_full = jd.get('foo:l2')
+    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    if child_l2 is not None:
+        children['l2'] = from_json_foo__state__c1__l2(child_l2)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__state__c1(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_l1 = n.children.get('l1')
+    if child_l1 is not None:
+        if isinstance(child_l1, yang.gdata.Leaf):
+            children['l1'] = child_l1.val
+    child_l2 = n.children.get('l2')
+    if child_l2 is not None:
+        if isinstance(child_l2, yang.gdata.Leaf):
+            children['l2'] = child_l2.val
+    return children
+
+
+class foo__state(yang.adata.MNode):
+    c1: foo__state__c1
+
+    mut def __init__(self, c1: ?foo__state__c1=None):
+        self._ns = "http://example.com/foo"
+        if c1 is not None:
+            self.c1 = c1
+        else:
+            self.c1 = foo__state__c1()
+        self_c1 = self.c1
+        if self_c1 is not None:
+            self_c1._parent = self
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c1 = self.c1
+        if _c1 is not None:
+            children['c1'] = _c1.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
+        if n != None:
+            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_container("c1")))
+        return foo__state()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__state:
+        if n != None:
+            return foo__state(c1=foo__state__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1")))
+        return foo__state()
+
+
+mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:c1' or point == 'c1':
+            child = {'c1': from_json_path_foo__state__c1(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__state(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_c1_full = jd.get('foo:c1')
+    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    if child_c1 is not None and isinstance(child_c1, dict):
+        children['c1'] = from_json_foo__state__c1(child_c1)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__state(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_c1 = n.children.get('c1')
+    if child_c1 is not None:
+        if isinstance(child_c1, yang.gdata.Container):
+            children['c1'] = to_json_foo__state__c1(child_c1)
+    return children
+
+
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -2069,9 +2217,10 @@ class root(yang.adata.MNode):
     special: foo__special
     nested: foo__nested
     li_union: foo__li_union
+    state: foo__state
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, bar_conflict: ?bar__conflict=None):
         self._ns = ""
         if c1 is not None:
             self.c1 = c1
@@ -2124,6 +2273,13 @@ class root(yang.adata.MNode):
             self_nested._parent = self
         self.li_union = foo__li_union(elements=li_union)
         self.li_union._parent = self
+        if state is not None:
+            self.state = state
+        else:
+            self.state = foo__state()
+        self_state = self.state
+        if self_state is not None:
+            self_state._parent = self
         if bar_conflict is not None:
             self.bar_conflict = bar_conflict
         else:
@@ -2159,6 +2315,7 @@ class root(yang.adata.MNode):
         _special = self.special
         _nested = self.nested
         _li_union = self.li_union
+        _state = self.state
         _bar_conflict = self.bar_conflict
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
@@ -2180,6 +2337,8 @@ class root(yang.adata.MNode):
             children['nested'] = _nested.to_gdata()
         if _li_union is not None:
             children['li-union'] = _li_union.to_gdata()
+        if _state is not None:
+            children['state'] = _state.to_gdata()
         if _bar_conflict is not None:
             children['bar:conflict'] = _bar_conflict.to_gdata()
         return yang.gdata.Root(children)
@@ -2187,13 +2346,13 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), pc2=foo__pc2.from_gdata(n.get_opt_container("pc2")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), special=foo__special.from_gdata(n.get_opt_list("special")), nested=foo__nested.from_gdata(n.get_opt_container("nested")), li_union=foo__li_union.from_gdata(n.get_opt_list("li-union")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container("c1")), pc1=foo__pc1.from_gdata(n.get_opt_container("pc1")), pc2=foo__pc2.from_gdata(n.get_opt_container("pc2")), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container("empty-presence")), c_dot=foo__c_dot.from_gdata(n.get_opt_container("c.dot")), cc=foo__cc.from_gdata(n.get_opt_container("cc")), foo_conflict=foo__conflict.from_gdata(n.get_opt_container("foo:conflict")), special=foo__special.from_gdata(n.get_opt_list("special")), nested=foo__nested.from_gdata(n.get_opt_container("nested")), li_union=foo__li_union.from_gdata(n.get_opt_list("li-union")), state=foo__state.from_gdata(n.get_opt_container("state")), bar_conflict=bar__conflict.from_gdata(n.get_opt_container("bar:conflict")))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "http://example.com/foo")), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, "pc2", "http://example.com/foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "http://example.com/foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "http://example.com/foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "http://example.com/foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/foo")), special=foo__special.from_xml(yang.gdata.get_xml_children(n, "special", "http://example.com/foo")), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, "nested", "http://example.com/foo")), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, "li-union", "http://example.com/foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/bar")))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, "c1", "http://example.com/foo")), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, "pc1", "http://example.com/foo")), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, "pc2", "http://example.com/foo")), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, "empty-presence", "http://example.com/foo")), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, "c.dot", "http://example.com/foo")), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, "cc", "http://example.com/foo")), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/foo")), special=foo__special.from_xml(yang.gdata.get_xml_children(n, "special", "http://example.com/foo")), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, "nested", "http://example.com/foo")), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, "li-union", "http://example.com/foo")), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, "state", "http://example.com/foo")), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, "conflict", "http://example.com/bar")))
         return root()
 
 
@@ -2231,6 +2390,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str="merge") -> yang.
             return yang.gdata.Root(child)
         if point == 'foo:li-union':
             child = {'li-union': from_json_path_foo__li_union(jd, rest_path, op) }
+            return yang.gdata.Root(child)
+        if point == 'foo:state':
+            child = {'state': from_json_path_foo__state(jd, rest_path, op) }
             return yang.gdata.Root(child)
         if point == 'bar:conflict':
             child = {'conflict': from_json_path_bar__conflict(jd, rest_path, op) }
@@ -2276,6 +2438,9 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Root:
     child_li_union = jd.get('foo:li-union')
     if child_li_union is not None and isinstance(child_li_union, list):
         children['li-union'] = from_json_foo__li_union(child_li_union)
+    child_state = jd.get('foo:state')
+    if child_state is not None and isinstance(child_state, dict):
+        children['state'] = from_json_foo__state(child_state)
     child_bar_conflict = jd.get('bar:conflict')
     if child_bar_conflict is not None and isinstance(child_bar_conflict, dict):
         children['conflict'] = from_json_bar__conflict(child_bar_conflict)
@@ -2323,6 +2488,10 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
     if child_li_union is not None:
         if isinstance(child_li_union, yang.gdata.List):
             children['foo:li-union'] = to_json_foo__li_union(child_li_union)
+    child_state = n.children.get('state')
+    if child_state is not None:
+        if isinstance(child_state, yang.gdata.Container):
+            children['foo:state'] = to_json_foo__state(child_state)
     child_bar_conflict = n.children.get('conflict')
     if child_bar_conflict is not None:
         if isinstance(child_bar_conflict, yang.gdata.Container):

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
@@ -17,5 +17,8 @@ Root(children={
     })
   }),
   'li-union': List(['k1', 'k2'], ns='http://example.com/foo'),
+  'state': Container(ns='http://example.com/foo', children={
+    'c1': Container()
+  }),
   'bar:conflict': Container(ns='http://example.com/bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
@@ -16,5 +16,8 @@ Root(children={
     })
   }),
   'li-union': List(['k1', 'k2'], ns='http://example.com/foo'),
+  'state': Container(ns='http://example.com/foo', children={
+    'c1': Container()
+  }),
   'bar:conflict': Container(ns='http://example.com/bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -54,6 +54,9 @@ Root(children={
       'k2': Leaf(unlimited)
     })
   ]),
+  'state': Container(ns='http://example.com/foo', children={
+    'c1': Container()
+  }),
   'bar:conflict': Container(ns='http://example.com/bar', children={
     'foo': Leaf(foo-bar)
   })

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -5,7 +5,7 @@ import yang
 
 def yang_to_act(wfcap: file.WriteFileCap, yangs: list[str], filename: str, loose=False) -> None:
     root = yang.compile(yangs)
-    src = root.prdaclass(loose=loose)
+    src = root.prdaclass(loose=loose, include_state=True)
     wf = file.WriteFile(wfcap, filename)
     wf.write(src.encode())
     await async wf.close()
@@ -168,6 +168,17 @@ ys_foo = """module foo {
                 type enumeration {
                     enum "unlimited";
                 }
+            }
+        }
+    }
+    container state {
+        config false;
+        container c1 {
+            leaf l1 {
+                type string;
+            }
+            leaf l2 {
+                type string;
             }
         }
     }


### PR DESCRIPTION
When generating adata we now by default skip operational state subtrees, as well as action and rpc nodes.