### PR TITLE
Fix regex for matching characters that require argument quoting

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -183,7 +183,7 @@ class Statement(object):
             # Always quote the argument if the argument contains any character
             # that require quoting to make it valid YANG (RFC 7950, section 6.1.3):
             res += " "
-            m = re.match(r"[\s'\\";{}]|//|/\\*|\\*/", arg)
+            m = re.match(r"[\s'\";{}]|//|/\\*|\\*/", arg)
             quoted_arg = True if self.kw in _quoted_arg_keywords or m != None else False
             if quoted_arg:
                 res += '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"'

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -179,7 +179,7 @@ class Statement(object):
             # Always quote the argument if the argument contains any character
             # that require quoting to make it valid YANG (RFC 7950, section 6.1.3):
             res += " "
-            m = re.match(r"[\s'\\";{}]|//|/\\*|\\*/", arg)
+            m = re.match(r"[\s'\";{}]|//|/\\*|\\*/", arg)
             quoted_arg = True if self.kw in _quoted_arg_keywords or m != None else False
             if quoted_arg:
                 res += '"' + arg.replace('\\', '\\\\').replace('"', '\\"') + '"'


### PR DESCRIPTION
The " character was incorrectly escaped, also matching the literal \