### PR TITLE
Include namespaces in generated Acton modules

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -314,7 +314,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')
@@ -322,9 +322,11 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
+        if self.namespace != "":
+            schema_ns.add(self.namespace)
         res = []
         if top:
             res.append("import base64")
@@ -366,7 +368,7 @@ class DNodeInner(DNode):
             return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:
-            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -932,7 +934,12 @@ class DNodeInner(DNode):
             res.append("    return elements")
             res.append("")
 
-        res.append("")
+        if top:
+            res.append("schema_namespaces: set[str] = {")
+            for ns in schema_ns:
+                res.append("    \"%s\"," % ns)
+            res.append("}")
+            res.append("")
 
         return "\n".join(res)
 
@@ -1137,7 +1144,9 @@ class DLeaf(DNodeLeaf):
                 return True
         return False
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+        if self.namespace != "":
+            schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return ""
         fname = "from_json_" + get_path_name(self)
@@ -1175,7 +1184,9 @@ class DLeafList(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+        if self.namespace != "":
+            schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return ""
         fname = "from_json_" + get_path_name(self)
@@ -1343,7 +1354,7 @@ class SchemaNode(object):
         """
         raise NotImplementedError('SchemaNode prsrc')
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -310,7 +310,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')
@@ -318,9 +318,11 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
+        if self.namespace != "":
+            schema_ns.add(self.namespace)
         res = []
         if top:
             res.append("import base64")
@@ -362,7 +364,7 @@ class DNodeInner(DNode):
             return _safe_name(unique_name).replace(":", "_")
 
         for child in self.children:
-            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+            res.append(child.prdaclass(loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -928,7 +930,12 @@ class DNodeInner(DNode):
             res.append("    return elements")
             res.append("")
 
-        res.append("")
+        if top:
+            res.append("schema_namespaces: set[str] = {")
+            for ns in schema_ns:
+                res.append("    \"%s\"," % ns)
+            res.append("}")
+            res.append("")
 
         return "\n".join(res)
 
@@ -1133,7 +1140,9 @@ class DLeaf(DNodeLeaf):
                 return True
         return False
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+        if self.namespace != "":
+            schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return ""
         fname = "from_json_" + get_path_name(self)
@@ -1171,7 +1180,9 @@ class DLeafList(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+        if self.namespace != "":
+            schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return ""
         fname = "from_json_" + get_path_name(self)
@@ -1339,7 +1350,7 @@ class SchemaNode(object):
         """
         raise NotImplementedError('SchemaNode prsrc')
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -87,7 +87,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l2'] = child_l2.val
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -153,3 +152,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -52,7 +52,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -118,3 +117,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -86,7 +86,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['bar:l2'] = child_l2.val
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -152,3 +151,7 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+    "http://example.com/bar",
+}

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -90,7 +90,6 @@ mut def to_json_foo__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l3'] = child_l3.val
     return children
 
-
 class foo__c1(yang.adata.MNode):
     l1: ?str
     c2: foo__c1__c2
@@ -172,7 +171,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['c2'] = to_json_foo__c1__c2(child_c2)
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -238,3 +236,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -89,7 +89,6 @@ mut def to_json_foo__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
             children['baz:l3'] = child_l3.val
     return children
 
-
 class foo__c1(yang.adata.MNode):
     l1: ?str
     c2: foo__c1__c2
@@ -170,7 +169,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['bar:c2'] = to_json_foo__c1__c2(child_c2)
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -236,3 +234,8 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/baz",
+    "http://example.com/foo",
+    "http://example.com/bar",
+}

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -69,7 +69,6 @@ mut def to_json_foo__c1__c2(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 class foo__c1(yang.adata.MNode):
     c2: foo__c1__c2
 
@@ -136,7 +135,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['c2'] = to_json_foo__c1__c2(child_c2)
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -202,3 +200,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -86,7 +86,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['bar:l2'] = child_l2.val
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -152,3 +151,7 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+    "http://example.com/bar",
+}

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -169,7 +169,6 @@ mut def to_json_foo__c1__things(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__c1__things_element(e))
     return elements
 
-
 class foo__c1(yang.adata.MNode):
     things: foo__c1__things
 
@@ -230,7 +229,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_things, yang.gdata.List):
             children['things'] = to_json_foo__c1__things(child_things)
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -297,3 +295,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -69,7 +69,6 @@ mut def to_json_acme_foo_bar__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 class root(yang.adata.MNode):
     c1: acme_foo_bar__c1
 
@@ -135,3 +134,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['acme_foo-bar:c1'] = to_json_acme_foo_bar__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -151,7 +151,6 @@ mut def to_json_bar__c1__li1(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_bar__c1__li1_element(e))
     return elements
 
-
 class bar__c1(yang.adata.MNode):
     li1: bar__c1__li1
 
@@ -212,7 +211,6 @@ mut def to_json_bar__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_li1, yang.gdata.List):
             children['li1'] = to_json_bar__c1__li1(child_li1)
     return children
-
 
 class root(yang.adata.MNode):
     c1: bar__c1
@@ -279,3 +277,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['bar:c1'] = to_json_bar__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/bar",
+}

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -70,7 +70,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.vals
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -136,3 +135,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -69,7 +69,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 mut def from_json_foo__c2__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -131,7 +130,6 @@ mut def to_json_foo__c2(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l2, yang.gdata.Leaf):
             children['l2'] = child_l2.val
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -219,3 +217,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c2'] = to_json_foo__c2(child_c2)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -151,7 +151,6 @@ mut def to_json_foo__c1__li1(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__c1__li1_element(e))
     return elements
 
-
 class foo__c1(yang.adata.MNode):
     li1: foo__c1__li1
 
@@ -212,7 +211,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_li1, yang.gdata.List):
             children['li1'] = to_json_foo__c1__li1(child_li1)
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -279,3 +277,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -87,7 +87,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l2'] = child_l2.val
     return children
 
-
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -153,3 +152,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -66,7 +66,6 @@ mut def to_json_foo__c__li__bar(n: yang.gdata.Container) -> dict[str, ?value]:
             children['man'] = child_man.val
     return children
 
-
 class foo__c__li_entry(yang.adata.MNode):
     name: str
     foo: str
@@ -241,4 +240,3 @@ mut def to_json_foo__c__li(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__c__li_element(e))
     return elements
-

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -142,7 +142,6 @@ mut def to_json_base__c1__base_l1(n: yang.gdata.List) -> list[dict[str, ?value]]
         elements.append(to_json_base__c1__base_l1_element(e))
     return elements
 
-
 mut def from_json_base__c1__foo_l1__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -287,7 +286,6 @@ mut def to_json_base__c1__foo_l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_base__c1__foo_l1_element(e))
     return elements
 
-
 class base__c1(yang.adata.MNode):
     base_l1: base__c1__base_l1
     foo_l1: base__c1__foo_l1
@@ -365,7 +363,6 @@ mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo:l1'] = to_json_base__c1__foo_l1(child_foo_l1)
     return children
 
-
 class root(yang.adata.MNode):
     c1: base__c1
 
@@ -430,4 +427,3 @@ mut def to_json_root(n: yang.gdata.Root) -> dict[str, ?value]:
         if isinstance(child_c1, yang.gdata.Container):
             children['base:c1'] = to_json_base__c1(child_c1)
     return children
-

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -60,7 +60,6 @@ mut def to_json_base__c1__base_c2(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo'] = child_foo.val
     return children
 
-
 mut def from_json_base__c1__foo_c2__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -122,7 +121,6 @@ mut def to_json_base__c1__foo_c2(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_foo, yang.gdata.Leaf):
             children['foo'] = child_foo.val
     return children
-
 
 class base__c1(yang.adata.MNode):
     base_c2: base__c1__base_c2
@@ -211,7 +209,6 @@ mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo:c2'] = to_json_base__c1__foo_c2(child_foo_c2)
     return children
 
-
 class root(yang.adata.MNode):
     c1: base__c1
 
@@ -276,4 +273,3 @@ mut def to_json_root(n: yang.gdata.Root) -> dict[str, ?value]:
         if isinstance(child_c1, yang.gdata.Container):
             children['base:c1'] = to_json_base__c1(child_c1)
     return children
-

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -75,4 +75,3 @@ mut def to_json_base__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_foo_foo, yang.gdata.Leaf):
             children['foo:foo'] = child_foo_foo.val
     return children
-

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -69,7 +69,6 @@ mut def to_json_foo__ieee_802_3(n: yang.gdata.Container) -> dict[str, ?value]:
             children['ieee-802.3'] = child_ieee_802_3.val
     return children
 
-
 class root(yang.adata.MNode):
     ieee_802_3: foo__ieee_802_3
 
@@ -135,3 +134,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:ieee-802.3'] = to_json_foo__ieee_802_3(child_ieee_802_3)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -131,4 +131,3 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_with_, yang.gdata.Leaf):
             children['with'] = child_with_.val
     return children
-

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -141,4 +141,3 @@ mut def to_json_foo__l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__l1_element(e))
     return elements
-

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -159,4 +159,3 @@ mut def to_json_foo__l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__l1_element(e))
     return elements
-

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -60,7 +60,6 @@ mut def to_json_foo__foo__bar(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 class foo__foo(yang.adata.MNode):
     bar: foo__foo__bar
 
@@ -126,4 +125,3 @@ mut def to_json_foo__foo(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_bar, yang.gdata.Container):
             children['bar'] = to_json_foo__foo__bar(child_bar)
     return children
-

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -60,7 +60,6 @@ mut def to_json_foo__foo__bar(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
 
@@ -128,4 +127,3 @@ mut def to_json_foo__foo(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_bar, yang.gdata.Container):
             children['bar'] = to_json_foo__foo__bar(child_bar)
     return children
-

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -151,7 +151,6 @@ mut def to_json_foo__li1(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__li1_element(e))
     return elements
 
-
 mut def from_json_foo__ll1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
@@ -230,3 +229,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:ll1'] = child_ll1.vals
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -75,7 +75,6 @@ mut def to_json_foo__l1__bar(n: yang.gdata.Container) -> dict[str, ?value]:
             children['hi'] = child_hi.val
     return children
 
-
 class foo__l1_entry(yang.adata.MNode):
     name: str
     id: ?str
@@ -253,7 +252,6 @@ mut def to_json_foo__l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__l1_element(e))
     return elements
 
-
 class root(yang.adata.MNode):
     l1: foo__l1
 
@@ -314,3 +312,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:l1'] = to_json_foo__l1(child_l1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -159,4 +159,3 @@ mut def to_json_foo__l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__l1_element(e))
     return elements
-

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -63,7 +63,6 @@ mut def to_json_foo__l1__bar(n: yang.gdata.Container) -> dict[str, ?value]:
             children['hi'] = child_hi.val
     return children
 
-
 class foo__l1_entry(yang.adata.MNode):
     name: str
     bar: ?foo__l1__bar
@@ -227,4 +226,3 @@ mut def to_json_foo__l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__l1_element(e))
     return elements
-

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -69,7 +69,6 @@ mut def to_json_bar__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -131,7 +130,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l1, yang.gdata.Leaf):
             children['l1'] = child_l1.val
     return children
-
 
 class root(yang.adata.MNode):
     bar_c1: bar__c1
@@ -219,3 +217,7 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_foo_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+    "http://example.com/bar",
+}

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -69,7 +69,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l1'] = child_l1.val
     return children
 
-
 mut def from_json_foo__pc1__foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -131,7 +130,6 @@ mut def to_json_foo__pc1__foo(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l1, yang.gdata.Leaf):
             children['l1'] = child_l1.val
     return children
-
 
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
@@ -198,7 +196,6 @@ mut def to_json_foo__pc1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_foo, yang.gdata.Container):
             children['foo'] = to_json_foo__pc1__foo(child_foo)
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -288,3 +285,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:pc1'] = to_json_foo__pc1(child_pc1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -195,7 +195,6 @@ mut def to_json_foo__c1__l1(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__c1__l1_element(e))
     return elements
 
-
 class foo__c1(yang.adata.MNode):
     l1: foo__c1__l1
 
@@ -256,7 +255,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l1, yang.gdata.List):
             children['l1'] = to_json_foo__c1__l1(child_l1)
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -323,3 +321,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:c1'] = to_json_foo__c1(child_c1)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -119,3 +119,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:l4'] = child_l4.val
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -68,3 +68,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:l1'] = child_l1.val
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -71,3 +71,6 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:l1'] = child_l1.val
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -241,7 +241,6 @@ mut def to_json_basics__c(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l_binary_def'] = child_l_binary_def.val
     return children
 
-
 class root(yang.adata.MNode):
     c: basics__c
 
@@ -307,6 +306,9 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['b:c'] = to_json_basics__c(child_c)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/basics",
+}
 def src_yang():
     res = []
     res.append("""module basics {

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -179,7 +179,6 @@ mut def to_json_foo__c1__li(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__c1__li_element(e))
     return elements
 
-
 mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
@@ -358,7 +357,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['bar:l2'] = child_l2.val
     return children
 
-
 mut def from_json_foo__pc1__foo__l1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
@@ -421,7 +419,6 @@ mut def to_json_foo__pc1__foo(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l1, yang.gdata.LeafList):
             children['l1'] = child_l1.vals
     return children
-
 
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
@@ -489,7 +486,6 @@ mut def to_json_foo__pc1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo'] = to_json_foo__pc1__foo(child_foo)
     return children
 
-
 mut def from_json_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -552,7 +548,6 @@ mut def to_json_foo__pc2__foo(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l_mandatory'] = child_l_mandatory.val
     return children
 
-
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
@@ -614,7 +609,6 @@ mut def to_json_foo__pc2(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo'] = to_json_foo__pc2__foo(child_foo)
     return children
 
-
 class foo__empty_presence(yang.adata.MNode):
 
     mut def __init__(self):
@@ -659,7 +653,6 @@ mut def from_json_foo__empty_presence(jd: dict[str, ?value]) -> yang.gdata.Conta
 mut def to_json_foo__empty_presence(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
-
 
 mut def from_json_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -739,7 +732,6 @@ mut def to_json_foo__c_dot(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l_dot2, yang.gdata.Leaf):
             children['bar:l.dot2'] = child_l_dot2.val
     return children
-
 
 mut def from_json_foo__cc__cake(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -888,7 +880,6 @@ mut def to_json_foo__cc__death(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__cc__death_element(e))
     return elements
 
-
 class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
@@ -965,7 +956,6 @@ mut def to_json_foo__cc(n: yang.gdata.Container) -> dict[str, ?value]:
             children['death'] = to_json_foo__cc__death(child_death)
     return children
 
-
 mut def from_json_foo__conflict__foo_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -1014,7 +1004,6 @@ mut def to_json_foo__conflict__foo_inner(n: yang.gdata.Container) -> dict[str, ?
     children = {}
     return children
 
-
 mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -1062,7 +1051,6 @@ mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.
 mut def to_json_foo__conflict__bar_inner(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
-
 
 class foo__conflict(yang.adata.MNode):
     foo_foo: ?str
@@ -1183,7 +1171,6 @@ mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_bar_inner, yang.gdata.Container):
             children['bar:inner'] = to_json_foo__conflict__bar_inner(child_bar_inner)
     return children
-
 
 mut def from_json_foo__special__yes(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("boolean", val)
@@ -1328,7 +1315,6 @@ mut def to_json_foo__special(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__special_element(e))
     return elements
-
 
 mut def from_json_foo__nested__inner__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -1520,7 +1506,6 @@ mut def to_json_foo__nested__inner__li1__li2(n: yang.gdata.List) -> list[dict[st
         elements.append(to_json_foo__nested__inner__li1__li2_element(e))
     return elements
 
-
 class foo__nested__inner__li1_entry(yang.adata.MNode):
     name: str
     bar: ?str
@@ -1693,7 +1678,6 @@ mut def to_json_foo__nested__inner__li1(n: yang.gdata.List) -> list[dict[str, ?v
         elements.append(to_json_foo__nested__inner__li1_element(e))
     return elements
 
-
 class foo__nested__inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__inner__li1
@@ -1770,7 +1754,6 @@ mut def to_json_foo__nested__inner(n: yang.gdata.Container) -> dict[str, ?value]
             children['li1'] = to_json_foo__nested__inner__li1(child_li1)
     return children
 
-
 class foo__nested(yang.adata.MNode):
     inner: foo__nested__inner
 
@@ -1836,7 +1819,6 @@ mut def to_json_foo__nested(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_inner, yang.gdata.Container):
             children['inner'] = to_json_foo__nested__inner(child_inner)
     return children
-
 
 mut def from_json_foo__li_union__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -2032,7 +2014,6 @@ mut def to_json_foo__li_union(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__li_union_element(e))
     return elements
 
-
 mut def from_json_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -2113,7 +2094,6 @@ mut def to_json_foo__state__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l2'] = child_l2.val
     return children
 
-
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
@@ -2180,7 +2160,6 @@ mut def to_json_foo__state(n: yang.gdata.Container) -> dict[str, ?value]:
             children['c1'] = to_json_foo__state__c1(child_c1)
     return children
 
-
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -2242,7 +2221,6 @@ mut def to_json_bar__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_foo, yang.gdata.Leaf):
             children['foo'] = child_foo.val
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -2536,6 +2514,10 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['bar:conflict'] = to_json_bar__conflict(child_bar_conflict)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+    "http://example.com/bar",
+}
 def src_yang():
     res = []
     res.append("""module foo {

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -179,7 +179,6 @@ mut def to_json_foo__c1__li(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__c1__li_element(e))
     return elements
 
-
 mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
@@ -358,7 +357,6 @@ mut def to_json_foo__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['bar:l2'] = child_l2.val
     return children
 
-
 mut def from_json_foo__pc1__foo__l1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
@@ -421,7 +419,6 @@ mut def to_json_foo__pc1__foo(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l1, yang.gdata.LeafList):
             children['l1'] = child_l1.vals
     return children
-
 
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
@@ -489,7 +486,6 @@ mut def to_json_foo__pc1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo'] = to_json_foo__pc1__foo(child_foo)
     return children
 
-
 mut def from_json_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -551,7 +547,6 @@ mut def to_json_foo__pc2__foo(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l_mandatory, yang.gdata.Leaf):
             children['l_mandatory'] = child_l_mandatory.val
     return children
-
 
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
@@ -619,7 +614,6 @@ mut def to_json_foo__pc2(n: yang.gdata.Container) -> dict[str, ?value]:
             children['foo'] = to_json_foo__pc2__foo(child_foo)
     return children
 
-
 class foo__empty_presence(yang.adata.MNode):
 
     mut def __init__(self):
@@ -664,7 +658,6 @@ mut def from_json_foo__empty_presence(jd: dict[str, ?value]) -> yang.gdata.Conta
 mut def to_json_foo__empty_presence(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
-
 
 mut def from_json_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -744,7 +737,6 @@ mut def to_json_foo__c_dot(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l_dot2, yang.gdata.Leaf):
             children['bar:l.dot2'] = child_l_dot2.val
     return children
-
 
 mut def from_json_foo__cc__cake(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -893,7 +885,6 @@ mut def to_json_foo__cc__death(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__cc__death_element(e))
     return elements
 
-
 class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
@@ -970,7 +961,6 @@ mut def to_json_foo__cc(n: yang.gdata.Container) -> dict[str, ?value]:
             children['death'] = to_json_foo__cc__death(child_death)
     return children
 
-
 mut def from_json_foo__conflict__foo_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -1019,7 +1009,6 @@ mut def to_json_foo__conflict__foo_inner(n: yang.gdata.Container) -> dict[str, ?
     children = {}
     return children
 
-
 mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -1067,7 +1056,6 @@ mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.
 mut def to_json_foo__conflict__bar_inner(n: yang.gdata.Container) -> dict[str, ?value]:
     children = {}
     return children
-
 
 class foo__conflict(yang.adata.MNode):
     foo_foo: ?str
@@ -1188,7 +1176,6 @@ mut def to_json_foo__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_bar_inner, yang.gdata.Container):
             children['bar:inner'] = to_json_foo__conflict__bar_inner(child_bar_inner)
     return children
-
 
 mut def from_json_foo__special__yes(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("boolean", val)
@@ -1333,7 +1320,6 @@ mut def to_json_foo__special(n: yang.gdata.List) -> list[dict[str, ?value]]:
     for e in n.elements:
         elements.append(to_json_foo__special_element(e))
     return elements
-
 
 mut def from_json_foo__nested__inner__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -1525,7 +1511,6 @@ mut def to_json_foo__nested__inner__li1__li2(n: yang.gdata.List) -> list[dict[st
         elements.append(to_json_foo__nested__inner__li1__li2_element(e))
     return elements
 
-
 class foo__nested__inner__li1_entry(yang.adata.MNode):
     name: str
     bar: ?str
@@ -1698,7 +1683,6 @@ mut def to_json_foo__nested__inner__li1(n: yang.gdata.List) -> list[dict[str, ?v
         elements.append(to_json_foo__nested__inner__li1_element(e))
     return elements
 
-
 class foo__nested__inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__inner__li1
@@ -1775,7 +1759,6 @@ mut def to_json_foo__nested__inner(n: yang.gdata.Container) -> dict[str, ?value]
             children['li1'] = to_json_foo__nested__inner__li1(child_li1)
     return children
 
-
 class foo__nested(yang.adata.MNode):
     inner: foo__nested__inner
 
@@ -1841,7 +1824,6 @@ mut def to_json_foo__nested(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_inner, yang.gdata.Container):
             children['inner'] = to_json_foo__nested__inner(child_inner)
     return children
-
 
 mut def from_json_foo__li_union__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
@@ -2037,7 +2019,6 @@ mut def to_json_foo__li_union(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__li_union_element(e))
     return elements
 
-
 mut def from_json_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -2118,7 +2099,6 @@ mut def to_json_foo__state__c1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l2'] = child_l2.val
     return children
 
-
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
@@ -2185,7 +2165,6 @@ mut def to_json_foo__state(n: yang.gdata.Container) -> dict[str, ?value]:
             children['c1'] = to_json_foo__state__c1(child_c1)
     return children
 
-
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -2247,7 +2226,6 @@ mut def to_json_bar__conflict(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_foo, yang.gdata.Leaf):
             children['foo'] = child_foo.val
     return children
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -2541,6 +2519,10 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['bar:conflict'] = to_json_bar__conflict(child_bar_conflict)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+    "http://example.com/bar",
+}
 def src_yang():
     res = []
     res.append("""module foo {

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -88,7 +88,6 @@ mut def to_json_foo__tc1(n: yang.gdata.Container) -> dict[str, ?value]:
             children['l2'] = child_l2.val
     return children
 
-
 mut def from_json_foo__li__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf("string", val)
 
@@ -171,7 +170,6 @@ mut def to_json_foo__li__c1(n: yang.gdata.Container) -> dict[str, ?value]:
         if isinstance(child_l2, yang.gdata.Leaf):
             children['l2'] = child_l2.val
     return children
-
 
 class foo__li_entry(yang.adata.MNode):
     name: str
@@ -330,7 +328,6 @@ mut def to_json_foo__li(n: yang.gdata.List) -> list[dict[str, ?value]]:
         elements.append(to_json_foo__li_element(e))
     return elements
 
-
 class root(yang.adata.MNode):
     tc1: foo__tc1
     li: foo__li
@@ -407,6 +404,9 @@ mut def to_json(n: yang.gdata.Root) -> dict[str, ?value]:
             children['foo:li'] = to_json_foo__li(child_li)
     return children
 
+schema_namespaces: set[str] = {
+    "http://example.com/foo",
+}
 def src_yang():
     res = []
     res.append("""module foo {


### PR DESCRIPTION
The YANG namespaces of the modules we compiled from, or rather, the namespaces that made it into nodes in the final tree are now included as schema_namespaces constant in the generated Acton module. This can be useful to latest inspect what namespaces we can expect from a particular schema.