### PR TITLE
Refactor SchemaNode.prsrc()

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1349,10 +1349,35 @@ class SchemaNode(object):
     def get_attrs(self) -> list[(str, ?value)]:
         raise NotImplementedError('SchemaNode get_attrs')
 
-    def prsrc(self, indent=0) -> str:
+    _get_class_name: pure() -> str
+
+    def prsrc(self, indent=0):
         """Print Acton source code for this schema node and its subnodes
         """
-        raise NotImplementedError('SchemaNode prsrc')
+        res = []
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
+        attrs_text = _prsrc_attrs(indent, self.get_attrs())
+        if len(attrs_text) > 0:
+            args.append(_prsrc_attrs(indent, self.get_attrs()))
+        have_children = True if isinstance(self, SchemaNodeInner) and len(self.children) > 0 else False
+        if have_children:
+            args.append("children=[")
+        args_text = ", ".join(args)
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
+        if not have_children:
+            text_line += ')'
+        res.append(text_line)
+        if isinstance(self, SchemaNodeInner) and have_children:
+            child_res = []
+            for child in self.children:
+                child_res.append(child.prsrc(indent+1))
+            res.append(",\n".join(child_res))
+            res.append(_ind(indent) + "])")
+        return "\n".join(res)
 
     def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
@@ -1805,6 +1830,9 @@ class Ext(SchemaNode):
         if len(parts) != 2:
             raise ValueError("Invalid extension name %s, extensions must always have a prefix like: foo:bar 'test';" % fullname)
         return Ext(parts[0], parts[1], None)
+
+    def _get_class_name(self):
+        return "Ext"
 
     def prsrc(self, indent=0):
         """Print Acton source of this node"""

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1184,7 +1184,7 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             res.append("        if len(self.children) > 0:")
             res.append("            args.append(\"children=[\")")
         res.append("        args_text = \", \".join(args)")
-        text_prscr_attrs = "        text_line = _ind(indent) + \"%s(\" + args_text" % (_class_name(stmt_name))
+        text_prscr_attrs = "        text_line = _ind(indent) + self._get_class_name() + \"(\" + args_text"
         if not have_children:
             text_prscr_attrs += " + \")\""
         res.append(text_prscr_attrs)
@@ -1236,6 +1236,10 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         res.append("    def __str__(self):")
         strret = "\"%s \" + self.%s" % (_class_name(stmt_name), _attr_name(arg_name)) if arg_name is not None else "\"%s\"" % (_class_name(stmt_name))
         res.append("        return " + strret)
+        res.append("")
+
+        res.append("    def _get_class_name(self) -> str:")
+        res.append("        return \"%s\"" % _class_name(stmt_name))
         res.append("")
 
         res.append("    def _get_argname(self) -> ?str:")

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1172,10 +1172,11 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         res.append('        """Print Acton source of this node"""')
         res.append("        res = []")
 
-        if arg_name is not None:
-            res.append("        args = [\"'\" + str(self.%s) + \"'\"]" % _attr_name(arg_name))
-        else:
-            res.append("        args = []")
+        res.append("        self_arg = self._get_arg()")
+        res.append("        if self_arg is not None:")
+        res.append("            args = [\"'\" + self_arg + \"'\"]")
+        res.append("        else:")
+        res.append("            args = []")
         res.append("        attrs_text = _prsrc_attrs(indent, self.get_attrs())")
         res.append("        if len(attrs_text) > 0:")
         res.append("            args.append(_prsrc_attrs(indent, self.get_attrs()))")

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1172,13 +1172,6 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         res.append('        """Print Acton source of this node"""')
         res.append("        res = []")
 
-        args = []
-        res.append("        attrs: list[(str, ?value)] = [")
-        for attr in kwattrs:
-            res.append("            (\"%s\", self.%s)," % (attr, _attr_name(attr)))
-        res.append("            (\"exts\", self.exts),")
-        res.append("        ]")
-
         if arg_name is not None:
             res.append("        args = [\"'\" + str(self.%s) + \"'\"]" % _attr_name(arg_name))
         else:

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -288,28 +288,6 @@ def _attr_defval(name, stmt, stms) -> str:
         return "=[]"
     raise ValueError("Unknown cardinality: %s" % cardinality)
 
-header = """
-def _prsrc_attrs(attrs):
-    res = []
-    for attr in attrs:
-        name, value = attr
-        if isinstance(value, list):
-            if len(value) > 0:
-                res.append(name + "=[" + ", ".join(value) + "]")
-        else:
-            if value is not None:
-                res.append(name + "=" + repr(value))
-    return res
-
-def _ind(indent):
-    return "    " * indent
-
-class SchemaNode(object):
-    def prsrc(self, indent=0) -> list[str]:
-        raise NotImplementedError("prsrc")
-
-"""
-
 snode_methods = {
     "action": {
         "get": """    def get(self, name: str, ns: ?str=None) -> SchemaNode:

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1145,42 +1145,6 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             res.append("        self.exts.extend(refine.exts)")
             res.append("")
 
-        # -- prsrc
-        res.append("    def prsrc(self, indent=0):")
-        res.append('        """Print Acton source of this node"""')
-        res.append("        res = []")
-
-        res.append("        self_arg = self._get_arg()")
-        res.append("        if self_arg is not None:")
-        res.append("            args = [\"'\" + self_arg + \"'\"]")
-        res.append("        else:")
-        res.append("            args = []")
-        res.append("        attrs_text = _prsrc_attrs(indent, self.get_attrs())")
-        res.append("        if len(attrs_text) > 0:")
-        res.append("            args.append(_prsrc_attrs(indent, self.get_attrs()))")
-        if have_children:
-            res.append("        if len(self.children) > 0:")
-            res.append("            args.append(\"children=[\")")
-        res.append("        args_text = \", \".join(args)")
-        text_prscr_attrs = "        text_line = _ind(indent) + self._get_class_name() + \"(\" + args_text"
-        if not have_children:
-            text_prscr_attrs += " + \")\""
-        res.append(text_prscr_attrs)
-        if have_children:
-            res.append("        if len(self.children) == 0:")
-            res.append("            text_line += ')'")
-        res.append("        res.append(text_line)")
-        if have_children:
-            res.append("        if len(self.children) > 0:")
-            res.append("            child_res = []")
-            res.append("            for child in self.children:")
-            res.append("                child_res.append(child.prsrc(indent+1))")
-            res.append("            res.append(\",\\n\".join(child_res))")
-            res.append("            res.append(_ind(indent) + \"])\")")
-
-        res.append("        return \"\\n\".join(res)")
-        res.append("")
-
         manual_methods = []
         # == Statement specific methods ================================
         for method_name in snode_methods.get_def(stmt_name, {}):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2636,7 +2636,7 @@ class Action(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Action(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -2706,6 +2706,9 @@ class Action(SchemaNodeInner):
 
     def __str__(self):
         return "Action " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Action"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -2811,7 +2814,7 @@ class Anydata(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Anydata(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -2848,6 +2851,9 @@ class Anydata(SchemaNodeOuter):
 
     def __str__(self):
         return "Anydata " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Anydata"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -2953,7 +2959,7 @@ class Anyxml(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Anyxml(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -2990,6 +2996,9 @@ class Anyxml(SchemaNodeOuter):
 
     def __str__(self):
         return "Anyxml " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Anyxml"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3080,7 +3089,7 @@ class Augment(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Augment(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -3107,6 +3116,9 @@ class Augment(SchemaNodeInner):
 
     def __str__(self):
         return "Augment " + self.target_node
+
+    def _get_class_name(self) -> str:
+        return "Augment"
 
     def _get_argname(self) -> ?str:
         return 'target_node'
@@ -3162,7 +3174,7 @@ class BelongsTo(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "BelongsTo(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -3176,6 +3188,9 @@ class BelongsTo(SchemaNodeOuter):
 
     def __str__(self):
         return "BelongsTo " + self.module
+
+    def _get_class_name(self) -> str:
+        return "BelongsTo"
 
     def _get_argname(self) -> ?str:
         return 'module'
@@ -3255,7 +3270,7 @@ class Bit(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Bit(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -3273,6 +3288,9 @@ class Bit(SchemaNodeOuter):
 
     def __str__(self):
         return "Bit " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Bit"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3363,7 +3381,7 @@ class Case(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Case(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -3390,6 +3408,9 @@ class Case(SchemaNodeInner):
 
     def __str__(self):
         return "Case " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Case"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3499,7 +3520,7 @@ class Choice(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Choice(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -3529,6 +3550,9 @@ class Choice(SchemaNodeInner):
 
     def __str__(self):
         return "Choice " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Choice"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3645,7 +3669,7 @@ class Container(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Container(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -3701,6 +3725,9 @@ class Container(SchemaNodeInner):
 
     def __str__(self):
         return "Container " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Container"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3780,7 +3807,7 @@ class Enum(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Enum(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -3798,6 +3825,9 @@ class Enum(SchemaNodeOuter):
 
     def __str__(self):
         return "Enum " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Enum"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3871,7 +3901,7 @@ class Extension(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Extension(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -3888,6 +3918,9 @@ class Extension(SchemaNodeOuter):
 
     def __str__(self):
         return "Extension " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Extension"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -3964,7 +3997,7 @@ class Feature(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Feature(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -3981,6 +4014,9 @@ class Feature(SchemaNodeOuter):
 
     def __str__(self):
         return "Feature " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Feature"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -4062,7 +4098,7 @@ class Grouping(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Grouping(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -4087,6 +4123,9 @@ class Grouping(SchemaNodeInner):
 
     def __str__(self):
         return "Grouping " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Grouping"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -4166,7 +4205,7 @@ class Identity(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Identity(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -4184,6 +4223,9 @@ class Identity(SchemaNodeOuter):
 
     def __str__(self):
         return "Identity " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Identity"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -4257,7 +4299,7 @@ class Import(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Import(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -4274,6 +4316,9 @@ class Import(SchemaNodeOuter):
 
     def __str__(self):
         return "Import " + self.module
+
+    def _get_class_name(self) -> str:
+        return "Import"
 
     def _get_argname(self) -> ?str:
         return 'module'
@@ -4344,7 +4389,7 @@ class Include(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Include(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -4360,6 +4405,9 @@ class Include(SchemaNodeOuter):
 
     def __str__(self):
         return "Include " + self.module
+
+    def _get_class_name(self) -> str:
+        return "Include"
 
     def _get_argname(self) -> ?str:
         return 'module'
@@ -4438,7 +4486,7 @@ class Input(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Input(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -4471,6 +4519,9 @@ class Input(SchemaNodeInner):
         return new
 
     def __str__(self):
+        return "Input"
+
+    def _get_class_name(self) -> str:
         return "Input"
 
     def _get_argname(self) -> ?str:
@@ -4597,7 +4648,7 @@ class Leaf(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Leaf(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -4651,6 +4702,9 @@ class Leaf(SchemaNodeOuter):
 
     def __str__(self):
         return "Leaf " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Leaf"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -4784,7 +4838,7 @@ class LeafList(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "LeafList(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -4848,6 +4902,9 @@ class LeafList(SchemaNodeOuter):
 
     def __str__(self):
         return "LeafList " + self.name
+
+    def _get_class_name(self) -> str:
+        return "LeafList"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -4921,7 +4978,7 @@ class Length(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Length(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -4938,6 +4995,9 @@ class Length(SchemaNodeOuter):
 
     def __str__(self):
         return "Length " + self.value
+
+    def _get_class_name(self) -> str:
+        return "Length"
 
     def _get_argname(self) -> ?str:
         return 'value'
@@ -5069,7 +5129,7 @@ class List(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "List(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -5143,6 +5203,9 @@ class List(SchemaNodeInner):
 
     def __str__(self):
         return "List " + self.name
+
+    def _get_class_name(self) -> str:
+        return "List"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -5305,7 +5368,7 @@ class Module(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Module(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -5395,6 +5458,9 @@ class Module(SchemaNodeInner):
     def __str__(self):
         return "Module " + self.name
 
+    def _get_class_name(self) -> str:
+        return "Module"
+
     def _get_argname(self) -> ?str:
         return 'name'
 
@@ -5473,7 +5539,7 @@ class Must(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Must(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -5490,6 +5556,9 @@ class Must(SchemaNodeOuter):
 
     def __str__(self):
         return "Must " + self.condition
+
+    def _get_class_name(self) -> str:
+        return "Must"
 
     def _get_argname(self) -> ?str:
         return 'condition'
@@ -5591,7 +5660,7 @@ class Notification(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Notification(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -5637,6 +5706,9 @@ class Notification(SchemaNodeInner):
 
     def __str__(self):
         return "Notification " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Notification"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -5715,7 +5787,7 @@ class Output(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Output(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -5751,6 +5823,9 @@ class Output(SchemaNodeInner):
         return new
 
     def __str__(self):
+        return "Output"
+
+    def _get_class_name(self) -> str:
         return "Output"
 
     def _get_argname(self) -> ?str:
@@ -5828,7 +5903,7 @@ class Pattern(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Pattern(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -5846,6 +5921,9 @@ class Pattern(SchemaNodeOuter):
 
     def __str__(self):
         return "Pattern " + self.value
+
+    def _get_class_name(self) -> str:
+        return "Pattern"
 
     def _get_argname(self) -> ?str:
         return 'value'
@@ -5919,7 +5997,7 @@ class Range(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Range(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -5936,6 +6014,9 @@ class Range(SchemaNodeOuter):
 
     def __str__(self):
         return "Range " + self.value
+
+    def _get_class_name(self) -> str:
+        return "Range"
 
     def _get_argname(self) -> ?str:
         return 'value'
@@ -6059,7 +6140,7 @@ class Refine(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Refine(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -6082,6 +6163,9 @@ class Refine(SchemaNodeOuter):
 
     def __str__(self):
         return "Refine " + self.target_node
+
+    def _get_class_name(self) -> str:
+        return "Refine"
 
     def _get_argname(self) -> ?str:
         return 'target_node'
@@ -6149,7 +6233,7 @@ class Revision(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Revision(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -6164,6 +6248,9 @@ class Revision(SchemaNodeOuter):
 
     def __str__(self):
         return "Revision " + self.date
+
+    def _get_class_name(self) -> str:
+        return "Revision"
 
     def _get_argname(self) -> ?str:
         return 'date'
@@ -6273,7 +6360,7 @@ class Rpc(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Rpc(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -6343,6 +6430,9 @@ class Rpc(SchemaNodeInner):
 
     def __str__(self):
         return "Rpc " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Rpc"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -6509,7 +6599,7 @@ class Submodule(SchemaNodeInner):
         if len(self.children) > 0:
             args.append("children=[")
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Submodule(" + args_text
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
         if len(self.children) == 0:
             text_line += ')'
         res.append(text_line)
@@ -6555,6 +6645,9 @@ class Submodule(SchemaNodeInner):
 
     def __str__(self):
         return "Submodule " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Submodule"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -6685,7 +6778,7 @@ class Type(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Type(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -6744,6 +6837,9 @@ class Type(SchemaNodeOuter):
 
     def __str__(self):
         return "Type " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Type"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -6834,7 +6930,7 @@ class Typedef(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Typedef(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -6861,6 +6957,9 @@ class Typedef(SchemaNodeOuter):
 
     def __str__(self):
         return "Typedef " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Typedef"
 
     def _get_argname(self) -> ?str:
         return 'name'
@@ -6962,7 +7061,7 @@ class Uses(SchemaNodeOuter):
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
         args_text = ", ".join(args)
-        text_line = _ind(indent) + "Uses(" + args_text + ")"
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
         res.append(text_line)
         return "\n".join(res)
 
@@ -6991,6 +7090,9 @@ class Uses(SchemaNodeOuter):
 
     def __str__(self):
         return "Uses " + self.name
+
+    def _get_class_name(self) -> str:
+        return "Uses"
 
     def _get_argname(self) -> ?str:
         return 'name'

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1345,10 +1345,35 @@ class SchemaNode(object):
     def get_attrs(self) -> list[(str, ?value)]:
         raise NotImplementedError('SchemaNode get_attrs')
 
-    def prsrc(self, indent=0) -> str:
+    _get_class_name: pure() -> str
+
+    def prsrc(self, indent=0):
         """Print Acton source code for this schema node and its subnodes
         """
-        raise NotImplementedError('SchemaNode prsrc')
+        res = []
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
+        attrs_text = _prsrc_attrs(indent, self.get_attrs())
+        if len(attrs_text) > 0:
+            args.append(_prsrc_attrs(indent, self.get_attrs()))
+        have_children = True if isinstance(self, SchemaNodeInner) and len(self.children) > 0 else False
+        if have_children:
+            args.append("children=[")
+        args_text = ", ".join(args)
+        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
+        if not have_children:
+            text_line += ')'
+        res.append(text_line)
+        if isinstance(self, SchemaNodeInner) and have_children:
+            child_res = []
+            for child in self.children:
+                child_res.append(child.prsrc(indent+1))
+            res.append(",\n".join(child_res))
+            res.append(_ind(indent) + "])")
+        return "\n".join(res)
 
     def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
         """Print the data class for this schema node
@@ -1801,6 +1826,9 @@ class Ext(SchemaNode):
         if len(parts) != 2:
             raise ValueError("Invalid extension name %s, extensions must always have a prefix like: foo:bar 'test';" % fullname)
         return Ext(parts[0], parts[1], None)
+
+    def _get_class_name(self):
+        return "Ext"
 
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
@@ -2622,32 +2650,6 @@ class Action(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def get(self, name: str, ns: ?str=None) -> SchemaNode:
         # TODO: support looking up qualified by namespace
         #tns = ns if ns is not None else self.get_namespace()
@@ -2802,22 +2804,6 @@ class Anydata(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def to_dnode(self) -> DAnydata:
         return DAnydata(
             namespace=self.get_namespace(),
@@ -2947,22 +2933,6 @@ class Anyxml(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def to_dnode(self) -> DAnyxml:
         return DAnyxml(
             namespace=self.get_namespace(),
@@ -3075,32 +3045,6 @@ class Augment(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Augment(self.target_node,
                       description=self.description,
@@ -3161,22 +3105,6 @@ class BelongsTo(SchemaNodeOuter):
             ("prefix", self.prefix),
             ("exts", self.exts),
         ]
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = BelongsTo(self.module,
@@ -3257,22 +3185,6 @@ class Bit(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Bit(self.name,
@@ -3366,32 +3278,6 @@ class Case(SchemaNodeInner):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Case(self.name,
@@ -3505,32 +3391,6 @@ class Choice(SchemaNodeInner):
         if ref_config != None:
             self.config = ref_config
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Choice(self.name,
@@ -3655,32 +3515,6 @@ class Container(SchemaNodeInner):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def is_presence(self) -> bool:
         selfpresence = self.presence
         if selfpresence is not None:
@@ -3795,22 +3629,6 @@ class Enum(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Enum(self.name,
                    description=self.description,
@@ -3888,22 +3706,6 @@ class Extension(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Extension(self.name,
@@ -3984,22 +3786,6 @@ class Feature(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Feature(self.name,
@@ -4084,32 +3870,6 @@ class Grouping(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Grouping(self.name,
                        description=self.description,
@@ -4193,22 +3953,6 @@ class Identity(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Identity(self.name,
                        base=self.base,
@@ -4287,22 +4031,6 @@ class Import(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Import(self.module,
                      prefix=self.prefix,
@@ -4376,22 +4104,6 @@ class Include(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Include(self.module,
@@ -4471,32 +4183,6 @@ class Input(SchemaNodeInner):
             if ref_must not in self.must:
                 self.must.append(ref_must)
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
 
     def to_dnode(self) -> DInput:
         new_dnode = DInput(
@@ -4635,22 +4321,6 @@ class Leaf(SchemaNodeOuter):
         if ref_config != None:
             self.config = ref_config
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
@@ -4826,22 +4496,6 @@ class LeafList(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
@@ -4965,22 +4619,6 @@ class Length(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Length(self.value,
@@ -5114,32 +4752,6 @@ class List(SchemaNodeInner):
         if ref_config != None:
             self.config = ref_config
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
 
     def keys(self) -> list[str]:
         selfkey = self.key
@@ -5354,32 +4966,6 @@ class Module(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def get_import_by_prefix(self, prefix: str) -> Import:
         for imp in self.import_:
             if imp.prefix == prefix:
@@ -5527,22 +5113,6 @@ class Must(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Must(self.condition,
                    description=self.description,
@@ -5646,32 +5216,6 @@ class Notification(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
             namespace=self.get_namespace(),
@@ -5773,32 +5317,6 @@ class Output(SchemaNodeInner):
                 self.must.append(ref_must)
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def to_dnode(self) -> DOutput:
         new_dnode = DOutput(
             namespace=self.get_namespace(),
@@ -5891,22 +5409,6 @@ class Pattern(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Pattern(self.value,
                       description=self.description,
@@ -5984,22 +5486,6 @@ class Range(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Range(self.value,
@@ -6128,22 +5614,6 @@ class Refine(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Refine(self.target_node,
                      config=self.config,
@@ -6220,22 +5690,6 @@ class Revision(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         new = Revision(self.date,
@@ -6345,32 +5799,6 @@ class Rpc(SchemaNodeInner):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
 
     def get(self, name: str, ns: ?str=None) -> SchemaNode:
         # TODO: support looking up qualified by namespace
@@ -6585,32 +6013,6 @@ class Submodule(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        if len(self.children) > 0:
-            args.append("children=[")
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text
-        if len(self.children) == 0:
-            text_line += ')'
-        res.append(text_line)
-        if len(self.children) > 0:
-            child_res = []
-            for child in self.children:
-                child_res.append(child.prsrc(indent+1))
-            res.append(",\n".join(child_res))
-            res.append(_ind(indent) + "])")
-        return "\n".join(res)
-
     def get_modrev(self) -> ModRev:
         rev = self.get_revision()
         rev_date = rev.date if rev is not None else None
@@ -6766,22 +6168,6 @@ class Type(SchemaNodeOuter):
             ("exts", self.exts),
         ]
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def resolve_union_types(self, context: Context) -> Type:
         if self.name == "union":
             resolved_union_types = []
@@ -6918,22 +6304,6 @@ class Typedef(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
-
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
@@ -7048,22 +6418,6 @@ class Uses(SchemaNodeOuter):
         if ref_description != None:
             self.description = ref_description
         self.exts.extend(refine.exts)
-
-    def prsrc(self, indent=0):
-        """Print Acton source of this node"""
-        res = []
-        self_arg = self._get_arg()
-        if self_arg is not None:
-            args = ["'" + self_arg + "'"]
-        else:
-            args = []
-        attrs_text = _prsrc_attrs(indent, self.get_attrs())
-        if len(attrs_text) > 0:
-            args.append(_prsrc_attrs(indent, self.get_attrs()))
-        args_text = ", ".join(args)
-        text_line = _ind(indent) + self._get_class_name() + "(" + args_text + ")"
-        res.append(text_line)
-        return "\n".join(res)
 
     def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
         raise ValueError("Cannot compile 'uses'")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2625,7 +2625,11 @@ class Action(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -2798,7 +2802,11 @@ class Anydata(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -2936,7 +2944,11 @@ class Anyxml(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3057,7 +3069,11 @@ class Augment(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.target_node) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3137,7 +3153,11 @@ class BelongsTo(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.module) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3226,7 +3246,11 @@ class Bit(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3328,7 +3352,11 @@ class Case(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3460,7 +3488,11 @@ class Choice(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3602,7 +3634,11 @@ class Container(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3735,7 +3771,11 @@ class Enum(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3822,7 +3862,11 @@ class Extension(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -3911,7 +3955,11 @@ class Feature(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4003,7 +4051,11 @@ class Grouping(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4105,7 +4157,11 @@ class Identity(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4192,7 +4248,11 @@ class Import(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.module) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4275,7 +4335,11 @@ class Include(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.module) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4363,7 +4427,11 @@ class Input(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = []
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4520,7 +4588,11 @@ class Leaf(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4703,7 +4775,11 @@ class LeafList(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4836,7 +4912,11 @@ class Length(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.value) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -4978,7 +5058,11 @@ class List(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5210,7 +5294,11 @@ class Module(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5376,7 +5464,11 @@ class Must(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.condition) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5488,7 +5580,11 @@ class Notification(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5608,7 +5704,11 @@ class Output(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = []
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5719,7 +5819,11 @@ class Pattern(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.value) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5806,7 +5910,11 @@ class Range(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.value) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -5942,7 +6050,11 @@ class Refine(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.target_node) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -6028,7 +6140,11 @@ class Revision(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.date) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -6146,7 +6262,11 @@ class Rpc(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -6378,7 +6498,11 @@ class Submodule(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -6552,7 +6676,11 @@ class Type(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -6697,7 +6825,11 @@ class Typedef(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))
@@ -6821,7 +6953,11 @@ class Uses(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        args = ["'" + str(self.name) + "'"]
+        self_arg = self._get_arg()
+        if self_arg is not None:
+            args = ["'" + self_arg + "'"]
+        else:
+            args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
             args.append(_prsrc_attrs(indent, self.get_attrs()))

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2625,15 +2625,6 @@ class Action(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("input", self.input),
-            ("output", self.output),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -2807,17 +2798,6 @@ class Anydata(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("config", self.config),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("mandatory", self.mandatory),
-            ("must", self.must),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -2956,17 +2936,6 @@ class Anyxml(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("config", self.config),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("mandatory", self.mandatory),
-            ("must", self.must),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3088,14 +3057,6 @@ class Augment(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.target_node) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3176,10 +3137,6 @@ class BelongsTo(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("prefix", self.prefix),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.module) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3269,14 +3226,6 @@ class Bit(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("position", self.position),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3379,14 +3328,6 @@ class Case(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3519,17 +3460,6 @@ class Choice(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("config", self.config),
-            ("default", self.default),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("mandatory", self.mandatory),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3672,17 +3602,6 @@ class Container(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("config", self.config),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("must", self.must),
-            ("presence", self.presence),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3816,14 +3735,6 @@ class Enum(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("value", self.value),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -3911,13 +3822,6 @@ class Extension(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("argument", self.argument),
-            ("description", self.description),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4007,13 +3911,6 @@ class Feature(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4106,12 +4003,6 @@ class Grouping(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4214,14 +4105,6 @@ class Identity(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("base", self.base),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4309,13 +4192,6 @@ class Import(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("prefix", self.prefix),
-            ("description", self.description),
-            ("reference", self.reference),
-            ("revision-date", self.revision_date),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.module) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4399,12 +4275,6 @@ class Include(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("reference", self.reference),
-            ("revision-date", self.revision_date),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.module) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4493,10 +4363,6 @@ class Input(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("must", self.must),
-            ("exts", self.exts),
-        ]
         args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4654,20 +4520,6 @@ class Leaf(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("type", self.type_),
-            ("config", self.config),
-            ("default", self.default),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("mandatory", self.mandatory),
-            ("must", self.must),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("units", self.units),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -4851,22 +4703,6 @@ class LeafList(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("type", self.type_),
-            ("config", self.config),
-            ("default", self.default),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("max-elements", self.max_elements),
-            ("min-elements", self.min_elements),
-            ("must", self.must),
-            ("ordered-by", self.ordered_by),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("units", self.units),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5000,13 +4836,6 @@ class Length(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("error-app-tag", self.error_app_tag),
-            ("error-message", self.error_message),
-            ("reference", self.reference),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.value) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5149,21 +4978,6 @@ class List(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("config", self.config),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("key", self.key),
-            ("max-elements", self.max_elements),
-            ("min-elements", self.min_elements),
-            ("must", self.must),
-            ("ordered-by", self.ordered_by),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("unique", self.unique),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5396,23 +5210,6 @@ class Module(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("yang-version", self.yang_version),
-            ("namespace", self.namespace),
-            ("prefix", self.prefix),
-            ("import", self.import_),
-            ("include", self.include),
-            ("organization", self.organization),
-            ("contact", self.contact),
-            ("description", self.description),
-            ("reference", self.reference),
-            ("revision", self.revision),
-            ("augment", self.augment),
-            ("deviation", self.deviation),
-            ("extension", self.extension_),
-            ("feature", self.feature),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5579,13 +5376,6 @@ class Must(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("error-app-tag", self.error_app_tag),
-            ("error-message", self.error_message),
-            ("reference", self.reference),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.condition) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5698,14 +5488,6 @@ class Notification(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("must", self.must),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5826,10 +5608,6 @@ class Output(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("must", self.must),
-            ("exts", self.exts),
-        ]
         args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -5941,14 +5719,6 @@ class Pattern(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("error-app-tag", self.error_app_tag),
-            ("error-message", self.error_message),
-            ("modifier", self.modifier),
-            ("reference", self.reference),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.value) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6036,13 +5806,6 @@ class Range(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("error-app-tag", self.error_app_tag),
-            ("error-message", self.error_message),
-            ("reference", self.reference),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.value) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6179,19 +5942,6 @@ class Refine(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("config", self.config),
-            ("default", self.default),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("mandatory", self.mandatory),
-            ("max-elements", self.max_elements),
-            ("min-elements", self.min_elements),
-            ("must", self.must),
-            ("presence", self.presence),
-            ("reference", self.reference),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.target_node) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6278,11 +6028,6 @@ class Revision(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("reference", self.reference),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.date) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6401,15 +6146,6 @@ class Rpc(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("input", self.input),
-            ("output", self.output),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6642,22 +6378,6 @@ class Submodule(SchemaNodeInner):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("yang-version", self.yang_version),
-            ("import", self.import_),
-            ("include", self.include),
-            ("organization", self.organization),
-            ("contact", self.contact),
-            ("description", self.description),
-            ("reference", self.reference),
-            ("revision", self.revision),
-            ("belongs-to", self.belongs_to),
-            ("augment", self.augment),
-            ("deviation", self.deviation),
-            ("extension", self.extension_),
-            ("feature", self.feature),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6832,19 +6552,6 @@ class Type(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("base", self.base),
-            ("bit", self.bit),
-            ("enum", self.enum),
-            ("fraction-digits", self.fraction_digits),
-            ("length", self.length),
-            ("path", self.path),
-            ("pattern", self.pattern),
-            ("range", self.range_),
-            ("require-instance", self.require_instance),
-            ("type", self.type_),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -6990,15 +6697,6 @@ class Typedef(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("type", self.type_),
-            ("default", self.default),
-            ("description", self.description),
-            ("reference", self.reference),
-            ("status", self.status),
-            ("units", self.units),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:
@@ -7123,16 +6821,6 @@ class Uses(SchemaNodeOuter):
     def prsrc(self, indent=0):
         """Print Acton source of this node"""
         res = []
-        attrs: list[(str, ?value)] = [
-            ("augment", self.augment),
-            ("description", self.description),
-            ("if-feature", self.if_feature),
-            ("reference", self.reference),
-            ("refine", self.refine),
-            ("status", self.status),
-            ("when", self.when),
-            ("exts", self.exts),
-        ]
         args = ["'" + str(self.name) + "'"]
         attrs_text = _prsrc_attrs(indent, self.get_attrs())
         if len(attrs_text) > 0:


### PR DESCRIPTION
By moving the remaining node-specific parameters, like class and arg name to node-specific properties (or rather getters), we can use a single `SchemaNode.prsrc()` implementation instead of generating individual tailored for each node.