### PR TITLE
Do not set default leaf values for loose adata

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -417,7 +417,7 @@ class DNodeInner(DNode):
             elif isinstance(child, DLeaf):
                 defval = ""
                 child_default = child.default
-                if child_default != None:
+                if not loose and child_default != None:
                     defval = "=None"
                 child_arg = "%s: %s%s" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_acton_arg_type(child, loose), defval)
                 if is_optional_arg_yang_leaf(child, loose):
@@ -453,7 +453,7 @@ class DNodeInner(DNode):
                     res.append("        self.%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DLeaf):
                 child_default = child.default
-                if child_default != None:
+                if not loose and child_default != None:
                     res.append("        if %s != None:" % (_unique_safe_name(child.name, child.prefix)))
                     res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                     res.append("        else:")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -413,7 +413,7 @@ class DNodeInner(DNode):
             elif isinstance(child, DLeaf):
                 defval = ""
                 child_default = child.default
-                if child_default != None:
+                if not loose and child_default != None:
                     defval = "=None"
                 child_arg = "%s: %s%s" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_acton_arg_type(child, loose), defval)
                 if is_optional_arg_yang_leaf(child, loose):
@@ -449,7 +449,7 @@ class DNodeInner(DNode):
                     res.append("        self.%s._parent = self" % (_unique_safe_name(child.name, child.prefix)))
             elif isinstance(child, DLeaf):
                 child_default = child.default
-                if child_default != None:
+                if not loose and child_default != None:
                     res.append("        if %s != None:" % (_unique_safe_name(child.name, child.prefix)))
                     res.append("            self.%s = %s" % (_unique_safe_name(child.name, child.prefix), _unique_safe_name(child.name, child.prefix)))
                     res.append("        else:")

--- a/test/golden/test_yang/prdaclass_loose_leaf_default
+++ b/test/golden/test_yang/prdaclass_loose_leaf_default
@@ -1,0 +1,61 @@
+mut def from_json_foo__foo__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf("string", val)
+
+class foo__foo(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = "http://example.com/foo"
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo:
+        if n != None:
+            return foo__foo(l1=n.get_opt_str("l1"))
+        return foo__foo()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__foo:
+        if n != None:
+            return foo__foo(l1=yang.gdata.from_xml_opt_str(n, "l1"))
+        return foo__foo()
+
+
+mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str="merge") -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:l1' or point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__foo(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l1_full = jd.get('foo:l1')
+    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    if child_l1 is not None:
+        children['l1'] = from_json_foo__foo__l1(child_l1)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__foo(n: yang.gdata.Container) -> dict[str, ?value]:
+    children = {}
+    child_l1 = n.children.get('l1')
+    if child_l1 is not None:
+        if isinstance(child_l1, yang.gdata.Leaf):
+            children['l1'] = child_l1.val
+    return children


### PR DESCRIPTION
If we're generating "loose" adata, then all leaves are optional. We must not provide provide defaults in __init__(), let them remain unset!