### PR TITLE
Make mandatory leaves optional in loose mode

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -544,11 +544,11 @@ class DNodeInner(DNode):
         from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
-                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
+                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), child.name, _maybe_ns(child)))
             elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
+                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), child.name, _maybe_ns(child)))
             elif isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
                     from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
@@ -2114,9 +2114,8 @@ def taker_name(n: DNode, loose: bool=False, key_required=True) -> str:
         return yang_type_to_acton_type(n.type_) + "s"
     raise ValueError("unreachable - unknown node type %s" % type(n))
 
-def yang_leaf_to_getval(leaf: DNodeLeaf) -> str:
-    # TODO: uh, do we need loose arg?
-    optional = is_optional_arg_yang_leaf(leaf)
+def yang_leaf_to_getval(leaf: DNodeLeaf, loose: bool) -> str:
+    optional = is_optional_arg_yang_leaf(leaf, loose)
     optional_str = "opt_" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -540,11 +540,11 @@ class DNodeInner(DNode):
         from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
-                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
+                from_gdata_args_list.append("%s=n.get_%s(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%s(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), child.name, _maybe_ns(child)))
             elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), _unique_name(child.name, child.prefix)))
-                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child), child.name, _maybe_ns(child)))
+                from_gdata_args_list.append("%s=n.get_%ss(\"%s\")" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), _unique_name(child.name, child.prefix)))
+                from_xml_args_list.append("%s=yang.gdata.from_xml_%ss(n, \"%s\"%s)" % (_unique_safe_name(child.name, child.prefix), yang_leaf_to_getval(child, loose), child.name, _maybe_ns(child)))
             elif isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
                     from_gdata_args_list.append("%s=%s.from_gdata(n.get_opt_container(\"%s\"))" % (_unique_safe_name(child.name, child.prefix), get_path_name(child), _unique_name(child.name, child.prefix)))
@@ -2110,9 +2110,8 @@ def taker_name(n: DNode, loose: bool=False, key_required=True) -> str:
         return yang_type_to_acton_type(n.type_) + "s"
     raise ValueError("unreachable - unknown node type %s" % type(n))
 
-def yang_leaf_to_getval(leaf: DNodeLeaf) -> str:
-    # TODO: uh, do we need loose arg?
-    optional = is_optional_arg_yang_leaf(leaf)
+def yang_leaf_to_getval(leaf: DNodeLeaf, loose: bool) -> str:
+    optional = is_optional_arg_yang_leaf(leaf, loose)
     optional_str = "opt_" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -18,13 +18,13 @@ class foo__foo__bar(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo__bar:
         if n != None:
-            return foo__foo__bar(l1=n.get_str("l1"))
+            return foo__foo__bar(l1=n.get_opt_str("l1"))
         raise ValueError("Missing required subtree foo__foo__bar")
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__foo__bar:
         if n != None:
-            return foo__foo__bar(l1=yang.gdata.from_xml_str(n, "l1"))
+            return foo__foo__bar(l1=yang.gdata.from_xml_opt_str(n, "l1"))
         raise ValueError("Missing required subtree foo__foo__bar")
 
 

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -18,13 +18,13 @@ class foo__foo__bar(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo__bar:
         if n != None:
-            return foo__foo__bar(l1=n.get_str("l1"))
+            return foo__foo__bar(l1=n.get_opt_str("l1"))
         return None
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> ?foo__foo__bar:
         if n != None:
-            return foo__foo__bar(l1=yang.gdata.from_xml_str(n, "l1"))
+            return foo__foo__bar(l1=yang.gdata.from_xml_opt_str(n, "l1"))
         return None
 
 

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -33,13 +33,13 @@ class foo__l1__bar(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__l1__bar:
         if n != None:
-            return foo__l1__bar(hi=n.get_str("hi"))
+            return foo__l1__bar(hi=n.get_opt_str("hi"))
         raise ValueError("Missing required subtree foo__l1__bar")
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__l1__bar:
         if n != None:
-            return foo__l1__bar(hi=yang.gdata.from_xml_str(n, "hi"))
+            return foo__l1__bar(hi=yang.gdata.from_xml_opt_str(n, "hi"))
         raise ValueError("Missing required subtree foo__l1__bar")
 
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -506,13 +506,13 @@ class foo__pc2__foo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc2__foo:
         if n != None:
-            return foo__pc2__foo(l_mandatory=n.get_str("l_mandatory"))
+            return foo__pc2__foo(l_mandatory=n.get_opt_str("l_mandatory"))
         raise ValueError("Missing required subtree foo__pc2__foo")
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__pc2__foo:
         if n != None:
-            return foo__pc2__foo(l_mandatory=yang.gdata.from_xml_str(n, "l_mandatory"))
+            return foo__pc2__foo(l_mandatory=yang.gdata.from_xml_opt_str(n, "l_mandatory"))
         raise ValueError("Missing required subtree foo__pc2__foo")
 
 


### PR DESCRIPTION
When parsing XML, which should be done using loose mode, we should treat mandatory leaves as optional since they are only required in the datastore, not in an individual NETCONF message.