### PR TITLE
Fix JSON namespace-qualified names

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1334,6 +1334,7 @@ class Context(object):
 
 class SchemaNode(object):
     parent: ?SchemaNode
+    mod: ?str
     ns: ?str
     pfx: ?str
     exts: list[Ext]
@@ -1428,19 +1429,12 @@ class SchemaNode(object):
         raise ValueError(f"get_dnode_children() called on non-inner node {type(self)}")
 
     def get_module_name(self) -> str:
-        """Get the module name for the containing module
-
-        That is, climb up the ladder of parents from the current node until we
-        find a module node. This is used to determine the module name for the
-        current node. If we're in a submodule the module name is resolved to
-        the parent module the submodule belongs to.
-        """
+        # TODO: return belongs_to.name for submodule??
         n = self
         for i in range(RECURSION_LIMIT+1):
-            if isinstance(n, Module):
-                return n.name
-            elif isinstance(n, Submodule):
-                return n.belongs_to.module
+            nmod = n.mod
+            if nmod is not None:
+                return nmod
             nparent = n.parent
             if nparent is not None:
                 n = nparent
@@ -1622,7 +1616,7 @@ class SchemaNode(object):
             break
         raise ValueError("Unable to find Module")
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None) -> SchemaNode:
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None) -> SchemaNode:
         """Compile an abstract YANG into a concrete one
         - expand uses / groupings
         - handle augments
@@ -1695,7 +1689,7 @@ class SchemaNode(object):
                     target = get_target(target_base, aug.target_node)
                     if isinstance(target, SchemaNodeInner):
                         # Just move the child to the target
-                        aug.expand_children(context, target, new_ns=aug.get_namespace(), new_pfx=aug.get_prefix())
+                        aug.expand_children(context, target, new_mod=aug.get_module_name(), new_ns=aug.get_namespace(), new_pfx=aug.get_prefix())
                         target.exts.extend(aug.exts)
                     else:
                         raise ValueError("Augment target " + str(target) + " is not an inner node")
@@ -1710,18 +1704,18 @@ class SchemaNode(object):
         else:
             raise ValueError("Node type does not have augment substatements")
 
-    def expand_children(self, context: Context, target: SchemaNodeInner, new_ns: ?str = None, new_pfx: ?str = None):
+    def expand_children(self, context: Context, target: SchemaNodeInner, new_mod: ?str = None, new_ns: ?str = None, new_pfx: ?str = None):
         """Expand abstract children into concrete nodes
         """
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
                 if isinstance(child, Uses):
                     grouping = child.get_grouping(child.name, context)
-                    grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
+                    grouping.expand_children(context, target, new_mod if new_mod is not None else target.mod, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
                 else:
-                    c_child = child.compile(context, new_ns, new_pfx)
+                    c_child = child.compile(context, new_mod, new_ns, new_pfx)
                     c_child.parent = target
                     target.children.append(c_child)
         else:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -277,6 +277,7 @@ def nest(n):
 class DNode(object):
     parent: ?DNode
     gname: str       # The name of the GData class, e.g. "Container" for yang.gdata.Container
+    module: str      # The name of the module this node belongs to
     namespace: str
     prefix: str
     name: str
@@ -940,7 +941,8 @@ class DAction(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -960,7 +962,8 @@ class DAnydata(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -982,7 +985,8 @@ class DAnyxml(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1003,7 +1007,8 @@ class DContainer(DNodeInner):
     presence: bool
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1021,7 +1026,8 @@ class DContainer(DNodeInner):
 class DInput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, must=[], exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = "input"
@@ -1043,7 +1049,8 @@ class DModule(DNodeInner):
     revision: list[Revision]
     yang_version: float
 
-    def __init__(self, namespace: str, prefix: str, name: str, yang_version: ?float, description: ?str=None, contact=None, deviation=[], extension_=[], feature=[], import_=[], include=[], organization=None, reference=None, revision=[], exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, yang_version: ?float, description: ?str=None, contact=None, deviation=[], extension_=[], feature=[], import_=[], include=[], organization=None, reference=None, revision=[], exts=[], children=[]):
+        self.module = module
         self.name = name
         self.gname = "Container"
         self.namespace = namespace
@@ -1079,7 +1086,8 @@ class DList(DNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1103,7 +1111,8 @@ class DLeaf(DNodeLeaf):
     default: ?str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1149,7 +1158,8 @@ class DLeafList(DNodeLeaf):
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1186,7 +1196,8 @@ class DLeafList(DNodeLeaf):
 class DNotification(DNodeInner):
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1200,7 +1211,8 @@ class DNotification(DNodeInner):
 class DOutput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, must=[], exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = "output"
@@ -1230,7 +1242,8 @@ class DRpc(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1413,6 +1426,30 @@ class SchemaNode(object):
                 new_children.append(dnode_child)
             return new_children
         raise ValueError(f"get_dnode_children() called on non-inner node {type(self)}")
+
+    def get_module_name(self) -> str:
+        """Get the module name for the containing module
+
+        That is, climb up the ladder of parents from the current node until we
+        find a module node. This is used to determine the module name for the
+        current node. If we're in a submodule the module name is resolved to
+        the parent module the submodule belongs to.
+        """
+        n = self
+        for i in range(RECURSION_LIMIT+1):
+            if isinstance(n, Module):
+                return n.name
+            elif isinstance(n, Submodule):
+                return n.belongs_to.module
+            nparent = n.parent
+            if nparent is not None:
+                n = nparent
+                continue
+            else:
+                raise ValueError("Unable to find module")
+            if i > RECURSION_LIMIT:
+                raise ValueError("Recursion limit reached")
+        raise ValueError("Unable to find module")
 
     def get_namespace(self) -> str:
         n = self

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -769,9 +769,9 @@ class DNodeInner(DNode):
                 res.append("        rest_path = path[1:]")
                 for child in self.children:
                     if top == True or child.namespace != self.namespace:
-                        res.append(f"        if point == '{child.prefix}:{child.name}':")
+                        res.append(f"        if point == '{child.module}:{child.name}':")
                     else:
-                        res.append(f"        if point == '{child.prefix}:{child.name}' or point == '{child.name}':")
+                        res.append(f"        if point == '{child.module}:{child.name}' or point == '{child.name}':")
                     if isinstance(child, DNodeInner):
                         res += [nest(12) + f"child = {{'{child.name}': from_json_path_{pname(child)}(jd, rest_path, op) }}"]
                         res += [nest(12) + "return yang.gdata." + dnode_to_gd_type(self) + "(child)"]
@@ -803,9 +803,9 @@ class DNodeInner(DNode):
             res.append("    children = {}")
             for child in self.children:
                 if top == True or child.namespace != self.namespace:
-                    res.append(f"    child_{usname(child)} = jd.get('{child.prefix}:{child.name}')")
+                    res.append(f"    child_{usname(child)} = jd.get('{child.module}:{child.name}')")
                 else:
-                    res.append(f"    child_{usname(child)}_full = jd.get('{child.prefix}:{child.name}')")
+                    res.append(f"    child_{usname(child)}_full = jd.get('{child.module}:{child.name}')")
                     res.append(f"    child_{usname(child)} = child_{usname(child)}_full if child_{usname(child)}_full is not None else jd.get('{child.name}')")
 
                 if isinstance(child, DContainer):
@@ -868,7 +868,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                child_name = (child.prefix + ":" + child.name) if child.namespace != self.namespace else child.name
+                child_name = f"{child.module}:{child.name}" if child.namespace != self.namespace else child.name
                 res.append(f"    child_{usname(child)} = n.children.get('{uname(child)}')")
                 res.append(f"    if child_{usname(child)} is not None:")
                 if isinstance(child, DLeaf):

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -304,7 +304,7 @@ snode_methods = {
         return SchemaNode.get(self, name, ns)
 
 """,
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -323,6 +323,7 @@ snode_methods = {
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns, new_pfx)
@@ -576,7 +577,7 @@ snode_methods = {
     },
     "leaf": {
         # TODO: keep track of constraints in the derived type(s) that we resolve
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -600,6 +601,7 @@ snode_methods = {
                    units=new_units,
                    when=self.when,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
 
@@ -630,7 +632,7 @@ snode_methods = {
     },
     "leaf-list": {
         # TODO: keep track of constraints in the derived type(s) that we resolve
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_units = self.units
@@ -652,6 +654,7 @@ snode_methods = {
                        units=new_units,
                        when=self.when,
                        exts=self.exts,
+                       mod=new_mod if new_mod is not None else self.mod,
                        ns=new_ns if new_ns is not None else self.ns,
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -729,7 +732,7 @@ snode_methods = {
         return SchemaNode.get(self, name, ns)
 
 """,
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -748,6 +751,7 @@ snode_methods = {
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
+                  mod=new_mod if new_mod is not None else self.mod,
                   ns=new_ns if new_ns is not None else self.ns,
                   pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns, new_pfx)
@@ -834,7 +838,7 @@ snode_methods = {
 """,
     },
     "typedef": {
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -858,7 +862,7 @@ snode_methods = {
 """,
     },
     "uses": {
-        "compile": """    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         raise ValueError("Cannot compile 'uses'")
 
 """,
@@ -1038,24 +1042,32 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             init_attrs.append("children=[]")
         if "parent" not in set(cattrs):
             init_attrs.append("parent=None")
+        if "mod" not in set(cattrs):
+            init_attrs.append("mod=None")
         if "ns" not in set(cattrs):
             init_attrs.append("ns=None")
         if "pfx" not in set(cattrs):
             init_attrs.append("pfx=None")
         res.append("    def __init__(" + ", ".join(init_attrs) + "):")
         res.append("        self.parent = parent")
+        res.append("        new_mod = mod")
         res.append("        new_ns = ns")
         res.append("        new_pfx = pfx")
         if stmt_name == "module":
+            res.append("        if new_mod is None:")
+            res.append("            new_mod = name")
             res.append("        if new_ns is None:")
             res.append("            new_ns = namespace")
             res.append("        if new_pfx is None:")
             res.append("            new_pfx = prefix")
         else:
+            res.append("        if new_mod is None and parent is not None:")
+            res.append("            new_mod = parent.mod")
             res.append("        if new_ns is None and parent is not None:")
             res.append("            new_ns = parent.ns")
             res.append("        if new_pfx is None and parent is not None:")
             res.append("            new_pfx = parent.pfx")
+        res.append("        self.mod = new_mod")
         res.append("        self.ns = new_ns")
         res.append("        self.pfx = new_pfx")
 #        res.append("        self.cname = \"%s\"" % _class_name(stmt_name))
@@ -1070,6 +1082,9 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                     if substmt.cardinality == "0..1":
                         res.append("        if %s is not None:" % _attr_name(substmt.name))
                         res.append("            %s.parent = self" % _attr_name(substmt.name))
+                        res.append("            n_mod = %s.mod" % _attr_name(substmt.name))
+                        res.append("            if n_mod is None:")
+                        res.append("                %s.mod = self.mod" % _attr_name(substmt.name))
                         res.append("            n_ns = %s.ns" % _attr_name(substmt.name))
                         res.append("            if n_ns is None:")
                         res.append("                %s.ns = self.ns" % _attr_name(substmt.name))
@@ -1078,6 +1093,9 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                         res.append("                %s.pfx = self.pfx" % _attr_name(substmt.name))
                     elif substmt.cardinality == "1":
                         res.append("        %s.parent = self" % _attr_name(substmt.name))
+                        res.append("        n_mod = %s.mod" % _attr_name(substmt.name))
+                        res.append("        if n_mod is None:")
+                        res.append("            %s.mod = self.mod" % _attr_name(substmt.name))
                         res.append("        n_ns = %s.ns" % _attr_name(substmt.name))
                         res.append("        if n_ns is None:")
                         res.append("            %s.ns = self.ns" % _attr_name(substmt.name))
@@ -1087,6 +1105,9 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                     elif substmt.cardinality == "0..n":
                         res.append("        for n in %s:" % _attr_name(substmt.name))
                         res.append("            n.parent = self")
+                        res.append("            n_mod = n.mod")
+                        res.append("            if n_mod is None:")
+                        res.append("                n.mod = self.mod")
                         res.append("            n_ns = n.ns")
                         res.append("            if n_ns is None:")
                         res.append("                n.ns = self.ns")
@@ -1105,6 +1126,9 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
         if have_children:
             res.append("        for n in children:")
             res.append("            n.parent = self")
+            res.append("            n_mod = n.mod")
+            res.append("            if n_mod is None:")
+            res.append("                n.mod = self.mod")
             res.append("            n_ns = n.ns")
             res.append("            if n_ns is None:")
             res.append("                n.ns = self.ns")
@@ -1168,19 +1192,20 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
 
         # -- compile
         if "compile" not in manual_methods:
-            res.append("    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):")
+            res.append("    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):")
             new_args = []
             if arg_name is not None:
                 new_args += ["self." + _attr_name(arg_name)]
             new_args += list(map(lambda x: "%s=self.%s" % (_attr_name(x), _attr_name(x)), kwattrs))
             new_args.append("exts=self.exts")
             if stmt_name not in {"module", "submodule"}:
+                new_args.append("mod=new_mod if new_mod is not None else self.mod")
                 new_args.append("ns=new_ns if new_ns is not None else self.ns")
                 new_args.append("pfx=new_pfx if new_pfx is not None else self.pfx")
 
             res.append("        new = %s(%s)" % (_class_name(stmt_name), (",\n               " + " " * len(_class_name(stmt_name))).join(new_args)))
             if have_children:
-                res.append("        self.expand_children(context, new, new_ns)")
+                res.append("        self.expand_children(context, new, new_mod, new_ns, new_pfx)")
             for substmt in stmt.substmts.values():
                 if substmt.name == "augment":
                     res.append("        new.expand_augments(context)")

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -331,6 +331,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DAction:
         new_dnode = DAction(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -354,6 +355,7 @@ snode_methods = {
     "anydata": {
         "to_dnode": """    def to_dnode(self) -> DAnydata:
         return DAnydata(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -373,6 +375,7 @@ snode_methods = {
     "anyxml": {
         "to_dnode": """    def to_dnode(self) -> DAnyxml:
         return DAnyxml(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -399,6 +402,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DContainer:
         new_dnode = DContainer(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -422,6 +426,7 @@ snode_methods = {
     "input": {
         "to_dnode": """    def to_dnode(self) -> DInput:
         new_dnode = DInput(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             must=self.must,
@@ -478,6 +483,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DModule:
         new_dnode = DModule(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -500,6 +506,7 @@ snode_methods = {
     "notification": {
         "to_dnode": """    def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -544,6 +551,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DList:
         new_dnode = DList(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -600,6 +608,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DLeaf:
         return DLeaf(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -664,6 +673,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DLeafList:
         return DLeafList(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -687,6 +697,7 @@ snode_methods = {
     "output": {
         "to_dnode": """    def to_dnode(self) -> DOutput:
         new_dnode = DOutput(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             must=self.must,
@@ -745,6 +756,7 @@ snode_methods = {
 """,
         "to_dnode": """    def to_dnode(self) -> DRpc:
         new_dnode = DRpc(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -765,9 +765,9 @@ class DNodeInner(DNode):
                 res.append("        rest_path = path[1:]")
                 for child in self.children:
                     if top == True or child.namespace != self.namespace:
-                        res.append(f"        if point == '{child.prefix}:{child.name}':")
+                        res.append(f"        if point == '{child.module}:{child.name}':")
                     else:
-                        res.append(f"        if point == '{child.prefix}:{child.name}' or point == '{child.name}':")
+                        res.append(f"        if point == '{child.module}:{child.name}' or point == '{child.name}':")
                     if isinstance(child, DNodeInner):
                         res += [nest(12) + f"child = {{'{child.name}': from_json_path_{pname(child)}(jd, rest_path, op) }}"]
                         res += [nest(12) + "return yang.gdata." + dnode_to_gd_type(self) + "(child)"]
@@ -799,9 +799,9 @@ class DNodeInner(DNode):
             res.append("    children = {}")
             for child in self.children:
                 if top == True or child.namespace != self.namespace:
-                    res.append(f"    child_{usname(child)} = jd.get('{child.prefix}:{child.name}')")
+                    res.append(f"    child_{usname(child)} = jd.get('{child.module}:{child.name}')")
                 else:
-                    res.append(f"    child_{usname(child)}_full = jd.get('{child.prefix}:{child.name}')")
+                    res.append(f"    child_{usname(child)}_full = jd.get('{child.module}:{child.name}')")
                     res.append(f"    child_{usname(child)} = child_{usname(child)}_full if child_{usname(child)}_full is not None else jd.get('{child.name}')")
 
                 if isinstance(child, DContainer):
@@ -864,7 +864,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                child_name = (child.prefix + ":" + child.name) if child.namespace != self.namespace else child.name
+                child_name = f"{child.module}:{child.name}" if child.namespace != self.namespace else child.name
                 res.append(f"    child_{usname(child)} = n.children.get('{uname(child)}')")
                 res.append(f"    if child_{usname(child)} is not None:")
                 if isinstance(child, DLeaf):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -273,6 +273,7 @@ def nest(n):
 class DNode(object):
     parent: ?DNode
     gname: str       # The name of the GData class, e.g. "Container" for yang.gdata.Container
+    module: str      # The name of the module this node belongs to
     namespace: str
     prefix: str
     name: str
@@ -936,7 +937,8 @@ class DAction(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -956,7 +958,8 @@ class DAnydata(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -978,7 +981,8 @@ class DAnyxml(DNode):
     status: ?str
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -999,7 +1003,8 @@ class DContainer(DNodeInner):
     presence: bool
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, if_feature=[], must=[], presence: bool, reference=None, status=None, when=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1017,7 +1022,8 @@ class DContainer(DNodeInner):
 class DInput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, must=[], exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = "input"
@@ -1039,7 +1045,8 @@ class DModule(DNodeInner):
     revision: list[Revision]
     yang_version: float
 
-    def __init__(self, namespace: str, prefix: str, name: str, yang_version: ?float, description: ?str=None, contact=None, deviation=[], extension_=[], feature=[], import_=[], include=[], organization=None, reference=None, revision=[], exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, yang_version: ?float, description: ?str=None, contact=None, deviation=[], extension_=[], feature=[], import_=[], include=[], organization=None, reference=None, revision=[], exts=[], children=[]):
+        self.module = module
         self.name = name
         self.gname = "Container"
         self.namespace = namespace
@@ -1075,7 +1082,8 @@ class DList(DNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, key: list[str], config: bool, description: ?str=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, unique=[], when=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1099,7 +1107,8 @@ class DLeaf(DNodeLeaf):
     default: ?str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], mandatory=False, must=[], reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1145,7 +1154,8 @@ class DLeafList(DNodeLeaf):
     ordered_by: str
     units: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, config: bool, description: ?str=None, default=None, if_feature=[], max_elements: ?int=None, min_elements=0, must=[], ordered_by="system", reference=None, status=None, type_: Type, units=None, when=None, exts=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1182,7 +1192,8 @@ class DLeafList(DNodeLeaf):
 class DNotification(DNodeInner):
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], must=[], reference=None, status=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1196,7 +1207,8 @@ class DNotification(DNodeInner):
 class DOutput(DNodeInner):
     must: list[Must]
 
-    def __init__(self, namespace: str, prefix: str, must=[], exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, must=[], exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = "output"
@@ -1226,7 +1238,8 @@ class DRpc(DNodeInner):
     must: list[Must]
     status: ?str
 
-    def __init__(self, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+        self.module = module
         self.namespace = namespace
         self.prefix = prefix
         self.name = name
@@ -1409,6 +1422,30 @@ class SchemaNode(object):
                 new_children.append(dnode_child)
             return new_children
         raise ValueError(f"get_dnode_children() called on non-inner node {type(self)}")
+
+    def get_module_name(self) -> str:
+        """Get the module name for the containing module
+
+        That is, climb up the ladder of parents from the current node until we
+        find a module node. This is used to determine the module name for the
+        current node. If we're in a submodule the module name is resolved to
+        the parent module the submodule belongs to.
+        """
+        n = self
+        for i in range(RECURSION_LIMIT+1):
+            if isinstance(n, Module):
+                return n.name
+            elif isinstance(n, Submodule):
+                return n.belongs_to.module
+            nparent = n.parent
+            if nparent is not None:
+                n = nparent
+                continue
+            else:
+                raise ValueError("Unable to find module")
+            if i > RECURSION_LIMIT:
+                raise ValueError("Recursion limit reached")
+        raise ValueError("Unable to find module")
 
     def get_namespace(self) -> str:
         n = self
@@ -2674,6 +2711,7 @@ class Action(SchemaNodeInner):
 
     def to_dnode(self) -> DAction:
         new_dnode = DAction(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -2791,6 +2829,7 @@ class Anydata(SchemaNodeOuter):
 
     def to_dnode(self) -> DAnydata:
         return DAnydata(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -2920,6 +2959,7 @@ class Anyxml(SchemaNodeOuter):
 
     def to_dnode(self) -> DAnyxml:
         return DAnyxml(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -3508,6 +3548,7 @@ class Container(SchemaNodeInner):
 
     def to_dnode(self) -> DContainer:
         new_dnode = DContainer(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -4171,6 +4212,7 @@ class Input(SchemaNodeInner):
 
     def to_dnode(self) -> DInput:
         new_dnode = DInput(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             must=self.must,
@@ -4338,6 +4380,7 @@ class Leaf(SchemaNodeOuter):
 
     def to_dnode(self) -> DLeaf:
         return DLeaf(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -4521,6 +4564,7 @@ class LeafList(SchemaNodeOuter):
 
     def to_dnode(self) -> DLeafList:
         return DLeafList(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -4758,6 +4802,7 @@ class List(SchemaNodeInner):
 
     def to_dnode(self) -> DList:
         new_dnode = DList(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -4989,6 +5034,7 @@ class Module(SchemaNodeInner):
 
     def to_dnode(self) -> DModule:
         new_dnode = DModule(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -5203,6 +5249,7 @@ class Notification(SchemaNodeInner):
 
     def to_dnode(self) -> DNotification:
         new_dnode = DNotification(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,
@@ -5304,6 +5351,7 @@ class Output(SchemaNodeInner):
 
     def to_dnode(self) -> DOutput:
         new_dnode = DOutput(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             must=self.must,
@@ -5824,6 +5872,7 @@ class Rpc(SchemaNodeInner):
 
     def to_dnode(self) -> DRpc:
         new_dnode = DRpc(
+            module=self.get_module_name(),
             namespace=self.get_namespace(),
             prefix=self.get_prefix(),
             name=self.name,

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1330,6 +1330,7 @@ class Context(object):
 
 class SchemaNode(object):
     parent: ?SchemaNode
+    mod: ?str
     ns: ?str
     pfx: ?str
     exts: list[Ext]
@@ -1424,19 +1425,12 @@ class SchemaNode(object):
         raise ValueError(f"get_dnode_children() called on non-inner node {type(self)}")
 
     def get_module_name(self) -> str:
-        """Get the module name for the containing module
-
-        That is, climb up the ladder of parents from the current node until we
-        find a module node. This is used to determine the module name for the
-        current node. If we're in a submodule the module name is resolved to
-        the parent module the submodule belongs to.
-        """
+        # TODO: return belongs_to.name for submodule??
         n = self
         for i in range(RECURSION_LIMIT+1):
-            if isinstance(n, Module):
-                return n.name
-            elif isinstance(n, Submodule):
-                return n.belongs_to.module
+            nmod = n.mod
+            if nmod is not None:
+                return nmod
             nparent = n.parent
             if nparent is not None:
                 n = nparent
@@ -1618,7 +1612,7 @@ class SchemaNode(object):
             break
         raise ValueError("Unable to find Module")
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None) -> SchemaNode:
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None) -> SchemaNode:
         """Compile an abstract YANG into a concrete one
         - expand uses / groupings
         - handle augments
@@ -1691,7 +1685,7 @@ class SchemaNode(object):
                     target = get_target(target_base, aug.target_node)
                     if isinstance(target, SchemaNodeInner):
                         # Just move the child to the target
-                        aug.expand_children(context, target, new_ns=aug.get_namespace(), new_pfx=aug.get_prefix())
+                        aug.expand_children(context, target, new_mod=aug.get_module_name(), new_ns=aug.get_namespace(), new_pfx=aug.get_prefix())
                         target.exts.extend(aug.exts)
                     else:
                         raise ValueError("Augment target " + str(target) + " is not an inner node")
@@ -1706,18 +1700,18 @@ class SchemaNode(object):
         else:
             raise ValueError("Node type does not have augment substatements")
 
-    def expand_children(self, context: Context, target: SchemaNodeInner, new_ns: ?str = None, new_pfx: ?str = None):
+    def expand_children(self, context: Context, target: SchemaNodeInner, new_mod: ?str = None, new_ns: ?str = None, new_pfx: ?str = None):
         """Expand abstract children into concrete nodes
         """
         if isinstance(self, SchemaNodeInner):
             for child in self.children:
                 if isinstance(child, Uses):
                     grouping = child.get_grouping(child.name, context)
-                    grouping.expand_children(context, target, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
+                    grouping.expand_children(context, target, new_mod if new_mod is not None else target.mod, new_ns if new_ns is not None else target.ns, new_pfx if new_pfx is not None else target.pfx)
                     child.expand_augments(context, target, in_uses=True)
                     child.expand_refines(target)
                 else:
-                    c_child = child.compile(context, new_ns, new_pfx)
+                    c_child = child.compile(context, new_mod, new_ns, new_pfx)
                     c_child.parent = target
                     target.children.append(c_child)
         else:
@@ -2604,19 +2598,26 @@ class Action(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "action"
         if input is not None:
             input.parent = self
+            n_mod = input.mod
+            if n_mod is None:
+                input.mod = self.mod
             n_ns = input.ns
             if n_ns is None:
                 input.ns = self.ns
@@ -2625,6 +2626,9 @@ class Action(SchemaNodeInner):
                 input.pfx = self.pfx
         if output is not None:
             output.parent = self
+            n_mod = output.mod
+            if n_mod is None:
+                output.mod = self.mod
             n_ns = output.ns
             if n_ns is None:
                 output.ns = self.ns
@@ -2641,6 +2645,9 @@ class Action(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -2685,7 +2692,7 @@ class Action(SchemaNodeInner):
                 return _output
         return SchemaNode.get(self, name, ns)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -2704,6 +2711,7 @@ class Action(SchemaNodeInner):
                      reference=self.reference,
                      status=self.status,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns, new_pfx)
@@ -2763,19 +2771,26 @@ class Anydata(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "anydata"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -2844,7 +2859,7 @@ class Anydata(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Anydata(self.name,
                       config=self.config,
                       description=self.description,
@@ -2855,6 +2870,7 @@ class Anydata(SchemaNodeOuter):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
+                      mod=new_mod if new_mod is not None else self.mod,
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -2893,19 +2909,26 @@ class Anyxml(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "anyxml"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -2974,7 +2997,7 @@ class Anyxml(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Anyxml(self.name,
                      config=self.config,
                      description=self.description,
@@ -2985,6 +3008,7 @@ class Anyxml(SchemaNodeOuter):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -3020,14 +3044,18 @@ class Augment(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, target_node: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, target_node: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "augment"
@@ -3040,6 +3068,9 @@ class Augment(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -3070,7 +3101,7 @@ class Augment(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Augment(self.target_node,
                       description=self.description,
                       if_feature=self.if_feature,
@@ -3078,9 +3109,10 @@ class Augment(SchemaNodeInner):
                       status=self.status,
                       when=self.when,
                       exts=self.exts,
+                      mod=new_mod if new_mod is not None else self.mod,
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -3110,14 +3142,18 @@ class BelongsTo(SchemaNodeOuter):
     module: str
     prefix: str
 
-    def __init__(self, module: str, prefix: str, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, module: str, prefix: str, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "belongs-to"
@@ -3131,10 +3167,11 @@ class BelongsTo(SchemaNodeOuter):
             ("exts", self.exts),
         ]
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = BelongsTo(self.module,
                         prefix=self.prefix,
                         exts=self.exts,
+                        mod=new_mod if new_mod is not None else self.mod,
                         ns=new_ns if new_ns is not None else self.ns,
                         pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -3170,14 +3207,18 @@ class Bit(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], position: ?int=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], position: ?int=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "bit"
@@ -3211,7 +3252,7 @@ class Bit(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Bit(self.name,
                   description=self.description,
                   if_feature=self.if_feature,
@@ -3219,6 +3260,7 @@ class Bit(SchemaNodeOuter):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
+                  mod=new_mod if new_mod is not None else self.mod,
                   ns=new_ns if new_ns is not None else self.ns,
                   pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -3254,14 +3296,18 @@ class Case(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "case"
@@ -3274,6 +3320,9 @@ class Case(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -3304,7 +3353,7 @@ class Case(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Case(self.name,
                    description=self.description,
                    if_feature=self.if_feature,
@@ -3312,9 +3361,10 @@ class Case(SchemaNodeInner):
                    status=self.status,
                    when=self.when,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -3351,14 +3401,18 @@ class Choice(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "choice"
@@ -3374,6 +3428,9 @@ class Choice(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -3417,7 +3474,7 @@ class Choice(SchemaNodeInner):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Choice(self.name,
                      config=self.config,
                      default=self.default,
@@ -3428,9 +3485,10 @@ class Choice(SchemaNodeInner):
                      status=self.status,
                      when=self.when,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -3467,19 +3525,26 @@ class Container(SchemaNodeInner):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], presence: ?str=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], presence: ?str=None, reference: ?str=None, status: ?str=None, when: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "container"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -3498,6 +3563,9 @@ class Container(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -3567,7 +3635,7 @@ class Container(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Container(self.name,
                         config=self.config,
                         description=self.description,
@@ -3578,9 +3646,10 @@ class Container(SchemaNodeInner):
                         status=self.status,
                         when=self.when,
                         exts=self.exts,
+                        mod=new_mod if new_mod is not None else self.mod,
                         ns=new_ns if new_ns is not None else self.ns,
                         pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -3614,14 +3683,18 @@ class Enum(SchemaNodeOuter):
     status: ?str
     value: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, value: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, value: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "enum"
@@ -3655,7 +3728,7 @@ class Enum(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Enum(self.name,
                    description=self.description,
                    if_feature=self.if_feature,
@@ -3663,6 +3736,7 @@ class Enum(SchemaNodeOuter):
                    status=self.status,
                    value=self.value,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -3697,14 +3771,18 @@ class Extension(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, argument: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, argument: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "extension"
@@ -3733,13 +3811,14 @@ class Extension(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Extension(self.name,
                         argument=self.argument,
                         description=self.description,
                         reference=self.reference,
                         status=self.status,
                         exts=self.exts,
+                        mod=new_mod if new_mod is not None else self.mod,
                         ns=new_ns if new_ns is not None else self.ns,
                         pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -3774,14 +3853,18 @@ class Feature(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "feature"
@@ -3813,13 +3896,14 @@ class Feature(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Feature(self.name,
                       description=self.description,
                       if_feature=self.if_feature,
                       reference=self.reference,
                       status=self.status,
                       exts=self.exts,
+                      mod=new_mod if new_mod is not None else self.mod,
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -3853,14 +3937,18 @@ class Grouping(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "grouping"
@@ -3871,6 +3959,9 @@ class Grouping(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -3896,15 +3987,16 @@ class Grouping(SchemaNodeInner):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Grouping(self.name,
                        description=self.description,
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
+                       mod=new_mod if new_mod is not None else self.mod,
                        ns=new_ns if new_ns is not None else self.ns,
                        pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -3938,14 +4030,18 @@ class Identity(SchemaNodeOuter):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, base: list[str]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, base: list[str]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "identity"
@@ -3979,7 +4075,7 @@ class Identity(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Identity(self.name,
                        base=self.base,
                        description=self.description,
@@ -3987,6 +4083,7 @@ class Identity(SchemaNodeOuter):
                        reference=self.reference,
                        status=self.status,
                        exts=self.exts,
+                       mod=new_mod if new_mod is not None else self.mod,
                        ns=new_ns if new_ns is not None else self.ns,
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -4021,14 +4118,18 @@ class Import(SchemaNodeOuter):
     reference: ?str
     revision_date: ?str
 
-    def __init__(self, module: str, prefix: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, module: str, prefix: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "import"
@@ -4057,13 +4158,14 @@ class Import(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Import(self.module,
                      prefix=self.prefix,
                      description=self.description,
                      reference=self.reference,
                      revision_date=self.revision_date,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -4097,14 +4199,18 @@ class Include(SchemaNodeOuter):
     reference: ?str
     revision_date: ?str
 
-    def __init__(self, module: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, module: str, description: ?str=None, reference: ?str=None, revision_date: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "include"
@@ -4131,12 +4237,13 @@ class Include(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Include(self.module,
                       description=self.description,
                       reference=self.reference,
                       revision_date=self.revision_date,
                       exts=self.exts,
+                      mod=new_mod if new_mod is not None else self.mod,
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -4167,19 +4274,26 @@ class Input(SchemaNodeInner):
     """
     must: list[Must]
 
-    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "input"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4190,6 +4304,9 @@ class Input(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4223,12 +4340,13 @@ class Input(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Input(must=self.must,
                     exts=self.exts,
+                    mod=new_mod if new_mod is not None else self.mod,
                     ns=new_ns if new_ns is not None else self.ns,
                     pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -4268,19 +4386,26 @@ class Leaf(SchemaNodeOuter):
     units: ?str
     when: ?str
 
-    def __init__(self, name: str, type_: Type, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, type_: Type, config: ?bool=None, default: ?str=None, description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, must: list[Must]=[], reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "leaf"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4288,6 +4413,9 @@ class Leaf(SchemaNodeOuter):
             if n_pfx is None:
                 n.pfx = self.pfx
         type_.parent = self
+        n_mod = type_.mod
+        if n_mod is None:
+            type_.mod = self.mod
         n_ns = type_.ns
         if n_ns is None:
             type_.ns = self.ns
@@ -4349,7 +4477,7 @@ class Leaf(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -4373,6 +4501,7 @@ class Leaf(SchemaNodeOuter):
                    units=new_units,
                    when=self.when,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
 
@@ -4437,19 +4566,26 @@ class LeafList(SchemaNodeOuter):
     units: ?str
     when: ?str
 
-    def __init__(self, name: str, type_: Type, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, type_: Type, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, when: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "leaf-list"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4457,6 +4593,9 @@ class LeafList(SchemaNodeOuter):
             if n_pfx is None:
                 n.pfx = self.pfx
         type_.parent = self
+        n_mod = type_.mod
+        if n_mod is None:
+            type_.mod = self.mod
         n_ns = type_.ns
         if n_ns is None:
             type_.ns = self.ns
@@ -4524,7 +4663,7 @@ class LeafList(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_units = self.units
@@ -4546,6 +4685,7 @@ class LeafList(SchemaNodeOuter):
                        units=new_units,
                        when=self.when,
                        exts=self.exts,
+                       mod=new_mod if new_mod is not None else self.mod,
                        ns=new_ns if new_ns is not None else self.ns,
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -4613,14 +4753,18 @@ class Length(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "length"
@@ -4649,13 +4793,14 @@ class Length(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Length(self.value,
                      description=self.description,
                      error_app_tag=self.error_app_tag,
                      error_message=self.error_message,
                      reference=self.reference,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -4698,19 +4843,26 @@ class List(SchemaNodeInner):
     unique: list[str]
     when: ?str
 
-    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], key: ?str=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, unique: list[str]=[], when: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, config: ?bool=None, description: ?str=None, if_feature: list[str]=[], key: ?str=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], ordered_by: ?str=None, reference: ?str=None, status: ?str=None, unique: list[str]=[], when: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "list"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4733,6 +4885,9 @@ class List(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4823,7 +4978,7 @@ class List(SchemaNodeInner):
             child.parent = new_dnode
         return new_dnode
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = List(self.name,
                    config=self.config,
                    description=self.description,
@@ -4838,9 +4993,10 @@ class List(SchemaNodeInner):
                    unique=self.unique,
                    when=self.when,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -4883,19 +5039,26 @@ class Module(SchemaNodeInner):
     extension_: list[Extension]
     feature: list[Feature]
 
-    def __init__(self, name: str, namespace: str, prefix: str, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, namespace: str, prefix: str, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None:
+            new_mod = name
         if new_ns is None:
             new_ns = namespace
         if new_pfx is None:
             new_pfx = prefix
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "module"
         for n in augment:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4904,6 +5067,9 @@ class Module(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in extension_:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4912,6 +5078,9 @@ class Module(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in feature:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4920,6 +5089,9 @@ class Module(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in import_:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4928,6 +5100,9 @@ class Module(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in include:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4936,6 +5111,9 @@ class Module(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in revision:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -4960,6 +5138,9 @@ class Module(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5051,7 +5232,7 @@ class Module(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Module(self.name,
                      yang_version=self.yang_version,
                      namespace=self.namespace,
@@ -5068,7 +5249,7 @@ class Module(SchemaNodeInner):
                      extension_=self.extension_,
                      feature=self.feature,
                      exts=self.exts)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         new.expand_augments(context)
         return new
 
@@ -5108,14 +5289,18 @@ class Must(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, condition: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, condition: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "must"
@@ -5144,13 +5329,14 @@ class Must(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Must(self.condition,
                    description=self.description,
                    error_app_tag=self.error_app_tag,
                    error_message=self.error_message,
                    reference=self.reference,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -5186,19 +5372,26 @@ class Notification(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], must: list[Must]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "notification"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5214,6 +5407,9 @@ class Notification(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5267,7 +5463,7 @@ class Notification(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Notification(self.name,
                            description=self.description,
                            if_feature=self.if_feature,
@@ -5275,9 +5471,10 @@ class Notification(SchemaNodeInner):
                            reference=self.reference,
                            status=self.status,
                            exts=self.exts,
+                           mod=new_mod if new_mod is not None else self.mod,
                            ns=new_ns if new_ns is not None else self.ns,
                            pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -5306,19 +5503,26 @@ class Output(SchemaNodeInner):
     """
     must: list[Must]
 
-    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, must: list[Must]=[], exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "output"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5329,6 +5533,9 @@ class Output(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5365,12 +5572,13 @@ class Output(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Output(must=self.must,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
     def __str__(self):
@@ -5404,14 +5612,18 @@ class Pattern(SchemaNodeOuter):
     modifier: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, modifier: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, modifier: ?str=None, reference: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "pattern"
@@ -5442,7 +5654,7 @@ class Pattern(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Pattern(self.value,
                       description=self.description,
                       error_app_tag=self.error_app_tag,
@@ -5450,6 +5662,7 @@ class Pattern(SchemaNodeOuter):
                       modifier=self.modifier,
                       reference=self.reference,
                       exts=self.exts,
+                      mod=new_mod if new_mod is not None else self.mod,
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -5484,14 +5697,18 @@ class Range(SchemaNodeOuter):
     error_message: ?str
     reference: ?str
 
-    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, value: str, description: ?str=None, error_app_tag: ?str=None, error_message: ?str=None, reference: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "range"
@@ -5520,13 +5737,14 @@ class Range(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Range(self.value,
                     description=self.description,
                     error_app_tag=self.error_app_tag,
                     error_message=self.error_message,
                     reference=self.reference,
                     exts=self.exts,
+                    mod=new_mod if new_mod is not None else self.mod,
                     ns=new_ns if new_ns is not None else self.ns,
                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -5567,19 +5785,26 @@ class Refine(SchemaNodeOuter):
     presence: ?str
     reference: ?str
 
-    def __init__(self, target_node: str, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], presence: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, target_node: str, config: ?bool=None, default: list[str]=[], description: ?str=None, if_feature: list[str]=[], mandatory: ?bool=None, max_elements: ?str=None, min_elements: ?str=None, must: list[Must]=[], presence: ?str=None, reference: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "refine"
         for n in must:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5647,7 +5872,7 @@ class Refine(SchemaNodeOuter):
             self.config = ref_config
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Refine(self.target_node,
                      config=self.config,
                      default=self.default,
@@ -5660,6 +5885,7 @@ class Refine(SchemaNodeOuter):
                      presence=self.presence,
                      reference=self.reference,
                      exts=self.exts,
+                     mod=new_mod if new_mod is not None else self.mod,
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -5692,14 +5918,18 @@ class Revision(SchemaNodeOuter):
     description: ?str
     reference: ?str
 
-    def __init__(self, date: str, description: ?str=None, reference: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, date: str, description: ?str=None, reference: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "revision"
@@ -5724,11 +5954,12 @@ class Revision(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Revision(self.date,
                        description=self.description,
                        reference=self.reference,
                        exts=self.exts,
+                       mod=new_mod if new_mod is not None else self.mod,
                        ns=new_ns if new_ns is not None else self.ns,
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -5765,19 +5996,26 @@ class Rpc(SchemaNodeInner):
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "rpc"
         if input is not None:
             input.parent = self
+            n_mod = input.mod
+            if n_mod is None:
+                input.mod = self.mod
             n_ns = input.ns
             if n_ns is None:
                 input.ns = self.ns
@@ -5786,6 +6024,9 @@ class Rpc(SchemaNodeInner):
                 input.pfx = self.pfx
         if output is not None:
             output.parent = self
+            n_mod = output.mod
+            if n_mod is None:
+                output.mod = self.mod
             n_ns = output.ns
             if n_ns is None:
                 output.ns = self.ns
@@ -5802,6 +6043,9 @@ class Rpc(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5846,7 +6090,7 @@ class Rpc(SchemaNodeInner):
                 return _output
         return SchemaNode.get(self, name, ns)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         self_input = self.input
         self_output = self.output
         # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
@@ -5865,6 +6109,7 @@ class Rpc(SchemaNodeInner):
                   reference=self.reference,
                   status=self.status,
                   exts=self.exts,
+                  mod=new_mod if new_mod is not None else self.mod,
                   ns=new_ns if new_ns is not None else self.ns,
                   pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_ns, new_pfx)
@@ -5929,19 +6174,26 @@ class Submodule(SchemaNodeInner):
     extension_: list[Extension]
     feature: list[Feature]
 
-    def __init__(self, name: str, belongs_to: BelongsTo, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, belongs_to: BelongsTo, yang_version: float=1.1, augment: list[Augment]=[], contact: ?str=None, description: ?str=None, deviation: list[str]=[], extension_: list[Extension]=[], feature: list[Feature]=[], import_: list[Import]=[], include: list[Include]=[], organization: ?str=None, reference: ?str=None, revision: list[Revision]=[], exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "submodule"
         for n in augment:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5949,6 +6201,9 @@ class Submodule(SchemaNodeInner):
             if n_pfx is None:
                 n.pfx = self.pfx
         belongs_to.parent = self
+        n_mod = belongs_to.mod
+        if n_mod is None:
+            belongs_to.mod = self.mod
         n_ns = belongs_to.ns
         if n_ns is None:
             belongs_to.ns = self.ns
@@ -5957,6 +6212,9 @@ class Submodule(SchemaNodeInner):
             belongs_to.pfx = self.pfx
         for n in extension_:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5965,6 +6223,9 @@ class Submodule(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in feature:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5973,6 +6234,9 @@ class Submodule(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in import_:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5981,6 +6245,9 @@ class Submodule(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in include:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -5989,6 +6256,9 @@ class Submodule(SchemaNodeInner):
                 n.pfx = self.pfx
         for n in revision:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6012,6 +6282,9 @@ class Submodule(SchemaNodeInner):
         self.exts = exts
         for n in children:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6059,7 +6332,7 @@ class Submodule(SchemaNodeInner):
                 latest = rev
         return latest
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Submodule(self.name,
                         yang_version=self.yang_version,
                         import_=self.import_,
@@ -6075,7 +6348,7 @@ class Submodule(SchemaNodeInner):
                         extension_=self.extension_,
                         feature=self.feature,
                         exts=self.exts)
-        self.expand_children(context, new, new_ns)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
         new.expand_augments(context)
         return new
 
@@ -6115,19 +6388,26 @@ class Type(SchemaNodeOuter):
     require_instance: ?bool
     type_: list[Type]
 
-    def __init__(self, name: str, base: list[str]=[], bit: list[Bit]=[], enum: list[Enum]=[], fraction_digits: ?int=None, length: ?Length=None, path: ?str=None, pattern: list[Pattern]=[], range_: ?Range=None, require_instance: ?bool=None, type_: list[Type]=[], exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, base: list[str]=[], bit: list[Bit]=[], enum: list[Enum]=[], fraction_digits: ?int=None, length: ?Length=None, path: ?str=None, pattern: list[Pattern]=[], range_: ?Range=None, require_instance: ?bool=None, type_: list[Type]=[], exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "type"
         for n in bit:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6136,6 +6416,9 @@ class Type(SchemaNodeOuter):
                 n.pfx = self.pfx
         for n in enum:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6144,6 +6427,9 @@ class Type(SchemaNodeOuter):
                 n.pfx = self.pfx
         if length is not None:
             length.parent = self
+            n_mod = length.mod
+            if n_mod is None:
+                length.mod = self.mod
             n_ns = length.ns
             if n_ns is None:
                 length.ns = self.ns
@@ -6152,6 +6438,9 @@ class Type(SchemaNodeOuter):
                 length.pfx = self.pfx
         for n in pattern:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6160,6 +6449,9 @@ class Type(SchemaNodeOuter):
                 n.pfx = self.pfx
         if range_ is not None:
             range_.parent = self
+            n_mod = range_.mod
+            if n_mod is None:
+                range_.mod = self.mod
             n_ns = range_.ns
             if n_ns is None:
                 range_.ns = self.ns
@@ -6168,6 +6460,9 @@ class Type(SchemaNodeOuter):
                 range_.pfx = self.pfx
         for n in type_:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6238,7 +6533,7 @@ class Type(SchemaNodeOuter):
                 raise ValueError("Recursion limit reached for typedef %s" % self.name)
         raise ValueError("Unable to resolve typedef %s" % self.name)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         new = Type(self.name,
                    base=self.base,
                    bit=self.bit,
@@ -6251,6 +6546,7 @@ class Type(SchemaNodeOuter):
                    require_instance=self.require_instance,
                    type_=self.type_,
                    exts=self.exts,
+                   mod=new_mod if new_mod is not None else self.mod,
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
@@ -6287,18 +6583,25 @@ class Typedef(SchemaNodeOuter):
     status: ?str
     units: ?str
 
-    def __init__(self, name: str, type_: Type, default: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, type_: Type, default: ?str=None, description: ?str=None, reference: ?str=None, status: ?str=None, units: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "typedef"
         type_.parent = self
+        n_mod = type_.mod
+        if n_mod is None:
+            type_.mod = self.mod
         n_ns = type_.ns
         if n_ns is None:
             type_.ns = self.ns
@@ -6338,7 +6641,7 @@ class Typedef(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         base_typedef = self.type_.resolve_typedef(context)
 
         new_default = self.default
@@ -6392,19 +6695,26 @@ class Uses(SchemaNodeOuter):
     status: ?str
     when: ?str
 
-    def __init__(self, name: str, augment: list[Augment]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, refine: list[Refine]=[], status: ?str=None, when: ?str=None, exts=[], parent=None, ns=None, pfx=None):
+    def __init__(self, name: str, augment: list[Augment]=[], description: ?str=None, if_feature: list[str]=[], reference: ?str=None, refine: list[Refine]=[], status: ?str=None, when: ?str=None, exts=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
+        new_mod = mod
         new_ns = ns
         new_pfx = pfx
+        if new_mod is None and parent is not None:
+            new_mod = parent.mod
         if new_ns is None and parent is not None:
             new_ns = parent.ns
         if new_pfx is None and parent is not None:
             new_pfx = parent.pfx
+        self.mod = new_mod
         self.ns = new_ns
         self.pfx = new_pfx
         self._yname = "uses"
         for n in augment:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6413,6 +6723,9 @@ class Uses(SchemaNodeOuter):
                 n.pfx = self.pfx
         for n in refine:
             n.parent = self
+            n_mod = n.mod
+            if n_mod is None:
+                n.mod = self.mod
             n_ns = n.ns
             if n_ns is None:
                 n.ns = self.ns
@@ -6453,7 +6766,7 @@ class Uses(SchemaNodeOuter):
             self.description = ref_description
         self.exts.extend(refine.exts)
 
-    def compile(self, context: Context, new_ns: ?str=None, new_pfx: ?str=None):
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
         raise ValueError("Cannot compile 'uses'")
 
     mut def expand_refines(self, target_base: SchemaNode):

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -42,7 +42,7 @@ mut def from_json_path_acme_foo_bar__c1(jd: value, path: list[str]=[], op: ?str=
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'acme_qux-baz:l1' or point == 'l1':
+        if point == 'acme_foo-bar:l1' or point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,7 +55,7 @@ mut def from_json_path_acme_foo_bar__c1(jd: value, path: list[str]=[], op: ?str=
 
 mut def from_json_acme_foo_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('acme_qux-baz:l1')
+    child_l1_full = jd.get('acme_foo-bar:l1')
     child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_acme_foo_bar__c1__l1(child_l1)

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -124,7 +124,7 @@ mut def from_json_path_bar__c1__li1(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_bar__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_l1_full = jd.get('foo:l1')
+    child_l1_full = jd.get('bar:l1')
     child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_bar__c1__li1__l1(child_l1)
@@ -183,7 +183,7 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:li1' or point == 'li1':
+        if point == 'bar:li1' or point == 'li1':
             child = {'li1': from_json_path_bar__c1__li1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -197,7 +197,7 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_li1_full = jd.get('foo:li1')
+    child_li1_full = jd.get('bar:li1')
     child_li1 = child_li1_full if child_li1_full is not None else jd.get('li1')
     if child_li1 is not None and isinstance(child_li1, list):
         children['li1'] = from_json_bar__c1__li1(child_li1)

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -98,6 +98,7 @@ def _test_foo_from_xml_full():
   <ll_uint64>42</ll_uint64>
   <ll_str>kava</ll_str>
   <ll_str>čaj</ll_str>
+  <l4>foo-qux</l4>
   <l1 xmlns="http://example.com/bar">foo-bar</l1>
   <l2 xmlns="http://example.com/bar">bar</l2>
 </c1>
@@ -141,6 +142,9 @@ def _test_foo_from_xml_full():
   <k2>aGk=</k2>
   <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
 </li-union>
+<c2 xmlns="http://example.com/foo">
+  <l1>foo-qux</l1>
+</c2>
 <conflict xmlns="http://example.com/bar">
   <foo>foo-bar</foo>
 </conflict>

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -107,23 +107,23 @@ mut def from_json_path_basics__c(jd: value, path: list[str]=[], op: ?str='merge'
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'b:l_str_def' or point == 'l_str_def':
+        if point == 'basics:l_str_def' or point == 'l_str_def':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_str_def_quoted' or point == 'l_str_def_quoted':
+        if point == 'basics:l_str_def_quoted' or point == 'l_str_def_quoted':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_uint64_def' or point == 'l_uint64_def':
+        if point == 'basics:l_uint64_def' or point == 'l_uint64_def':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_union_def_str' or point == 'l_union_def_str':
+        if point == 'basics:l_union_def_str' or point == 'l_union_def_str':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_union_def_int' or point == 'l_union_def_int':
+        if point == 'basics:l_union_def_int' or point == 'l_union_def_int':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_union_def_float' or point == 'l_union_def_float':
+        if point == 'basics:l_union_def_float' or point == 'l_union_def_float':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_union_def_bool' or point == 'l_union_def_bool':
+        if point == 'basics:l_union_def_bool' or point == 'l_union_def_bool':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_union_def_enumeration' or point == 'l_union_def_enumeration':
+        if point == 'basics:l_union_def_enumeration' or point == 'l_union_def_enumeration':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'b:l_binary_def' or point == 'l_binary_def':
+        if point == 'basics:l_binary_def' or point == 'l_binary_def':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -136,39 +136,39 @@ mut def from_json_path_basics__c(jd: value, path: list[str]=[], op: ?str='merge'
 
 mut def from_json_basics__c(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_str_def_full = jd.get('b:l_str_def')
+    child_l_str_def_full = jd.get('basics:l_str_def')
     child_l_str_def = child_l_str_def_full if child_l_str_def_full is not None else jd.get('l_str_def')
     if child_l_str_def is not None:
         children['l_str_def'] = from_json_basics__c__l_str_def(child_l_str_def)
-    child_l_str_def_quoted_full = jd.get('b:l_str_def_quoted')
+    child_l_str_def_quoted_full = jd.get('basics:l_str_def_quoted')
     child_l_str_def_quoted = child_l_str_def_quoted_full if child_l_str_def_quoted_full is not None else jd.get('l_str_def_quoted')
     if child_l_str_def_quoted is not None:
         children['l_str_def_quoted'] = from_json_basics__c__l_str_def_quoted(child_l_str_def_quoted)
-    child_l_uint64_def_full = jd.get('b:l_uint64_def')
+    child_l_uint64_def_full = jd.get('basics:l_uint64_def')
     child_l_uint64_def = child_l_uint64_def_full if child_l_uint64_def_full is not None else jd.get('l_uint64_def')
     if child_l_uint64_def is not None:
         children['l_uint64_def'] = from_json_basics__c__l_uint64_def(child_l_uint64_def)
-    child_l_union_def_str_full = jd.get('b:l_union_def_str')
+    child_l_union_def_str_full = jd.get('basics:l_union_def_str')
     child_l_union_def_str = child_l_union_def_str_full if child_l_union_def_str_full is not None else jd.get('l_union_def_str')
     if child_l_union_def_str is not None:
         children['l_union_def_str'] = from_json_basics__c__l_union_def_str(child_l_union_def_str)
-    child_l_union_def_int_full = jd.get('b:l_union_def_int')
+    child_l_union_def_int_full = jd.get('basics:l_union_def_int')
     child_l_union_def_int = child_l_union_def_int_full if child_l_union_def_int_full is not None else jd.get('l_union_def_int')
     if child_l_union_def_int is not None:
         children['l_union_def_int'] = from_json_basics__c__l_union_def_int(child_l_union_def_int)
-    child_l_union_def_float_full = jd.get('b:l_union_def_float')
+    child_l_union_def_float_full = jd.get('basics:l_union_def_float')
     child_l_union_def_float = child_l_union_def_float_full if child_l_union_def_float_full is not None else jd.get('l_union_def_float')
     if child_l_union_def_float is not None:
         children['l_union_def_float'] = from_json_basics__c__l_union_def_float(child_l_union_def_float)
-    child_l_union_def_bool_full = jd.get('b:l_union_def_bool')
+    child_l_union_def_bool_full = jd.get('basics:l_union_def_bool')
     child_l_union_def_bool = child_l_union_def_bool_full if child_l_union_def_bool_full is not None else jd.get('l_union_def_bool')
     if child_l_union_def_bool is not None:
         children['l_union_def_bool'] = from_json_basics__c__l_union_def_bool(child_l_union_def_bool)
-    child_l_union_def_enumeration_full = jd.get('b:l_union_def_enumeration')
+    child_l_union_def_enumeration_full = jd.get('basics:l_union_def_enumeration')
     child_l_union_def_enumeration = child_l_union_def_enumeration_full if child_l_union_def_enumeration_full is not None else jd.get('l_union_def_enumeration')
     if child_l_union_def_enumeration is not None:
         children['l_union_def_enumeration'] = from_json_basics__c__l_union_def_enumeration(child_l_union_def_enumeration)
-    child_l_binary_def_full = jd.get('b:l_binary_def')
+    child_l_binary_def_full = jd.get('basics:l_binary_def')
     child_l_binary_def = child_l_binary_def_full if child_l_binary_def_full is not None else jd.get('l_binary_def')
     if child_l_binary_def is not None:
         children['l_binary_def'] = from_json_basics__c__l_binary_def(child_l_binary_def)
@@ -246,7 +246,7 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'b:c':
+        if point == 'basics:c':
             child = {'c': from_json_path_basics__c(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -260,7 +260,7 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
 
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_c = jd.get('b:c')
+    child_c = jd.get('basics:c')
     if child_c is not None and isinstance(child_c, dict):
         children['c'] = from_json_basics__c(child_c)
     return yang.gdata.Container(children)
@@ -270,7 +270,7 @@ mut def to_json(n: yang.gdata.Node) -> dict[str, ?value]:
     child_c = n.children.get('c')
     if child_c is not None:
         if isinstance(child_c, yang.gdata.Container):
-            children['b:c'] = to_json_basics__c(child_c)
+            children['basics:c'] = to_json_basics__c(child_c)
     return children
 
 schema_namespaces: set[str] = {

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -8,7 +8,7 @@ import yang.gdata
 # == This file is generated ==
 
 
-mut def from_json_foo__c1__foo_l1(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__c1__f_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__c1__l3(val: value) -> yang.gdata.Leaf:
@@ -185,6 +185,9 @@ mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
 mut def from_json_foo__c1__ll_str(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
+mut def from_json_foo__c1__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__bar_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -192,31 +195,33 @@ mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1(yang.adata.MNode):
-    foo_l1: ?str
+    f_l1: ?str
     l3: ?int
     l_empty: ?bool
     li: foo__c1__li
     ll_uint64: list[int]
     ll_str: list[str]
+    l4: ?str
     bar_l1: ?str
     l2: ?str
 
-    mut def __init__(self, foo_l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[int]=None, ll_str: ?list[str]=None, bar_l1: ?str, l2: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[int]=None, ll_str: ?list[str]=None, l4: ?str, bar_l1: ?str, l2: ?str):
         self._ns = 'http://example.com/foo'
-        self.foo_l1 = foo_l1
+        self.f_l1 = f_l1
         self.l3 = l3
         self.l_empty = l_empty
         self.li = foo__c1__li(elements=li)
         self.ll_uint64 = ll_uint64 if ll_uint64 is not None else []
         self.ll_str = ll_str if ll_str is not None else []
+        self.l4 = l4
         self.bar_l1 = bar_l1
         self.l2 = l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_l1 = self.foo_l1
-        if _foo_l1 is not None:
-            children['foo:l1'] = yang.gdata.Leaf('string', _foo_l1)
+        _f_l1 = self.f_l1
+        if _f_l1 is not None:
+            children['f:l1'] = yang.gdata.Leaf('string', _f_l1)
         _l3 = self.l3
         if _l3 is not None:
             children['l3'] = yang.gdata.Leaf('uint64', _l3)
@@ -228,6 +233,9 @@ class foo__c1(yang.adata.MNode):
             children['li'] = _li.to_gdata()
         children['ll_uint64'] = yang.gdata.LeafList(self.ll_uint64)
         children['ll_str'] = yang.gdata.LeafList(self.ll_str)
+        _l4 = self.l4
+        if _l4 is not None:
+            children['l4'] = yang.gdata.Leaf('string', _l4)
         _bar_l1 = self.bar_l1
         if _bar_l1 is not None:
             children['bar:l1'] = yang.gdata.Leaf('string', _bar_l1, ns='http://example.com/bar')
@@ -239,13 +247,13 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(foo_l1=n.get_opt_str('foo:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
+            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(foo_l1=yang.gdata.from_xml_opt_str(n, 'l1'), l3=yang.gdata.from_xml_opt_int(n, 'l3'), l_empty=yang.gdata.from_xml_opt_bool(n, 'l_empty'), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, 'li')), ll_uint64=yang.gdata.from_xml_opt_ints(n, 'll_uint64'), ll_str=yang.gdata.from_xml_opt_strs(n, 'll_str'), bar_l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
+            return foo__c1(f_l1=yang.gdata.from_xml_opt_str(n, 'l1'), l3=yang.gdata.from_xml_opt_int(n, 'l3'), l_empty=yang.gdata.from_xml_opt_bool(n, 'l_empty'), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, 'li')), ll_uint64=yang.gdata.from_xml_opt_ints(n, 'll_uint64'), ll_str=yang.gdata.from_xml_opt_strs(n, 'll_str'), l4=yang.gdata.from_xml_opt_str(n, 'l4'), bar_l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
         return foo__c1()
 
 
@@ -267,6 +275,8 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
             raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:ll_str' or point == 'll_str':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'foo:l4' or point == 'l4':
+            raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l2':
@@ -282,10 +292,10 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_l1_full = jd.get('foo:l1')
-    child_foo_l1 = child_foo_l1_full if child_foo_l1_full is not None else jd.get('l1')
-    if child_foo_l1 is not None:
-        children['foo:l1'] = from_json_foo__c1__foo_l1(child_foo_l1)
+    child_f_l1_full = jd.get('foo:l1')
+    child_f_l1 = child_f_l1_full if child_f_l1_full is not None else jd.get('l1')
+    if child_f_l1 is not None:
+        children['f:l1'] = from_json_foo__c1__f_l1(child_f_l1)
     child_l3_full = jd.get('foo:l3')
     child_l3 = child_l3_full if child_l3_full is not None else jd.get('l3')
     if child_l3 is not None:
@@ -306,6 +316,10 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_ll_str = child_ll_str_full if child_ll_str_full is not None else jd.get('ll_str')
     if child_ll_str is not None and isinstance(child_ll_str, list):
         children['ll_str'] = from_json_foo__c1__ll_str(child_ll_str)
+    child_l4_full = jd.get('foo:l4')
+    child_l4 = child_l4_full if child_l4_full is not None else jd.get('l4')
+    if child_l4 is not None:
+        children['l4'] = from_json_foo__c1__l4(child_l4)
     child_bar_l1 = jd.get('bar:l1')
     if child_bar_l1 is not None:
         children['bar:l1'] = from_json_foo__c1__bar_l1(child_bar_l1)
@@ -316,10 +330,10 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
 
 mut def to_json_foo__c1(n: yang.gdata.Node) -> dict[str, ?value]:
     children = {}
-    child_foo_l1 = n.children.get('foo:l1')
-    if child_foo_l1 is not None:
-        if isinstance(child_foo_l1, yang.gdata.Leaf):
-            children['l1'] = child_foo_l1.val
+    child_f_l1 = n.children.get('f:l1')
+    if child_f_l1 is not None:
+        if isinstance(child_f_l1, yang.gdata.Leaf):
+            children['l1'] = child_f_l1.val
     child_l3 = n.children.get('l3')
     if child_l3 is not None:
         if isinstance(child_l3, yang.gdata.Leaf):
@@ -340,6 +354,10 @@ mut def to_json_foo__c1(n: yang.gdata.Node) -> dict[str, ?value]:
     if child_ll_str is not None:
         if isinstance(child_ll_str, yang.gdata.LeafList):
             children['ll_str'] = child_ll_str.vals
+    child_l4 = n.children.get('l4')
+    if child_l4 is not None:
+        if isinstance(child_l4, yang.gdata.Leaf):
+            children['l4'] = child_l4.val
     child_bar_l1 = n.children.get('bar:l1')
     if child_bar_l1 is not None:
         if isinstance(child_bar_l1, yang.gdata.Leaf):
@@ -938,10 +956,10 @@ mut def to_json_foo__cc(n: yang.gdata.Node) -> dict[str, ?value]:
             children['death'] = to_json_foo__cc__death(child_death)
     return children
 
-mut def from_json_foo__conflict__foo_foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class foo__conflict__foo_inner(yang.adata.MNode):
+class foo__conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = 'http://example.com/foo'
@@ -952,19 +970,19 @@ class foo__conflict__foo_inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__foo_inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__f_inner:
         if n != None:
-            return foo__conflict__foo_inner()
+            return foo__conflict__f_inner()
         return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__foo_inner:
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__f_inner:
         if n != None:
-            return foo__conflict__foo_inner()
+            return foo__conflict__f_inner()
         return None
 
 
-mut def from_json_path_foo__conflict__foo_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -972,17 +990,17 @@ mut def from_json_path_foo__conflict__foo_inner(jd: value, path: list[str]=[], o
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__foo_inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__conflict__f_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__foo_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-mut def to_json_foo__conflict__foo_inner(n: yang.gdata.Node) -> dict[str, ?value]:
+mut def to_json_foo__conflict__f_inner(n: yang.gdata.Node) -> dict[str, ?value]:
     children = {}
     return children
 
@@ -1035,21 +1053,21 @@ mut def to_json_foo__conflict__bar_inner(n: yang.gdata.Node) -> dict[str, ?value
     return children
 
 class foo__conflict(yang.adata.MNode):
-    foo_foo: ?str
-    foo_inner: ?foo__conflict__foo_inner
+    f_foo: ?str
+    f_inner: ?foo__conflict__f_inner
     bar_foo: ?str
     bar_inner: ?foo__conflict__bar_inner
 
-    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__foo_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
+    mut def __init__(self, f_foo: ?str, f_inner: ?foo__conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
         self._ns = 'http://example.com/foo'
-        self.foo_foo = foo_foo
-        self.foo_inner = foo_inner
+        self.f_foo = f_foo
+        self.f_inner = f_inner
         self.bar_foo = bar_foo
         self.bar_inner = bar_inner
 
-    mut def create_foo_inner(self):
-        res = foo__conflict__foo_inner()
-        self.foo_inner = res
+    mut def create_f_inner(self):
+        res = foo__conflict__f_inner()
+        self.f_inner = res
         return res
 
     mut def create_bar_inner(self):
@@ -1059,12 +1077,12 @@ class foo__conflict(yang.adata.MNode):
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_foo = self.foo_foo
-        if _foo_foo is not None:
-            children['foo:foo'] = yang.gdata.Leaf('string', _foo_foo)
-        _foo_inner = self.foo_inner
-        if _foo_inner is not None:
-            children['foo:inner'] = _foo_inner.to_gdata()
+        _f_foo = self.f_foo
+        if _f_foo is not None:
+            children['f:foo'] = yang.gdata.Leaf('string', _f_foo)
+        _f_inner = self.f_inner
+        if _f_inner is not None:
+            children['f:inner'] = _f_inner.to_gdata()
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
             children['bar:foo'] = yang.gdata.Leaf('string', _bar_foo, ns='http://example.com/bar')
@@ -1076,13 +1094,13 @@ class foo__conflict(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=n.get_opt_str('foo:foo'), foo_inner=foo__conflict__foo_inner.from_gdata(n.get_opt_container('foo:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
+            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
         return foo__conflict()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, 'foo'), foo_inner=foo__conflict__foo_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
+            return foo__conflict(f_foo=yang.gdata.from_xml_opt_str(n, 'foo'), f_inner=foo__conflict__f_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
         return foo__conflict()
 
 
@@ -1094,7 +1112,7 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
         if point == 'foo:foo' or point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:inner' or point == 'inner':
-            child = {'inner': from_json_path_foo__conflict__foo_inner(jd, rest_path, op) }
+            child = {'inner': from_json_path_foo__conflict__f_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:foo':
             raise ValueError("Invalid json path to non-inner node")
@@ -1112,14 +1130,14 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_foo_full = jd.get('foo:foo')
-    child_foo_foo = child_foo_foo_full if child_foo_foo_full is not None else jd.get('foo')
-    if child_foo_foo is not None:
-        children['foo:foo'] = from_json_foo__conflict__foo_foo(child_foo_foo)
-    child_foo_inner_full = jd.get('foo:inner')
-    child_foo_inner = child_foo_inner_full if child_foo_inner_full is not None else jd.get('inner')
-    if child_foo_inner is not None and isinstance(child_foo_inner, dict):
-        children['foo:inner'] = from_json_foo__conflict__foo_inner(child_foo_inner)
+    child_f_foo_full = jd.get('foo:foo')
+    child_f_foo = child_f_foo_full if child_f_foo_full is not None else jd.get('foo')
+    if child_f_foo is not None:
+        children['f:foo'] = from_json_foo__conflict__f_foo(child_f_foo)
+    child_f_inner_full = jd.get('foo:inner')
+    child_f_inner = child_f_inner_full if child_f_inner_full is not None else jd.get('inner')
+    if child_f_inner is not None and isinstance(child_f_inner, dict):
+        children['f:inner'] = from_json_foo__conflict__f_inner(child_f_inner)
     child_bar_foo = jd.get('bar:foo')
     if child_bar_foo is not None:
         children['bar:foo'] = from_json_foo__conflict__bar_foo(child_bar_foo)
@@ -1130,14 +1148,14 @@ mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
 
 mut def to_json_foo__conflict(n: yang.gdata.Node) -> dict[str, ?value]:
     children = {}
-    child_foo_foo = n.children.get('foo:foo')
-    if child_foo_foo is not None:
-        if isinstance(child_foo_foo, yang.gdata.Leaf):
-            children['foo'] = child_foo_foo.val
-    child_foo_inner = n.children.get('foo:inner')
-    if child_foo_inner is not None:
-        if isinstance(child_foo_inner, yang.gdata.Container):
-            children['inner'] = to_json_foo__conflict__foo_inner(child_foo_inner)
+    child_f_foo = n.children.get('f:foo')
+    if child_f_foo is not None:
+        if isinstance(child_f_foo, yang.gdata.Leaf):
+            children['foo'] = child_f_foo.val
+    child_f_inner = n.children.get('f:inner')
+    if child_f_inner is not None:
+        if isinstance(child_f_inner, yang.gdata.Container):
+            children['inner'] = to_json_foo__conflict__f_inner(child_f_inner)
     child_bar_foo = n.children.get('bar:foo')
     if child_bar_foo is not None:
         if isinstance(child_bar_foo, yang.gdata.Leaf):
@@ -2122,6 +2140,68 @@ mut def to_json_foo__state(n: yang.gdata.Node) -> dict[str, ?value]:
             children['c1'] = to_json_foo__state__c1(child_c1)
     return children
 
+mut def from_json_foo__c2__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class foo__c2(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = 'http://example.com/foo'
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c2:
+        if n != None:
+            return foo__c2(l1=n.get_opt_str('l1'))
+        return foo__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c2:
+        if n != None:
+            return foo__c2(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
+        return foo__c2()
+
+
+mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:l1' or point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__c2(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l1_full = jd.get('foo:l1')
+    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    if child_l1 is not None:
+        children['l1'] = from_json_foo__c2__l1(child_l1)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__c2(n: yang.gdata.Node) -> dict[str, ?value]:
+    children = {}
+    child_l1 = n.children.get('l1')
+    if child_l1 is not None:
+        if isinstance(child_l1, yang.gdata.Leaf):
+            children['l1'] = child_l1.val
+    return children
+
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -2191,14 +2271,15 @@ class root(yang.adata.MNode):
     empty_presence: ?foo__empty_presence
     c_dot: foo__c_dot
     cc: foo__cc
-    foo_conflict: foo__conflict
+    f_conflict: foo__conflict
     special: foo__special
     nested: foo__nested
     li_union: foo__li_union
     state: foo__state
+    c2: foo__c2
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -2206,11 +2287,12 @@ class root(yang.adata.MNode):
         self.empty_presence = empty_presence
         self.c_dot = c_dot if c_dot is not None else foo__c_dot()
         self.cc = cc if cc is not None else foo__cc()
-        self.foo_conflict = foo_conflict if foo_conflict is not None else foo__conflict()
+        self.f_conflict = f_conflict if f_conflict is not None else foo__conflict()
         self.special = foo__special(elements=special)
         self.nested = nested if nested is not None else foo__nested()
         self.li_union = foo__li_union(elements=li_union)
         self.state = state if state is not None else foo__state()
+        self.c2 = c2 if c2 is not None else foo__c2()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
 
     mut def create_pc1(self):
@@ -2248,9 +2330,9 @@ class root(yang.adata.MNode):
         _cc = self.cc
         if _cc is not None:
             children['cc'] = _cc.to_gdata()
-        _foo_conflict = self.foo_conflict
-        if _foo_conflict is not None:
-            children['foo:conflict'] = _foo_conflict.to_gdata()
+        _f_conflict = self.f_conflict
+        if _f_conflict is not None:
+            children['f:conflict'] = _f_conflict.to_gdata()
         _special = self.special
         if _special is not None:
             children['special'] = _special.to_gdata()
@@ -2263,6 +2345,9 @@ class root(yang.adata.MNode):
         _state = self.state
         if _state is not None:
             children['state'] = _state.to_gdata()
+        _c2 = self.c2
+        if _c2 is not None:
+            children['c2'] = _c2.to_gdata()
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
             children['bar:conflict'] = _bar_conflict.to_gdata()
@@ -2271,13 +2356,13 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), foo_conflict=foo__conflict.from_gdata(n.get_opt_container('foo:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_container('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), c2=foo__c2.from_gdata(n.get_opt_container('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), f_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
         return root()
 
 
@@ -2319,6 +2404,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         if point == 'foo:state':
             child = {'state': from_json_path_foo__state(jd, rest_path, op) }
             return yang.gdata.Container(child)
+        if point == 'foo:c2':
+            child = {'c2': from_json_path_foo__c2(jd, rest_path, op) }
+            return yang.gdata.Container(child)
         if point == 'bar:conflict':
             child = {'conflict': from_json_path_bar__conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
@@ -2351,9 +2439,9 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_cc = jd.get('foo:cc')
     if child_cc is not None and isinstance(child_cc, dict):
         children['cc'] = from_json_foo__cc(child_cc)
-    child_foo_conflict = jd.get('foo:conflict')
-    if child_foo_conflict is not None and isinstance(child_foo_conflict, dict):
-        children['foo:conflict'] = from_json_foo__conflict(child_foo_conflict)
+    child_f_conflict = jd.get('foo:conflict')
+    if child_f_conflict is not None and isinstance(child_f_conflict, dict):
+        children['f:conflict'] = from_json_foo__conflict(child_f_conflict)
     child_special = jd.get('foo:special')
     if child_special is not None and isinstance(child_special, list):
         children['special'] = from_json_foo__special(child_special)
@@ -2366,6 +2454,9 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_state = jd.get('foo:state')
     if child_state is not None and isinstance(child_state, dict):
         children['state'] = from_json_foo__state(child_state)
+    child_c2 = jd.get('foo:c2')
+    if child_c2 is not None and isinstance(child_c2, dict):
+        children['c2'] = from_json_foo__c2(child_c2)
     child_bar_conflict = jd.get('bar:conflict')
     if child_bar_conflict is not None and isinstance(child_bar_conflict, dict):
         children['bar:conflict'] = from_json_bar__conflict(child_bar_conflict)
@@ -2397,10 +2488,10 @@ mut def to_json(n: yang.gdata.Node) -> dict[str, ?value]:
     if child_cc is not None:
         if isinstance(child_cc, yang.gdata.Container):
             children['foo:cc'] = to_json_foo__cc(child_cc)
-    child_foo_conflict = n.children.get('foo:conflict')
-    if child_foo_conflict is not None:
-        if isinstance(child_foo_conflict, yang.gdata.Container):
-            children['foo:conflict'] = to_json_foo__conflict(child_foo_conflict)
+    child_f_conflict = n.children.get('f:conflict')
+    if child_f_conflict is not None:
+        if isinstance(child_f_conflict, yang.gdata.Container):
+            children['foo:conflict'] = to_json_foo__conflict(child_f_conflict)
     child_special = n.children.get('special')
     if child_special is not None:
         if isinstance(child_special, yang.gdata.List):
@@ -2417,6 +2508,10 @@ mut def to_json(n: yang.gdata.Node) -> dict[str, ?value]:
     if child_state is not None:
         if isinstance(child_state, yang.gdata.Container):
             children['foo:state'] = to_json_foo__state(child_state)
+    child_c2 = n.children.get('c2')
+    if child_c2 is not None:
+        if isinstance(child_c2, yang.gdata.Container):
+            children['foo:c2'] = to_json_foo__c2(child_c2)
     child_bar_conflict = n.children.get('bar:conflict')
     if child_bar_conflict is not None:
         if isinstance(child_bar_conflict, yang.gdata.Container):
@@ -2432,7 +2527,8 @@ def src_yang():
     res.append("""module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
-    prefix "foo";
+    prefix "f";
+    include qux;
     grouping g1 {
         leaf l1 {
             type string;
@@ -2578,18 +2674,35 @@ def src_yang():
         }
     }
 }""")
+    res.append("""submodule qux {
+    yang-version "1.1";
+    belongs-to foo {
+        prefix "f";
+    }
+    // Must not conflict with /f:c1
+    container c2 {
+        leaf l1 {
+            type string;
+        }
+    }
+    augment /f:c1 {
+        leaf l4 {
+            type string;
+        }
+    }
+}""")
     res.append("""module bar {
     yang-version "1.1";
     namespace "http://example.com/bar";
     prefix "bar";
     import foo {
-        prefix "foo";
+        prefix "f";
     }
-    augment /foo:c1 {
-        // create a conflict with /foo:c1/l1
-        uses foo:g1;
+    augment /f:c1 {
+        // create a conflict with /f:c1/l1
+        uses f:g1;
     }
-    augment /foo:c.dot {
+    augment /f:c.dot {
         leaf l.dot2 {
             type string;
         }
@@ -2599,7 +2712,7 @@ def src_yang():
             type string;
         }
     }
-    augment /foo:conflict {
+    augment /f:conflict {
         leaf foo {
             type string;
         }
@@ -2612,7 +2725,9 @@ def src_yang():
 
 def src_schema():
     res = {}
-    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='foo', children=[
+    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[
+        Include('qux')
+    ], children=[
     Grouping('g1', children=[
         Leaf('l1', type_=Type('string')),
         Leaf('l2', type_=Type('string'))
@@ -2692,16 +2807,25 @@ def src_schema():
         ])
     ])
 ])
+    res["qux"] = Submodule('qux', yang_version=1.1, belongs_to=BelongsTo('foo', prefix='f'), augment=[
+        Augment('/f:c1', children=[
+            Leaf('l4', type_=Type('string'))
+        ])
+    ], children=[
+    Container('c2', children=[
+        Leaf('l1', type_=Type('string'))
+    ])
+])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='foo')
+        Import('foo', prefix='f')
     ], augment=[
-        Augment('/foo:c1', children=[
-            Uses('foo:g1')
+        Augment('/f:c1', children=[
+            Uses('f:g1')
         ]),
-        Augment('/foo:c.dot', children=[
+        Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/foo:conflict', children=[
+        Augment('/f:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ])
@@ -2714,7 +2838,11 @@ def src_schema():
 
 def src_schema_compiled():
     res = {}
-    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='foo', children=[
+    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', augment=[
+        Augment('/f:c1', children=[
+            Leaf('l4', type_=Type('string'))
+        ])
+    ], children=[
     Grouping('g1', children=[
         Leaf('l1', type_=Type('string')),
         Leaf('l2', type_=Type('string'))
@@ -2729,6 +2857,7 @@ def src_schema_compiled():
         ]),
         LeafList('ll_uint64', type_=Type('uint64')),
         LeafList('ll_str', type_=Type('string')),
+        Leaf('l4', type_=Type('string')),
         Leaf('l1', type_=Type('string')),
         Leaf('l2', type_=Type('string'))
     ]),
@@ -2798,18 +2927,21 @@ def src_schema_compiled():
             Leaf('l1', type_=Type('string')),
             Leaf('l2', type_=Type('string'))
         ])
+    ]),
+    Container('c2', children=[
+        Leaf('l1', type_=Type('string'))
     ])
 ])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='foo')
+        Import('foo', prefix='f')
     ], augment=[
-        Augment('/foo:c1', children=[
-            Uses('foo:g1')
+        Augment('/f:c1', children=[
+            Uses('f:g1')
         ]),
-        Augment('/foo:c.dot', children=[
+        Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/foo:conflict', children=[
+        Augment('/f:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ])

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -8,7 +8,7 @@ import yang.gdata
 # == This file is generated ==
 
 
-mut def from_json_foo__c1__foo_l1(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__c1__f_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__c1__l3(val: value) -> yang.gdata.Leaf:
@@ -185,6 +185,9 @@ mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
 mut def from_json_foo__c1__ll_str(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList(val)
 
+mut def from_json_foo__c1__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__bar_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -192,31 +195,33 @@ mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1(yang.adata.MNode):
-    foo_l1: ?str
+    f_l1: ?str
     l3: ?int
     l_empty: ?bool
     li: foo__c1__li
     ll_uint64: list[int]
     ll_str: list[str]
+    l4: ?str
     bar_l1: ?str
     l2: ?str
 
-    mut def __init__(self, foo_l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[int]=None, ll_str: ?list[str]=None, bar_l1: ?str, l2: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[int]=None, ll_str: ?list[str]=None, l4: ?str, bar_l1: ?str, l2: ?str):
         self._ns = 'http://example.com/foo'
-        self.foo_l1 = foo_l1
+        self.f_l1 = f_l1
         self.l3 = l3
         self.l_empty = l_empty
         self.li = foo__c1__li(elements=li)
         self.ll_uint64 = ll_uint64 if ll_uint64 is not None else []
         self.ll_str = ll_str if ll_str is not None else []
+        self.l4 = l4
         self.bar_l1 = bar_l1
         self.l2 = l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_l1 = self.foo_l1
-        if _foo_l1 is not None:
-            children['foo:l1'] = yang.gdata.Leaf('string', _foo_l1)
+        _f_l1 = self.f_l1
+        if _f_l1 is not None:
+            children['f:l1'] = yang.gdata.Leaf('string', _f_l1)
         _l3 = self.l3
         if _l3 is not None:
             children['l3'] = yang.gdata.Leaf('uint64', _l3)
@@ -228,6 +233,9 @@ class foo__c1(yang.adata.MNode):
             children['li'] = _li.to_gdata()
         children['ll_uint64'] = yang.gdata.LeafList(self.ll_uint64)
         children['ll_str'] = yang.gdata.LeafList(self.ll_str)
+        _l4 = self.l4
+        if _l4 is not None:
+            children['l4'] = yang.gdata.Leaf('string', _l4)
         _bar_l1 = self.bar_l1
         if _bar_l1 is not None:
             children['bar:l1'] = yang.gdata.Leaf('string', _bar_l1, ns='http://example.com/bar')
@@ -239,13 +247,13 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(foo_l1=n.get_opt_str('foo:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
+            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__c1:
         if n != None:
-            return foo__c1(foo_l1=yang.gdata.from_xml_opt_str(n, 'l1'), l3=yang.gdata.from_xml_opt_int(n, 'l3'), l_empty=yang.gdata.from_xml_opt_bool(n, 'l_empty'), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, 'li')), ll_uint64=yang.gdata.from_xml_opt_ints(n, 'll_uint64'), ll_str=yang.gdata.from_xml_opt_strs(n, 'll_str'), bar_l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
+            return foo__c1(f_l1=yang.gdata.from_xml_opt_str(n, 'l1'), l3=yang.gdata.from_xml_opt_int(n, 'l3'), l_empty=yang.gdata.from_xml_opt_bool(n, 'l_empty'), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, 'li')), ll_uint64=yang.gdata.from_xml_opt_ints(n, 'll_uint64'), ll_str=yang.gdata.from_xml_opt_strs(n, 'll_str'), l4=yang.gdata.from_xml_opt_str(n, 'l4'), bar_l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
         return foo__c1()
 
 
@@ -267,6 +275,8 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
             raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:ll_str' or point == 'll_str':
             raise ValueError("Invalid json path to non-inner node")
+        if point == 'foo:l4' or point == 'l4':
+            raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l2':
@@ -282,10 +292,10 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_l1_full = jd.get('foo:l1')
-    child_foo_l1 = child_foo_l1_full if child_foo_l1_full is not None else jd.get('l1')
-    if child_foo_l1 is not None:
-        children['foo:l1'] = from_json_foo__c1__foo_l1(child_foo_l1)
+    child_f_l1_full = jd.get('foo:l1')
+    child_f_l1 = child_f_l1_full if child_f_l1_full is not None else jd.get('l1')
+    if child_f_l1 is not None:
+        children['f:l1'] = from_json_foo__c1__f_l1(child_f_l1)
     child_l3_full = jd.get('foo:l3')
     child_l3 = child_l3_full if child_l3_full is not None else jd.get('l3')
     if child_l3 is not None:
@@ -306,6 +316,10 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_ll_str = child_ll_str_full if child_ll_str_full is not None else jd.get('ll_str')
     if child_ll_str is not None and isinstance(child_ll_str, list):
         children['ll_str'] = from_json_foo__c1__ll_str(child_ll_str)
+    child_l4_full = jd.get('foo:l4')
+    child_l4 = child_l4_full if child_l4_full is not None else jd.get('l4')
+    if child_l4 is not None:
+        children['l4'] = from_json_foo__c1__l4(child_l4)
     child_bar_l1 = jd.get('bar:l1')
     if child_bar_l1 is not None:
         children['bar:l1'] = from_json_foo__c1__bar_l1(child_bar_l1)
@@ -316,10 +330,10 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
 
 mut def to_json_foo__c1(n: yang.gdata.Node) -> dict[str, ?value]:
     children = {}
-    child_foo_l1 = n.children.get('foo:l1')
-    if child_foo_l1 is not None:
-        if isinstance(child_foo_l1, yang.gdata.Leaf):
-            children['l1'] = child_foo_l1.val
+    child_f_l1 = n.children.get('f:l1')
+    if child_f_l1 is not None:
+        if isinstance(child_f_l1, yang.gdata.Leaf):
+            children['l1'] = child_f_l1.val
     child_l3 = n.children.get('l3')
     if child_l3 is not None:
         if isinstance(child_l3, yang.gdata.Leaf):
@@ -340,6 +354,10 @@ mut def to_json_foo__c1(n: yang.gdata.Node) -> dict[str, ?value]:
     if child_ll_str is not None:
         if isinstance(child_ll_str, yang.gdata.LeafList):
             children['ll_str'] = child_ll_str.vals
+    child_l4 = n.children.get('l4')
+    if child_l4 is not None:
+        if isinstance(child_l4, yang.gdata.Leaf):
+            children['l4'] = child_l4.val
     child_bar_l1 = n.children.get('bar:l1')
     if child_bar_l1 is not None:
         if isinstance(child_bar_l1, yang.gdata.Leaf):
@@ -938,10 +956,10 @@ mut def to_json_foo__cc(n: yang.gdata.Node) -> dict[str, ?value]:
             children['death'] = to_json_foo__cc__death(child_death)
     return children
 
-mut def from_json_foo__conflict__foo_foo(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class foo__conflict__foo_inner(yang.adata.MNode):
+class foo__conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = 'http://example.com/foo'
@@ -952,19 +970,19 @@ class foo__conflict__foo_inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__foo_inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__f_inner:
         if n != None:
-            return foo__conflict__foo_inner()
+            return foo__conflict__f_inner()
         return None
 
     @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__foo_inner:
+    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__f_inner:
         if n != None:
-            return foo__conflict__foo_inner()
+            return foo__conflict__f_inner()
         return None
 
 
-mut def from_json_path_foo__conflict__foo_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -972,17 +990,17 @@ mut def from_json_path_foo__conflict__foo_inner(jd: value, path: list[str]=[], o
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__foo_inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__conflict__f_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__foo_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-mut def to_json_foo__conflict__foo_inner(n: yang.gdata.Node) -> dict[str, ?value]:
+mut def to_json_foo__conflict__f_inner(n: yang.gdata.Node) -> dict[str, ?value]:
     children = {}
     return children
 
@@ -1035,21 +1053,21 @@ mut def to_json_foo__conflict__bar_inner(n: yang.gdata.Node) -> dict[str, ?value
     return children
 
 class foo__conflict(yang.adata.MNode):
-    foo_foo: ?str
-    foo_inner: ?foo__conflict__foo_inner
+    f_foo: ?str
+    f_inner: ?foo__conflict__f_inner
     bar_foo: ?str
     bar_inner: ?foo__conflict__bar_inner
 
-    mut def __init__(self, foo_foo: ?str, foo_inner: ?foo__conflict__foo_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
+    mut def __init__(self, f_foo: ?str, f_inner: ?foo__conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
         self._ns = 'http://example.com/foo'
-        self.foo_foo = foo_foo
-        self.foo_inner = foo_inner
+        self.f_foo = f_foo
+        self.f_inner = f_inner
         self.bar_foo = bar_foo
         self.bar_inner = bar_inner
 
-    mut def create_foo_inner(self):
-        res = foo__conflict__foo_inner()
-        self.foo_inner = res
+    mut def create_f_inner(self):
+        res = foo__conflict__f_inner()
+        self.f_inner = res
         return res
 
     mut def create_bar_inner(self):
@@ -1059,12 +1077,12 @@ class foo__conflict(yang.adata.MNode):
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _foo_foo = self.foo_foo
-        if _foo_foo is not None:
-            children['foo:foo'] = yang.gdata.Leaf('string', _foo_foo)
-        _foo_inner = self.foo_inner
-        if _foo_inner is not None:
-            children['foo:inner'] = _foo_inner.to_gdata()
+        _f_foo = self.f_foo
+        if _f_foo is not None:
+            children['f:foo'] = yang.gdata.Leaf('string', _f_foo)
+        _f_inner = self.f_inner
+        if _f_inner is not None:
+            children['f:inner'] = _f_inner.to_gdata()
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
             children['bar:foo'] = yang.gdata.Leaf('string', _bar_foo, ns='http://example.com/bar')
@@ -1076,13 +1094,13 @@ class foo__conflict(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=n.get_opt_str('foo:foo'), foo_inner=foo__conflict__foo_inner.from_gdata(n.get_opt_container('foo:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
+            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
         return foo__conflict()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(foo_foo=yang.gdata.from_xml_opt_str(n, 'foo'), foo_inner=foo__conflict__foo_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
+            return foo__conflict(f_foo=yang.gdata.from_xml_opt_str(n, 'foo'), f_inner=foo__conflict__f_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
         return foo__conflict()
 
 
@@ -1094,7 +1112,7 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
         if point == 'foo:foo' or point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:inner' or point == 'inner':
-            child = {'inner': from_json_path_foo__conflict__foo_inner(jd, rest_path, op) }
+            child = {'inner': from_json_path_foo__conflict__f_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:foo':
             raise ValueError("Invalid json path to non-inner node")
@@ -1112,14 +1130,14 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_foo_full = jd.get('foo:foo')
-    child_foo_foo = child_foo_foo_full if child_foo_foo_full is not None else jd.get('foo')
-    if child_foo_foo is not None:
-        children['foo:foo'] = from_json_foo__conflict__foo_foo(child_foo_foo)
-    child_foo_inner_full = jd.get('foo:inner')
-    child_foo_inner = child_foo_inner_full if child_foo_inner_full is not None else jd.get('inner')
-    if child_foo_inner is not None and isinstance(child_foo_inner, dict):
-        children['foo:inner'] = from_json_foo__conflict__foo_inner(child_foo_inner)
+    child_f_foo_full = jd.get('foo:foo')
+    child_f_foo = child_f_foo_full if child_f_foo_full is not None else jd.get('foo')
+    if child_f_foo is not None:
+        children['f:foo'] = from_json_foo__conflict__f_foo(child_f_foo)
+    child_f_inner_full = jd.get('foo:inner')
+    child_f_inner = child_f_inner_full if child_f_inner_full is not None else jd.get('inner')
+    if child_f_inner is not None and isinstance(child_f_inner, dict):
+        children['f:inner'] = from_json_foo__conflict__f_inner(child_f_inner)
     child_bar_foo = jd.get('bar:foo')
     if child_bar_foo is not None:
         children['bar:foo'] = from_json_foo__conflict__bar_foo(child_bar_foo)
@@ -1130,14 +1148,14 @@ mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
 
 mut def to_json_foo__conflict(n: yang.gdata.Node) -> dict[str, ?value]:
     children = {}
-    child_foo_foo = n.children.get('foo:foo')
-    if child_foo_foo is not None:
-        if isinstance(child_foo_foo, yang.gdata.Leaf):
-            children['foo'] = child_foo_foo.val
-    child_foo_inner = n.children.get('foo:inner')
-    if child_foo_inner is not None:
-        if isinstance(child_foo_inner, yang.gdata.Container):
-            children['inner'] = to_json_foo__conflict__foo_inner(child_foo_inner)
+    child_f_foo = n.children.get('f:foo')
+    if child_f_foo is not None:
+        if isinstance(child_f_foo, yang.gdata.Leaf):
+            children['foo'] = child_f_foo.val
+    child_f_inner = n.children.get('f:inner')
+    if child_f_inner is not None:
+        if isinstance(child_f_inner, yang.gdata.Container):
+            children['inner'] = to_json_foo__conflict__f_inner(child_f_inner)
     child_bar_foo = n.children.get('bar:foo')
     if child_bar_foo is not None:
         if isinstance(child_bar_foo, yang.gdata.Leaf):
@@ -2122,6 +2140,68 @@ mut def to_json_foo__state(n: yang.gdata.Node) -> dict[str, ?value]:
             children['c1'] = to_json_foo__state__c1(child_c1)
     return children
 
+mut def from_json_foo__c2__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class foo__c2(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = 'http://example.com/foo'
+        self.l1 = l1
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l1 = self.l1
+        if _l1 is not None:
+            children['l1'] = yang.gdata.Leaf('string', _l1)
+        return yang.gdata.Container(children, ns='http://example.com/foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c2:
+        if n != None:
+            return foo__c2(l1=n.get_opt_str('l1'))
+        return foo__c2()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> foo__c2:
+        if n != None:
+            return foo__c2(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
+        return foo__c2()
+
+
+mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:l1' or point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__c2(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l1_full = jd.get('foo:l1')
+    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    if child_l1 is not None:
+        children['l1'] = from_json_foo__c2__l1(child_l1)
+    return yang.gdata.Container(children)
+
+mut def to_json_foo__c2(n: yang.gdata.Node) -> dict[str, ?value]:
+    children = {}
+    child_l1 = n.children.get('l1')
+    if child_l1 is not None:
+        if isinstance(child_l1, yang.gdata.Leaf):
+            children['l1'] = child_l1.val
+    return children
+
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -2191,14 +2271,15 @@ class root(yang.adata.MNode):
     empty_presence: ?foo__empty_presence
     c_dot: foo__c_dot
     cc: foo__cc
-    foo_conflict: foo__conflict
+    f_conflict: foo__conflict
     special: foo__special
     nested: foo__nested
     li_union: foo__li_union
     state: foo__state
+    c2: foo__c2
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, foo_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -2206,11 +2287,12 @@ class root(yang.adata.MNode):
         self.empty_presence = empty_presence
         self.c_dot = c_dot if c_dot is not None else foo__c_dot()
         self.cc = cc if cc is not None else foo__cc()
-        self.foo_conflict = foo_conflict if foo_conflict is not None else foo__conflict()
+        self.f_conflict = f_conflict if f_conflict is not None else foo__conflict()
         self.special = foo__special(elements=special)
         self.nested = nested if nested is not None else foo__nested()
         self.li_union = foo__li_union(elements=li_union)
         self.state = state if state is not None else foo__state()
+        self.c2 = c2 if c2 is not None else foo__c2()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
 
     mut def create_pc1(self):
@@ -2248,9 +2330,9 @@ class root(yang.adata.MNode):
         _cc = self.cc
         if _cc is not None:
             children['cc'] = _cc.to_gdata()
-        _foo_conflict = self.foo_conflict
-        if _foo_conflict is not None:
-            children['foo:conflict'] = _foo_conflict.to_gdata()
+        _f_conflict = self.f_conflict
+        if _f_conflict is not None:
+            children['f:conflict'] = _f_conflict.to_gdata()
         _special = self.special
         if _special is not None:
             children['special'] = _special.to_gdata()
@@ -2263,6 +2345,9 @@ class root(yang.adata.MNode):
         _state = self.state
         if _state is not None:
             children['state'] = _state.to_gdata()
+        _c2 = self.c2
+        if _c2 is not None:
+            children['c2'] = _c2.to_gdata()
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
             children['bar:conflict'] = _bar_conflict.to_gdata()
@@ -2271,13 +2356,13 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), foo_conflict=foo__conflict.from_gdata(n.get_opt_container('foo:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_container('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), c2=foo__c2.from_gdata(n.get_opt_container('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
         return root()
 
     @staticmethod
     mut def from_xml(n: ?xml.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), foo_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
+            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), f_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
         return root()
 
 
@@ -2319,6 +2404,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         if point == 'foo:state':
             child = {'state': from_json_path_foo__state(jd, rest_path, op) }
             return yang.gdata.Container(child)
+        if point == 'foo:c2':
+            child = {'c2': from_json_path_foo__c2(jd, rest_path, op) }
+            return yang.gdata.Container(child)
         if point == 'bar:conflict':
             child = {'conflict': from_json_path_bar__conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
@@ -2351,9 +2439,9 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_cc = jd.get('foo:cc')
     if child_cc is not None and isinstance(child_cc, dict):
         children['cc'] = from_json_foo__cc(child_cc)
-    child_foo_conflict = jd.get('foo:conflict')
-    if child_foo_conflict is not None and isinstance(child_foo_conflict, dict):
-        children['foo:conflict'] = from_json_foo__conflict(child_foo_conflict)
+    child_f_conflict = jd.get('foo:conflict')
+    if child_f_conflict is not None and isinstance(child_f_conflict, dict):
+        children['f:conflict'] = from_json_foo__conflict(child_f_conflict)
     child_special = jd.get('foo:special')
     if child_special is not None and isinstance(child_special, list):
         children['special'] = from_json_foo__special(child_special)
@@ -2366,6 +2454,9 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_state = jd.get('foo:state')
     if child_state is not None and isinstance(child_state, dict):
         children['state'] = from_json_foo__state(child_state)
+    child_c2 = jd.get('foo:c2')
+    if child_c2 is not None and isinstance(child_c2, dict):
+        children['c2'] = from_json_foo__c2(child_c2)
     child_bar_conflict = jd.get('bar:conflict')
     if child_bar_conflict is not None and isinstance(child_bar_conflict, dict):
         children['bar:conflict'] = from_json_bar__conflict(child_bar_conflict)
@@ -2397,10 +2488,10 @@ mut def to_json(n: yang.gdata.Node) -> dict[str, ?value]:
     if child_cc is not None:
         if isinstance(child_cc, yang.gdata.Container):
             children['foo:cc'] = to_json_foo__cc(child_cc)
-    child_foo_conflict = n.children.get('foo:conflict')
-    if child_foo_conflict is not None:
-        if isinstance(child_foo_conflict, yang.gdata.Container):
-            children['foo:conflict'] = to_json_foo__conflict(child_foo_conflict)
+    child_f_conflict = n.children.get('f:conflict')
+    if child_f_conflict is not None:
+        if isinstance(child_f_conflict, yang.gdata.Container):
+            children['foo:conflict'] = to_json_foo__conflict(child_f_conflict)
     child_special = n.children.get('special')
     if child_special is not None:
         if isinstance(child_special, yang.gdata.List):
@@ -2417,6 +2508,10 @@ mut def to_json(n: yang.gdata.Node) -> dict[str, ?value]:
     if child_state is not None:
         if isinstance(child_state, yang.gdata.Container):
             children['foo:state'] = to_json_foo__state(child_state)
+    child_c2 = n.children.get('c2')
+    if child_c2 is not None:
+        if isinstance(child_c2, yang.gdata.Container):
+            children['foo:c2'] = to_json_foo__c2(child_c2)
     child_bar_conflict = n.children.get('bar:conflict')
     if child_bar_conflict is not None:
         if isinstance(child_bar_conflict, yang.gdata.Container):
@@ -2432,7 +2527,8 @@ def src_yang():
     res.append("""module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
-    prefix "foo";
+    prefix "f";
+    include qux;
     grouping g1 {
         leaf l1 {
             type string;
@@ -2578,18 +2674,35 @@ def src_yang():
         }
     }
 }""")
+    res.append("""submodule qux {
+    yang-version "1.1";
+    belongs-to foo {
+        prefix "f";
+    }
+    // Must not conflict with /f:c1
+    container c2 {
+        leaf l1 {
+            type string;
+        }
+    }
+    augment /f:c1 {
+        leaf l4 {
+            type string;
+        }
+    }
+}""")
     res.append("""module bar {
     yang-version "1.1";
     namespace "http://example.com/bar";
     prefix "bar";
     import foo {
-        prefix "foo";
+        prefix "f";
     }
-    augment /foo:c1 {
-        // create a conflict with /foo:c1/l1
-        uses foo:g1;
+    augment /f:c1 {
+        // create a conflict with /f:c1/l1
+        uses f:g1;
     }
-    augment /foo:c.dot {
+    augment /f:c.dot {
         leaf l.dot2 {
             type string;
         }
@@ -2599,7 +2712,7 @@ def src_yang():
             type string;
         }
     }
-    augment /foo:conflict {
+    augment /f:conflict {
         leaf foo {
             type string;
         }
@@ -2612,7 +2725,9 @@ def src_yang():
 
 def src_schema():
     res = {}
-    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='foo', children=[
+    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[
+        Include('qux')
+    ], children=[
     Grouping('g1', children=[
         Leaf('l1', type_=Type('string')),
         Leaf('l2', type_=Type('string'))
@@ -2692,16 +2807,25 @@ def src_schema():
         ])
     ])
 ])
+    res["qux"] = Submodule('qux', yang_version=1.1, belongs_to=BelongsTo('foo', prefix='f'), augment=[
+        Augment('/f:c1', children=[
+            Leaf('l4', type_=Type('string'))
+        ])
+    ], children=[
+    Container('c2', children=[
+        Leaf('l1', type_=Type('string'))
+    ])
+])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='foo')
+        Import('foo', prefix='f')
     ], augment=[
-        Augment('/foo:c1', children=[
-            Uses('foo:g1')
+        Augment('/f:c1', children=[
+            Uses('f:g1')
         ]),
-        Augment('/foo:c.dot', children=[
+        Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/foo:conflict', children=[
+        Augment('/f:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ])
@@ -2714,7 +2838,11 @@ def src_schema():
 
 def src_schema_compiled():
     res = {}
-    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='foo', children=[
+    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', augment=[
+        Augment('/f:c1', children=[
+            Leaf('l4', type_=Type('string'))
+        ])
+    ], children=[
     Grouping('g1', children=[
         Leaf('l1', type_=Type('string')),
         Leaf('l2', type_=Type('string'))
@@ -2729,6 +2857,7 @@ def src_schema_compiled():
         ]),
         LeafList('ll_uint64', type_=Type('uint64')),
         LeafList('ll_str', type_=Type('string')),
+        Leaf('l4', type_=Type('string')),
         Leaf('l1', type_=Type('string')),
         Leaf('l2', type_=Type('string'))
     ]),
@@ -2798,18 +2927,21 @@ def src_schema_compiled():
             Leaf('l1', type_=Type('string')),
             Leaf('l2', type_=Type('string'))
         ])
+    ]),
+    Container('c2', children=[
+        Leaf('l1', type_=Type('string'))
     ])
 ])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='foo')
+        Import('foo', prefix='f')
     ], augment=[
-        Augment('/foo:c1', children=[
-            Uses('foo:g1')
+        Augment('/f:c1', children=[
+            Uses('f:g1')
         ]),
-        Augment('/foo:c.dot', children=[
+        Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/foo:conflict', children=[
+        Augment('/f:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ])

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -409,7 +409,7 @@ def src_yang():
     res.append("""module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
-    prefix "foo";
+    prefix "f";
     container tc1 {
         leaf l1 {
             type string;
@@ -440,7 +440,7 @@ def src_yang():
 
 def src_schema():
     res = {}
-    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='foo', children=[
+    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', children=[
     Container('tc1', children=[
         Leaf('l1', type_=Type('string'), mandatory=True),
         Leaf('l2', type_=Type('string'))
@@ -457,7 +457,7 @@ def src_schema():
 
 def src_schema_compiled():
     res = {}
-    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='foo', children=[
+    res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', children=[
     Container('tc1', children=[
         Leaf('l1', type_=Type('string'), mandatory=True),
         Leaf('l2', type_=Type('string'))

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
@@ -1,6 +1,5 @@
 Container({
   'c1': Container({
-    'foo:l1': Leaf(foo-foo),
     'li': List(['name']),
     'll_uint64': LeafList([]),
     'll_str': LeafList([]),
@@ -11,7 +10,7 @@ Container({
   'cc': Container({
     'death': List(['name'])
   }, ns='http://example.com/foo'),
-  'foo:conflict': Container(ns='http://example.com/foo'),
+  'f:conflict': Container(ns='http://example.com/foo'),
   'special': List(['yes'], ns='http://example.com/foo'),
   'nested': Container({
     'inner': Container({
@@ -22,5 +21,6 @@ Container({
   'state': Container({
     'c1': Container()
   }, ns='http://example.com/foo'),
+  'c2': Container(ns='http://example.com/foo'),
   'bar:conflict': Container(ns='http://example.com/bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
@@ -8,7 +8,7 @@ Container({
   'cc': Container({
     'death': List(['name'])
   }, ns='http://example.com/foo'),
-  'foo:conflict': Container(ns='http://example.com/foo'),
+  'f:conflict': Container(ns='http://example.com/foo'),
   'special': List(['yes'], ns='http://example.com/foo'),
   'nested': Container({
     'inner': Container({
@@ -19,5 +19,6 @@ Container({
   'state': Container({
     'c1': Container()
   }, ns='http://example.com/foo'),
+  'c2': Container(ns='http://example.com/foo'),
   'bar:conflict': Container(ns='http://example.com/bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -1,6 +1,6 @@
 Container({
   'c1': Container({
-    'foo:l1': Leaf(foo-foo),
+    'f:l1': Leaf(foo-foo),
     'l3': Leaf(18446744073709551615),
     'li': List(['name'], elements=[
       Container({
@@ -10,6 +10,7 @@ Container({
     ]),
     'll_uint64': LeafList([4, 42]),
     'll_str': LeafList(['kava', 'čaj']),
+    'l4': Leaf(foo-qux),
     'bar:l1': Leaf(foo-bar, ns='http://example.com/bar'),
     'l2': Leaf(bar, ns='http://example.com/bar')
   }, ns='http://example.com/foo'),
@@ -30,9 +31,9 @@ Container({
     'cake': Leaf(cake),
     'death': List(['name'])
   }, ns='http://example.com/foo'),
-  'foo:conflict': Container({
-    'foo:foo': Leaf(foo-foo),
-    'foo:inner': Container(presence=True),
+  'f:conflict': Container({
+    'f:foo': Leaf(foo-foo),
+    'f:inner': Container(presence=True),
     'bar:foo': Leaf(foo-augmented-from-bar, ns='http://example.com/bar'),
     'bar:inner': Container(presence=True, ns='http://example.com/bar')
   }, ns='http://example.com/foo'),
@@ -65,6 +66,9 @@ Container({
   ]),
   'state': Container({
     'c1': Container()
+  }, ns='http://example.com/foo'),
+  'c2': Container({
+    'l1': Leaf(foo-qux)
   }, ns='http://example.com/foo'),
   'bar:conflict': Container({
     'foo': Leaf(foo-bar)

--- a/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
@@ -1,6 +1,6 @@
 Container({
   'c1': Container({
-    'foo:l1': Leaf(foo-foo),
+    'f:l1': Leaf(foo-foo),
     'l3': Leaf(123),
     'li': List(['name'], elements=[
       Container({

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -43,7 +43,7 @@ def yang_to_act(wfcap: file.WriteFileCap, yangs: list[str], filename: str, loose
 ys_one = """module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
-    prefix "foo";
+    prefix "f";
     container tc1 {
         leaf l1 {
             type string;
@@ -74,7 +74,8 @@ ys_one = """module foo {
 ys_foo = """module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
-    prefix "foo";
+    prefix "f";
+    include qux;
     grouping g1 {
         leaf l1 {
             type string;
@@ -226,13 +227,13 @@ ys_bar = """module bar {
     namespace "http://example.com/bar";
     prefix "bar";
     import foo {
-        prefix "foo";
+        prefix "f";
     }
-    augment /foo:c1 {
-        // create a conflict with /foo:c1/l1
-        uses foo:g1;
+    augment /f:c1 {
+        // create a conflict with /f:c1/l1
+        uses f:g1;
     }
-    augment /foo:c.dot {
+    augment /f:c.dot {
         leaf l.dot2 {
             type string;
         }
@@ -242,12 +243,30 @@ ys_bar = """module bar {
             type string;
         }
     }
-    augment /foo:conflict {
+    augment /f:conflict {
         leaf foo {
             type string;
         }
         container inner {
             presence "inner presence from bar";
+        }
+    }
+}"""
+
+ys_qux = """submodule qux {
+    yang-version "1.1";
+    belongs-to foo {
+        prefix "f";
+    }
+    // Must not conflict with /f:c1
+    container c2 {
+        leaf l1 {
+            type string;
+        }
+    }
+    augment /f:c1 {
+        leaf l4 {
+            type string;
         }
     }
 }"""
@@ -317,7 +336,7 @@ ys_basics = """module basics {
 actor main(env: Env):
     wfcap = file.WriteFileCap(file.FileCap(env.cap))
     yang_to_act(wfcap, yangs=[ys_one], filename="../test_data_classes/src/yang_one.act")
-    yang_to_act(wfcap, yangs=[ys_foo, ys_bar], filename="../test_data_classes/src/yang_foo.act")
-    yang_to_act(wfcap, yangs=[ys_foo, ys_bar], filename="../test_data_classes/src/yang_foo_loose.act", loose=True)
+    yang_to_act(wfcap, yangs=[ys_foo, ys_qux, ys_bar], filename="../test_data_classes/src/yang_foo.act")
+    yang_to_act(wfcap, yangs=[ys_foo, ys_qux, ys_bar], filename="../test_data_classes/src/yang_foo_loose.act", loose=True)
     yang_to_act(wfcap, yangs=[ys_basics], filename="../test_data_classes/src/yang_basics.act")
     env.exit(0)


### PR DESCRIPTION
As per https://datatracker.ietf.org/doc/html/rfc7951#section-4, we must use the
module name, not prefix!

To that end, I added a new `SchemaNode.mod` attribute (to avoid conflicting with YANG *module* attribute and `DNode.module` that are adjacent to existing `namespace` and `prefix` attributes.