### PR TITLE
Unique child gdata names in from_json_path_*

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -721,16 +721,16 @@ class DNodeInner(DNode):
                 res += ["        point = path[1]"]
                 res += ["        rest_path = path[2:]"]
                 res += ["        children: dict[str, yang.gdata.Node] = {}"]
-                res += [f"        for idx, key in enumerate({repr(self.key)}):"]
-                res += ["            children[key] = yang.gdata.Leaf(\"str\", keys[idx])"]
                 for child in self.children:
-                    if child.name in self.key:
-                        continue
-                    res += [f"        if point == '{child.name}':"]
-                    if isinstance(child, DNodeInner):
-                        res += [f"            children['{child.name}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
-                    else:
-                        res += ["            raise ValueError(\"Invalid json path to non-inner node\")"]
+                    try:
+                        idx = self.key.index(child.name)
+                        res += [f"        children['{uname(child)}'] = from_json_{pname(child)}(keys[{idx}])"]
+                    except KeyError:
+                        res += [f"        if point == '{child.name}':"]
+                        if isinstance(child, DNodeInner):
+                            res += [f"            children['{uname(child)}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
+                        else:
+                            res += ["            raise ValueError(\"Invalid json path to non-inner node\")"]
                 res += ["        return yang.gdata.Container(children, keys)"]
                 res += ["    raise ValueError(\"unreachable - no keys to list element\")"]
                 res += [""]

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -717,16 +717,16 @@ class DNodeInner(DNode):
                 res += ["        point = path[1]"]
                 res += ["        rest_path = path[2:]"]
                 res += ["        children: dict[str, yang.gdata.Node] = {}"]
-                res += [f"        for idx, key in enumerate({repr(self.key)}):"]
-                res += ["            children[key] = yang.gdata.Leaf(\"str\", keys[idx])"]
                 for child in self.children:
-                    if child.name in self.key:
-                        continue
-                    res += [f"        if point == '{child.name}':"]
-                    if isinstance(child, DNodeInner):
-                        res += [f"            children['{child.name}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
-                    else:
-                        res += ["            raise ValueError(\"Invalid json path to non-inner node\")"]
+                    try:
+                        idx = self.key.index(child.name)
+                        res += [f"        children['{uname(child)}'] = from_json_{pname(child)}(keys[{idx}])"]
+                    except KeyError:
+                        res += [f"        if point == '{child.name}':"]
+                        if isinstance(child, DNodeInner):
+                            res += [f"            children['{uname(child)}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
+                        else:
+                            res += ["            raise ValueError(\"Invalid json path to non-inner node\")"]
                 res += ["        return yang.gdata.Container(children, keys)"]
                 res += ["    raise ValueError(\"unreachable - no keys to list element\")"]
                 res += [""]

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -100,8 +100,7 @@ mut def from_json_path_foo__c1__things_element(jd: value, path: list[str]=[], op
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__c1__things__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -92,8 +92,7 @@ mut def from_json_path_bar__c1__li1_element(jd: value, path: list[str]=[], op: ?
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['l1']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['l1'] = from_json_bar__c1__li1__l1(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -92,8 +92,7 @@ mut def from_json_path_foo__c1__li1_element(jd: value, path: list[str]=[], op: ?
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['l1']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['l1'] = from_json_foo__c1__li1__l1(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -158,8 +158,7 @@ mut def from_json_path_foo__c__li_element(jd: value, path: list[str]=[], op: ?st
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__c__li__name(keys[0])
         if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar':

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -83,8 +83,7 @@ mut def from_json_path_base__c1__base_l1_element(jd: value, path: list[str]=[], 
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['k1']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['k1'] = from_json_base__c1__base_l1__k1(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 
@@ -227,8 +226,7 @@ mut def from_json_path_base__c1__foo_l1_element(jd: value, path: list[str]=[], o
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['k2']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['k2'] = from_json_base__c1__foo_l1__k2(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -83,8 +83,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__l1__name(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -91,8 +91,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -92,8 +92,7 @@ mut def from_json_path_foo__li1_element(jd: value, path: list[str]=[], op: ?str=
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['l1']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['l1'] = from_json_foo__li1__l1(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -167,8 +167,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar':

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -91,8 +91,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -155,8 +155,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'bar':
             children['bar'] = from_json_path_foo__l1__bar(jd, rest_path, op)
         return yang.gdata.Container(children, keys)

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -118,8 +118,8 @@ mut def from_json_path_foo__c1__l1_element(jd: value, path: list[str]=[], op: ?s
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['k1', 'k2']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['k1'] = from_json_foo__c1__l1__k1(keys[0])
+        children['k2'] = from_json_foo__c1__l1__k2(keys[1])
         if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -110,8 +110,7 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__c1__li__name(keys[0])
         if point == 'val':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)
@@ -822,8 +821,7 @@ mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op:
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__cc__death__name(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 
@@ -1251,8 +1249,7 @@ mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['yes']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['yes'] = from_json_foo__special__yes(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 
@@ -1423,8 +1420,8 @@ mut def from_json_path_foo__nested__inner__li1__li2_element(jd: value, path: lis
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['key1', 'key2']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['key1'] = from_json_foo__nested__inner__li1__li2__key1(keys[0])
+        children['key2'] = from_json_foo__nested__inner__li1__li2__key2(keys[1])
         if point == 'baz':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)
@@ -1592,8 +1589,7 @@ mut def from_json_path_foo__nested__inner__li1_element(jd: value, path: list[str
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__nested__inner__li1__name(keys[0])
         if point == 'bar':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'li2':
@@ -1925,8 +1921,9 @@ mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: 
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['k1', 'k2', 'k3']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['k1'] = from_json_foo__li_union__k1(keys[0])
+        children['k2'] = from_json_foo__li_union__k2(keys[1])
+        children['k3'] = from_json_foo__li_union__k3(keys[2])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -110,8 +110,7 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__c1__li__name(keys[0])
         if point == 'val':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)
@@ -822,8 +821,7 @@ mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op:
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__cc__death__name(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 
@@ -1251,8 +1249,7 @@ mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['yes']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['yes'] = from_json_foo__special__yes(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 
@@ -1423,8 +1420,8 @@ mut def from_json_path_foo__nested__inner__li1__li2_element(jd: value, path: lis
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['key1', 'key2']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['key1'] = from_json_foo__nested__inner__li1__li2__key1(keys[0])
+        children['key2'] = from_json_foo__nested__inner__li1__li2__key2(keys[1])
         if point == 'baz':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)
@@ -1592,8 +1589,7 @@ mut def from_json_path_foo__nested__inner__li1_element(jd: value, path: list[str
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__nested__inner__li1__name(keys[0])
         if point == 'bar':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'li2':
@@ -1925,8 +1921,9 @@ mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: 
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['k1', 'k2', 'k3']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['k1'] = from_json_foo__li_union__k1(keys[0])
+        children['k2'] = from_json_foo__li_union__k2(keys[1])
+        children['k3'] = from_json_foo__li_union__k3(keys[2])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -258,8 +258,7 @@ mut def from_json_path_foo__li_element(jd: value, path: list[str]=[], op: ?str='
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        for idx, key in enumerate(['name']):
-            children[key] = yang.gdata.Leaf("str", keys[idx])
+        children['name'] = from_json_foo__li__name(keys[0])
         if point == 'c1':
             children['c1'] = from_json_path_foo__li__c1(jd, rest_path, op)
         return yang.gdata.Container(children, keys)


### PR DESCRIPTION
Also use the generated `from_json_*()` function for constructing a correctly typed `yang.gdata.Leaf` for key values.