### PR TITLE
RESTCONF resource identifier rules

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -469,7 +469,7 @@ class DNodeInner(DNode):
         for child in self.children:
             if not isinstance(child, DLeafList):
                 res.append(f"        _{usname(child)} = self.{usname(child)}")
-            child_ns = ", ns='" + child.namespace + "'" if child.namespace != self.namespace else ""
+            child_ns = ", ns='" + child.namespace + "'" if top or child.namespace != self.namespace else ""
             if isinstance(child, DLeafList):
                 res.append(f"        children['{uname(child)}'] = yang.gdata.LeafList(self.{usname(child)}{child_ns})")
             else:
@@ -501,7 +501,7 @@ class DNodeInner(DNode):
         res.append("")
 #
         def _maybe_ns(child: DNode) -> str:
-            if child.namespace != self.namespace:
+            if top or child.namespace != self.namespace:
                 return f", '{child.namespace}'"
             return ""
 
@@ -743,7 +743,7 @@ class DNodeInner(DNode):
                 res.append("        point = path[0]")
                 res.append("        rest_path = path[1:]")
                 for child in self.children:
-                    if top == True or child.namespace != self.namespace:
+                    if top or child.namespace != self.namespace:
                         res.append(f"        if point == '{child.module}:{child.name}':")
                     else:
                         res.append(f"        if point == '{child.name}':")
@@ -777,7 +777,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                if top == True or child.namespace != self.namespace:
+                if top or child.namespace != self.namespace:
                     res.append(f"    child_{usname(child)} = jd.get('{child.module}:{child.name}')")
                 else:
                     res.append(f"    child_{usname(child)} = jd.get('{child.name}')")
@@ -842,7 +842,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                child_name = f"{child.module}:{child.name}" if child.namespace != self.namespace else child.name
+                child_name = f"{child.module}:{child.name}" if top or child.namespace != self.namespace else child.name
                 res.append(f"    child_{usname(child)} = n.children.get('{uname(child)}')")
                 res.append(f"    if child_{usname(child)} is not None:")
                 if isinstance(child, DLeaf):

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -698,7 +698,10 @@ class DNodeInner(DNode):
                         idx = self.key.index(child.name)
                         res += [f"        children['{uname(child)}'] = from_json_{pname(child)}(keys[{idx}])"]
                     except KeyError:
-                        res += [f"        if point == '{child.name}':"]
+                        if top or child.namespace != self.namespace:
+                            res += [f"        if point == '{child.module}:{child.name}':"]
+                        else:
+                            res += [f"        if point == '{child.name}':"]
                         if isinstance(child, DNodeInner):
                             res += [f"            children['{uname(child)}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
                         else:
@@ -743,7 +746,7 @@ class DNodeInner(DNode):
                     if top == True or child.namespace != self.namespace:
                         res.append(f"        if point == '{child.module}:{child.name}':")
                     else:
-                        res.append(f"        if point == '{child.module}:{child.name}' or point == '{child.name}':")
+                        res.append(f"        if point == '{child.name}':")
                     if isinstance(child, DNodeInner):
                         res += [nest(12) + f"child = {{'{child.name}': from_json_path_{pname(child)}(jd, rest_path, op) }}"]
                         res += [nest(12) + "return yang.gdata." + self.gname + "(child)"]
@@ -777,8 +780,7 @@ class DNodeInner(DNode):
                 if top == True or child.namespace != self.namespace:
                     res.append(f"    child_{usname(child)} = jd.get('{child.module}:{child.name}')")
                 else:
-                    res.append(f"    child_{usname(child)}_full = jd.get('{child.module}:{child.name}')")
-                    res.append(f"    child_{usname(child)} = child_{usname(child)}_full if child_{usname(child)}_full is not None else jd.get('{child.name}')")
+                    res.append(f"    child_{usname(child)} = jd.get('{child.name}')")
 
                 if isinstance(child, DContainer):
                     res.append(f"    if child_{usname(child)} is not None and isinstance(child_{usname(child)}, dict):")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -694,7 +694,10 @@ class DNodeInner(DNode):
                         idx = self.key.index(child.name)
                         res += [f"        children['{uname(child)}'] = from_json_{pname(child)}(keys[{idx}])"]
                     except KeyError:
-                        res += [f"        if point == '{child.name}':"]
+                        if top or child.namespace != self.namespace:
+                            res += [f"        if point == '{child.module}:{child.name}':"]
+                        else:
+                            res += [f"        if point == '{child.name}':"]
                         if isinstance(child, DNodeInner):
                             res += [f"            children['{uname(child)}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
                         else:
@@ -739,7 +742,7 @@ class DNodeInner(DNode):
                     if top == True or child.namespace != self.namespace:
                         res.append(f"        if point == '{child.module}:{child.name}':")
                     else:
-                        res.append(f"        if point == '{child.module}:{child.name}' or point == '{child.name}':")
+                        res.append(f"        if point == '{child.name}':")
                     if isinstance(child, DNodeInner):
                         res += [nest(12) + f"child = {{'{child.name}': from_json_path_{pname(child)}(jd, rest_path, op) }}"]
                         res += [nest(12) + "return yang.gdata." + self.gname + "(child)"]
@@ -773,8 +776,7 @@ class DNodeInner(DNode):
                 if top == True or child.namespace != self.namespace:
                     res.append(f"    child_{usname(child)} = jd.get('{child.module}:{child.name}')")
                 else:
-                    res.append(f"    child_{usname(child)}_full = jd.get('{child.module}:{child.name}')")
-                    res.append(f"    child_{usname(child)} = child_{usname(child)}_full if child_{usname(child)}_full is not None else jd.get('{child.name}')")
+                    res.append(f"    child_{usname(child)} = jd.get('{child.name}')")
 
                 if isinstance(child, DContainer):
                     res.append(f"    if child_{usname(child)} is not None and isinstance(child_{usname(child)}, dict):")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -465,7 +465,7 @@ class DNodeInner(DNode):
         for child in self.children:
             if not isinstance(child, DLeafList):
                 res.append(f"        _{usname(child)} = self.{usname(child)}")
-            child_ns = ", ns='" + child.namespace + "'" if child.namespace != self.namespace else ""
+            child_ns = ", ns='" + child.namespace + "'" if top or child.namespace != self.namespace else ""
             if isinstance(child, DLeafList):
                 res.append(f"        children['{uname(child)}'] = yang.gdata.LeafList(self.{usname(child)}{child_ns})")
             else:
@@ -497,7 +497,7 @@ class DNodeInner(DNode):
         res.append("")
 #
         def _maybe_ns(child: DNode) -> str:
-            if child.namespace != self.namespace:
+            if top or child.namespace != self.namespace:
                 return f", '{child.namespace}'"
             return ""
 
@@ -739,7 +739,7 @@ class DNodeInner(DNode):
                 res.append("        point = path[0]")
                 res.append("        rest_path = path[1:]")
                 for child in self.children:
-                    if top == True or child.namespace != self.namespace:
+                    if top or child.namespace != self.namespace:
                         res.append(f"        if point == '{child.module}:{child.name}':")
                     else:
                         res.append(f"        if point == '{child.name}':")
@@ -773,7 +773,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                if top == True or child.namespace != self.namespace:
+                if top or child.namespace != self.namespace:
                     res.append(f"    child_{usname(child)} = jd.get('{child.module}:{child.name}')")
                 else:
                     res.append(f"    child_{usname(child)} = jd.get('{child.name}')")
@@ -838,7 +838,7 @@ class DNodeInner(DNode):
 
             res.append("    children = {}")
             for child in self.children:
-                child_name = f"{child.module}:{child.name}" if child.namespace != self.namespace else child.name
+                child_name = f"{child.module}:{child.name}" if top or child.namespace != self.namespace else child.name
                 res.append(f"    child_{usname(child)} = n.children.get('{uname(child)}')")
                 res.append(f"    if child_{usname(child)} is not None:")
                 if isinstance(child, DLeaf):

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -50,9 +50,9 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -65,12 +65,10 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__c1__l2(child_l2)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -50,7 +50,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l2':
             raise ValueError("Invalid json path to non-inner node")
@@ -65,8 +65,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
     child_l2 = jd.get('bar:l2')

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -53,9 +53,9 @@ mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merg
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l3' or point == 'l3':
+        if point == 'l3':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -68,12 +68,10 @@ mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__c1__c2__l2(child_l2)
-    child_l3_full = jd.get('foo:l3')
-    child_l3 = child_l3_full if child_l3_full is not None else jd.get('l3')
+    child_l3 = jd.get('l3')
     if child_l3 is not None:
         children['l3'] = from_json_foo__c1__c2__l3(child_l3)
     return yang.gdata.Container(children)
@@ -127,9 +125,9 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:c2' or point == 'c2':
+        if point == 'c2':
             child = {'c2': from_json_path_foo__c1__c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -143,12 +141,10 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
-    child_c2_full = jd.get('foo:c2')
-    child_c2 = child_c2_full if child_c2_full is not None else jd.get('c2')
+    child_c2 = jd.get('c2')
     if child_c2 is not None and isinstance(child_c2, dict):
         children['c2'] = from_json_foo__c1__c2(child_c2)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -53,7 +53,7 @@ mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merg
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'bar:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'baz:l3':
             raise ValueError("Invalid json path to non-inner node")
@@ -68,8 +68,7 @@ mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l2_full = jd.get('bar:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__c1__c2__l2(child_l2)
     child_l3 = jd.get('baz:l3')
@@ -126,7 +125,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:c2':
             child = {'c2': from_json_path_foo__c1__c2(jd, rest_path, op) }
@@ -142,8 +141,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
     child_c2 = jd.get('bar:c2')

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -42,7 +42,7 @@ mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merg
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,8 +55,7 @@ mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__c1__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__c2__l1(child_l1)
     return yang.gdata.Container(children)
@@ -101,7 +100,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:c2' or point == 'c2':
+        if point == 'c2':
             child = {'c2': from_json_path_foo__c1__c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -115,8 +114,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_c2_full = jd.get('foo:c2')
-    child_c2 = child_c2_full if child_c2_full is not None else jd.get('c2')
+    child_c2 = jd.get('c2')
     if child_c2 is not None and isinstance(child_c2, dict):
         children['c2'] = from_json_foo__c1__c2(child_c2)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -50,7 +50,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l2':
             raise ValueError("Invalid json path to non-inner node")
@@ -65,8 +65,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
     child_l2 = jd.get('bar:l2')

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -133,12 +133,10 @@ mut def from_json_path_foo__c1__things(jd: value, path: list[str]=[], op: ?str='
 
 mut def from_json_foo__c1__things_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__c1__things__name(child_name)
-    child_id_full = jd.get('foo:id')
-    child_id = child_id_full if child_id_full is not None else jd.get('id')
+    child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__c1__things__id(child_id)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -200,7 +198,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:things' or point == 'things':
+        if point == 'things':
             child = {'things': from_json_path_foo__c1__things(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -214,8 +212,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_things_full = jd.get('foo:things')
-    child_things = child_things_full if child_things_full is not None else jd.get('things')
+    child_things = jd.get('things')
     if child_things is not None and isinstance(child_things, list):
         children['things'] = from_json_foo__c1__things(child_things)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -42,7 +42,7 @@ mut def from_json_path_acme_foo_bar__c1(jd: value, path: list[str]=[], op: ?str=
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'acme_foo-bar:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,8 +55,7 @@ mut def from_json_path_acme_foo_bar__c1(jd: value, path: list[str]=[], op: ?str=
 
 mut def from_json_acme_foo_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('acme_foo-bar:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_acme_foo_bar__c1__l1(child_l1)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -123,8 +123,7 @@ mut def from_json_path_bar__c1__li1(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_bar__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_l1_full = jd.get('bar:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_bar__c1__li1__l1(child_l1)
     return yang.gdata.Container(children, [str(child_l1 if child_l1 is not None else '')])
@@ -182,7 +181,7 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'bar:li1' or point == 'li1':
+        if point == 'li1':
             child = {'li1': from_json_path_bar__c1__li1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -196,8 +195,7 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_li1_full = jd.get('bar:li1')
-    child_li1 = child_li1_full if child_li1_full is not None else jd.get('li1')
+    child_li1 = jd.get('li1')
     if child_li1 is not None and isinstance(child_li1, list):
         children['li1'] = from_json_bar__c1__li1(child_li1)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -40,7 +40,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -53,8 +53,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None and isinstance(child_l1, list):
         children['l1'] = from_json_foo__c1__l1(child_l1)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -42,7 +42,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,8 +55,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
     return yang.gdata.Container(children)
@@ -104,7 +103,7 @@ mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -117,8 +116,7 @@ mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__c2__l2(child_l2)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -123,8 +123,7 @@ mut def from_json_path_foo__c1__li1(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_foo__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__li1__l1(child_l1)
     return yang.gdata.Container(children, [str(child_l1 if child_l1 is not None else '')])
@@ -182,7 +181,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:li1' or point == 'li1':
+        if point == 'li1':
             child = {'li1': from_json_path_foo__c1__li1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -196,8 +195,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_li1_full = jd.get('foo:li1')
-    child_li1 = child_li1_full if child_li1_full is not None else jd.get('li1')
+    child_li1 = jd.get('li1')
     if child_li1 is not None and isinstance(child_li1, list):
         children['li1'] = from_json_foo__c1__li1(child_li1)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -50,9 +50,9 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -65,12 +65,10 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__c1__l2(child_l2)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -39,7 +39,7 @@ mut def from_json_path_foo__c__li__bar(jd: value, path: list[str]=[], op: ?str='
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:man' or point == 'man':
+        if point == 'man':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -52,8 +52,7 @@ mut def from_json_path_foo__c__li__bar(jd: value, path: list[str]=[], op: ?str='
 
 mut def from_json_foo__c__li__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_man_full = jd.get('foo:man')
-    child_man = child_man_full if child_man_full is not None else jd.get('man')
+    child_man = jd.get('man')
     if child_man is not None:
         children['man'] = from_json_foo__c__li__bar__man(child_man)
     return yang.gdata.Container(children)
@@ -193,16 +192,13 @@ mut def from_json_path_foo__c__li(jd: value, path: list[str]=[], op: ?str='merge
 
 mut def from_json_foo__c__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__c__li__name(child_name)
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_foo__c__li__foo(child_foo)
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__c__li__bar(child_bar)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -114,8 +114,7 @@ mut def from_json_path_base__c1__base_l1(jd: value, path: list[str]=[], op: ?str
 
 mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_k1_full = jd.get('base:k1')
-    child_k1 = child_k1_full if child_k1_full is not None else jd.get('k1')
+    child_k1 = jd.get('k1')
     if child_k1 is not None:
         children['k1'] = from_json_base__c1__base_l1__k1(child_k1)
     return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else '')])
@@ -257,8 +256,7 @@ mut def from_json_path_base__c1__foo_l1(jd: value, path: list[str]=[], op: ?str=
 
 mut def from_json_base__c1__foo_l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_k2_full = jd.get('foo:k2')
-    child_k2 = child_k2_full if child_k2_full is not None else jd.get('k2')
+    child_k2 = jd.get('k2')
     if child_k2 is not None:
         children['k2'] = from_json_base__c1__foo_l1__k2(child_k2)
     return yang.gdata.Container(children, [str(child_k2 if child_k2 is not None else '')])
@@ -321,7 +319,7 @@ mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'base:l1' or point == 'l1':
+        if point == 'l1':
             child = {'l1': from_json_path_base__c1__base_l1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:l1':
@@ -338,8 +336,7 @@ mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_base_l1_full = jd.get('base:l1')
-    child_base_l1 = child_base_l1_full if child_base_l1_full is not None else jd.get('l1')
+    child_base_l1 = jd.get('l1')
     if child_base_l1 is not None and isinstance(child_base_l1, list):
         children['base:l1'] = from_json_base__c1__base_l1(child_base_l1)
     child_foo_l1 = jd.get('foo:l1')

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -33,7 +33,7 @@ mut def from_json_path_base__c1__base_c2(jd: value, path: list[str]=[], op: ?str
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'base:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -46,8 +46,7 @@ mut def from_json_path_base__c1__base_c2(jd: value, path: list[str]=[], op: ?str
 
 mut def from_json_base__c1__base_c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('base:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_base__c1__base_c2__foo(child_foo)
     return yang.gdata.Container(children)
@@ -95,7 +94,7 @@ mut def from_json_path_base__c1__foo_c2(jd: value, path: list[str]=[], op: ?str=
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -108,8 +107,7 @@ mut def from_json_path_base__c1__foo_c2(jd: value, path: list[str]=[], op: ?str=
 
 mut def from_json_base__c1__foo_c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_base__c1__foo_c2__foo(child_foo)
     return yang.gdata.Container(children)
@@ -159,7 +157,7 @@ mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'base:c2' or point == 'c2':
+        if point == 'c2':
             child = {'c2': from_json_path_base__c1__base_c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:c2':
@@ -176,8 +174,7 @@ mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_base_c2_full = jd.get('base:c2')
-    child_base_c2 = child_base_c2_full if child_base_c2_full is not None else jd.get('c2')
+    child_base_c2 = jd.get('c2')
     if child_base_c2 is not None and isinstance(child_base_c2, dict):
         children['base:c2'] = from_json_base__c1__base_c2(child_base_c2)
     child_foo_c2 = jd.get('foo:c2')

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -42,7 +42,7 @@ mut def from_json_path_foo__ieee_802_3(jd: value, path: list[str]=[], op: ?str='
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:ieee-802.3' or point == 'ieee-802.3':
+        if point == 'ieee-802.3':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,8 +55,7 @@ mut def from_json_path_foo__ieee_802_3(jd: value, path: list[str]=[], op: ?str='
 
 mut def from_json_foo__ieee_802_3(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_ieee_802_3_full = jd.get('foo:ieee-802.3')
-    child_ieee_802_3 = child_ieee_802_3_full if child_ieee_802_3_full is not None else jd.get('ieee-802.3')
+    child_ieee_802_3 = jd.get('ieee-802.3')
     if child_ieee_802_3 is not None:
         children['ieee-802.3'] = from_json_foo__ieee_802_3__ieee_802_3(child_ieee_802_3)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -65,15 +65,15 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:as' or point == 'as':
+        if point == 'as':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:for' or point == 'for':
+        if point == 'for':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:import' or point == 'import':
+        if point == 'import':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:in' or point == 'in':
+        if point == 'in':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:with' or point == 'with':
+        if point == 'with':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -86,24 +86,19 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_as__full = jd.get('foo:as')
-    child_as_ = child_as__full if child_as__full is not None else jd.get('as')
+    child_as_ = jd.get('as')
     if child_as_ is not None:
         children['as'] = from_json_foo__c1__as(child_as_)
-    child_for__full = jd.get('foo:for')
-    child_for_ = child_for__full if child_for__full is not None else jd.get('for')
+    child_for_ = jd.get('for')
     if child_for_ is not None:
         children['for'] = from_json_foo__c1__for(child_for_)
-    child_import__full = jd.get('foo:import')
-    child_import_ = child_import__full if child_import__full is not None else jd.get('import')
+    child_import_ = jd.get('import')
     if child_import_ is not None:
         children['import'] = from_json_foo__c1__import(child_import_)
-    child_in__full = jd.get('foo:in')
-    child_in_ = child_in__full if child_in__full is not None else jd.get('in')
+    child_in_ = jd.get('in')
     if child_in_ is not None:
         children['in'] = from_json_foo__c1__in(child_in_)
-    child_with__full = jd.get('foo:with')
-    child_with_ = child_with__full if child_with__full is not None else jd.get('with')
+    child_with_ = jd.get('with')
     if child_with_ is not None:
         children['with'] = from_json_foo__c1__with(child_with_)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -114,8 +114,7 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -124,12 +124,10 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
-    child_id_full = jd.get('foo:id')
-    child_id = child_id_full if child_id_full is not None else jd.get('id')
+    child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -33,7 +33,7 @@ mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -46,8 +46,7 @@ mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__foo__bar__l1(child_l1)
     return yang.gdata.Container(children)
@@ -92,7 +91,7 @@ mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:bar' or point == 'bar':
+        if point == 'bar':
             child = {'bar': from_json_path_foo__foo__bar(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -106,8 +105,7 @@ mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__foo__bar(child_bar)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -33,7 +33,7 @@ mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -46,8 +46,7 @@ mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__foo__bar__l1(child_l1)
     return yang.gdata.Container(children)
@@ -97,7 +96,7 @@ mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:bar' or point == 'bar':
+        if point == 'bar':
             child = {'bar': from_json_path_foo__foo__bar(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -111,8 +110,7 @@ mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__foo__bar(child_bar)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -123,8 +123,7 @@ mut def from_json_path_foo__li1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__li1__l1(child_l1)
     return yang.gdata.Container(children, [str(child_l1 if child_l1 is not None else '')])

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -48,7 +48,7 @@ mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='mer
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:hi' or point == 'hi':
+        if point == 'hi':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -61,8 +61,7 @@ mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_foo__l1__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_hi_full = jd.get('foo:hi')
-    child_hi = child_hi_full if child_hi_full is not None else jd.get('hi')
+    child_hi = jd.get('hi')
     if child_hi is not None:
         children['hi'] = from_json_foo__l1__bar__hi(child_hi)
     return yang.gdata.Container(children)
@@ -202,16 +201,13 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
-    child_id_full = jd.get('foo:id')
-    child_id = child_id_full if child_id_full is not None else jd.get('id')
+    child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__l1__bar(child_bar)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -124,12 +124,10 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
-    child_id_full = jd.get('foo:id')
-    child_id = child_id_full if child_id_full is not None else jd.get('id')
+    child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -36,7 +36,7 @@ mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='mer
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:hi' or point == 'hi':
+        if point == 'hi':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -49,8 +49,7 @@ mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_foo__l1__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_hi_full = jd.get('foo:hi')
-    child_hi = child_hi_full if child_hi_full is not None else jd.get('hi')
+    child_hi = jd.get('hi')
     if child_hi is not None:
         children['hi'] = from_json_foo__l1__bar__hi(child_hi)
     return yang.gdata.Container(children)
@@ -188,12 +187,10 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__l1__bar(child_bar)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -42,7 +42,7 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'bar:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,8 +55,7 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('bar:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_bar__c1__l1(child_l1)
     return yang.gdata.Container(children)
@@ -104,7 +103,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -117,8 +116,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -42,7 +42,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -55,8 +55,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1(child_l1)
     return yang.gdata.Container(children)
@@ -104,7 +103,7 @@ mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -117,8 +116,7 @@ mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__pc1__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__pc1__foo__l1(child_l1)
     return yang.gdata.Container(children)
@@ -163,7 +161,7 @@ mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             child = {'foo': from_json_path_foo__pc1__foo(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -177,8 +175,7 @@ mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None and isinstance(child_foo, dict):
         children['foo'] = from_json_foo__pc1__foo(child_foo)
     return yang.gdata.Container(children)

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -152,16 +152,13 @@ mut def from_json_path_foo__c1__l1(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__c1__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_k1_full = jd.get('foo:k1')
-    child_k1 = child_k1_full if child_k1_full is not None else jd.get('k1')
+    child_k1 = jd.get('k1')
     if child_k1 is not None:
         children['k1'] = from_json_foo__c1__l1__k1(child_k1)
-    child_k2_full = jd.get('foo:k2')
-    child_k2 = child_k2_full if child_k2_full is not None else jd.get('k2')
+    child_k2 = jd.get('k2')
     if child_k2 is not None:
         children['k2'] = from_json_foo__c1__l1__k2(child_k2)
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1__l1(child_l1)
     return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else ''), str(child_k2 if child_k2 is not None else '')])
@@ -227,7 +224,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             child = {'l1': from_json_path_foo__c1__l1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -241,8 +238,7 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None and isinstance(child_l1, list):
         children['l1'] = from_json_foo__c1__l1(child_l1)
     return yang.gdata.Container(children)

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -107,23 +107,23 @@ mut def from_json_path_basics__c(jd: value, path: list[str]=[], op: ?str='merge'
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'basics:l_str_def' or point == 'l_str_def':
+        if point == 'l_str_def':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_str_def_quoted' or point == 'l_str_def_quoted':
+        if point == 'l_str_def_quoted':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_uint64_def' or point == 'l_uint64_def':
+        if point == 'l_uint64_def':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_union_def_str' or point == 'l_union_def_str':
+        if point == 'l_union_def_str':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_union_def_int' or point == 'l_union_def_int':
+        if point == 'l_union_def_int':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_union_def_float' or point == 'l_union_def_float':
+        if point == 'l_union_def_float':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_union_def_bool' or point == 'l_union_def_bool':
+        if point == 'l_union_def_bool':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_union_def_enumeration' or point == 'l_union_def_enumeration':
+        if point == 'l_union_def_enumeration':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'basics:l_binary_def' or point == 'l_binary_def':
+        if point == 'l_binary_def':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -136,40 +136,31 @@ mut def from_json_path_basics__c(jd: value, path: list[str]=[], op: ?str='merge'
 
 mut def from_json_basics__c(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_str_def_full = jd.get('basics:l_str_def')
-    child_l_str_def = child_l_str_def_full if child_l_str_def_full is not None else jd.get('l_str_def')
+    child_l_str_def = jd.get('l_str_def')
     if child_l_str_def is not None:
         children['l_str_def'] = from_json_basics__c__l_str_def(child_l_str_def)
-    child_l_str_def_quoted_full = jd.get('basics:l_str_def_quoted')
-    child_l_str_def_quoted = child_l_str_def_quoted_full if child_l_str_def_quoted_full is not None else jd.get('l_str_def_quoted')
+    child_l_str_def_quoted = jd.get('l_str_def_quoted')
     if child_l_str_def_quoted is not None:
         children['l_str_def_quoted'] = from_json_basics__c__l_str_def_quoted(child_l_str_def_quoted)
-    child_l_uint64_def_full = jd.get('basics:l_uint64_def')
-    child_l_uint64_def = child_l_uint64_def_full if child_l_uint64_def_full is not None else jd.get('l_uint64_def')
+    child_l_uint64_def = jd.get('l_uint64_def')
     if child_l_uint64_def is not None:
         children['l_uint64_def'] = from_json_basics__c__l_uint64_def(child_l_uint64_def)
-    child_l_union_def_str_full = jd.get('basics:l_union_def_str')
-    child_l_union_def_str = child_l_union_def_str_full if child_l_union_def_str_full is not None else jd.get('l_union_def_str')
+    child_l_union_def_str = jd.get('l_union_def_str')
     if child_l_union_def_str is not None:
         children['l_union_def_str'] = from_json_basics__c__l_union_def_str(child_l_union_def_str)
-    child_l_union_def_int_full = jd.get('basics:l_union_def_int')
-    child_l_union_def_int = child_l_union_def_int_full if child_l_union_def_int_full is not None else jd.get('l_union_def_int')
+    child_l_union_def_int = jd.get('l_union_def_int')
     if child_l_union_def_int is not None:
         children['l_union_def_int'] = from_json_basics__c__l_union_def_int(child_l_union_def_int)
-    child_l_union_def_float_full = jd.get('basics:l_union_def_float')
-    child_l_union_def_float = child_l_union_def_float_full if child_l_union_def_float_full is not None else jd.get('l_union_def_float')
+    child_l_union_def_float = jd.get('l_union_def_float')
     if child_l_union_def_float is not None:
         children['l_union_def_float'] = from_json_basics__c__l_union_def_float(child_l_union_def_float)
-    child_l_union_def_bool_full = jd.get('basics:l_union_def_bool')
-    child_l_union_def_bool = child_l_union_def_bool_full if child_l_union_def_bool_full is not None else jd.get('l_union_def_bool')
+    child_l_union_def_bool = jd.get('l_union_def_bool')
     if child_l_union_def_bool is not None:
         children['l_union_def_bool'] = from_json_basics__c__l_union_def_bool(child_l_union_def_bool)
-    child_l_union_def_enumeration_full = jd.get('basics:l_union_def_enumeration')
-    child_l_union_def_enumeration = child_l_union_def_enumeration_full if child_l_union_def_enumeration_full is not None else jd.get('l_union_def_enumeration')
+    child_l_union_def_enumeration = jd.get('l_union_def_enumeration')
     if child_l_union_def_enumeration is not None:
         children['l_union_def_enumeration'] = from_json_basics__c__l_union_def_enumeration(child_l_union_def_enumeration)
-    child_l_binary_def_full = jd.get('basics:l_binary_def')
-    child_l_binary_def = child_l_binary_def_full if child_l_binary_def_full is not None else jd.get('l_binary_def')
+    child_l_binary_def = jd.get('l_binary_def')
     if child_l_binary_def is not None:
         children['l_binary_def'] = from_json_basics__c__l_binary_def(child_l_binary_def)
     return yang.gdata.Container(children)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -143,12 +143,10 @@ mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__c1__li__name(child_name)
-    child_val_full = jd.get('foo:val')
-    child_val = child_val_full if child_val_full is not None else jd.get('val')
+    child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -261,20 +259,20 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l3' or point == 'l3':
+        if point == 'l3':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l_empty' or point == 'l_empty':
+        if point == 'l_empty':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:li' or point == 'li':
+        if point == 'li':
             child = {'li': from_json_path_foo__c1__li(jd, rest_path, op) }
             return yang.gdata.Container(child)
-        if point == 'foo:ll_uint64' or point == 'll_uint64':
+        if point == 'll_uint64':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:ll_str' or point == 'll_str':
+        if point == 'll_str':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l4' or point == 'l4':
+        if point == 'l4':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l1':
             raise ValueError("Invalid json path to non-inner node")
@@ -291,32 +289,25 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_f_l1_full = jd.get('foo:l1')
-    child_f_l1 = child_f_l1_full if child_f_l1_full is not None else jd.get('l1')
+    child_f_l1 = jd.get('l1')
     if child_f_l1 is not None:
         children['f:l1'] = from_json_foo__c1__f_l1(child_f_l1)
-    child_l3_full = jd.get('foo:l3')
-    child_l3 = child_l3_full if child_l3_full is not None else jd.get('l3')
+    child_l3 = jd.get('l3')
     if child_l3 is not None:
         children['l3'] = from_json_foo__c1__l3(child_l3)
-    child_l_empty_full = jd.get('foo:l_empty')
-    child_l_empty = child_l_empty_full if child_l_empty_full is not None else jd.get('l_empty')
+    child_l_empty = jd.get('l_empty')
     if child_l_empty is not None:
         children['l_empty'] = from_json_foo__c1__l_empty(child_l_empty)
-    child_li_full = jd.get('foo:li')
-    child_li = child_li_full if child_li_full is not None else jd.get('li')
+    child_li = jd.get('li')
     if child_li is not None and isinstance(child_li, list):
         children['li'] = from_json_foo__c1__li(child_li)
-    child_ll_uint64_full = jd.get('foo:ll_uint64')
-    child_ll_uint64 = child_ll_uint64_full if child_ll_uint64_full is not None else jd.get('ll_uint64')
+    child_ll_uint64 = jd.get('ll_uint64')
     if child_ll_uint64 is not None and isinstance(child_ll_uint64, list):
         children['ll_uint64'] = from_json_foo__c1__ll_uint64(child_ll_uint64)
-    child_ll_str_full = jd.get('foo:ll_str')
-    child_ll_str = child_ll_str_full if child_ll_str_full is not None else jd.get('ll_str')
+    child_ll_str = jd.get('ll_str')
     if child_ll_str is not None and isinstance(child_ll_str, list):
         children['ll_str'] = from_json_foo__c1__ll_str(child_ll_str)
-    child_l4_full = jd.get('foo:l4')
-    child_l4 = child_l4_full if child_l4_full is not None else jd.get('l4')
+    child_l4 = jd.get('l4')
     if child_l4 is not None:
         children['l4'] = from_json_foo__c1__l4(child_l4)
     child_bar_l1 = jd.get('bar:l1')
@@ -400,7 +391,7 @@ mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -413,8 +404,7 @@ mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__pc1__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None and isinstance(child_l1, list):
         children['l1'] = from_json_foo__pc1__foo__l1(child_l1)
     return yang.gdata.Container(children)
@@ -459,7 +449,7 @@ mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             child = {'foo': from_json_path_foo__pc1__foo(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -473,8 +463,7 @@ mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None and isinstance(child_foo, dict):
         children['foo'] = from_json_foo__pc1__foo(child_foo)
     return yang.gdata.Container(children)
@@ -522,7 +511,7 @@ mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l_mandatory' or point == 'l_mandatory':
+        if point == 'l_mandatory':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -535,8 +524,7 @@ mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__pc2__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_mandatory_full = jd.get('foo:l_mandatory')
-    child_l_mandatory = child_l_mandatory_full if child_l_mandatory_full is not None else jd.get('l_mandatory')
+    child_l_mandatory = jd.get('l_mandatory')
     if child_l_mandatory is not None:
         children['l_mandatory'] = from_json_foo__pc2__foo__l_mandatory(child_l_mandatory)
     return yang.gdata.Container(children)
@@ -581,7 +569,7 @@ mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             child = {'foo': from_json_path_foo__pc2__foo(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -595,8 +583,7 @@ mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__pc2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None and isinstance(child_foo, dict):
         children['foo'] = from_json_foo__pc2__foo(child_foo)
     return yang.gdata.Container(children)
@@ -697,7 +684,7 @@ mut def from_json_path_foo__c_dot(jd: value, path: list[str]=[], op: ?str='merge
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l.dot1' or point == 'l.dot1':
+        if point == 'l.dot1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l.dot2':
             raise ValueError("Invalid json path to non-inner node")
@@ -712,8 +699,7 @@ mut def from_json_path_foo__c_dot(jd: value, path: list[str]=[], op: ?str='merge
 
 mut def from_json_foo__c_dot(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_dot1_full = jd.get('foo:l.dot1')
-    child_l_dot1 = child_l_dot1_full if child_l_dot1_full is not None else jd.get('l.dot1')
+    child_l_dot1 = jd.get('l.dot1')
     if child_l_dot1 is not None:
         children['l.dot1'] = from_json_foo__c_dot__l_dot1(child_l_dot1)
     child_l_dot2 = jd.get('bar:l.dot2')
@@ -852,8 +838,7 @@ mut def from_json_path_foo__cc__death(jd: value, path: list[str]=[], op: ?str='m
 
 mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__cc__death__name(child_name)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -916,9 +901,9 @@ mut def from_json_path_foo__cc(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:cake' or point == 'cake':
+        if point == 'cake':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:death' or point == 'death':
+        if point == 'death':
             child = {'death': from_json_path_foo__cc__death(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -932,12 +917,10 @@ mut def from_json_path_foo__cc(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__cc(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_cake_full = jd.get('foo:cake')
-    child_cake = child_cake_full if child_cake_full is not None else jd.get('cake')
+    child_cake = jd.get('cake')
     if child_cake is not None:
         children['cake'] = from_json_foo__cc__cake(child_cake)
-    child_death_full = jd.get('foo:death')
-    child_death = child_death_full if child_death_full is not None else jd.get('death')
+    child_death = jd.get('death')
     if child_death is not None and isinstance(child_death, list):
         children['death'] = from_json_foo__cc__death(child_death)
     return yang.gdata.Container(children)
@@ -1107,9 +1090,9 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:inner' or point == 'inner':
+        if point == 'inner':
             child = {'inner': from_json_path_foo__conflict__f_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:foo':
@@ -1128,12 +1111,10 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_f_foo_full = jd.get('foo:foo')
-    child_f_foo = child_f_foo_full if child_f_foo_full is not None else jd.get('foo')
+    child_f_foo = jd.get('foo')
     if child_f_foo is not None:
         children['f:foo'] = from_json_foo__conflict__f_foo(child_f_foo)
-    child_f_inner_full = jd.get('foo:inner')
-    child_f_inner = child_f_inner_full if child_f_inner_full is not None else jd.get('inner')
+    child_f_inner = jd.get('inner')
     if child_f_inner is not None and isinstance(child_f_inner, dict):
         children['f:inner'] = from_json_foo__conflict__f_inner(child_f_inner)
     child_bar_foo = jd.get('bar:foo')
@@ -1280,8 +1261,7 @@ mut def from_json_path_foo__special(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_yes_full = jd.get('foo:yes')
-    child_yes = child_yes_full if child_yes_full is not None else jd.get('yes')
+    child_yes = jd.get('yes')
     if child_yes is not None:
         children['yes'] = from_json_foo__special__yes(child_yes)
     return yang.gdata.Container(children, [str(child_yes if child_yes is not None else '')])
@@ -1454,16 +1434,13 @@ mut def from_json_path_foo__nested__inner__li1__li2(jd: value, path: list[str]=[
 
 mut def from_json_foo__nested__inner__li1__li2_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_key1_full = jd.get('foo:key1')
-    child_key1 = child_key1_full if child_key1_full is not None else jd.get('key1')
+    child_key1 = jd.get('key1')
     if child_key1 is not None:
         children['key1'] = from_json_foo__nested__inner__li1__li2__key1(child_key1)
-    child_key2_full = jd.get('foo:key2')
-    child_key2 = child_key2_full if child_key2_full is not None else jd.get('key2')
+    child_key2 = jd.get('key2')
     if child_key2 is not None:
         children['key2'] = from_json_foo__nested__inner__li1__li2__key2(child_key2)
-    child_baz_full = jd.get('foo:baz')
-    child_baz = child_baz_full if child_baz_full is not None else jd.get('baz')
+    child_baz = jd.get('baz')
     if child_baz is not None:
         children['baz'] = from_json_foo__nested__inner__li1__li2__baz(child_baz)
     return yang.gdata.Container(children, [str(child_key1 if child_key1 is not None else ''), str(child_key2 if child_key2 is not None else '')])
@@ -1624,16 +1601,13 @@ mut def from_json_path_foo__nested__inner__li1(jd: value, path: list[str]=[], op
 
 mut def from_json_foo__nested__inner__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__nested__inner__li1__name(child_name)
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None:
         children['bar'] = from_json_foo__nested__inner__li1__bar(child_bar)
-    child_li2_full = jd.get('foo:li2')
-    child_li2 = child_li2_full if child_li2_full is not None else jd.get('li2')
+    child_li2 = jd.get('li2')
     if child_li2 is not None and isinstance(child_li2, list):
         children['li2'] = from_json_foo__nested__inner__li1__li2(child_li2)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -1704,9 +1678,9 @@ mut def from_json_path_foo__nested__inner(jd: value, path: list[str]=[], op: ?st
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:li1' or point == 'li1':
+        if point == 'li1':
             child = {'li1': from_json_path_foo__nested__inner__li1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -1720,12 +1694,10 @@ mut def from_json_path_foo__nested__inner(jd: value, path: list[str]=[], op: ?st
 
 mut def from_json_foo__nested__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_foo__nested__inner__foo(child_foo)
-    child_li1_full = jd.get('foo:li1')
-    child_li1 = child_li1_full if child_li1_full is not None else jd.get('li1')
+    child_li1 = jd.get('li1')
     if child_li1 is not None and isinstance(child_li1, list):
         children['li1'] = from_json_foo__nested__inner__li1(child_li1)
     return yang.gdata.Container(children)
@@ -1774,7 +1746,7 @@ mut def from_json_path_foo__nested(jd: value, path: list[str]=[], op: ?str='merg
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:inner' or point == 'inner':
+        if point == 'inner':
             child = {'inner': from_json_path_foo__nested__inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -1788,8 +1760,7 @@ mut def from_json_path_foo__nested(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__nested(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_inner_full = jd.get('foo:inner')
-    child_inner = child_inner_full if child_inner_full is not None else jd.get('inner')
+    child_inner = jd.get('inner')
     if child_inner is not None and isinstance(child_inner, dict):
         children['inner'] = from_json_foo__nested__inner(child_inner)
     return yang.gdata.Container(children)
@@ -1954,16 +1925,13 @@ mut def from_json_path_foo__li_union(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_k1_full = jd.get('foo:k1')
-    child_k1 = child_k1_full if child_k1_full is not None else jd.get('k1')
+    child_k1 = jd.get('k1')
     if child_k1 is not None:
         children['k1'] = from_json_foo__li_union__k1(child_k1)
-    child_k2_full = jd.get('foo:k2')
-    child_k2 = child_k2_full if child_k2_full is not None else jd.get('k2')
+    child_k2 = jd.get('k2')
     if child_k2 is not None:
         children['k2'] = from_json_foo__li_union__k2(child_k2)
-    child_k3_full = jd.get('foo:k3')
-    child_k3 = child_k3_full if child_k3_full is not None else jd.get('k3')
+    child_k3 = jd.get('k3')
     if child_k3 is not None:
         children['k3'] = from_json_foo__li_union__k3(child_k3)
     return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else ''), str(child_k2 if child_k2 is not None else ''), str(child_k3 if child_k3 is not None else '')])
@@ -2040,9 +2008,9 @@ mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str='m
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -2055,12 +2023,10 @@ mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str='m
 
 mut def from_json_foo__state__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__state__c1__l1(child_l1)
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__state__c1__l2(child_l2)
     return yang.gdata.Container(children)
@@ -2109,7 +2075,7 @@ mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str='merge
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:c1' or point == 'c1':
+        if point == 'c1':
             child = {'c1': from_json_path_foo__state__c1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -2123,8 +2089,7 @@ mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str='merge
 
 mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_c1_full = jd.get('foo:c1')
-    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    child_c1 = jd.get('c1')
     if child_c1 is not None and isinstance(child_c1, dict):
         children['c1'] = from_json_foo__state__c1(child_c1)
     return yang.gdata.Container(children)
@@ -2172,7 +2137,7 @@ mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -2185,8 +2150,7 @@ mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c2__l1(child_l1)
     return yang.gdata.Container(children)
@@ -2234,7 +2198,7 @@ mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'bar:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -2247,8 +2211,7 @@ mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_bar__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('bar:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_bar__conflict__foo(child_foo)
     return yang.gdata.Container(children)

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -143,12 +143,10 @@ mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__c1__li__name(child_name)
-    child_val_full = jd.get('foo:val')
-    child_val = child_val_full if child_val_full is not None else jd.get('val')
+    child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -261,20 +259,20 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l3' or point == 'l3':
+        if point == 'l3':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l_empty' or point == 'l_empty':
+        if point == 'l_empty':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:li' or point == 'li':
+        if point == 'li':
             child = {'li': from_json_path_foo__c1__li(jd, rest_path, op) }
             return yang.gdata.Container(child)
-        if point == 'foo:ll_uint64' or point == 'll_uint64':
+        if point == 'll_uint64':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:ll_str' or point == 'll_str':
+        if point == 'll_str':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l4' or point == 'l4':
+        if point == 'l4':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l1':
             raise ValueError("Invalid json path to non-inner node")
@@ -291,32 +289,25 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_f_l1_full = jd.get('foo:l1')
-    child_f_l1 = child_f_l1_full if child_f_l1_full is not None else jd.get('l1')
+    child_f_l1 = jd.get('l1')
     if child_f_l1 is not None:
         children['f:l1'] = from_json_foo__c1__f_l1(child_f_l1)
-    child_l3_full = jd.get('foo:l3')
-    child_l3 = child_l3_full if child_l3_full is not None else jd.get('l3')
+    child_l3 = jd.get('l3')
     if child_l3 is not None:
         children['l3'] = from_json_foo__c1__l3(child_l3)
-    child_l_empty_full = jd.get('foo:l_empty')
-    child_l_empty = child_l_empty_full if child_l_empty_full is not None else jd.get('l_empty')
+    child_l_empty = jd.get('l_empty')
     if child_l_empty is not None:
         children['l_empty'] = from_json_foo__c1__l_empty(child_l_empty)
-    child_li_full = jd.get('foo:li')
-    child_li = child_li_full if child_li_full is not None else jd.get('li')
+    child_li = jd.get('li')
     if child_li is not None and isinstance(child_li, list):
         children['li'] = from_json_foo__c1__li(child_li)
-    child_ll_uint64_full = jd.get('foo:ll_uint64')
-    child_ll_uint64 = child_ll_uint64_full if child_ll_uint64_full is not None else jd.get('ll_uint64')
+    child_ll_uint64 = jd.get('ll_uint64')
     if child_ll_uint64 is not None and isinstance(child_ll_uint64, list):
         children['ll_uint64'] = from_json_foo__c1__ll_uint64(child_ll_uint64)
-    child_ll_str_full = jd.get('foo:ll_str')
-    child_ll_str = child_ll_str_full if child_ll_str_full is not None else jd.get('ll_str')
+    child_ll_str = jd.get('ll_str')
     if child_ll_str is not None and isinstance(child_ll_str, list):
         children['ll_str'] = from_json_foo__c1__ll_str(child_ll_str)
-    child_l4_full = jd.get('foo:l4')
-    child_l4 = child_l4_full if child_l4_full is not None else jd.get('l4')
+    child_l4 = jd.get('l4')
     if child_l4 is not None:
         children['l4'] = from_json_foo__c1__l4(child_l4)
     child_bar_l1 = jd.get('bar:l1')
@@ -400,7 +391,7 @@ mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -413,8 +404,7 @@ mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__pc1__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None and isinstance(child_l1, list):
         children['l1'] = from_json_foo__pc1__foo__l1(child_l1)
     return yang.gdata.Container(children)
@@ -459,7 +449,7 @@ mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             child = {'foo': from_json_path_foo__pc1__foo(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -473,8 +463,7 @@ mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None and isinstance(child_foo, dict):
         children['foo'] = from_json_foo__pc1__foo(child_foo)
     return yang.gdata.Container(children)
@@ -522,7 +511,7 @@ mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l_mandatory' or point == 'l_mandatory':
+        if point == 'l_mandatory':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -535,8 +524,7 @@ mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__pc2__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_mandatory_full = jd.get('foo:l_mandatory')
-    child_l_mandatory = child_l_mandatory_full if child_l_mandatory_full is not None else jd.get('l_mandatory')
+    child_l_mandatory = jd.get('l_mandatory')
     if child_l_mandatory is not None:
         children['l_mandatory'] = from_json_foo__pc2__foo__l_mandatory(child_l_mandatory)
     return yang.gdata.Container(children)
@@ -581,7 +569,7 @@ mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             child = {'foo': from_json_path_foo__pc2__foo(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -595,8 +583,7 @@ mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__pc2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None and isinstance(child_foo, dict):
         children['foo'] = from_json_foo__pc2__foo(child_foo)
     return yang.gdata.Container(children)
@@ -697,7 +684,7 @@ mut def from_json_path_foo__c_dot(jd: value, path: list[str]=[], op: ?str='merge
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l.dot1' or point == 'l.dot1':
+        if point == 'l.dot1':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:l.dot2':
             raise ValueError("Invalid json path to non-inner node")
@@ -712,8 +699,7 @@ mut def from_json_path_foo__c_dot(jd: value, path: list[str]=[], op: ?str='merge
 
 mut def from_json_foo__c_dot(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_dot1_full = jd.get('foo:l.dot1')
-    child_l_dot1 = child_l_dot1_full if child_l_dot1_full is not None else jd.get('l.dot1')
+    child_l_dot1 = jd.get('l.dot1')
     if child_l_dot1 is not None:
         children['l.dot1'] = from_json_foo__c_dot__l_dot1(child_l_dot1)
     child_l_dot2 = jd.get('bar:l.dot2')
@@ -852,8 +838,7 @@ mut def from_json_path_foo__cc__death(jd: value, path: list[str]=[], op: ?str='m
 
 mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__cc__death__name(child_name)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -916,9 +901,9 @@ mut def from_json_path_foo__cc(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:cake' or point == 'cake':
+        if point == 'cake':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:death' or point == 'death':
+        if point == 'death':
             child = {'death': from_json_path_foo__cc__death(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -932,12 +917,10 @@ mut def from_json_path_foo__cc(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__cc(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_cake_full = jd.get('foo:cake')
-    child_cake = child_cake_full if child_cake_full is not None else jd.get('cake')
+    child_cake = jd.get('cake')
     if child_cake is not None:
         children['cake'] = from_json_foo__cc__cake(child_cake)
-    child_death_full = jd.get('foo:death')
-    child_death = child_death_full if child_death_full is not None else jd.get('death')
+    child_death = jd.get('death')
     if child_death is not None and isinstance(child_death, list):
         children['death'] = from_json_foo__cc__death(child_death)
     return yang.gdata.Container(children)
@@ -1107,9 +1090,9 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:inner' or point == 'inner':
+        if point == 'inner':
             child = {'inner': from_json_path_foo__conflict__f_inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:foo':
@@ -1128,12 +1111,10 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_f_foo_full = jd.get('foo:foo')
-    child_f_foo = child_f_foo_full if child_f_foo_full is not None else jd.get('foo')
+    child_f_foo = jd.get('foo')
     if child_f_foo is not None:
         children['f:foo'] = from_json_foo__conflict__f_foo(child_f_foo)
-    child_f_inner_full = jd.get('foo:inner')
-    child_f_inner = child_f_inner_full if child_f_inner_full is not None else jd.get('inner')
+    child_f_inner = jd.get('inner')
     if child_f_inner is not None and isinstance(child_f_inner, dict):
         children['f:inner'] = from_json_foo__conflict__f_inner(child_f_inner)
     child_bar_foo = jd.get('bar:foo')
@@ -1280,8 +1261,7 @@ mut def from_json_path_foo__special(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_yes_full = jd.get('foo:yes')
-    child_yes = child_yes_full if child_yes_full is not None else jd.get('yes')
+    child_yes = jd.get('yes')
     if child_yes is not None:
         children['yes'] = from_json_foo__special__yes(child_yes)
     return yang.gdata.Container(children, [str(child_yes if child_yes is not None else '')])
@@ -1454,16 +1434,13 @@ mut def from_json_path_foo__nested__inner__li1__li2(jd: value, path: list[str]=[
 
 mut def from_json_foo__nested__inner__li1__li2_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_key1_full = jd.get('foo:key1')
-    child_key1 = child_key1_full if child_key1_full is not None else jd.get('key1')
+    child_key1 = jd.get('key1')
     if child_key1 is not None:
         children['key1'] = from_json_foo__nested__inner__li1__li2__key1(child_key1)
-    child_key2_full = jd.get('foo:key2')
-    child_key2 = child_key2_full if child_key2_full is not None else jd.get('key2')
+    child_key2 = jd.get('key2')
     if child_key2 is not None:
         children['key2'] = from_json_foo__nested__inner__li1__li2__key2(child_key2)
-    child_baz_full = jd.get('foo:baz')
-    child_baz = child_baz_full if child_baz_full is not None else jd.get('baz')
+    child_baz = jd.get('baz')
     if child_baz is not None:
         children['baz'] = from_json_foo__nested__inner__li1__li2__baz(child_baz)
     return yang.gdata.Container(children, [str(child_key1 if child_key1 is not None else ''), str(child_key2 if child_key2 is not None else '')])
@@ -1624,16 +1601,13 @@ mut def from_json_path_foo__nested__inner__li1(jd: value, path: list[str]=[], op
 
 mut def from_json_foo__nested__inner__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__nested__inner__li1__name(child_name)
-    child_bar_full = jd.get('foo:bar')
-    child_bar = child_bar_full if child_bar_full is not None else jd.get('bar')
+    child_bar = jd.get('bar')
     if child_bar is not None:
         children['bar'] = from_json_foo__nested__inner__li1__bar(child_bar)
-    child_li2_full = jd.get('foo:li2')
-    child_li2 = child_li2_full if child_li2_full is not None else jd.get('li2')
+    child_li2 = jd.get('li2')
     if child_li2 is not None and isinstance(child_li2, list):
         children['li2'] = from_json_foo__nested__inner__li1__li2(child_li2)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
@@ -1704,9 +1678,9 @@ mut def from_json_path_foo__nested__inner(jd: value, path: list[str]=[], op: ?st
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:li1' or point == 'li1':
+        if point == 'li1':
             child = {'li1': from_json_path_foo__nested__inner__li1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -1720,12 +1694,10 @@ mut def from_json_path_foo__nested__inner(jd: value, path: list[str]=[], op: ?st
 
 mut def from_json_foo__nested__inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('foo:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_foo__nested__inner__foo(child_foo)
-    child_li1_full = jd.get('foo:li1')
-    child_li1 = child_li1_full if child_li1_full is not None else jd.get('li1')
+    child_li1 = jd.get('li1')
     if child_li1 is not None and isinstance(child_li1, list):
         children['li1'] = from_json_foo__nested__inner__li1(child_li1)
     return yang.gdata.Container(children)
@@ -1774,7 +1746,7 @@ mut def from_json_path_foo__nested(jd: value, path: list[str]=[], op: ?str='merg
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:inner' or point == 'inner':
+        if point == 'inner':
             child = {'inner': from_json_path_foo__nested__inner(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -1788,8 +1760,7 @@ mut def from_json_path_foo__nested(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__nested(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_inner_full = jd.get('foo:inner')
-    child_inner = child_inner_full if child_inner_full is not None else jd.get('inner')
+    child_inner = jd.get('inner')
     if child_inner is not None and isinstance(child_inner, dict):
         children['inner'] = from_json_foo__nested__inner(child_inner)
     return yang.gdata.Container(children)
@@ -1954,16 +1925,13 @@ mut def from_json_path_foo__li_union(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_k1_full = jd.get('foo:k1')
-    child_k1 = child_k1_full if child_k1_full is not None else jd.get('k1')
+    child_k1 = jd.get('k1')
     if child_k1 is not None:
         children['k1'] = from_json_foo__li_union__k1(child_k1)
-    child_k2_full = jd.get('foo:k2')
-    child_k2 = child_k2_full if child_k2_full is not None else jd.get('k2')
+    child_k2 = jd.get('k2')
     if child_k2 is not None:
         children['k2'] = from_json_foo__li_union__k2(child_k2)
-    child_k3_full = jd.get('foo:k3')
-    child_k3 = child_k3_full if child_k3_full is not None else jd.get('k3')
+    child_k3 = jd.get('k3')
     if child_k3 is not None:
         children['k3'] = from_json_foo__li_union__k3(child_k3)
     return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else ''), str(child_k2 if child_k2 is not None else ''), str(child_k3 if child_k3 is not None else '')])
@@ -2040,9 +2008,9 @@ mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str='m
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -2055,12 +2023,10 @@ mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str='m
 
 mut def from_json_foo__state__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__state__c1__l1(child_l1)
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__state__c1__l2(child_l2)
     return yang.gdata.Container(children)
@@ -2109,7 +2075,7 @@ mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str='merge
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:c1' or point == 'c1':
+        if point == 'c1':
             child = {'c1': from_json_path_foo__state__c1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
@@ -2123,8 +2089,7 @@ mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str='merge
 
 mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_c1_full = jd.get('foo:c1')
-    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    child_c1 = jd.get('c1')
     if child_c1 is not None and isinstance(child_c1, dict):
         children['c1'] = from_json_foo__state__c1(child_c1)
     return yang.gdata.Container(children)
@@ -2172,7 +2137,7 @@ mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') 
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -2185,8 +2150,7 @@ mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c2__l1(child_l1)
     return yang.gdata.Container(children)
@@ -2234,7 +2198,7 @@ mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='me
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'bar:foo' or point == 'foo':
+        if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -2247,8 +2211,7 @@ mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_bar__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_foo_full = jd.get('bar:foo')
-    child_foo = child_foo_full if child_foo_full is not None else jd.get('foo')
+    child_foo = jd.get('foo')
     if child_foo is not None:
         children['foo'] = from_json_bar__conflict__foo(child_foo)
     return yang.gdata.Container(children)

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -51,9 +51,9 @@ mut def from_json_path_foo__tc1(jd: value, path: list[str]=[], op: ?str='merge')
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -66,12 +66,10 @@ mut def from_json_path_foo__tc1(jd: value, path: list[str]=[], op: ?str='merge')
 
 mut def from_json_foo__tc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__tc1__l1(child_l1)
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__tc1__l2(child_l2)
     return yang.gdata.Container(children)
@@ -134,9 +132,9 @@ mut def from_json_path_foo__li__c1(jd: value, path: list[str]=[], op: ?str='merg
     if len(path) > 0:
         point = path[0]
         rest_path = path[1:]
-        if point == 'foo:l1' or point == 'l1':
+        if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        if point == 'foo:l2' or point == 'l2':
+        if point == 'l2':
             raise ValueError("Invalid json path to non-inner node")
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -149,12 +147,10 @@ mut def from_json_path_foo__li__c1(jd: value, path: list[str]=[], op: ?str='merg
 
 mut def from_json_foo__li__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1_full = jd.get('foo:l1')
-    child_l1 = child_l1_full if child_l1_full is not None else jd.get('l1')
+    child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__li__c1__l1(child_l1)
-    child_l2_full = jd.get('foo:l2')
-    child_l2 = child_l2_full if child_l2_full is not None else jd.get('l2')
+    child_l2 = jd.get('l2')
     if child_l2 is not None:
         children['l2'] = from_json_foo__li__c1__l2(child_l2)
     return yang.gdata.Container(children)
@@ -291,12 +287,10 @@ mut def from_json_path_foo__li(jd: value, path: list[str]=[], op: ?str='merge') 
 
 mut def from_json_foo__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name_full = jd.get('foo:name')
-    child_name = child_name_full if child_name_full is not None else jd.get('name')
+    child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__li__name(child_name)
-    child_c1_full = jd.get('foo:c1')
-    child_c1 = child_c1_full if child_c1_full is not None else jd.get('c1')
+    child_c1 = jd.get('c1')
     if child_c1 is not None and isinstance(child_c1, dict):
         children['c1'] = from_json_foo__li__c1(child_c1)
     return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])


### PR DESCRIPTION
According to RFC8040:

    The syntax for "api-identifier" and "key-value" MUST conform to the
    JSON identifier encoding rules in Section 4 of RFC7951

From Section 4 of RFC7951:

    A namespace-qualified member name MUST be used for all members of a
    top-level JSON object and then also whenever the namespaces of the
    data node and its parent node are different.  In all other cases,
    the simple form of the member name MUST be used.

I interpret this as meaning that the namespace-qualified name MUST not
appear in the path unless necessary.