### PR TITLE
Baseline test for existing adata to_json() function

### DIFF
--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -448,6 +448,104 @@ def _test_empty_presence():
     return xml_out_text
 
 # JSON
+
+# TODO: "l_empty": [null],
+# TODO: uint64 as string: https://www.rfc-editor.org/rfc/rfc7951.html#section-6.1
+json_full = {
+    "foo:c1": {
+        "l1": "foo-foo",
+        # "l3": 18446744073709551615,
+        "l3": 4,
+        "li": [
+            {
+                "name": "tuta",
+                "val": "baba"
+            }
+        ],
+        "ll_uint64": [4, 42],
+        "ll_str": ["kava", "čaj"],
+        "l4": "foo-qux",
+        "bar:l1": "foo-bar",
+        "bar:l2": "bar"
+    },
+    "foo:pc1": {
+        "foo": {
+            "l1": ["SGVsbG8gQWN0b24g8J+roQ=="]
+        }
+    },
+    "foo:pc2": {
+        "foo": {
+            "l_mandatory": "baz"
+        }
+    },
+    "foo:c.dot": {
+        "l.dot1": "who put that here?!"
+    },
+    "foo:cc": {
+        "cake": "cake"
+    },
+    "foo:conflict": {
+        "foo": "foo-foo",
+        "inner": {},
+        "bar:foo": "foo-augmented-from-bar",
+        "bar:inner": {}
+    },
+    "foo:special": [
+        {
+            "yes": True
+        }
+    ],
+    "foo:nested": {
+        "inner": {
+            "foo": "WINNING",
+            "li1": [
+                {
+                    "name": "AAA",
+                    "bar": "WINNING",
+                    "li2": [
+                        {
+                            "key1": "BBB",
+                            "key2": "CCC",
+                            "baz": "WINNING"
+                        }
+                    ]
+                }
+            ]
+        }
+    },
+    "foo:li-union": [
+        {
+            "k1": "first",
+            "k2": 4,
+            "k3": "SGVsbG8gQWN0b24g8J+roQ=="
+        },
+        {
+            "k1": "second",
+            "k2": "unlimited",
+            "k3": "SGVsbG8gQWN0b24g8J+roQ=="
+        },
+        {
+            "k1": "third",
+            "k2": "aGk=",
+            "k3": "SGVsbG8gQWN0b24g8J+roQ=="
+        }
+    ],
+    "foo:c2": {
+        "l1": "foo-qux"
+    },
+    "bar:conflict":
+    {
+        "foo": "foo-bar"
+    }
+}
+
+def _test_foo_from_json_full():
+    gdata_json = yang_foo.from_json(json_full)
+    print(gdata_json.prsrc(), err=True)
+    json_out = json.encode(yang_foo.to_json(gdata_json))
+    testing.assertEqual(json.encode(json_full), json_out)
+    return gdata_json.prsrc()
+
 def _test_from_json():
     """Test mandatory field handling - success case"""
     json_data = {

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -1,0 +1,85 @@
+Container({
+  'c1': Container({
+    'f:l1': Leaf(foo-foo),
+    'l3': Leaf(4),
+    'li': List(['name'], user_order=True, elements=[
+      Container({
+        'name': Leaf(tuta),
+        'val': Leaf(baba)
+      }, ['tuta'])
+    ]),
+    'll_uint64': LeafList([4, 42]),
+    'll_str': LeafList(['kava', 'čaj']),
+    'l4': Leaf(foo-qux),
+    'bar:l1': Leaf(foo-bar),
+    'l2': Leaf(bar)
+  }),
+  'pc1': Container({
+    'foo': Container({
+      'l1': LeafList(['SGVsbG8gQWN0b24g8J+roQ=='])
+    })
+  }),
+  'pc2': Container({
+    'foo': Container({
+      'l_mandatory': Leaf(baz)
+    })
+  }),
+  'c.dot': Container({
+    'l.dot1': Leaf(who put that here?!)
+  }),
+  'cc': Container({
+    'cake': Leaf(cake)
+  }),
+  'f:conflict': Container({
+    'f:foo': Leaf(foo-foo),
+    'f:inner': Container(),
+    'bar:foo': Leaf(foo-augmented-from-bar),
+    'bar:inner': Container()
+  }),
+  'special': List(['yes'], elements=[
+    Container({
+      'yes': Leaf(True)
+    }, ['True'])
+  ]),
+  'nested': Container({
+    'f:inner': Container({
+      'foo': Leaf(WINNING),
+      'li1': List(['name'], elements=[
+        Container({
+          'name': Leaf(AAA),
+          'f:bar': Leaf(WINNING),
+          'li2': List(['key1', 'key2'], elements=[
+            Container({
+              'key1': Leaf(BBB),
+              'key2': Leaf(CCC),
+              'baz': Leaf(WINNING)
+            }, ['BBB', 'CCC'])
+          ])
+        }, ['AAA'])
+      ])
+    })
+  }),
+  'li-union': List(['k1', 'k2', 'k3'], elements=[
+    Container({
+      'k1': Leaf(first),
+      'k2': Leaf(4),
+      'k3': Leaf(SGVsbG8gQWN0b24g8J+roQ==)
+    }, ['first', '4', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    Container({
+      'k1': Leaf(second),
+      'k2': Leaf(unlimited),
+      'k3': Leaf(SGVsbG8gQWN0b24g8J+roQ==)
+    }, ['second', 'unlimited', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    Container({
+      'k1': Leaf(third),
+      'k2': Leaf(aGk=),
+      'k3': Leaf(SGVsbG8gQWN0b24g8J+roQ==)
+    }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
+  ]),
+  'c2': Container({
+    'l1': Leaf(foo-qux)
+  }),
+  'bar:conflict': Container({
+    'foo': Leaf(foo-bar)
+  })
+})


### PR DESCRIPTION
Before removing adata to_json*() functions to replace them with gdata.Node.to_json(), we establish a baseline by proving the existing generated adata functions work.