### PR TITLE
Use unique safe names for list keys attributes

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -806,7 +806,9 @@ class DNodeInner(DNode):
             #    res += ["    yang.gdata.maybe_add(children, '%s', lambda x: from_json_%s(unwrap_dict(x)) if x is not None else None, yang.gdata.take_json_%s(jd, '%s', '%s'))" % (child.name, taker_name(child, key_required=False), child.name, child.prefix)]
 
             if isinstance(self, DList):
-                list_keys_str = ", ".join(map(lambda x: f"str(child_{_safe_name(x)} if child_{_safe_name(x)} is not None else '')", self.key))
+                # Collect keys leaf values in a list of strings by using the
+                # non-optional local variables defined above.
+                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -336,6 +336,15 @@ class DNodeInner(DNode):
         def pname(n):
             return get_path_name(n)
 
+        def us_list_key():
+            """Convert list key names (DList.key) to their unique safe names
+
+            We use the containing list node prefix since the list keys must be
+            defined in the same namespace as the list."""
+            if isinstance(self, DList):
+                return list(map(lambda x: unique_namer.unique_safe_name(x, self.prefix), self.key))
+            raise ValueError(f"{self} not a list node")
+
         def maybe_user_order(n: DList):
             return ", user_order=True" if n.ordered_by == "user" else ""
 
@@ -483,7 +492,7 @@ class DNodeInner(DNode):
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
             # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{_safe_name(x)})", self.key))
+            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key()))
             # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
             res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
         elif isinstance(self, DRoot):

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -584,12 +584,14 @@ class DNodeInner(DNode):
             res.append("        self.elements = elements")
             res.append("")
 
-            list_key_args = list(map(lambda x: _safe_name(x), self.key))
+            # list_key_args contains the list keys names and also any
+            # non-optional children. We use unique safe names for both to avoid conflicts.
+            list_key_args = us_list_key()
             list_key_types = {}
             for child in self.children:
                 if isinstance(child, DLeaf):
-                    if child.name in self.key:
-                        list_key_types[child.name] = child.type_
+                    if usname(child) in list_key_args:
+                        list_key_types[usname(child)] = child.type_
                         continue
                     if child.mandatory:
                         list_key_args.append(usname(child))
@@ -600,15 +602,15 @@ class DNodeInner(DNode):
             res.append(f"    mut def create({list_create_args_str}):")
             res.append("        for e in self.elements:")
             res.append("            match = True")
-            for key in self.key:
+            for us_key in us_list_key():
                 unique_base_types = set()
-                for t in list_key_types[key].type_:
+                for t in list_key_types[us_key].type_:
                     unique_base_types.add(yang_type_to_acton_type(t))
                 if len(unique_base_types) <= 1:
                     # Class attribute is a not a "value" Acton type because it
                     # is either not an union or it an union that was resolved
                     # to a single builtin type, it has equality check
-                    res.append(f"            if e.{_safe_name(key)} != {_safe_name(key)}:")
+                    res.append(f"            if e.{us_key} != {us_key}:")
                     res.append("                match = False")
                     res.append("                continue")
                 else:
@@ -616,9 +618,9 @@ class DNodeInner(DNode):
                     # we need to first attempt to bind them to a more specific type
                     # TODO: use Acton unions
                     for t in unique_base_types:
-                        res.append(f"            e_{_safe_name(key)} = e.{_safe_name(key)}")
-                        res.append(f"            if isinstance(e_{_safe_name(key)}, {t}) and isinstance({_safe_name(key)}, {t}):")
-                        res.append(f"                if e_{_safe_name(key)} != {_safe_name(key)}:")
+                        res.append(f"            e_{us_key} = e.{us_key}")
+                        res.append(f"            if isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
+                        res.append(f"                if e_{us_key} != {us_key}:")
                         res.append("                    match = False")
                         res.append("                    continue")
             res.append("            if match:")

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -446,14 +446,16 @@ class DNodeInner(DNode):
         # container
         for child in self.children:
             if isinstance(child, DContainer) and child.presence:
+                # We must generate unique safe names for this node children too
+                child_unique_namer = _UniqueNamer(child)
                 pc_args = ["self"]
                 for cchild in child.children:
                     if isinstance(cchild, DLeaf):
                         if cchild.mandatory:
-                            pc_args.append(_safe_name(cchild.name))
+                            pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                     elif isinstance(cchild, DContainer):
                         if not (loose or optional_subtree(cchild)):
-                            pc_args.append(_safe_name(cchild.name))
+                            pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                 pc_args_str = ", ".join(pc_args)
                 pc_args_str1 = ", ".join(pc_args[1:])
                 res.append(f"    mut def create_{usname(child)}({pc_args_str}):")

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1775,6 +1775,46 @@ def _test_prdaclass_strict_list_mandatory():
     src = l1.prdaclass(top=False)
     return src
 
+def _test_prdaclass_strict_p_container_with_mandatory_leaf():
+    ys = """module foo {
+  yang-version "1.1";
+  namespace "http://example.com/foo";
+  prefix "foo";
+  container foo {
+    presence "foo presence";
+    container bar {
+      presence "bar presence";
+      leaf l1 {
+        type string;
+        mandatory true;
+      }
+    }
+  }
+}"""
+
+    ys_bar = """module bar {
+  yang-version "1.1";
+  namespace "http://example.com/bar";
+  prefix "bar";
+  import foo {
+    prefix "foo";
+  }
+  augment "/foo:foo/bar" {
+    // conflicts with /foo:foo/bar/l1
+    leaf l1 {
+      type string;
+      mandatory true;
+    }
+    leaf l2 {
+      type string;
+      mandatory true;
+    }
+  }
+}"""
+    root = yang.compile([ys, ys_bar])
+    src = root.prdaclass()
+    return src
+
 def _test_prdaclass_strict_list_p_container_with_mandatory_leaf():
     ys = """module foo {
     yang-version "1.1";

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1997,6 +1997,11 @@ def _test_prdaclass_augment_inner_list_conflict():
             }
         }
     }
+    augment "/b:c1/l1" {
+        leaf k1 {
+            type string;
+        }
+    }
 }"""
 
     root = yang.compile([ys_base, ys_foo])

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2000,6 +2000,7 @@ def _test_prdaclass_augment_inner_list_conflict():
     augment "/b:c1/l1" {
         leaf k1 {
             type string;
+            mandatory true;
         }
     }
 }"""

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -442,14 +442,16 @@ class DNodeInner(DNode):
         # container
         for child in self.children:
             if isinstance(child, DContainer) and child.presence:
+                # We must generate unique safe names for this node children too
+                child_unique_namer = _UniqueNamer(child)
                 pc_args = ["self"]
                 for cchild in child.children:
                     if isinstance(cchild, DLeaf):
                         if cchild.mandatory:
-                            pc_args.append(_safe_name(cchild.name))
+                            pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                     elif isinstance(cchild, DContainer):
                         if not (loose or optional_subtree(cchild)):
-                            pc_args.append(_safe_name(cchild.name))
+                            pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                 pc_args_str = ", ".join(pc_args)
                 pc_args_str1 = ", ".join(pc_args[1:])
                 res.append(f"    mut def create_{usname(child)}({pc_args_str}):")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -802,7 +802,9 @@ class DNodeInner(DNode):
             #    res += ["    yang.gdata.maybe_add(children, '%s', lambda x: from_json_%s(unwrap_dict(x)) if x is not None else None, yang.gdata.take_json_%s(jd, '%s', '%s'))" % (child.name, taker_name(child, key_required=False), child.name, child.prefix)]
 
             if isinstance(self, DList):
-                list_keys_str = ", ".join(map(lambda x: f"str(child_{_safe_name(x)} if child_{_safe_name(x)} is not None else '')", self.key))
+                # Collect keys leaf values in a list of strings by using the
+                # non-optional local variables defined above.
+                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -580,12 +580,14 @@ class DNodeInner(DNode):
             res.append("        self.elements = elements")
             res.append("")
 
-            list_key_args = list(map(lambda x: _safe_name(x), self.key))
+            # list_key_args contains the list keys names and also any
+            # non-optional children. We use unique safe names for both to avoid conflicts.
+            list_key_args = us_list_key()
             list_key_types = {}
             for child in self.children:
                 if isinstance(child, DLeaf):
-                    if child.name in self.key:
-                        list_key_types[child.name] = child.type_
+                    if usname(child) in list_key_args:
+                        list_key_types[usname(child)] = child.type_
                         continue
                     if child.mandatory:
                         list_key_args.append(usname(child))
@@ -596,15 +598,15 @@ class DNodeInner(DNode):
             res.append(f"    mut def create({list_create_args_str}):")
             res.append("        for e in self.elements:")
             res.append("            match = True")
-            for key in self.key:
+            for us_key in us_list_key():
                 unique_base_types = set()
-                for t in list_key_types[key].type_:
+                for t in list_key_types[us_key].type_:
                     unique_base_types.add(yang_type_to_acton_type(t))
                 if len(unique_base_types) <= 1:
                     # Class attribute is a not a "value" Acton type because it
                     # is either not an union or it an union that was resolved
                     # to a single builtin type, it has equality check
-                    res.append(f"            if e.{_safe_name(key)} != {_safe_name(key)}:")
+                    res.append(f"            if e.{us_key} != {us_key}:")
                     res.append("                match = False")
                     res.append("                continue")
                 else:
@@ -612,9 +614,9 @@ class DNodeInner(DNode):
                     # we need to first attempt to bind them to a more specific type
                     # TODO: use Acton unions
                     for t in unique_base_types:
-                        res.append(f"            e_{_safe_name(key)} = e.{_safe_name(key)}")
-                        res.append(f"            if isinstance(e_{_safe_name(key)}, {t}) and isinstance({_safe_name(key)}, {t}):")
-                        res.append(f"                if e_{_safe_name(key)} != {_safe_name(key)}:")
+                        res.append(f"            e_{us_key} = e.{us_key}")
+                        res.append(f"            if isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
+                        res.append(f"                if e_{us_key} != {us_key}:")
                         res.append("                    match = False")
                         res.append("                    continue")
             res.append("            if match:")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -332,6 +332,15 @@ class DNodeInner(DNode):
         def pname(n):
             return get_path_name(n)
 
+        def us_list_key():
+            """Convert list key names (DList.key) to their unique safe names
+
+            We use the containing list node prefix since the list keys must be
+            defined in the same namespace as the list."""
+            if isinstance(self, DList):
+                return list(map(lambda x: unique_namer.unique_safe_name(x, self.prefix), self.key))
+            raise ValueError(f"{self} not a list node")
+
         def maybe_user_order(n: DList):
             return ", user_order=True" if n.ordered_by == "user" else ""
 
@@ -479,7 +488,7 @@ class DNodeInner(DNode):
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
             # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{_safe_name(x)})", self.key))
+            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key()))
             # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
             res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
         elif isinstance(self, DRoot):

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -139,7 +139,7 @@ mut def from_json_foo__c1__things_element(jd: dict[str, ?value]) -> yang.gdata.N
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__c1__things__id(child_id)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__c1__things(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -126,7 +126,7 @@ mut def from_json_bar__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_bar__c1__li1__l1(child_l1)
-    return yang.gdata.Container(children, [str(child_l1 if child_l1 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
 
 mut def from_json_bar__c1__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -126,7 +126,7 @@ mut def from_json_foo__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__li1__l1(child_l1)
-    return yang.gdata.Container(children, [str(child_l1 if child_l1 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
 
 mut def from_json_foo__c1__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -193,7 +193,7 @@ mut def from_json_foo__c__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__c__li__bar(child_bar)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__c__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -21,7 +21,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         _foo_k1 = self.foo_k1
         if _foo_k1 is not None:
             children['foo:k1'] = yang.gdata.Leaf('string', _foo_k1, ns='http://example.com/foo', module='foo')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1)])
+        return yang.gdata.Container(children, [yang.gdata.yang_str(self.base_k1)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -38,16 +38,16 @@ class base__c1__base_l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k1):
+    mut def create(self, base_k1, foo_k1):
         for e in self.elements:
             match = True
-            if e.k1 != k1:
+            if e.base_k1 != base_k1:
                 match = False
                 continue
             if match:
                 return e
 
-        res = base__c1__base_l1_entry(k1)
+        res = base__c1__base_l1_entry(base_k1, foo_k1)
         self.elements.append(res)
         return res
 

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -1,27 +1,35 @@
-mut def from_json_base__c1__base_l1__k1(val: value) -> yang.gdata.Leaf:
+mut def from_json_base__c1__base_l1__base_k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class base__c1__base_l1_entry(yang.adata.MNode):
-    k1: str
+mut def from_json_base__c1__base_l1__foo_k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/foo', module='foo')
 
-    mut def __init__(self, k1: str):
+class base__c1__base_l1_entry(yang.adata.MNode):
+    base_k1: str
+    foo_k1: str
+
+    mut def __init__(self, base_k1: str, foo_k1: str):
         self._ns = 'http://example.com/base'
-        self.k1 = k1
+        self.base_k1 = base_k1
+        self.foo_k1 = foo_k1
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _k1 = self.k1
-        if _k1 is not None:
-            children['k1'] = yang.gdata.Leaf('string', _k1)
+        _base_k1 = self.base_k1
+        if _base_k1 is not None:
+            children['base:k1'] = yang.gdata.Leaf('string', _base_k1)
+        _foo_k1 = self.foo_k1
+        if _foo_k1 is not None:
+            children['foo:k1'] = yang.gdata.Leaf('string', _foo_k1, ns='http://example.com/foo', module='foo')
         return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
-        return base__c1__base_l1_entry(k1=n.get_str('k1'))
+        return base__c1__base_l1_entry(base_k1=n.get_str('base:k1'), foo_k1=n.get_str('foo:k1'))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> base__c1__base_l1_entry:
-        return base__c1__base_l1_entry(k1=yang.gdata.from_xml_str(n, 'k1'))
+        return base__c1__base_l1_entry(base_k1=yang.gdata.from_xml_str(n, 'k1'), foo_k1=yang.gdata.from_xml_str(n, 'k1', 'http://example.com/foo'))
 
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
@@ -83,7 +91,8 @@ mut def from_json_path_base__c1__base_l1_element(jd: value, path: list[str]=[], 
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        children['k1'] = from_json_base__c1__base_l1__k1(keys[0])
+        children['base:k1'] = from_json_base__c1__base_l1__base_k1(keys[0])
+        children['foo:k1'] = from_json_base__c1__base_l1__foo_k1(keys[0])
         return yang.gdata.Container(children, keys)
     raise ValueError("unreachable - no keys to list element")
 
@@ -114,9 +123,12 @@ mut def from_json_path_base__c1__base_l1(jd: value, path: list[str]=[], op: ?str
 
 mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_k1 = jd.get('k1')
-    if child_k1 is not None:
-        children['k1'] = from_json_base__c1__base_l1__k1(child_k1)
+    child_base_k1 = jd.get('k1')
+    if child_base_k1 is not None:
+        children['base:k1'] = from_json_base__c1__base_l1__base_k1(child_base_k1)
+    child_foo_k1 = jd.get('foo:k1')
+    if child_foo_k1 is not None:
+        children['foo:k1'] = from_json_base__c1__base_l1__foo_k1(child_foo_k1)
     return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else '')])
 
 mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -129,7 +129,7 @@ mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata
     child_foo_k1 = jd.get('foo:k1')
     if child_foo_k1 is not None:
         children['foo:k1'] = from_json_base__c1__base_l1__foo_k1(child_foo_k1)
-    return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_base_k1)])
 
 mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -257,7 +257,7 @@ mut def from_json_base__c1__foo_l1_element(jd: dict[str, ?value]) -> yang.gdata.
     child_k2 = jd.get('k2')
     if child_k2 is not None:
         children['k2'] = from_json_base__c1__foo_l1__k2(child_k2)
-    return yang.gdata.Container(children, [str(child_k2 if child_k2 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k2)])
 
 mut def from_json_base__c1__foo_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -117,7 +117,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -130,7 +130,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -126,7 +126,7 @@ mut def from_json_foo__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__li1__l1(child_l1)
-    return yang.gdata.Container(children, [str(child_l1 if child_l1 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
 
 mut def from_json_foo__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -202,7 +202,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__l1__bar(child_bar)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -130,7 +130,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -185,7 +185,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__l1__bar(child_bar)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -1,0 +1,204 @@
+import base64
+import json
+import xml
+import yang.adata
+import yang.gdata
+
+# == This file is generated ==
+
+
+mut def from_json_foo__foo__bar__foo_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_foo__foo__bar__bar_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_json_foo__foo__bar__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+class foo__foo__bar(yang.adata.MNode):
+    foo_l1: str
+    bar_l1: str
+    l2: str
+
+    mut def __init__(self, foo_l1: str, bar_l1: str, l2: str):
+        self._ns = 'http://example.com/foo'
+        self.foo_l1 = foo_l1
+        self.bar_l1 = bar_l1
+        self.l2 = l2
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo_l1 = self.foo_l1
+        if _foo_l1 is not None:
+            children['foo:l1'] = yang.gdata.Leaf('string', _foo_l1)
+        _bar_l1 = self.bar_l1
+        if _bar_l1 is not None:
+            children['bar:l1'] = yang.gdata.Leaf('string', _bar_l1, ns='http://example.com/bar', module='bar')
+        _l2 = self.l2
+        if _l2 is not None:
+            children['l2'] = yang.gdata.Leaf('string', _l2, ns='http://example.com/bar', module='bar')
+        return yang.gdata.Container(children, presence=True)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo__bar:
+        if n != None:
+            return foo__foo__bar(foo_l1=n.get_str('foo:l1'), bar_l1=n.get_str('bar:l1'), l2=n.get_str('l2'))
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__foo__bar:
+        if n != None:
+            return foo__foo__bar(foo_l1=yang.gdata.from_xml_str(n, 'l1'), bar_l1=yang.gdata.from_xml_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_str(n, 'l2', 'http://example.com/bar'))
+        return None
+
+
+mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'l1':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'bar:l1':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'bar:l2':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__foo__bar(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo_l1 = jd.get('l1')
+    if child_foo_l1 is not None:
+        children['foo:l1'] = from_json_foo__foo__bar__foo_l1(child_foo_l1)
+    child_bar_l1 = jd.get('bar:l1')
+    if child_bar_l1 is not None:
+        children['bar:l1'] = from_json_foo__foo__bar__bar_l1(child_bar_l1)
+    child_l2 = jd.get('bar:l2')
+    if child_l2 is not None:
+        children['l2'] = from_json_foo__foo__bar__l2(child_l2)
+    return yang.gdata.Container(children)
+
+class foo__foo(yang.adata.MNode):
+    bar: ?foo__foo__bar
+
+    mut def __init__(self, bar: ?foo__foo__bar=None):
+        self._ns = 'http://example.com/foo'
+        self.bar = bar
+
+    mut def create_bar(self, foo_l1, bar_l1, l2):
+        res = foo__foo__bar(foo_l1, bar_l1, l2)
+        self.bar = res
+        return res
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _bar = self.bar
+        if _bar is not None:
+            children['bar'] = _bar.to_gdata()
+        return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo:
+        if n != None:
+            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
+        return None
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> ?foo__foo:
+        if n != None:
+            return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
+        return None
+
+
+mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'bar':
+            child = {'bar': from_json_path_foo__foo__bar(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/foo', module='foo')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__foo(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_bar = jd.get('bar')
+    if child_bar is not None and isinstance(child_bar, dict):
+        children['bar'] = from_json_foo__foo__bar(child_bar)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+class root(yang.adata.MNode):
+    foo: ?foo__foo
+
+    mut def __init__(self, foo: ?foo__foo=None):
+        self._ns = ''
+        self.foo = foo
+
+    mut def create_foo(self, bar):
+        res = foo__foo(bar)
+        self.foo = res
+        return res
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _foo = self.foo
+        if _foo is not None:
+            children['foo'] = _foo.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n != None:
+            return root(foo=foo__foo.from_gdata(n.get_opt_container('foo')))
+        return root()
+
+    @staticmethod
+    mut def from_xml(n: ?xml.Node) -> root:
+        if n != None:
+            return root(foo=foo__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo', 'http://example.com/foo')))
+        return root()
+
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'foo:foo':
+            child = {'foo': from_json_path_foo__foo(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_foo = jd.get('foo:foo')
+    if child_foo is not None and isinstance(child_foo, dict):
+        children['foo'] = from_json_foo__foo(child_foo)
+    return yang.gdata.Container(children)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+    'http://example.com/bar',
+}

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -161,7 +161,7 @@ mut def from_json_foo__c1__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1__l1(child_l1)
-    return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else ''), str(child_k2 if child_k2 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2)])
 
 mut def from_json_foo__c1__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -151,7 +151,7 @@ mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -743,7 +743,7 @@ mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.No
     child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__cc__death__name(child_name)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__cc__death(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1112,7 +1112,7 @@ mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_yes = jd.get('yes')
     if child_yes is not None:
         children['yes'] = from_json_foo__special__yes(child_yes)
-    return yang.gdata.Container(children, [str(child_yes if child_yes is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
 
 mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1277,7 +1277,7 @@ mut def from_json_foo__nested__f_inner__li1__li2_element(jd: dict[str, ?value]) 
     child_baz = jd.get('baz')
     if child_baz is not None:
         children['baz'] = from_json_foo__nested__f_inner__li1__li2__baz(child_baz)
-    return yang.gdata.Container(children, [str(child_key1 if child_key1 is not None else ''), str(child_key2 if child_key2 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
 
 mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1435,7 +1435,7 @@ mut def from_json_foo__nested__f_inner__li1_element(jd: dict[str, ?value]) -> ya
     child_bar_bar = jd.get('bar:bar')
     if child_bar_bar is not None:
         children['bar:bar'] = from_json_foo__nested__f_inner__li1__bar_bar(child_bar_bar)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__nested__f_inner__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1781,7 +1781,7 @@ mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Nod
     child_k3 = jd.get('k3')
     if child_k3 is not None:
         children['k3'] = from_json_foo__li_union__k3(child_k3)
-    return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else ''), str(child_k2 if child_k2 is not None else ''), str(child_k3 if child_k3 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
 
 mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -151,7 +151,7 @@ mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -743,7 +743,7 @@ mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.No
     child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__cc__death__name(child_name)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__cc__death(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1112,7 +1112,7 @@ mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_yes = jd.get('yes')
     if child_yes is not None:
         children['yes'] = from_json_foo__special__yes(child_yes)
-    return yang.gdata.Container(children, [str(child_yes if child_yes is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
 
 mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1277,7 +1277,7 @@ mut def from_json_foo__nested__f_inner__li1__li2_element(jd: dict[str, ?value]) 
     child_baz = jd.get('baz')
     if child_baz is not None:
         children['baz'] = from_json_foo__nested__f_inner__li1__li2__baz(child_baz)
-    return yang.gdata.Container(children, [str(child_key1 if child_key1 is not None else ''), str(child_key2 if child_key2 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
 
 mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1435,7 +1435,7 @@ mut def from_json_foo__nested__f_inner__li1_element(jd: dict[str, ?value]) -> ya
     child_bar_bar = jd.get('bar:bar')
     if child_bar_bar is not None:
         children['bar:bar'] = from_json_foo__nested__f_inner__li1__bar_bar(child_bar_bar)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__nested__f_inner__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1781,7 +1781,7 @@ mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Nod
     child_k3 = jd.get('k3')
     if child_k3 is not None:
         children['k3'] = from_json_foo__li_union__k3(child_k3)
-    return yang.gdata.Container(children, [str(child_k1 if child_k1 is not None else ''), str(child_k2 if child_k2 is not None else ''), str(child_k3 if child_k3 is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
 
 mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -269,7 +269,7 @@ mut def from_json_foo__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_c1 = jd.get('c1')
     if child_c1 is not None and isinstance(child_c1, dict):
         children['c1'] = from_json_foo__li__c1(child_c1)
-    return yang.gdata.Container(children, [str(child_name if child_name is not None else '')])
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
 
 mut def from_json_foo__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -39,7 +39,7 @@ Container({
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'yes': Leaf('boolean', True)
-    }, ['True'])
+    }, ['true'])
   ]),
   'nested': Container({
     'f:inner': Container({


### PR DESCRIPTION
In places in adata where we access list keys with local names in code we must ensure the names are not in conflict with other child nodes from the list that may also appear in the vicinity. For example, the list entry `create()` method takes list keys as arguments, as well as any other non-optional child nodes. The `create_XXX()` method for a presence container also includes non-optional child nodes.

The same applies to accessing adata attributes and local variables.