### PR TITLE
Use correct output formatting for list key leaves in gdata -> XML, JSON 

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -336,14 +336,19 @@ class DNodeInner(DNode):
         def pname(n):
             return get_path_name(n)
 
-        def us_list_key():
+        def u_list_key(n: DList):
+            """Convert list key names (DList.key) to their unique names
+
+            We use the containing list node prefix since the list keys must be
+            defined in the same namespace as the list."""
+            return list(map(lambda x: unique_namer.unique_name(x, n.prefix), n.key))
+
+        def us_list_key(n: DList):
             """Convert list key names (DList.key) to their unique safe names
 
             We use the containing list node prefix since the list keys must be
             defined in the same namespace as the list."""
-            if isinstance(self, DList):
-                return list(map(lambda x: unique_namer.unique_safe_name(x, self.prefix), self.key))
-            raise ValueError(f"{self} not a list node")
+            return list(map(lambda x: unique_namer.unique_safe_name(x, n.prefix), n.key))
 
         def maybe_user_order(n: DList):
             return ", user_order=True" if n.ordered_by == "user" else ""
@@ -494,7 +499,7 @@ class DNodeInner(DNode):
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
             # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key()))
+            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key(self)))
             # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
             res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
         elif isinstance(self, DRoot):
@@ -588,7 +593,7 @@ class DNodeInner(DNode):
 
             # list_key_args contains the list keys names and also any
             # non-optional children. We use unique safe names for both to avoid conflicts.
-            list_key_args = us_list_key()
+            list_key_args = us_list_key(self)
             list_key_types = {}
             for child in self.children:
                 if isinstance(child, DLeaf):
@@ -604,7 +609,7 @@ class DNodeInner(DNode):
             res.append(f"    mut def create({list_create_args_str}):")
             res.append("        for e in self.elements:")
             res.append("            match = True")
-            for us_key in us_list_key():
+            for us_key in us_list_key(self):
                 unique_base_types = set()
                 for t in list_key_types[us_key].type_:
                     unique_base_types.add(yang_type_to_acton_type(t))
@@ -641,9 +646,9 @@ class DNodeInner(DNode):
             res.append("            if isinstance(e_gdata, yang.gdata.Container):")
             res.append("                elements.append(e_gdata)")
             if set_ns:
-                res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}, ns='{self.namespace}', module='{self.module}')")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, elements{maybe_user_order(self)}, ns='{self.namespace}', module='{self.module}')")
             else:
-                res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)})")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, elements{maybe_user_order(self)})")
             res.append("")
 
 #            # .from_gdata()
@@ -739,9 +744,9 @@ class DNodeInner(DNode):
                 res.append("            elements.append(element)")
                 res.append("        elif op == \"remove\":")
                 res.append("            elements.append(yang.gdata.Absent(element.key))")
-                res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}{gdata_nsq})")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, elements{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    elif len(path) > 1:")
-                res.append(f"        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    raise ValueError(\"Unable to resolve path, no keys provided\")")
 
             else:
@@ -812,7 +817,7 @@ class DNodeInner(DNode):
             if isinstance(self, DList):
                 # Collect keys leaf values in a list of strings by using the
                 # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
+                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key(self)))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
@@ -824,7 +829,7 @@ class DNodeInner(DNode):
             res.append(f"    for e in jd:")
             res.append(f"        if isinstance(e, dict):")
             res.append(f"            elements.append(from_json_{pname(self)}_element(e))")
-            res.append(f"    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
+            res.append(f"    return yang.gdata.List(keys={repr(u_list_key(self))}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
         if top:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -499,7 +499,7 @@ class DNodeInner(DNode):
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
             # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key(self)))
+            list_keys_str = ", ".join(map(lambda x: f"str(self.{x})", us_list_key(self)))
             # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
             res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
         elif isinstance(self, DRoot):
@@ -817,7 +817,7 @@ class DNodeInner(DNode):
             if isinstance(self, DList):
                 # Collect keys leaf values in a list of strings by using the
                 # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key(self)))
+                list_keys_str = ", ".join(map(lambda x: f"str(child_{x})", us_list_key(self)))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -191,7 +191,7 @@ def yang_str(v) -> str:
         s = s.lower()
     return s
 
-def json_val(yang_type: str, v: ?value) -> ?value:
+def json_val(yang_type: str, v: value) -> ?value:
     if isinstance(v, bytes):
         return base64.encode(v).decode()
     if yang_type == "int64" or yang_type == "uint64":
@@ -321,8 +321,9 @@ class Node(value):
                     for elem in child.elements if child.user_order else sorted(child.elements):
                         if isinstance(elem, Container):
                             elem_dict = {}
-                            for k, v in dict(zip(child.keys, elem.key)).items():
-                                elem_dict[k] = v
+                            for key_name in child.keys:
+                                key_leaf = elem.get_leaf(key_name)
+                                elem_dict[fmt_json_name(key_name)] = json_val(key_leaf.t, key_leaf.val)
                             elem_dict.update(elem.to_dict(pretty).items())
                             elems.append(elem_dict)
                         else:
@@ -373,8 +374,10 @@ class Node(value):
                 remove = isinstance(elem, Absent)
                 xml += _indent() + fmt_tag(name, either(self.ns, cns), attrs=remove_op if remove else []) + _nl()
                 # Print key leafs first
-                for key_idx, key_name in enumerate(self.keys):
-                    xml += _indent(1) + "<" + key_name + ">" + str(elem.key[key_idx]) + "</" + key_name + ">" + _nl()
+                for key_name in self.keys:
+                    key_leaf = elem.get_leaf(key_name)
+                    v = yang_str(key_leaf.val)
+                    xml += _indent(1) + fmt_tag(key_name) + v + fmt_tag(key_name, close=True) + _nl()
                 for nm,child in elem.children.items():
                     if nm in self.keys or remove:
                         continue
@@ -2237,10 +2240,14 @@ def _test_to_json():
             "a": Leaf("int", 1),
             "l1": List(["name", "name_two"], [
                 Container({
+                    "name": Leaf("str", "k1"),
+                    "name_two": Leaf("str", "k1a"),
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
                 }, ["k1", "k1a"]),
                 Container({
+                    "name": Leaf("str", "k4"),
+                    "name_two": Leaf("str", "k4a"),
                     "n4": Leaf("int", 4),
                 }, ["k4", "k4a"]),
             ]),
@@ -2262,10 +2269,14 @@ def _test_to_xmlstr():
             "a": Leaf("int", 1),
             "l1": List(["name", "name_two"], [
                 Container({
+                    "name": Leaf("str", "k1"),
+                    "name_two": Leaf("str", "k1a"),
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
                 }, ["k1", "k1a"]),
                 Container({
+                    "name": Leaf("str", "k4"),
+                    "name_two": Leaf("str", "k4a"),
                     "n4": Leaf("int", 4),
                 }, ["k4", "k4a"]),
             ]),
@@ -2315,6 +2326,7 @@ def _test_to_xmlstr_mixed():
     y1 = Container({
         "device": List(["name"], [
             Container({
+                "name": Leaf("str", "dev1"),
                 "config": Container({
                     "hostname": Container({
                         "system-network-name": Leaf("str", "dev1")
@@ -2322,6 +2334,7 @@ def _test_to_xmlstr_mixed():
                 }),
             }, ["dev1"]),
             Container({
+                "name": Leaf("str", "dev2"),
                 "config": Container({
                     "hostname": Container({
                         "system-network-name": Leaf("str", "dev2")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -332,14 +332,19 @@ class DNodeInner(DNode):
         def pname(n):
             return get_path_name(n)
 
-        def us_list_key():
+        def u_list_key(n: DList):
+            """Convert list key names (DList.key) to their unique names
+
+            We use the containing list node prefix since the list keys must be
+            defined in the same namespace as the list."""
+            return list(map(lambda x: unique_namer.unique_name(x, n.prefix), n.key))
+
+        def us_list_key(n: DList):
             """Convert list key names (DList.key) to their unique safe names
 
             We use the containing list node prefix since the list keys must be
             defined in the same namespace as the list."""
-            if isinstance(self, DList):
-                return list(map(lambda x: unique_namer.unique_safe_name(x, self.prefix), self.key))
-            raise ValueError(f"{self} not a list node")
+            return list(map(lambda x: unique_namer.unique_safe_name(x, n.prefix), n.key))
 
         def maybe_user_order(n: DList):
             return ", user_order=True" if n.ordered_by == "user" else ""
@@ -490,7 +495,7 @@ class DNodeInner(DNode):
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
             # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key()))
+            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key(self)))
             # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
             res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
         elif isinstance(self, DRoot):
@@ -584,7 +589,7 @@ class DNodeInner(DNode):
 
             # list_key_args contains the list keys names and also any
             # non-optional children. We use unique safe names for both to avoid conflicts.
-            list_key_args = us_list_key()
+            list_key_args = us_list_key(self)
             list_key_types = {}
             for child in self.children:
                 if isinstance(child, DLeaf):
@@ -600,7 +605,7 @@ class DNodeInner(DNode):
             res.append(f"    mut def create({list_create_args_str}):")
             res.append("        for e in self.elements:")
             res.append("            match = True")
-            for us_key in us_list_key():
+            for us_key in us_list_key(self):
                 unique_base_types = set()
                 for t in list_key_types[us_key].type_:
                     unique_base_types.add(yang_type_to_acton_type(t))
@@ -637,9 +642,9 @@ class DNodeInner(DNode):
             res.append("            if isinstance(e_gdata, yang.gdata.Container):")
             res.append("                elements.append(e_gdata)")
             if set_ns:
-                res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}, ns='{self.namespace}', module='{self.module}')")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, elements{maybe_user_order(self)}, ns='{self.namespace}', module='{self.module}')")
             else:
-                res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)})")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, elements{maybe_user_order(self)})")
             res.append("")
 
 #            # .from_gdata()
@@ -735,9 +740,9 @@ class DNodeInner(DNode):
                 res.append("            elements.append(element)")
                 res.append("        elif op == \"remove\":")
                 res.append("            elements.append(yang.gdata.Absent(element.key))")
-                res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}{gdata_nsq})")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, elements{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    elif len(path) > 1:")
-                res.append(f"        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
+                res.append(f"        return yang.gdata.List({repr(u_list_key(self))}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    raise ValueError(\"Unable to resolve path, no keys provided\")")
 
             else:
@@ -808,7 +813,7 @@ class DNodeInner(DNode):
             if isinstance(self, DList):
                 # Collect keys leaf values in a list of strings by using the
                 # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
+                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key(self)))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
@@ -820,7 +825,7 @@ class DNodeInner(DNode):
             res.append(f"    for e in jd:")
             res.append(f"        if isinstance(e, dict):")
             res.append(f"            elements.append(from_json_{pname(self)}_element(e))")
-            res.append(f"    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
+            res.append(f"    return yang.gdata.List(keys={repr(u_list_key(self))}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
         if top:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -495,7 +495,7 @@ class DNodeInner(DNode):
         if isinstance(self, DList):
             # keys contains a yang spec of the keys, like "k1 k2"
             # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key(self)))
+            list_keys_str = ", ".join(map(lambda x: f"str(self.{x})", us_list_key(self)))
             # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
             res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
         elif isinstance(self, DRoot):
@@ -813,7 +813,7 @@ class DNodeInner(DNode):
             if isinstance(self, DList):
                 # Collect keys leaf values in a list of strings by using the
                 # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key(self)))
+                list_keys_str = ", ".join(map(lambda x: f"str(child_{x})", us_list_key(self)))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -30,7 +30,7 @@ class foo__c1__things_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('string', _id)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__things_entry:
@@ -139,7 +139,7 @@ mut def from_json_foo__c1__things_element(jd: dict[str, ?value]) -> yang.gdata.N
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__c1__things__id(child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__c1__things(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -22,7 +22,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children, [str(self.l1)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> bar__c1__li1_entry:
@@ -126,7 +126,7 @@ mut def from_json_bar__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_bar__c1__li1__l1(child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children, [str(child_l1)])
 
 mut def from_json_bar__c1__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -22,7 +22,7 @@ class foo__c1__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children, [str(self.l1)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li1_entry:
@@ -126,7 +126,7 @@ mut def from_json_foo__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__li1__l1(child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children, [str(child_l1)])
 
 mut def from_json_foo__c1__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -79,7 +79,7 @@ class foo__c__li_entry(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c__li_entry:
@@ -193,7 +193,7 @@ mut def from_json_foo__c__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__c__li__bar(child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__c__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -57,7 +57,7 @@ class base__c1__base_l1(yang.adata.MNode):
             e_gdata = e.to_gdata()
             if isinstance(e_gdata, yang.gdata.Container):
                 elements.append(e_gdata)
-        return yang.gdata.List(['k1'], elements)
+        return yang.gdata.List(['base:k1'], elements)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.List) -> list[base__c1__base_l1_entry]:
@@ -116,9 +116,9 @@ mut def from_json_path_base__c1__base_l1(jd: value, path: list[str]=[], op: ?str
             elements.append(element)
         elif op == "remove":
             elements.append(yang.gdata.Absent(element.key))
-        return yang.gdata.List(['k1'], elements)
+        return yang.gdata.List(['base:k1'], elements)
     elif len(path) > 1:
-        return yang.gdata.List(['k1'], [from_json_path_base__c1__base_l1_element(jd, path, op)])
+        return yang.gdata.List(['base:k1'], [from_json_path_base__c1__base_l1_element(jd, path, op)])
     raise ValueError("Unable to resolve path, no keys provided")
 
 mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
@@ -136,7 +136,7 @@ mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.L
     for e in jd:
         if isinstance(e, dict):
             elements.append(from_json_base__c1__base_l1_element(e))
-    return yang.gdata.List(keys=['k1'], elements=elements)
+    return yang.gdata.List(keys=['base:k1'], elements=elements)
 
 mut def from_json_base__c1__foo_l1__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -21,7 +21,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         _foo_k1 = self.foo_k1
         if _foo_k1 is not None:
             children['foo:k1'] = yang.gdata.Leaf('string', _foo_k1, ns='http://example.com/foo', module='foo')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.base_k1)])
+        return yang.gdata.Container(children, [str(self.base_k1)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
@@ -129,7 +129,7 @@ mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata
     child_foo_k1 = jd.get('foo:k1')
     if child_foo_k1 is not None:
         children['foo:k1'] = from_json_base__c1__base_l1__foo_k1(child_foo_k1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_base_k1)])
+    return yang.gdata.Container(children, [str(child_base_k1)])
 
 mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -153,7 +153,7 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
         _k2 = self.k2
         if _k2 is not None:
             children['k2'] = yang.gdata.Leaf('string', _k2)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k2)])
+        return yang.gdata.Container(children, [str(self.k2)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__foo_l1_entry:
@@ -257,7 +257,7 @@ mut def from_json_base__c1__foo_l1_element(jd: dict[str, ?value]) -> yang.gdata.
     child_k2 = jd.get('k2')
     if child_k2 is not None:
         children['k2'] = from_json_base__c1__foo_l1__k2(child_k2)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k2)])
+    return yang.gdata.Container(children, [str(child_k2)])
 
 mut def from_json_base__c1__foo_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -13,7 +13,7 @@ class foo__l1_entry(yang.adata.MNode):
         _name = self.name
         if _name is not None:
             children['name'] = yang.gdata.Leaf('string', _name)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -117,7 +117,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__l1__name(child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -21,7 +21,7 @@ class foo__l1_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('string', _id)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -130,7 +130,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -22,7 +22,7 @@ class foo__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children, [str(self.l1)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
@@ -126,7 +126,7 @@ mut def from_json_foo__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__li1__l1(child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children, [str(child_l1)])
 
 mut def from_json_foo__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -88,7 +88,7 @@ class foo__l1_entry(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -202,7 +202,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__l1__bar(child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -21,7 +21,7 @@ class foo__l1_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('string', _id)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -130,7 +130,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_id = jd.get('id')
     if child_id is not None:
         children['id'] = from_json_foo__l1__id(child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -76,7 +76,7 @@ class foo__l1_entry(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -185,7 +185,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_bar = jd.get('bar')
     if child_bar is not None and isinstance(child_bar, dict):
         children['bar'] = from_json_foo__l1__bar(child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -38,7 +38,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1), yang.gdata.yang_str(self.k2)])
+        return yang.gdata.Container(children, [str(self.k1), str(self.k2)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
@@ -161,7 +161,7 @@ mut def from_json_foo__c1__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_l1 = jd.get('l1')
     if child_l1 is not None:
         children['l1'] = from_json_foo__c1__l1__l1(child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2)])
+    return yang.gdata.Container(children, [str(child_k1), str(child_k2)])
 
 mut def from_json_foo__c1__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -92,6 +92,7 @@ def _test_foo_from_xml_full():
   <l3>18446744073709551615</l3>
   <li>
     <name>tuta</name>
+    <name xmlns="http://example.com/bar">pela</name>
     <val>baba</val>
   </li>
   <ll_uint64>4</ll_uint64>
@@ -316,9 +317,9 @@ def _test_foo_from_xml_li_union():
 
 def _test_list_create_idempotency():
     r = yang_foo_root()
-    e1 = r.c1.li.create("a")
+    e1 = r.c1.li.create("a", "a-bar")
     e1.val = "1"
-    e2 = r.c1.li.create("a")
+    e2 = r.c1.li.create("a", "a-bar")
     e2.val = "2"
     # TODO: fix this!!!
     return r.to_gdata().to_xmlstr()
@@ -457,6 +458,7 @@ json_full = {
         "li": [
             {
                 "name": "tuta",
+                "bar:name": "pela",
                 "val": "baba"
             }
         ],
@@ -565,10 +567,12 @@ jd1 = {
         "li": [
             {
                 "name": "tuta",
+                "bar:name": "pela",
                 "val": "baba"
             },
             {
                 "name": "tata",
+                "bar:name": "pela",
                 "val": "baba"
             }
         ],

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -19,38 +19,46 @@ mut def from_json_foo__c1__l3(val: value) -> yang.gdata.Leaf:
 mut def from_json_foo__c1__l_empty(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
-mut def from_json_foo__c1__li__name(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__c1__li__f_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
+
+mut def from_json_foo__c1__li__bar_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 mut def from_json_foo__c1__li__val(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__li_entry(yang.adata.MNode):
-    name: str
+    f_name: str
+    bar_name: str
     val: ?str
 
-    mut def __init__(self, name: str, val: ?str):
+    mut def __init__(self, f_name: str, bar_name: str, val: ?str):
         self._ns = 'http://example.com/foo'
-        self.name = name
+        self.f_name = f_name
+        self.bar_name = bar_name
         self.val = val
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _name = self.name
-        if _name is not None:
-            children['name'] = yang.gdata.Leaf('string', _name)
+        _f_name = self.f_name
+        if _f_name is not None:
+            children['f:name'] = yang.gdata.Leaf('string', _f_name)
+        _bar_name = self.bar_name
+        if _bar_name is not None:
+            children['bar:name'] = yang.gdata.Leaf('string', _bar_name, ns='http://example.com/bar', module='bar')
         _val = self.val
         if _val is not None:
             children['val'] = yang.gdata.Leaf('string', _val)
-        return yang.gdata.Container(children, [str(self.name)])
+        return yang.gdata.Container(children, [str(self.f_name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=n.get_str('name'), val=n.get_opt_str('val'))
+        return foo__c1__li_entry(f_name=n.get_str('f:name'), bar_name=n.get_str('bar:name'), val=n.get_opt_str('val'))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=yang.gdata.from_xml_str(n, 'name'), val=yang.gdata.from_xml_opt_str(n, 'val'))
+        return foo__c1__li_entry(f_name=yang.gdata.from_xml_str(n, 'name'), bar_name=yang.gdata.from_xml_str(n, 'name', 'http://example.com/bar'), val=yang.gdata.from_xml_opt_str(n, 'val'))
 
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
@@ -59,16 +67,16 @@ class foo__c1__li(yang.adata.MNode):
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, f_name, bar_name):
         for e in self.elements:
             match = True
-            if e.name != name:
+            if e.f_name != f_name:
                 match = False
                 continue
             if match:
                 return e
 
-        res = foo__c1__li_entry(name)
+        res = foo__c1__li_entry(f_name, bar_name)
         self.elements.append(res)
         return res
 
@@ -78,7 +86,7 @@ class foo__c1__li(yang.adata.MNode):
             e_gdata = e.to_gdata()
             if isinstance(e_gdata, yang.gdata.Container):
                 elements.append(e_gdata)
-        return yang.gdata.List(['name'], elements, user_order=True)
+        return yang.gdata.List(['f:name'], elements, user_order=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.List) -> list[foo__c1__li_entry]:
@@ -112,7 +120,8 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        children['name'] = from_json_foo__c1__li__name(keys[0])
+        children['f:name'] = from_json_foo__c1__li__f_name(keys[0])
+        children['bar:name'] = from_json_foo__c1__li__bar_name(keys[0])
         if point == 'val':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)
@@ -138,27 +147,30 @@ mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merg
             elements.append(element)
         elif op == "remove":
             elements.append(yang.gdata.Absent(element.key))
-        return yang.gdata.List(['name'], elements, user_order=True)
+        return yang.gdata.List(['f:name'], elements, user_order=True)
     elif len(path) > 1:
-        return yang.gdata.List(['name'], [from_json_path_foo__c1__li_element(jd, path, op)], user_order=True)
+        return yang.gdata.List(['f:name'], [from_json_path_foo__c1__li_element(jd, path, op)], user_order=True)
     raise ValueError("Unable to resolve path, no keys provided")
 
 mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name = jd.get('name')
-    if child_name is not None:
-        children['name'] = from_json_foo__c1__li__name(child_name)
+    child_f_name = jd.get('name')
+    if child_f_name is not None:
+        children['f:name'] = from_json_foo__c1__li__f_name(child_f_name)
+    child_bar_name = jd.get('bar:name')
+    if child_bar_name is not None:
+        children['bar:name'] = from_json_foo__c1__li__bar_name(child_bar_name)
     child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
-    return yang.gdata.Container(children, [str(child_name)])
+    return yang.gdata.Container(children, [str(child_f_name)])
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
     for e in jd:
         if isinstance(e, dict):
             elements.append(from_json_foo__c1__li_element(e))
-    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+    return yang.gdata.List(keys=['f:name'], elements=elements, user_order=True)
 
 mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
     int_vals = []
@@ -2396,6 +2408,13 @@ def src_yang():
         // create a conflict with /f:c1/l1
         uses f:g1;
     }
+    augment /f:c1/li {
+        // create a conflict with /f:c1/li/name (key leaf)
+        leaf name {
+            type string;
+            mandatory true;
+        }
+    }
     augment /f:c.dot {
         leaf l.dot2 {
             type string;
@@ -2529,6 +2548,9 @@ def src_schema():
         Augment('/f:c1', children=[
             Uses('f:g1')
         ]),
+        Augment('/f:c1/li', children=[
+            Leaf('name', type_=Type('string'), mandatory=True)
+        ]),
         Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
@@ -2568,7 +2590,8 @@ def src_schema_compiled():
         Leaf('l_empty', type_=Type('empty')),
         List('li', key='name', ordered_by='user', children=[
             Leaf('name', type_=Type('string')),
-            Leaf('val', type_=Type('string'))
+            Leaf('val', type_=Type('string')),
+            Leaf('name', type_=Type('string'), mandatory=True)
         ]),
         LeafList('ll_uint64', type_=Type('uint64')),
         LeafList('ll_str', type_=Type('string')),
@@ -2656,6 +2679,9 @@ def src_schema_compiled():
     ], augment=[
         Augment('/f:c1', children=[
             Uses('f:g1')
+        ]),
+        Augment('/f:c1/li', children=[
+            Leaf('name', type_=Type('string'), mandatory=True)
         ]),
         Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -42,7 +42,7 @@ class foo__c1__li_entry(yang.adata.MNode):
         _val = self.val
         if _val is not None:
             children['val'] = yang.gdata.Leaf('string', _val)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
@@ -151,7 +151,7 @@ mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -639,7 +639,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         _name = self.name
         if _name is not None:
             children['name'] = yang.gdata.Leaf('string', _name)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
@@ -743,7 +743,7 @@ mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.No
     child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__cc__death__name(child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__cc__death(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1008,7 +1008,7 @@ class foo__special_entry(yang.adata.MNode):
         _yes = self.yes
         if _yes is not None:
             children['yes'] = yang.gdata.Leaf('boolean', _yes)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.yes)])
+        return yang.gdata.Container(children, [str(self.yes)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
@@ -1112,7 +1112,7 @@ mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_yes = jd.get('yes')
     if child_yes is not None:
         children['yes'] = from_json_foo__special__yes(child_yes)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+    return yang.gdata.Container(children, [str(child_yes)])
 
 mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1161,7 +1161,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         _baz = self.baz
         if _baz is not None:
             children['baz'] = yang.gdata.Leaf('string', _baz)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.key1), yang.gdata.yang_str(self.key2)])
+        return yang.gdata.Container(children, [str(self.key1), str(self.key2)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
@@ -1277,7 +1277,7 @@ mut def from_json_foo__nested__f_inner__li1__li2_element(jd: dict[str, ?value]) 
     child_baz = jd.get('baz')
     if child_baz is not None:
         children['baz'] = from_json_foo__nested__f_inner__li1__li2__baz(child_baz)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+    return yang.gdata.Container(children, [str(child_key1), str(child_key2)])
 
 mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1316,7 +1316,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
             children['bar:bar'] = yang.gdata.Leaf('string', _bar_bar, ns='http://example.com/bar', module='bar')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
@@ -1435,7 +1435,7 @@ mut def from_json_foo__nested__f_inner__li1_element(jd: dict[str, ?value]) -> ya
     child_bar_bar = jd.get('bar:bar')
     if child_bar_bar is not None:
         children['bar:bar'] = from_json_foo__nested__f_inner__li1__bar_bar(child_bar_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__nested__f_inner__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1651,7 +1651,7 @@ class foo__li_union_entry(yang.adata.MNode):
         _k3 = self.k3
         if _k3 is not None:
             children['k3'] = yang.gdata.Leaf('binary', _k3)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1), yang.gdata.yang_str(self.k2), yang.gdata.yang_str(self.k3)])
+        return yang.gdata.Container(children, [str(self.k1), str(self.k2), str(self.k3)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
@@ -1781,7 +1781,7 @@ mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Nod
     child_k3 = jd.get('k3')
     if child_k3 is not None:
         children['k3'] = from_json_foo__li_union__k3(child_k3)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+    return yang.gdata.Container(children, [str(child_k1), str(child_k2), str(child_k3)])
 
 mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -19,38 +19,46 @@ mut def from_json_foo__c1__l3(val: value) -> yang.gdata.Leaf:
 mut def from_json_foo__c1__l_empty(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
-mut def from_json_foo__c1__li__name(val: value) -> yang.gdata.Leaf:
+mut def from_json_foo__c1__li__f_name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
+
+mut def from_json_foo__c1__li__bar_name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 mut def from_json_foo__c1__li__val(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__li_entry(yang.adata.MNode):
-    name: str
+    f_name: str
+    bar_name: str
     val: ?str
 
-    mut def __init__(self, name: str, val: ?str):
+    mut def __init__(self, f_name: str, bar_name: str, val: ?str):
         self._ns = 'http://example.com/foo'
-        self.name = name
+        self.f_name = f_name
+        self.bar_name = bar_name
         self.val = val
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
-        _name = self.name
-        if _name is not None:
-            children['name'] = yang.gdata.Leaf('string', _name)
+        _f_name = self.f_name
+        if _f_name is not None:
+            children['f:name'] = yang.gdata.Leaf('string', _f_name)
+        _bar_name = self.bar_name
+        if _bar_name is not None:
+            children['bar:name'] = yang.gdata.Leaf('string', _bar_name, ns='http://example.com/bar', module='bar')
         _val = self.val
         if _val is not None:
             children['val'] = yang.gdata.Leaf('string', _val)
-        return yang.gdata.Container(children, [str(self.name)])
+        return yang.gdata.Container(children, [str(self.f_name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=n.get_str('name'), val=n.get_opt_str('val'))
+        return foo__c1__li_entry(f_name=n.get_str('f:name'), bar_name=n.get_str('bar:name'), val=n.get_opt_str('val'))
 
     @staticmethod
     mut def from_xml(n: xml.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=yang.gdata.from_xml_str(n, 'name'), val=yang.gdata.from_xml_opt_str(n, 'val'))
+        return foo__c1__li_entry(f_name=yang.gdata.from_xml_str(n, 'name'), bar_name=yang.gdata.from_xml_str(n, 'name', 'http://example.com/bar'), val=yang.gdata.from_xml_opt_str(n, 'val'))
 
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
@@ -59,16 +67,16 @@ class foo__c1__li(yang.adata.MNode):
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, f_name, bar_name):
         for e in self.elements:
             match = True
-            if e.name != name:
+            if e.f_name != f_name:
                 match = False
                 continue
             if match:
                 return e
 
-        res = foo__c1__li_entry(name)
+        res = foo__c1__li_entry(f_name, bar_name)
         self.elements.append(res)
         return res
 
@@ -78,7 +86,7 @@ class foo__c1__li(yang.adata.MNode):
             e_gdata = e.to_gdata()
             if isinstance(e_gdata, yang.gdata.Container):
                 elements.append(e_gdata)
-        return yang.gdata.List(['name'], elements, user_order=True)
+        return yang.gdata.List(['f:name'], elements, user_order=True)
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.List) -> list[foo__c1__li_entry]:
@@ -112,7 +120,8 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         point = path[1]
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
-        children['name'] = from_json_foo__c1__li__name(keys[0])
+        children['f:name'] = from_json_foo__c1__li__f_name(keys[0])
+        children['bar:name'] = from_json_foo__c1__li__bar_name(keys[0])
         if point == 'val':
             raise ValueError("Invalid json path to non-inner node")
         return yang.gdata.Container(children, keys)
@@ -138,27 +147,30 @@ mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merg
             elements.append(element)
         elif op == "remove":
             elements.append(yang.gdata.Absent(element.key))
-        return yang.gdata.List(['name'], elements, user_order=True)
+        return yang.gdata.List(['f:name'], elements, user_order=True)
     elif len(path) > 1:
-        return yang.gdata.List(['name'], [from_json_path_foo__c1__li_element(jd, path, op)], user_order=True)
+        return yang.gdata.List(['f:name'], [from_json_path_foo__c1__li_element(jd, path, op)], user_order=True)
     raise ValueError("Unable to resolve path, no keys provided")
 
 mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
-    child_name = jd.get('name')
-    if child_name is not None:
-        children['name'] = from_json_foo__c1__li__name(child_name)
+    child_f_name = jd.get('name')
+    if child_f_name is not None:
+        children['f:name'] = from_json_foo__c1__li__f_name(child_f_name)
+    child_bar_name = jd.get('bar:name')
+    if child_bar_name is not None:
+        children['bar:name'] = from_json_foo__c1__li__bar_name(child_bar_name)
     child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
-    return yang.gdata.Container(children, [str(child_name)])
+    return yang.gdata.Container(children, [str(child_f_name)])
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
     for e in jd:
         if isinstance(e, dict):
             elements.append(from_json_foo__c1__li_element(e))
-    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+    return yang.gdata.List(keys=['f:name'], elements=elements, user_order=True)
 
 mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
     int_vals = []
@@ -2396,6 +2408,13 @@ def src_yang():
         // create a conflict with /f:c1/l1
         uses f:g1;
     }
+    augment /f:c1/li {
+        // create a conflict with /f:c1/li/name (key leaf)
+        leaf name {
+            type string;
+            mandatory true;
+        }
+    }
     augment /f:c.dot {
         leaf l.dot2 {
             type string;
@@ -2529,6 +2548,9 @@ def src_schema():
         Augment('/f:c1', children=[
             Uses('f:g1')
         ]),
+        Augment('/f:c1/li', children=[
+            Leaf('name', type_=Type('string'), mandatory=True)
+        ]),
         Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
@@ -2568,7 +2590,8 @@ def src_schema_compiled():
         Leaf('l_empty', type_=Type('empty')),
         List('li', key='name', ordered_by='user', children=[
             Leaf('name', type_=Type('string')),
-            Leaf('val', type_=Type('string'))
+            Leaf('val', type_=Type('string')),
+            Leaf('name', type_=Type('string'), mandatory=True)
         ]),
         LeafList('ll_uint64', type_=Type('uint64')),
         LeafList('ll_str', type_=Type('string')),
@@ -2656,6 +2679,9 @@ def src_schema_compiled():
     ], augment=[
         Augment('/f:c1', children=[
             Uses('f:g1')
+        ]),
+        Augment('/f:c1/li', children=[
+            Leaf('name', type_=Type('string'), mandatory=True)
         ]),
         Augment('/f:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -42,7 +42,7 @@ class foo__c1__li_entry(yang.adata.MNode):
         _val = self.val
         if _val is not None:
             children['val'] = yang.gdata.Leaf('string', _val)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
@@ -151,7 +151,7 @@ mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_val = jd.get('val')
     if child_val is not None:
         children['val'] = from_json_foo__c1__li__val(child_val)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -639,7 +639,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         _name = self.name
         if _name is not None:
             children['name'] = yang.gdata.Leaf('string', _name)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
@@ -743,7 +743,7 @@ mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.No
     child_name = jd.get('name')
     if child_name is not None:
         children['name'] = from_json_foo__cc__death__name(child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__cc__death(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1008,7 +1008,7 @@ class foo__special_entry(yang.adata.MNode):
         _yes = self.yes
         if _yes is not None:
             children['yes'] = yang.gdata.Leaf('boolean', _yes)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.yes)])
+        return yang.gdata.Container(children, [str(self.yes)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
@@ -1112,7 +1112,7 @@ mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node
     child_yes = jd.get('yes')
     if child_yes is not None:
         children['yes'] = from_json_foo__special__yes(child_yes)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+    return yang.gdata.Container(children, [str(child_yes)])
 
 mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1161,7 +1161,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         _baz = self.baz
         if _baz is not None:
             children['baz'] = yang.gdata.Leaf('string', _baz)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.key1), yang.gdata.yang_str(self.key2)])
+        return yang.gdata.Container(children, [str(self.key1), str(self.key2)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
@@ -1277,7 +1277,7 @@ mut def from_json_foo__nested__f_inner__li1__li2_element(jd: dict[str, ?value]) 
     child_baz = jd.get('baz')
     if child_baz is not None:
         children['baz'] = from_json_foo__nested__f_inner__li1__li2__baz(child_baz)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+    return yang.gdata.Container(children, [str(child_key1), str(child_key2)])
 
 mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1316,7 +1316,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
             children['bar:bar'] = yang.gdata.Leaf('string', _bar_bar, ns='http://example.com/bar', module='bar')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
@@ -1435,7 +1435,7 @@ mut def from_json_foo__nested__f_inner__li1_element(jd: dict[str, ?value]) -> ya
     child_bar_bar = jd.get('bar:bar')
     if child_bar_bar is not None:
         children['bar:bar'] = from_json_foo__nested__f_inner__li1__bar_bar(child_bar_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__nested__f_inner__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1651,7 +1651,7 @@ class foo__li_union_entry(yang.adata.MNode):
         _k3 = self.k3
         if _k3 is not None:
             children['k3'] = yang.gdata.Leaf('binary', _k3)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1), yang.gdata.yang_str(self.k2), yang.gdata.yang_str(self.k3)])
+        return yang.gdata.Container(children, [str(self.k1), str(self.k2), str(self.k3)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
@@ -1781,7 +1781,7 @@ mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Nod
     child_k3 = jd.get('k3')
     if child_k3 is not None:
         children['k3'] = from_json_foo__li_union__k3(child_k3)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+    return yang.gdata.Container(children, [str(child_k1), str(child_k2), str(child_k3)])
 
 mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -160,7 +160,7 @@ class foo__li_entry(yang.adata.MNode):
         _c1 = self.c1
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children, [str(self.name)])
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_entry:
@@ -269,7 +269,7 @@ mut def from_json_foo__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     child_c1 = jd.get('c1')
     if child_c1 is not None and isinstance(child_c1, dict):
         children['c1'] = from_json_foo__li__c1(child_c1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children, [str(child_name)])
 
 mut def from_json_foo__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
@@ -1,6 +1,6 @@
 Container({
   'c1': Container({
-    'li': List(['name'], user_order=True),
+    'li': List(['f:name'], user_order=True),
     'll_uint64': LeafList('uint64', []),
     'll_str': LeafList('string', []),
     'bar:l1': Leaf('string', 'foo-bar', ns='http://example.com/bar', module='bar'),

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
@@ -1,6 +1,6 @@
 Container({
   'c1': Container({
-    'li': List(['name'], user_order=True),
+    'li': List(['f:name'], user_order=True),
     'll_uint64': LeafList('uint64', []),
     'll_str': LeafList('string', [])
   }, ns='http://example.com/foo', module='foo'),

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -39,7 +39,7 @@ Container({
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'yes': Leaf('boolean', True)
-    }, ['true'])
+    }, ['True'])
   ]),
   'nested': Container({
     'f:inner': Container({

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -2,9 +2,10 @@ Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
     'l3': Leaf('uint64', 18446744073709551615),
-    'li': List(['name'], user_order=True, elements=[
+    'li': List(['f:name'], user_order=True, elements=[
       Container({
-        'name': Leaf('string', 'tuta'),
+        'f:name': Leaf('string', 'tuta'),
+        'bar:name': Leaf('string', 'pela', ns='http://example.com/bar', module='bar'),
         'val': Leaf('string', 'baba')
       }, ['tuta'])
     ]),

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -40,7 +40,7 @@ Container({
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'yes': Leaf('boolean', True)
-    }, ['true'])
+    }, ['True'])
   ]),
   'nested': Container({
     'f:inner': Container({
@@ -53,17 +53,17 @@ Container({
       'k1': Leaf('string', 'first'),
       'k2': Leaf('union', '4'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['first', '4', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }, ['first', '4', "b'Hello Acton \\xf0\\x9f\\xab\\xa1'"]),
     Container({
       'k1': Leaf('string', 'second'),
       'k2': Leaf('union', 'unlimited'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['second', 'unlimited', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }, ['second', 'unlimited', "b'Hello Acton \\xf0\\x9f\\xab\\xa1'"]),
     Container({
       'k1': Leaf('string', 'third'),
       'k2': Leaf('union', 'aGk='),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
+    }, ['third', 'aGk=', "b'Hello Acton \\xf0\\x9f\\xab\\xa1'"])
   ]),
   'state': Container({
     'c1': Container()

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -2,9 +2,10 @@ Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
     'l3': Leaf('uint64', 18446744073709551615),
-    'li': List(['name'], user_order=True, elements=[
+    'li': List(['f:name'], user_order=True, elements=[
       Container({
-        'name': Leaf('string', 'tuta'),
+        'f:name': Leaf('string', 'tuta'),
+        'bar:name': Leaf('string', 'pela', ns='http://example.com/bar', module='bar'),
         'val': Leaf('string', 'baba')
       }, ['tuta'])
     ]),

--- a/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
@@ -2,13 +2,15 @@ Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
     'l3': Leaf('uint64', 18446744073709551615),
-    'li': List(['name'], user_order=True, elements=[
+    'li': List(['f:name'], user_order=True, elements=[
       Container({
-        'name': Leaf('string', 'tuta'),
+        'f:name': Leaf('string', 'tuta'),
+        'bar:name': Leaf('string', 'pela', ns='http://example.com/bar', module='bar'),
         'val': Leaf('string', 'baba')
       }, ['tuta']),
       Container({
-        'name': Leaf('string', 'tata'),
+        'f:name': Leaf('string', 'tata'),
+        'bar:name': Leaf('string', 'pela', ns='http://example.com/bar', module='bar'),
         'val': Leaf('string', 'baba')
       }, ['tata'])
     ]),

--- a/test/test_data_classes/test/golden/test_data_classes/list_create_idempotency
+++ b/test/test_data_classes/test/golden/test_data_classes/list_create_idempotency
@@ -1,6 +1,7 @@
 <c1 xmlns="http://example.com/foo">
   <li>
     <name>a</name>
+    <name xmlns="http://example.com/bar">a-bar</name>
     <val>2</val>
   </li>
 </c1>

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -234,6 +234,13 @@ ys_bar = """module bar {
         // create a conflict with /f:c1/l1
         uses f:g1;
     }
+    augment /f:c1/li {
+        // create a conflict with /f:c1/li/name (key leaf)
+        leaf name {
+            type string;
+            mandatory true;
+        }
+    }
     augment /f:c.dot {
         leaf l.dot2 {
             type string;


### PR DESCRIPTION
This PR changes the gdata `Node.to_dict()` and `Node.to_xmlstr()` methods such that they read the values for key leaves directly from the child `Leaf` objects, instead of using the `Container.key` attribute. My understanding is that the `Container.key` attribute is internal to gdata, used for sorting and list element access operations. As such it is orthogonal to the requirements of gdata output formats.

This change in how we lookup key values also influences how we must store the key leaf names in the gdata `List.keys` attribute. Because node names may have to include a prefix to make them unique, we must apply the same rules when storing key leaf names.