### PR TITLE
Test gdata source roundtrip

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,14 +21,20 @@ clean:
 test:
 	acton test
 	$(MAKE) test-daclass
+	$(MAKE) test-gdata-source-roundtrip
 
 .PHONY: test-daclass
 test-daclass:
 	cd test/test_data_classes_gen && acton build && out/bin/gen
 	cd test/test_data_classes && acton test
 
+.PHONY: test-gdata-source-roundtrip
+test-gdata-source-roundtrip:
+	cd test/test_gdata_source_roundtrip && acton test
+
 .PHONY: test-golden-update
 test-golden-update:
 	acton test --golden-update
 	cd test/test_data_classes_gen && acton build && out/bin/gen
 	cd test/test_data_classes && acton test --golden-update
+	cd test/test_gdata_source_roundtrip && acton test --golden-update

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -1,4 +1,5 @@
 
+import file
 import testing
 import json
 import xml
@@ -84,9 +85,8 @@ def _test_mandatory2():
 #     }
 # }
 
-def _test_foo_from_xml_full():
-    # TODO: add <l_empty/>
-    xml_text = """<data>
+# TODO: add <l_empty/>
+xml_text_full = """<data>
 <c1 xmlns="http://example.com/foo">
   <l1>foo-foo</l1>
   <l3>18446744073709551615</l3>
@@ -120,9 +120,9 @@ def _test_foo_from_xml_full():
 </cc>
 <conflict xmlns="http://example.com/foo">
   <foo>foo-foo</foo>
-  <inner></inner>
+  <inner/>
   <foo xmlns="http://example.com/bar">foo-augmented-from-bar</foo>
-  <inner xmlns="http://example.com/bar"></inner>
+  <inner xmlns="http://example.com/bar"/>
 </conflict>
 <special xmlns="http://example.com/foo">
   <yes>true</yes>
@@ -149,7 +149,9 @@ def _test_foo_from_xml_full():
   <foo>foo-bar</foo>
 </conflict>
 </data>"""
-    xml_in = xml.decode(xml_text)
+
+def _test_foo_from_xml_full():
+    xml_in = xml.decode(xml_text_full)
     d = yang_foo_root.from_xml(xml_in)
     g = d.to_gdata()
     print(g.prsrc(), err=True)
@@ -157,6 +159,16 @@ def _test_foo_from_xml_full():
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
     return d.to_gdata().prsrc()
+
+def _test_gdata_source_roundtrip_xml_full(t: testing.EnvT):
+    wfcap = file.WriteFileCap(file.FileCap(t.env.cap))
+    xml_in = xml.decode(xml_text_full)
+    d = yang_foo_root.from_xml(xml_in)
+    g = d.to_gdata()
+    wf = file.WriteFile(wfcap, "../test_gdata_source_roundtrip/src/xml_full.act")
+    await async wf.write(f"from yang.gdata import *\n\nxml_full = {g.prsrc()}".encode())
+    await async wf.close()
+    t.success()
 
 def _test_foo_from_xml1():
     """"""

--- a/test/test_gdata_source_roundtrip/.gitignore
+++ b/test/test_gdata_source_roundtrip/.gitignore
@@ -1,0 +1,5 @@
+.actonc.lock
+build.sh
+out
+zig-cache
+zig-out

--- a/test/test_gdata_source_roundtrip/README.md
+++ b/test/test_gdata_source_roundtrip/README.md
@@ -1,0 +1,4 @@
+# Test gdata persistence
+
+This is the project that contains the code to read gdata trees persisted with
+`gdata.prsrc()` in ../test_data_classes.

--- a/test/test_gdata_source_roundtrip/build.act.json
+++ b/test/test_gdata_source_roundtrip/build.act.json
@@ -1,0 +1,11 @@
+{
+    "dependencies": {
+        "yang": {
+            "path": "../../"
+        },
+        "foo": {
+            "path": "../test_data_classes"
+        }
+    },
+    "zig_dependencies": {}
+}

--- a/test/test_gdata_source_roundtrip/src/test_gdata_persistence.act
+++ b/test/test_gdata_source_roundtrip/src/test_gdata_persistence.act
@@ -1,0 +1,11 @@
+import testing
+
+import yang_foo
+import test_data_classes
+
+import xml_full
+
+def _test_xml_full():
+    xml_out_full = xml_full.xml_full.to_xmlstr()
+    xml_out_full_wrapped = f"<data>\n{xml_out_full}</data>"
+    testing.assertEqual(test_data_classes.xml_text_full, xml_out_full_wrapped)

--- a/test/test_gdata_source_roundtrip/src/xml_full.act
+++ b/test/test_gdata_source_roundtrip/src/xml_full.act
@@ -1,0 +1,79 @@
+from yang.gdata import *
+
+xml_full = Container({
+  'c1': Container({
+    'f:l1': Leaf('string', 'foo-foo'),
+    'l3': Leaf('uint64', 18446744073709551615),
+    'li': List(['name'], user_order=True, elements=[
+      Container({
+        'name': Leaf('string', 'tuta'),
+        'val': Leaf('string', 'baba')
+      }, ['tuta'])
+    ]),
+    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_str': LeafList('string', ['kava', 'čaj']),
+    'l4': Leaf('string', 'foo-qux'),
+    'bar:l1': Leaf('string', 'foo-bar', ns='http://example.com/bar', module='bar'),
+    'l2': Leaf('string', 'bar', ns='http://example.com/bar', module='bar')
+  }, ns='http://example.com/foo', module='foo'),
+  'pc1': Container({
+    'foo': Container({
+      'l1': LeafList('binary', [b'Hello Acton \xf0\x9f\xab\xa1'])
+    })
+  }, presence=True, ns='http://example.com/foo', module='foo'),
+  'pc2': Container({
+    'foo': Container({
+      'l_mandatory': Leaf('string', 'baz')
+    })
+  }, presence=True, ns='http://example.com/foo', module='foo'),
+  'c.dot': Container({
+    'l.dot1': Leaf('string', 'who put that here?!')
+  }, ns='http://example.com/foo', module='foo'),
+  'cc': Container({
+    'cake': Leaf('string', 'cake'),
+    'death': List(['name'])
+  }, ns='http://example.com/foo', module='foo'),
+  'f:conflict': Container({
+    'f:foo': Leaf('string', 'foo-foo'),
+    'f:inner': Container(presence=True),
+    'bar:foo': Leaf('string', 'foo-augmented-from-bar', ns='http://example.com/bar', module='bar'),
+    'bar:inner': Container(presence=True, ns='http://example.com/bar', module='bar')
+  }, ns='http://example.com/foo', module='foo'),
+  'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
+    Container({
+      'yes': Leaf('boolean', True)
+    }, ['true'])
+  ]),
+  'nested': Container({
+    'f:inner': Container({
+      'li1': List(['name'])
+    }),
+    'bar:inner': Container(ns='http://example.com/bar', module='bar')
+  }, ns='http://example.com/foo', module='foo'),
+  'li-union': List(['k1', 'k2', 'k3'], ns='http://example.com/foo', module='foo', elements=[
+    Container({
+      'k1': Leaf('string', 'first'),
+      'k2': Leaf('union', '4'),
+      'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
+    }, ['first', '4', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    Container({
+      'k1': Leaf('string', 'second'),
+      'k2': Leaf('union', 'unlimited'),
+      'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
+    }, ['second', 'unlimited', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    Container({
+      'k1': Leaf('string', 'third'),
+      'k2': Leaf('union', 'aGk='),
+      'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
+    }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
+  ]),
+  'state': Container({
+    'c1': Container()
+  }, ns='http://example.com/foo', module='foo'),
+  'c2': Container({
+    'l1': Leaf('string', 'foo-qux')
+  }, ns='http://example.com/foo', module='foo'),
+  'bar:conflict': Container({
+    'foo': Leaf('string', 'foo-bar')
+  }, ns='http://example.com/bar', module='bar')
+})


### PR DESCRIPTION
In test_data_classes we now also store the gdata test output as Acton code in
the test_gdata_persistence project. This makes test_gdata_persistence the third
project in the chain. We restore the gdata from code, dump it out to XML again
to check whether we get the same document that we used as input.