### PR TITLE
Parse XML directly to gdata

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -505,35 +505,23 @@ class DNodeInner(DNode):
         else:
             res.append(f"        return yang.gdata.{self.gname}(children{gdata_nsq})")
         res.append("")
-#
-        def _maybe_ns(child: DNode) -> str:
-            if child.namespace != self.namespace:
-                return f", '{child.namespace}'"
-            return ""
 
         # .from_gdata()
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
-        from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
                 from_gdata_args_list.append(f"{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}('{uname(child)}')")
-                from_xml_args_list.append(f"{usname(child)}=yang.gdata.from_xml_{yang_leaf_to_getval(child, loose)}(n, '{child.name}'{_maybe_ns(child)})")
             elif isinstance(child, DLeafList):
                 from_gdata_args_list.append(f"{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}s('{uname(child)}')")
-                from_xml_args_list.append(f"{usname(child)}=yang.gdata.from_xml_{yang_leaf_to_getval(child, loose)}s(n, '{child.name}'{_maybe_ns(child)})")
             elif isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
                     from_gdata_args_list.append(f"{usname(child)}={pname(child)}.from_gdata(n.get_opt_container('{uname(child)}'))")
-                    from_xml_args_list.append(f"{usname(child)}={pname(child)}.from_xml(yang.gdata.get_xml_opt_child(n, '{child.name}'{_maybe_ns(child)}))")
                 else:
                     from_gdata_args_list.append(f"{usname(child)}={pname(child)}.from_gdata(n.get_container('{uname(child)}'))")
-                    from_xml_args_list.append(f"{usname(child)}={pname(child)}.from_xml(yang.gdata.get_xml_child(n, '{child.name}'{_maybe_ns(child)}))")
             elif isinstance(child, DList):
                 from_gdata_args_list.append(f"{usname(child)}={pname(child)}.from_gdata(n.get_opt_list('{uname(child)}'))")
-                from_xml_args_list.append(f"{usname(child)}={pname(child)}.from_xml(yang.gdata.get_xml_children(n, '{child.name}'{_maybe_ns(child)}))")
         from_gdata_args = ", ".join(from_gdata_args_list)
-        from_xml_args = ", ".join(from_xml_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
             res.append(f"    mut def from_gdata(n: yang.gdata.Node) -> {pname(self)}_entry:")
@@ -543,23 +531,6 @@ class DNodeInner(DNode):
             res.append(f"    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname(self)}:")
             res.append("        if n != None:")
             res.append(f"            return {pname(self)}({from_gdata_args})")
-            if opt_cnt:
-                res.append("        return None")
-            elif optional_subtree(self):
-                res.append(f"        return {pname(self)}()")
-            else:
-                res.append(f"        raise ValueError('Missing required subtree {pname(self)}')")
-        res.append("")
-
-        res.append("    @staticmethod")
-        if isinstance(self, DList):
-            res.append(f"    mut def from_xml(n: xml.Node) -> {pname(self)}_entry:")
-            res.append(f"        return {pname(self)}_entry({from_xml_args})")
-        else:
-            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append(f"    mut def from_xml(n: ?xml.Node) -> {'?' if opt_cnt else ''}{pname(self)}:")
-            res.append("        if n != None:")
-            res.append(f"            return {pname(self)}({from_xml_args})")
             if opt_cnt:
                 res.append("        return None")
             elif optional_subtree(self):
@@ -656,19 +627,10 @@ class DNodeInner(DNode):
             res.append(f"                res.append({pname(self)}_entry.from_gdata(e))")
             res.append("        return res")
             #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname(self))
-            res.append("")
-            res.append("    @staticmethod")
-            res.append(f"    mut def from_xml(nodes: list[xml.Node]) -> list[{pname(self)}_entry]:")
-            res.append("        res = []")
-            res.append("        for node in nodes:")
-            res.append(f"            res.append({pname(self)}_entry.from_xml(node))")
-            res.append("        return res")
             # TODO: trying to use list(map(lambda)) here results in an error,
             # why? Above code that iterates over n.elements works fine... Error is:
             # ERROR: Error when compiling y_cfs module: Type error
             # mut must be a subclass of pure
-            #
-            #res.append("        return list(map(lambda x: %s_entry.from_xml(x), nodes))" % pname(self))
             res.append("")
         res.append("")
 

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -698,6 +698,8 @@ class DNodeInner(DNode):
                 # non-optional local variables defined above.
                 list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+            elif isinstance(self, DContainer) and self.presence:
+                res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
             res.append("")
@@ -834,6 +836,8 @@ class DNodeInner(DNode):
                 # non-optional local variables defined above.
                 list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+            elif isinstance(self, DContainer) and self.presence:
+                res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
             res.append("")

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -672,6 +672,44 @@ class DNodeInner(DNode):
             res.append("")
         res.append("")
 
+        # == XML serde ================================
+
+        # from_xml(): from XML -> gdata
+        if gen_xml and isinstance(self, DNodeInner):
+            fname = "from_xml"
+            if not top:
+                fname += "_" + pname(self)
+
+            if isinstance(self, DList):
+                res.append(f"mut def {fname}_element(node: xml.Node) -> yang.gdata.Node:")
+            else:
+                res.append(f"mut def {fname}(node: xml.Node) -> yang.gdata.{self.gname}:")
+
+            res.append("    children = {}")
+            for child in self.children:
+                maybe_ns = f", '{child.namespace}'" if child.namespace != self.namespace else ""
+                # TODO: no need for local variables when we switch from the
+                # gdata.Container.key attribute to key_str() method
+                res.append(f"    child_{usname(child)} = yang.gdata.from_xml_{taker_name(child, loose=loose)}(node, '{child.name}'{maybe_ns})")
+                res.append(f"    yang.gdata.maybe_add(children, '{uname(child)}', from_xml_{pname(child)}, child_{usname(child)})")
+
+            if isinstance(self, DList):
+                # Collect keys leaf values in a list of strings by using the
+                # non-optional local variables defined above.
+                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
+                res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+            else:
+                res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
+            res.append("")
+
+        if gen_xml and isinstance(self, DList):
+            res.append(f"mut def from_xml_{pname(self)}(nodes: list[xml.Node]) -> yang.gdata.List:")
+            res.append(f"    elements = []")
+            res.append(f"    for e in nodes:")
+            res.append(f"        elements.append(from_xml_{pname(self)}_element(e))")
+            res.append(f"    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
+            res.append("")
+
         # == JSON serde ================================
 
         # from_json(): from JSON -> gdata
@@ -1045,6 +1083,10 @@ class DLeaf(DNodeLeaf):
                 res.append(f"        return yang.gdata.Leaf('{self.type_.name}', int(val){gdata_nsq})")
             res.append(f"    return yang.gdata.Leaf('{self.type_.name}', val{gdata_nsq})")
             res.append("")
+        if gen_xml:
+            res.append(f"mut def from_xml_{pname(self)}(val: value) -> yang.gdata.Leaf:")
+            res.append(f"    return yang.gdata.Leaf('{self.type_.name}', val{gdata_nsq})")
+            res.append("")
         return "\n".join(res)
 
 
@@ -1101,6 +1143,10 @@ class DLeafList(DNodeLeaf):
                 res.append(f"    return yang.gdata.LeafList('{self.type_.name}', int_vals{maybe_user_order}{gdata_nsq})")
             else:
                 res.append(f"    return yang.gdata.LeafList('{self.type_.name}', val{maybe_user_order}{gdata_nsq})")
+            res.append("")
+        if gen_xml:
+            res.append(f"mut def from_xml_{pname(self)}(val: list[value]) -> yang.gdata.LeafList:")
+            res.append(f"    return yang.gdata.LeafList('{self.type_.name}', val{maybe_user_order}{gdata_nsq})")
             res.append("")
         return "\n".join(res)
 

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -735,6 +735,8 @@ def vals_equal(a: value, b: value) -> bool:
         return a == b
     if isinstance(a, str) and isinstance(b, str):
         return a == b
+    if isinstance(a, bytes) and isinstance(b, bytes):
+        return a == b
     # TODO: Add support for u8 and i8
     #if isinstance(a, u8) and isinstance(b, u8):
     #    return a == b
@@ -773,6 +775,8 @@ def vals_less_than(a: value, b: value) -> bool:
     if isinstance(a, float) and isinstance(b, float):
         return a < b
     if isinstance(a, str) and isinstance(b, str):
+        return a < b
+    if isinstance(a, bytes) and isinstance(b, bytes):
         return a < b
     # TODO: Add support for u8 and i8
     #if isinstance(a, u8) and isinstance(b, u8):

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1324,6 +1324,21 @@ def get_xml_children(n: xml.Node, name: str, ns: ?str) -> list[xml.Node]:
             res.append(child)
     return res
 
+def from_xml_opt_list(n: xml.Node, name: str, ns: ?str) -> ?list[xml.Node]:
+    return get_xml_children(n, name, ns)
+
+def from_xml_list(n: xml.Node, name: str, ns: ?str) -> list[xml.Node]:
+    r = from_xml_opt_list(n, name, ns)
+    if r is not None:
+        return r
+    raise ValueError("Cannot find xml child with name " + name)
+
+def from_xml_opt_cnt(n: xml.Node, name: str, ns: ?str) -> ?xml.Node:
+    return get_xml_opt_child(n, name, ns)
+
+def from_xml_cnt(n: xml.Node, name: str, ns: ?str) -> xml.Node:
+    return get_xml_child(n, name, ns)
+
 def from_xml_opt_bool(n: xml.Node, name: str, ns: ?str) -> ?bool:
     try:
         text = get_xml_child(n, name, ns).text
@@ -1410,6 +1425,12 @@ def from_xml_value(n: xml.Node, name: str, ns: ?str) -> value:
     raise ValueError("Cannot find xml child with name " + name)
 
 # plural
+def from_xml_strs(n: xml.Node, name: str, ns: ?str) -> list[str]:
+    r = from_xml_opt_strs(n, name, ns)
+    if r is not None:
+        return r
+    raise ValueError("Cannot find xml child with name " + name)
+
 def from_xml_opt_strs(n: xml.Node, name: str, ns: ?str) -> list[str]:
     res = []
     for child in get_xml_children(n, name, ns):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -668,6 +668,44 @@ class DNodeInner(DNode):
             res.append("")
         res.append("")
 
+        # == XML serde ================================
+
+        # from_xml(): from XML -> gdata
+        if gen_xml and isinstance(self, DNodeInner):
+            fname = "from_xml"
+            if not top:
+                fname += "_" + pname(self)
+
+            if isinstance(self, DList):
+                res.append(f"mut def {fname}_element(node: xml.Node) -> yang.gdata.Node:")
+            else:
+                res.append(f"mut def {fname}(node: xml.Node) -> yang.gdata.{self.gname}:")
+
+            res.append("    children = {}")
+            for child in self.children:
+                maybe_ns = f", '{child.namespace}'" if child.namespace != self.namespace else ""
+                # TODO: no need for local variables when we switch from the
+                # gdata.Container.key attribute to key_str() method
+                res.append(f"    child_{usname(child)} = yang.gdata.from_xml_{taker_name(child, loose=loose)}(node, '{child.name}'{maybe_ns})")
+                res.append(f"    yang.gdata.maybe_add(children, '{uname(child)}', from_xml_{pname(child)}, child_{usname(child)})")
+
+            if isinstance(self, DList):
+                # Collect keys leaf values in a list of strings by using the
+                # non-optional local variables defined above.
+                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
+                res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+            else:
+                res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
+            res.append("")
+
+        if gen_xml and isinstance(self, DList):
+            res.append(f"mut def from_xml_{pname(self)}(nodes: list[xml.Node]) -> yang.gdata.List:")
+            res.append(f"    elements = []")
+            res.append(f"    for e in nodes:")
+            res.append(f"        elements.append(from_xml_{pname(self)}_element(e))")
+            res.append(f"    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
+            res.append("")
+
         # == JSON serde ================================
 
         # from_json(): from JSON -> gdata
@@ -1041,6 +1079,10 @@ class DLeaf(DNodeLeaf):
                 res.append(f"        return yang.gdata.Leaf('{self.type_.name}', int(val){gdata_nsq})")
             res.append(f"    return yang.gdata.Leaf('{self.type_.name}', val{gdata_nsq})")
             res.append("")
+        if gen_xml:
+            res.append(f"mut def from_xml_{pname(self)}(val: value) -> yang.gdata.Leaf:")
+            res.append(f"    return yang.gdata.Leaf('{self.type_.name}', val{gdata_nsq})")
+            res.append("")
         return "\n".join(res)
 
 
@@ -1097,6 +1139,10 @@ class DLeafList(DNodeLeaf):
                 res.append(f"    return yang.gdata.LeafList('{self.type_.name}', int_vals{maybe_user_order}{gdata_nsq})")
             else:
                 res.append(f"    return yang.gdata.LeafList('{self.type_.name}', val{maybe_user_order}{gdata_nsq})")
+            res.append("")
+        if gen_xml:
+            res.append(f"mut def from_xml_{pname(self)}(val: list[value]) -> yang.gdata.LeafList:")
+            res.append(f"    return yang.gdata.LeafList('{self.type_.name}', val{maybe_user_order}{gdata_nsq})")
             res.append("")
         return "\n".join(res)
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -694,6 +694,8 @@ class DNodeInner(DNode):
                 # non-optional local variables defined above.
                 list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+            elif isinstance(self, DContainer) and self.presence:
+                res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
             res.append("")
@@ -830,6 +832,8 @@ class DNodeInner(DNode):
                 # non-optional local variables defined above.
                 list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
                 res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+            elif isinstance(self, DContainer) and self.presence:
+                res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:
                 res.append(f"    return yang.gdata.{self.gname}(children{gdata_nsq})")
             res.append("")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -501,35 +501,23 @@ class DNodeInner(DNode):
         else:
             res.append(f"        return yang.gdata.{self.gname}(children{gdata_nsq})")
         res.append("")
-#
-        def _maybe_ns(child: DNode) -> str:
-            if child.namespace != self.namespace:
-                return f", '{child.namespace}'"
-            return ""
 
         # .from_gdata()
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
-        from_xml_args_list = []
         for child in self.children:
             if isinstance(child, DLeaf):
                 from_gdata_args_list.append(f"{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}('{uname(child)}')")
-                from_xml_args_list.append(f"{usname(child)}=yang.gdata.from_xml_{yang_leaf_to_getval(child, loose)}(n, '{child.name}'{_maybe_ns(child)})")
             elif isinstance(child, DLeafList):
                 from_gdata_args_list.append(f"{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}s('{uname(child)}')")
-                from_xml_args_list.append(f"{usname(child)}=yang.gdata.from_xml_{yang_leaf_to_getval(child, loose)}s(n, '{child.name}'{_maybe_ns(child)})")
             elif isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
                     from_gdata_args_list.append(f"{usname(child)}={pname(child)}.from_gdata(n.get_opt_container('{uname(child)}'))")
-                    from_xml_args_list.append(f"{usname(child)}={pname(child)}.from_xml(yang.gdata.get_xml_opt_child(n, '{child.name}'{_maybe_ns(child)}))")
                 else:
                     from_gdata_args_list.append(f"{usname(child)}={pname(child)}.from_gdata(n.get_container('{uname(child)}'))")
-                    from_xml_args_list.append(f"{usname(child)}={pname(child)}.from_xml(yang.gdata.get_xml_child(n, '{child.name}'{_maybe_ns(child)}))")
             elif isinstance(child, DList):
                 from_gdata_args_list.append(f"{usname(child)}={pname(child)}.from_gdata(n.get_opt_list('{uname(child)}'))")
-                from_xml_args_list.append(f"{usname(child)}={pname(child)}.from_xml(yang.gdata.get_xml_children(n, '{child.name}'{_maybe_ns(child)}))")
         from_gdata_args = ", ".join(from_gdata_args_list)
-        from_xml_args = ", ".join(from_xml_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
             res.append(f"    mut def from_gdata(n: yang.gdata.Node) -> {pname(self)}_entry:")
@@ -539,23 +527,6 @@ class DNodeInner(DNode):
             res.append(f"    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname(self)}:")
             res.append("        if n != None:")
             res.append(f"            return {pname(self)}({from_gdata_args})")
-            if opt_cnt:
-                res.append("        return None")
-            elif optional_subtree(self):
-                res.append(f"        return {pname(self)}()")
-            else:
-                res.append(f"        raise ValueError('Missing required subtree {pname(self)}')")
-        res.append("")
-
-        res.append("    @staticmethod")
-        if isinstance(self, DList):
-            res.append(f"    mut def from_xml(n: xml.Node) -> {pname(self)}_entry:")
-            res.append(f"        return {pname(self)}_entry({from_xml_args})")
-        else:
-            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append(f"    mut def from_xml(n: ?xml.Node) -> {'?' if opt_cnt else ''}{pname(self)}:")
-            res.append("        if n != None:")
-            res.append(f"            return {pname(self)}({from_xml_args})")
             if opt_cnt:
                 res.append("        return None")
             elif optional_subtree(self):
@@ -652,19 +623,10 @@ class DNodeInner(DNode):
             res.append(f"                res.append({pname(self)}_entry.from_gdata(e))")
             res.append("        return res")
             #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname(self))
-            res.append("")
-            res.append("    @staticmethod")
-            res.append(f"    mut def from_xml(nodes: list[xml.Node]) -> list[{pname(self)}_entry]:")
-            res.append("        res = []")
-            res.append("        for node in nodes:")
-            res.append(f"            res.append({pname(self)}_entry.from_xml(node))")
-            res.append("        return res")
             # TODO: trying to use list(map(lambda)) here results in an error,
             # why? Above code that iterates over n.elements works fine... Error is:
             # ERROR: Error when compiling y_cfs module: Type error
             # mut must be a subclass of pure
-            #
-            #res.append("        return list(map(lambda x: %s_entry.from_xml(x), nodes))" % pname(self))
             res.append("")
         res.append("")
 

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -44,12 +44,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -103,12 +97,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1(yang.adata.MNode):
@@ -44,6 +50,14 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -97,6 +111,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -30,6 +30,10 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -74,6 +78,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -23,12 +23,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1()
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1()
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -70,12 +64,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -44,12 +44,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -103,12 +97,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__c1(yang.adata.MNode):
@@ -44,6 +50,14 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -97,6 +111,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -50,12 +50,6 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=n.get_opt_str('l2'), l3=n.get_opt_str('l3'))
         return foo__c1__c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
-        if n != None:
-            return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, 'l2'), l3=yang.gdata.from_xml_opt_str(n, 'l3'))
-        return foo__c1__c2()
-
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -116,12 +110,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_container('c2')))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2')))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -176,12 +164,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -10,10 +10,19 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__c2__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__c2__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__c2__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__c2__l3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__c2(yang.adata.MNode):
@@ -47,6 +56,14 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, 'l2'), l3=yang.gdata.from_xml_opt_str(n, 'l3'))
         return foo__c1__c2()
 
+
+mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__c2__l2, child_l2)
+    child_l3 = yang.gdata.from_xml_opt_str(node, 'l3')
+    yang.gdata.maybe_add(children, 'l3', from_xml_foo__c1__c2__l3, child_l3)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -106,6 +123,14 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2')
+    yang.gdata.maybe_add(children, 'c2', from_xml_foo__c1__c2, child_c2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -159,6 +184,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -50,12 +50,6 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=n.get_opt_str('l2'), l3=n.get_opt_str('l3'))
         return foo__c1__c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
-        if n != None:
-            return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, 'l2'), l3=yang.gdata.from_xml_opt_str(n, 'l3', 'http://example.com/baz'))
-        return foo__c1__c2()
-
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -116,12 +110,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_container('c2')))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/bar')))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -176,12 +164,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -10,10 +10,19 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__c2__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__c2__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__c2__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/baz', module='baz')
+
+mut def from_xml_foo__c1__c2__l3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/baz', module='baz')
 
 class foo__c1__c2(yang.adata.MNode):
@@ -47,6 +56,14 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=yang.gdata.from_xml_opt_str(n, 'l2'), l3=yang.gdata.from_xml_opt_str(n, 'l3', 'http://example.com/baz'))
         return foo__c1__c2()
 
+
+mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__c2__l2, child_l2)
+    child_l3 = yang.gdata.from_xml_opt_str(node, 'l3', 'http://example.com/baz')
+    yang.gdata.maybe_add(children, 'l3', from_xml_foo__c1__c2__l3, child_l3)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -106,6 +123,14 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'c2', from_xml_foo__c1__c2, child_c2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -159,6 +184,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__c1__c2__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__c2__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__c1__c2(yang.adata.MNode):
     l1: ?str
 
@@ -36,6 +39,12 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
         return foo__c1__c2()
 
+
+mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__c2__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__c1__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -86,6 +95,12 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2')
+    yang.gdata.maybe_add(children, 'c2', from_xml_foo__c1__c2, child_c2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -135,6 +150,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -33,12 +33,6 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l1=n.get_opt_str('l1'))
         return foo__c1__c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1__c2:
-        if n != None:
-            return foo__c1__c2(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__c1__c2()
-
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -86,12 +80,6 @@ class foo__c1(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
             return foo__c1(c2=foo__c1__c2.from_gdata(n.get_opt_container('c2')))
-        return foo__c1()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(c2=foo__c1__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2')))
         return foo__c1()
 
 
@@ -142,12 +130,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -44,12 +44,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -103,12 +97,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__c1(yang.adata.MNode):
@@ -44,6 +50,14 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -97,6 +111,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -42,10 +42,6 @@ class foo__c1__things_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__things_entry:
         return foo__c1__things_entry(name=n.get_str('name'), id=n.get_opt_str('id'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__c1__things_entry:
-        return foo__c1__things_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_opt_str(n, 'id'))
-
 class foo__c1__things(yang.adata.MNode):
     elements: list[foo__c1__things_entry]
     mut def __init__(self, elements=[]):
@@ -80,13 +76,6 @@ class foo__c1__things(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__c1__things_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__things_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__c1__things_entry.from_xml(node))
         return res
 
 
@@ -186,12 +175,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(things=foo__c1__things.from_gdata(n.get_opt_list('things')))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(things=foo__c1__things.from_xml(yang.gdata.get_xml_children(n, 'things')))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -240,12 +223,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_foo__c1__things__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__things__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__things__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__things__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__things_entry(yang.adata.MNode):
@@ -83,6 +89,20 @@ class foo__c1__things(yang.adata.MNode):
             res.append(foo__c1__things_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__c1__things_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__c1__things__name, child_name)
+    child_id = yang.gdata.from_xml_opt_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_foo__c1__things__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__c1__things(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__c1__things_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_foo__c1__things_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -173,6 +193,12 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_things = yang.gdata.from_xml_opt_list(node, 'things')
+    yang.gdata.maybe_add(children, 'things', from_xml_foo__c1__things, child_things)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -222,6 +248,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -33,12 +33,6 @@ class acme_foo_bar__c1(yang.adata.MNode):
             return acme_foo_bar__c1(l1=n.get_opt_str('l1'))
         return acme_foo_bar__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> acme_foo_bar__c1:
-        if n != None:
-            return acme_foo_bar__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return acme_foo_bar__c1()
-
 
 mut def from_xml_acme_foo_bar__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -86,12 +80,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=acme_foo_bar__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=acme_foo_bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_acme_foo_bar__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_acme_foo_bar__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class acme_foo_bar__c1(yang.adata.MNode):
     l1: ?str
 
@@ -36,6 +39,12 @@ class acme_foo_bar__c1(yang.adata.MNode):
             return acme_foo_bar__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
         return acme_foo_bar__c1()
 
+
+mut def from_xml_acme_foo_bar__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_acme_foo_bar__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='acme_foo-bar')
 
 mut def from_json_path_acme_foo_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -85,6 +94,12 @@ class root(yang.adata.MNode):
             return root(c1=acme_foo_bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_acme_foo_bar__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -31,10 +31,6 @@ class bar__c1__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> bar__c1__li1_entry:
         return bar__c1__li1_entry(l1=n.get_str('l1'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> bar__c1__li1_entry:
-        return bar__c1__li1_entry(l1=yang.gdata.from_xml_str(n, 'l1'))
-
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -69,13 +65,6 @@ class bar__c1__li1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(bar__c1__li1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[bar__c1__li1_entry]:
-        res = []
-        for node in nodes:
-            res.append(bar__c1__li1_entry.from_xml(node))
         return res
 
 
@@ -169,12 +158,6 @@ class bar__c1(yang.adata.MNode):
             return bar__c1(li1=bar__c1__li1.from_gdata(n.get_opt_list('li1')))
         return bar__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> bar__c1:
-        if n != None:
-            return bar__c1(li1=bar__c1__li1.from_xml(yang.gdata.get_xml_children(n, 'li1')))
-        return bar__c1()
-
 
 mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -223,12 +206,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=bar__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/bar')))
         return root()
 
 

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_bar__c1__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_bar__c1__li1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class bar__c1__li1_entry(yang.adata.MNode):
     l1: str
 
@@ -75,6 +78,18 @@ class bar__c1__li1(yang.adata.MNode):
             res.append(bar__c1__li1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_bar__c1__li1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_bar__c1__li1__l1, child_l1)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+
+mut def from_xml_bar__c1__li1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_bar__c1__li1_element(e))
+    return yang.gdata.List(keys=['l1'], elements=elements)
 
 mut def from_json_path_bar__c1__li1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -161,6 +176,12 @@ class bar__c1(yang.adata.MNode):
         return bar__c1()
 
 
+mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_li1 = yang.gdata.from_xml_opt_list(node, 'li1')
+    yang.gdata.maybe_add(children, 'li1', from_xml_bar__c1__li1, child_li1)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
 mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -210,6 +231,12 @@ class root(yang.adata.MNode):
             return root(c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/bar')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'c1', from_xml_bar__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
+mut def from_xml_foo__c1__l1(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
 class foo__c1(yang.adata.MNode):
     l1: list[str]
 
@@ -34,6 +37,12 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=yang.gdata.from_xml_opt_strs(n, 'l1'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_strs(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -83,6 +92,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -31,12 +31,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_strs('l1'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_strs(n, 'l1'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -84,12 +78,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -33,12 +33,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -94,12 +88,6 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l2=n.get_opt_str('l2'))
         return foo__c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c2:
-        if n != None:
-            return foo__c2(l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        return foo__c2()
-
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -152,12 +140,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), c2=foo__c2.from_gdata(n.get_opt_container('c2')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
@@ -37,6 +40,12 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -60,6 +69,9 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__c2__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c2__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c2(yang.adata.MNode):
@@ -88,6 +100,12 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l2=yang.gdata.from_xml_opt_str(n, 'l2'))
         return foo__c2()
 
+
+mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c2__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -142,6 +160,14 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__c1__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__li1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__c1__li1_entry(yang.adata.MNode):
     l1: str
 
@@ -75,6 +78,18 @@ class foo__c1__li1(yang.adata.MNode):
             res.append(foo__c1__li1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__c1__li1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__li1__l1, child_l1)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+
+mut def from_xml_foo__c1__li1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__c1__li1_element(e))
+    return yang.gdata.List(keys=['l1'], elements=elements)
 
 mut def from_json_path_foo__c1__li1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -161,6 +176,12 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_li1 = yang.gdata.from_xml_opt_list(node, 'li1')
+    yang.gdata.maybe_add(children, 'li1', from_xml_foo__c1__li1, child_li1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -210,6 +231,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -31,10 +31,6 @@ class foo__c1__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li1_entry:
         return foo__c1__li1_entry(l1=n.get_str('l1'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__c1__li1_entry:
-        return foo__c1__li1_entry(l1=yang.gdata.from_xml_str(n, 'l1'))
-
 class foo__c1__li1(yang.adata.MNode):
     elements: list[foo__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -69,13 +65,6 @@ class foo__c1__li1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__c1__li1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__li1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__c1__li1_entry.from_xml(node))
         return res
 
 
@@ -169,12 +158,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(li1=foo__c1__li1.from_gdata(n.get_opt_list('li1')))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(li1=foo__c1__li1.from_xml(yang.gdata.get_xml_children(n, 'li1')))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -223,12 +206,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -44,12 +44,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -103,12 +97,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -10,7 +10,13 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1(yang.adata.MNode):
@@ -44,6 +50,14 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -97,6 +111,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -1,10 +1,19 @@
 mut def from_json_foo__c__li__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c__li__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c__li__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c__li__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c__li__bar__man(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c__li__bar__man(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c__li__bar(yang.adata.MNode):
@@ -33,6 +42,12 @@ class foo__c__li__bar(yang.adata.MNode):
             return foo__c__li__bar(man=yang.gdata.from_xml_str(n, 'man'))
         raise ValueError('Missing required subtree foo__c__li__bar')
 
+
+mut def from_xml_foo__c__li__bar(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_man = yang.gdata.from_xml_str(node, 'man')
+    yang.gdata.maybe_add(children, 'man', from_xml_foo__c__li__bar__man, child_man)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__c__li__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -131,6 +146,22 @@ class foo__c__li(yang.adata.MNode):
             res.append(foo__c__li_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__c__li_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__c__li__name, child_name)
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__c__li__foo, child_foo)
+    child_bar = yang.gdata.from_xml_cnt(node, 'bar')
+    yang.gdata.maybe_add(children, 'bar', from_xml_foo__c__li__bar, child_bar)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__c__li(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__c__li_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c__li_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -36,12 +36,6 @@ class foo__c__li__bar(yang.adata.MNode):
             return foo__c__li__bar(man=n.get_str('man'))
         raise ValueError('Missing required subtree foo__c__li__bar')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c__li__bar:
-        if n != None:
-            return foo__c__li__bar(man=yang.gdata.from_xml_str(n, 'man'))
-        raise ValueError('Missing required subtree foo__c__li__bar')
-
 
 mut def from_xml_foo__c__li__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -99,10 +93,6 @@ class foo__c__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c__li_entry:
         return foo__c__li_entry(name=n.get_str('name'), foo=n.get_opt_str('foo'), bar=foo__c__li__bar.from_gdata(n.get_container('bar')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__c__li_entry:
-        return foo__c__li_entry(name=yang.gdata.from_xml_str(n, 'name'), foo=yang.gdata.from_xml_opt_str(n, 'foo'), bar=foo__c__li__bar.from_xml(yang.gdata.get_xml_child(n, 'bar')))
-
 class foo__c__li(yang.adata.MNode):
     elements: list[foo__c__li_entry]
     mut def __init__(self, elements=[]):
@@ -137,13 +127,6 @@ class foo__c__li(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__c__li_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c__li_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__c__li_entry.from_xml(node))
         return res
 
 

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -1,7 +1,13 @@
 mut def from_json_base__c1__base_l1__base_k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_base__c1__base_l1__base_k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_base__c1__base_l1__foo_k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/foo', module='foo')
+
+mut def from_xml_base__c1__base_l1__foo_k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/foo', module='foo')
 
 class base__c1__base_l1_entry(yang.adata.MNode):
@@ -75,6 +81,20 @@ class base__c1__base_l1(yang.adata.MNode):
         return res
 
 
+mut def from_xml_base__c1__base_l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_base_k1 = yang.gdata.from_xml_str(node, 'k1')
+    yang.gdata.maybe_add(children, 'base:k1', from_xml_base__c1__base_l1__base_k1, child_base_k1)
+    child_foo_k1 = yang.gdata.from_xml_str(node, 'k1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'foo:k1', from_xml_base__c1__base_l1__foo_k1, child_foo_k1)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_base_k1)])
+
+mut def from_xml_base__c1__base_l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_base__c1__base_l1_element(e))
+    return yang.gdata.List(keys=['k1'], elements=elements)
+
 mut def from_json_path_base__c1__base_l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -137,6 +157,9 @@ mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.L
     return yang.gdata.List(keys=['k1'], elements=elements)
 
 mut def from_json_base__c1__foo_l1__k2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_base__c1__foo_l1__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class base__c1__foo_l1_entry(yang.adata.MNode):
@@ -204,6 +227,18 @@ class base__c1__foo_l1(yang.adata.MNode):
             res.append(base__c1__foo_l1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_base__c1__foo_l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_k2 = yang.gdata.from_xml_str(node, 'k2')
+    yang.gdata.maybe_add(children, 'k2', from_xml_base__c1__foo_l1__k2, child_k2)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k2)])
+
+mut def from_xml_base__c1__foo_l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_base__c1__foo_l1_element(e))
+    return yang.gdata.List(keys=['k2'], elements=elements, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_base__c1__foo_l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -295,6 +330,14 @@ class base__c1(yang.adata.MNode):
         return base__c1()
 
 
+mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_base_l1 = yang.gdata.from_xml_opt_list(node, 'l1')
+    yang.gdata.maybe_add(children, 'base:l1', from_xml_base__c1__base_l1, child_base_l1)
+    child_foo_l1 = yang.gdata.from_xml_opt_list(node, 'l1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'foo:l1', from_xml_base__c1__foo_l1, child_foo_l1)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
 mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -349,6 +392,12 @@ class root(yang.adata.MNode):
             return root(c1=base__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/base')))
         return root()
 
+
+mut def from_xml_root(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/base')
+    yang.gdata.maybe_add(children, 'c1', from_xml_base__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_root(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -33,10 +33,6 @@ class base__c1__base_l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
         return base__c1__base_l1_entry(base_k1=n.get_str('base:k1'), foo_k1=n.get_str('foo:k1'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> base__c1__base_l1_entry:
-        return base__c1__base_l1_entry(base_k1=yang.gdata.from_xml_str(n, 'k1'), foo_k1=yang.gdata.from_xml_str(n, 'k1', 'http://example.com/foo'))
-
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
     mut def __init__(self, elements=[]):
@@ -71,13 +67,6 @@ class base__c1__base_l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(base__c1__base_l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[base__c1__base_l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(base__c1__base_l1_entry.from_xml(node))
         return res
 
 
@@ -180,10 +169,6 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__foo_l1_entry:
         return base__c1__foo_l1_entry(k2=n.get_str('k2'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> base__c1__foo_l1_entry:
-        return base__c1__foo_l1_entry(k2=yang.gdata.from_xml_str(n, 'k2'))
-
 class base__c1__foo_l1(yang.adata.MNode):
     elements: list[base__c1__foo_l1_entry]
     mut def __init__(self, elements=[]):
@@ -218,13 +203,6 @@ class base__c1__foo_l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(base__c1__foo_l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[base__c1__foo_l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(base__c1__foo_l1_entry.from_xml(node))
         return res
 
 
@@ -323,12 +301,6 @@ class base__c1(yang.adata.MNode):
             return base__c1(base_l1=base__c1__base_l1.from_gdata(n.get_opt_list('base:l1')), foo_l1=base__c1__foo_l1.from_gdata(n.get_opt_list('foo:l1')))
         return base__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1:
-        if n != None:
-            return base__c1(base_l1=base__c1__base_l1.from_xml(yang.gdata.get_xml_children(n, 'l1')), foo_l1=base__c1__foo_l1.from_xml(yang.gdata.get_xml_children(n, 'l1', 'http://example.com/foo')))
-        return base__c1()
-
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -384,12 +356,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=base__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=base__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/base')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -1,6 +1,9 @@
 mut def from_json_base__c1__base_c2__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_base__c1__base_c2__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class base__c1__base_c2(yang.adata.MNode):
     foo: ?str
 
@@ -28,6 +31,12 @@ class base__c1__base_c2(yang.adata.MNode):
         return base__c1__base_c2()
 
 
+mut def from_xml_base__c1__base_c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_base__c1__base_c2__foo, child_foo)
+    return yang.gdata.Container(children)
+
 mut def from_json_path_base__c1__base_c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -51,6 +60,9 @@ mut def from_json_base__c1__base_c2(jd: dict[str, ?value]) -> yang.gdata.Contain
     return yang.gdata.Container(children)
 
 mut def from_json_base__c1__foo_c2__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_base__c1__foo_c2__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class base__c1__foo_c2(yang.adata.MNode):
@@ -79,6 +91,12 @@ class base__c1__foo_c2(yang.adata.MNode):
             return base__c1__foo_c2(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return base__c1__foo_c2()
 
+
+mut def from_xml_base__c1__foo_c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_base__c1__foo_c2__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_base__c1__foo_c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -134,6 +152,14 @@ class base__c1(yang.adata.MNode):
         return base__c1()
 
 
+mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_base_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2')
+    yang.gdata.maybe_add(children, 'base:c2', from_xml_base__c1__base_c2, child_base_c2)
+    child_foo_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'foo:c2', from_xml_base__c1__foo_c2, child_foo_c2)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
 mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -188,6 +214,12 @@ class root(yang.adata.MNode):
             return root(c1=base__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/base')))
         return root()
 
+
+mut def from_xml_root(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/base')
+    yang.gdata.maybe_add(children, 'c1', from_xml_base__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_root(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -24,12 +24,6 @@ class base__c1__base_c2(yang.adata.MNode):
             return base__c1__base_c2(foo=n.get_opt_str('foo'))
         return base__c1__base_c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1__base_c2:
-        if n != None:
-            return base__c1__base_c2(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
-        return base__c1__base_c2()
-
 
 mut def from_xml_base__c1__base_c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -85,12 +79,6 @@ class base__c1__foo_c2(yang.adata.MNode):
             return base__c1__foo_c2(foo=n.get_opt_str('foo'))
         return base__c1__foo_c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1__foo_c2:
-        if n != None:
-            return base__c1__foo_c2(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
-        return base__c1__foo_c2()
-
 
 mut def from_xml_base__c1__foo_c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -143,12 +131,6 @@ class base__c1(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> base__c1:
         if n != None:
             return base__c1(base_c2=base__c1__base_c2.from_gdata(n.get_opt_container('base:c2')), foo_c2=base__c1__foo_c2.from_gdata(n.get_opt_container('foo:c2')))
-        return base__c1()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1:
-        if n != None:
-            return base__c1(base_c2=base__c1__base_c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2')), foo_c2=base__c1__foo_c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')))
         return base__c1()
 
 
@@ -206,12 +188,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=base__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=base__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/base')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -35,12 +35,6 @@ class base__c1(yang.adata.MNode):
             return base__c1(bar_foo=n.get_opt_str('bar:foo'), foo_foo=n.get_opt_str('foo:foo'))
         return base__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> base__c1:
-        if n != None:
-            return base__c1(bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), foo_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/foo'))
-        return base__c1()
-
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -1,7 +1,13 @@
 mut def from_json_base__c1__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
+mut def from_xml_base__c1__bar_foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
 mut def from_json_base__c1__foo_foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/foo', module='foo')
+
+mut def from_xml_base__c1__foo_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/foo', module='foo')
 
 class base__c1(yang.adata.MNode):
@@ -35,6 +41,14 @@ class base__c1(yang.adata.MNode):
             return base__c1(bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), foo_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/foo'))
         return base__c1()
 
+
+mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bar_foo = yang.gdata.from_xml_opt_str(node, 'foo', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:foo', from_xml_base__c1__bar_foo, child_bar_foo)
+    child_foo_foo = yang.gdata.from_xml_opt_str(node, 'foo', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'foo:foo', from_xml_base__c1__foo_foo, child_foo_foo)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
 
 mut def from_json_path_base__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -33,12 +33,6 @@ class foo__ieee_802_3(yang.adata.MNode):
             return foo__ieee_802_3(ieee_802_3=n.get_opt_str('ieee-802.3'))
         return foo__ieee_802_3()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__ieee_802_3:
-        if n != None:
-            return foo__ieee_802_3(ieee_802_3=yang.gdata.from_xml_opt_str(n, 'ieee-802.3'))
-        return foo__ieee_802_3()
-
 
 mut def from_xml_foo__ieee_802_3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -86,12 +80,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(ieee_802_3=foo__ieee_802_3.from_gdata(n.get_opt_container('ieee-802.3')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(ieee_802_3=foo__ieee_802_3.from_xml(yang.gdata.get_xml_opt_child(n, 'ieee-802.3', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__ieee_802_3__ieee_802_3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__ieee_802_3__ieee_802_3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__ieee_802_3(yang.adata.MNode):
     ieee_802_3: ?str
 
@@ -36,6 +39,12 @@ class foo__ieee_802_3(yang.adata.MNode):
             return foo__ieee_802_3(ieee_802_3=yang.gdata.from_xml_opt_str(n, 'ieee-802.3'))
         return foo__ieee_802_3()
 
+
+mut def from_xml_foo__ieee_802_3(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ieee_802_3 = yang.gdata.from_xml_opt_str(node, 'ieee-802.3')
+    yang.gdata.maybe_add(children, 'ieee-802.3', from_xml_foo__ieee_802_3__ieee_802_3, child_ieee_802_3)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__ieee_802_3(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -85,6 +94,12 @@ class root(yang.adata.MNode):
             return root(ieee_802_3=foo__ieee_802_3.from_xml(yang.gdata.get_xml_opt_child(n, 'ieee-802.3', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_ieee_802_3 = yang.gdata.from_xml_opt_cnt(node, 'ieee-802.3', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'ieee-802.3', from_xml_foo__ieee_802_3, child_ieee_802_3)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -1,16 +1,31 @@
 mut def from_json_foo__c1__as(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__as(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__for(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__for(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__c1__import(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__import(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__in(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__in(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__with(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__with(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1(yang.adata.MNode):
@@ -59,6 +74,20 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(as_=yang.gdata.from_xml_opt_str(n, 'as'), for_=yang.gdata.from_xml_opt_str(n, 'for'), import_=yang.gdata.from_xml_opt_str(n, 'import'), in_=yang.gdata.from_xml_opt_str(n, 'in'), with_=yang.gdata.from_xml_opt_str(n, 'with'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_as_ = yang.gdata.from_xml_opt_str(node, 'as')
+    yang.gdata.maybe_add(children, 'as', from_xml_foo__c1__as, child_as_)
+    child_for_ = yang.gdata.from_xml_opt_str(node, 'for')
+    yang.gdata.maybe_add(children, 'for', from_xml_foo__c1__for, child_for_)
+    child_import_ = yang.gdata.from_xml_opt_str(node, 'import')
+    yang.gdata.maybe_add(children, 'import', from_xml_foo__c1__import, child_import_)
+    child_in_ = yang.gdata.from_xml_opt_str(node, 'in')
+    yang.gdata.maybe_add(children, 'in', from_xml_foo__c1__in, child_in_)
+    child_with_ = yang.gdata.from_xml_opt_str(node, 'with')
+    yang.gdata.maybe_add(children, 'with', from_xml_foo__c1__with, child_with_)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -68,12 +68,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(as_=n.get_opt_str('as'), for_=n.get_opt_str('for'), import_=n.get_opt_str('import'), in_=n.get_opt_str('in'), with_=n.get_opt_str('with'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(as_=yang.gdata.from_xml_opt_str(n, 'as'), for_=yang.gdata.from_xml_opt_str(n, 'for'), import_=yang.gdata.from_xml_opt_str(n, 'import'), in_=yang.gdata.from_xml_opt_str(n, 'in'), with_=yang.gdata.from_xml_opt_str(n, 'with'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -1,6 +1,9 @@
 mut def from_json_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__l1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__l1_entry(yang.adata.MNode):
     name: str
 
@@ -66,6 +69,18 @@ class foo__l1(yang.adata.MNode):
             res.append(foo__l1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__l1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -22,10 +22,6 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=yang.gdata.from_xml_str(n, 'name'))
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -60,13 +56,6 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__l1_entry.from_xml(node))
         return res
 
 

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -1,7 +1,13 @@
 mut def from_json_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__l1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__l1__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__l1__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__l1_entry(yang.adata.MNode):
@@ -74,6 +80,20 @@ class foo__l1(yang.adata.MNode):
             res.append(foo__l1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
+    child_id = yang.gdata.from_xml_opt_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_foo__l1__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__l1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -33,10 +33,6 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), id=n.get_opt_str('id'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_opt_str(n, 'id'))
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -71,13 +67,6 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__l1_entry.from_xml(node))
         return res
 
 

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -24,12 +24,6 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=n.get_opt_str('l1'))
         raise ValueError('Missing required subtree foo__foo__bar')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo__bar:
-        if n != None:
-            return foo__foo__bar(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        raise ValueError('Missing required subtree foo__foo__bar')
-
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -77,12 +71,6 @@ class foo__foo(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo:
         if n != None:
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
-        raise ValueError('Missing required subtree foo__foo')
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__foo:
-        if n != None:
-            return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
         raise ValueError('Missing required subtree foo__foo')
 
 

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -1,6 +1,9 @@
 mut def from_json_foo__foo__bar__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__foo__bar__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__foo__bar(yang.adata.MNode):
     l1: ?str
 
@@ -27,6 +30,12 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
         raise ValueError('Missing required subtree foo__foo__bar')
 
+
+mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__foo__bar__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -76,6 +85,12 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
         raise ValueError('Missing required subtree foo__foo')
 
+
+mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
+    yang.gdata.maybe_add(children, 'bar', from_xml_foo__foo__bar, child_bar)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -24,12 +24,6 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=n.get_opt_str('l1'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__foo__bar:
-        if n != None:
-            return foo__foo__bar(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return None
-
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -82,12 +76,6 @@ class foo__foo(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo:
         if n != None:
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__foo:
-        if n != None:
-            return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
         return None
 
 

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -35,7 +35,7 @@ mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_l1 = yang.gdata.from_xml_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__foo__bar__l1, child_l1)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -57,7 +57,7 @@ mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_l1 = yang.gdata.take_json_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__foo__bar__l1, child_l1)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
@@ -95,7 +95,7 @@ mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_xml_foo__foo__bar, child_bar)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -118,4 +118,4 @@ mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_bar = yang.gdata.take_json_opt_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__foo__bar, child_bar)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -1,6 +1,9 @@
 mut def from_json_foo__foo__bar__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__foo__bar__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__foo__bar(yang.adata.MNode):
     l1: ?str
 
@@ -27,6 +30,12 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
         return None
 
+
+mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__foo__bar__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -81,6 +90,12 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
         return None
 
+
+mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
+    yang.gdata.maybe_add(children, 'bar', from_xml_foo__foo__bar, child_bar)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -31,10 +31,6 @@ class foo__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
         return foo__li1_entry(l1=n.get_str('l1'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__li1_entry:
-        return foo__li1_entry(l1=yang.gdata.from_xml_str(n, 'l1'))
-
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -69,13 +65,6 @@ class foo__li1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__li1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__li1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__li1_entry.from_xml(node))
         return res
 
 
@@ -176,12 +165,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(li1=foo__li1.from_gdata(n.get_opt_list('li1')), ll1=n.get_opt_strs('ll1'))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(li1=foo__li1.from_xml(yang.gdata.get_xml_children(n, 'li1', 'http://example.com/foo')), ll1=yang.gdata.from_xml_opt_strs(n, 'll1', 'http://example.com/foo'))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__li1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__li1_entry(yang.adata.MNode):
     l1: str
 
@@ -76,6 +79,18 @@ class foo__li1(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__li1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__li1__l1, child_l1)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+
+mut def from_xml_foo__li1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__li1_element(e))
+    return yang.gdata.List(keys=['l1'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__li1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -137,6 +152,9 @@ mut def from_json_foo__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
 mut def from_json_foo__ll1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val, ns='http://example.com/foo', module='foo')
 
+mut def from_xml_foo__ll1(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, ns='http://example.com/foo', module='foo')
+
 class root(yang.adata.MNode):
     li1: foo__li1
     ll1: list[str]
@@ -166,6 +184,14 @@ class root(yang.adata.MNode):
             return root(li1=foo__li1.from_xml(yang.gdata.get_xml_children(n, 'li1', 'http://example.com/foo')), ll1=yang.gdata.from_xml_opt_strs(n, 'll1', 'http://example.com/foo'))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_li1 = yang.gdata.from_xml_opt_list(node, 'li1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'li1', from_xml_foo__li1, child_li1)
+    child_ll1 = yang.gdata.from_xml_opt_strs(node, 'll1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'll1', from_xml_foo__ll1, child_ll1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -45,12 +45,6 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=n.get_opt_str('hi'))
         raise ValueError('Missing required subtree foo__l1__bar')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__l1__bar:
-        if n != None:
-            return foo__l1__bar(hi=yang.gdata.from_xml_opt_str(n, 'hi'))
-        raise ValueError('Missing required subtree foo__l1__bar')
-
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -108,10 +102,6 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), id=n.get_opt_str('id'), bar=foo__l1__bar.from_gdata(n.get_opt_container('bar')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_opt_str(n, 'id'), bar=foo__l1__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -146,13 +136,6 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__l1_entry.from_xml(node))
         return res
 
 
@@ -256,12 +239,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(l1=foo__l1.from_gdata(n.get_opt_list('l1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(l1=foo__l1.from_xml(yang.gdata.get_xml_children(n, 'l1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -10,10 +10,19 @@ import yang.gdata
 mut def from_json_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__l1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__l1__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__l1__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__l1__bar__hi(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__l1__bar__hi(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__l1__bar(yang.adata.MNode):
@@ -42,6 +51,12 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=yang.gdata.from_xml_opt_str(n, 'hi'))
         raise ValueError('Missing required subtree foo__l1__bar')
 
+
+mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_hi = yang.gdata.from_xml_str(node, 'hi')
+    yang.gdata.maybe_add(children, 'hi', from_xml_foo__l1__bar__hi, child_hi)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -141,6 +156,22 @@ class foo__l1(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
+    child_id = yang.gdata.from_xml_opt_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_foo__l1__id, child_id)
+    child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
+    yang.gdata.maybe_add(children, 'bar', from_xml_foo__l1__bar, child_bar)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__l1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -233,6 +264,12 @@ class root(yang.adata.MNode):
             return root(l1=foo__l1.from_xml(yang.gdata.get_xml_children(n, 'l1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_list(node, 'l1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -1,7 +1,13 @@
 mut def from_json_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__l1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__l1__id(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__l1__id(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__l1_entry(yang.adata.MNode):
@@ -74,6 +80,20 @@ class foo__l1(yang.adata.MNode):
             res.append(foo__l1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
+    child_id = yang.gdata.from_xml_str(node, 'id')
+    yang.gdata.maybe_add(children, 'id', from_xml_foo__l1__id, child_id)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__l1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -33,10 +33,6 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), id=n.get_str('id'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=yang.gdata.from_xml_str(n, 'name'), id=yang.gdata.from_xml_str(n, 'id'))
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -71,13 +67,6 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__l1_entry.from_xml(node))
         return res
 
 

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -1,7 +1,13 @@
 mut def from_json_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__l1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__l1__bar__hi(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__l1__bar__hi(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__l1__bar(yang.adata.MNode):
@@ -30,6 +36,12 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=yang.gdata.from_xml_str(n, 'hi'))
         return None
 
+
+mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_hi = yang.gdata.from_xml_str(node, 'hi')
+    yang.gdata.maybe_add(children, 'hi', from_xml_foo__l1__bar__hi, child_hi)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -128,6 +140,20 @@ class foo__l1(yang.adata.MNode):
             res.append(foo__l1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
+    child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
+    yang.gdata.maybe_add(children, 'bar', from_xml_foo__l1__bar, child_bar)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__l1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -30,12 +30,6 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=n.get_str('hi'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__l1__bar:
-        if n != None:
-            return foo__l1__bar(hi=yang.gdata.from_xml_str(n, 'hi'))
-        return None
-
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -93,10 +87,6 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), bar=foo__l1__bar.from_gdata(n.get_opt_container('bar')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=yang.gdata.from_xml_str(n, 'name'), bar=foo__l1__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -131,13 +121,6 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__l1_entry.from_xml(node))
         return res
 
 

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -41,7 +41,7 @@ mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_hi = yang.gdata.from_xml_str(node, 'hi')
     yang.gdata.maybe_add(children, 'hi', from_xml_foo__l1__bar__hi, child_hi)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -63,7 +63,7 @@ mut def from_json_foo__l1__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_hi = yang.gdata.take_json_str(jd, 'hi')
     yang.gdata.maybe_add(children, 'hi', from_json_foo__l1__bar__hi, child_hi)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class foo__l1_entry(yang.adata.MNode):
     name: str

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -10,10 +10,19 @@ import yang.gdata
 mut def from_json_foo__foo__bar__foo_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__foo__bar__foo_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__foo__bar__bar_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
+mut def from_xml_foo__foo__bar__bar_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
 mut def from_json_foo__foo__bar__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__foo__bar__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__foo__bar(yang.adata.MNode):
@@ -52,6 +61,16 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(foo_l1=yang.gdata.from_xml_str(n, 'l1'), bar_l1=yang.gdata.from_xml_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_str(n, 'l2', 'http://example.com/bar'))
         return None
 
+
+mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'foo:l1', from_xml_foo__foo__bar__foo_l1, child_foo_l1)
+    child_bar_l1 = yang.gdata.from_xml_str(node, 'l1', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:l1', from_xml_foo__foo__bar__bar_l1, child_bar_l1)
+    child_l2 = yang.gdata.from_xml_str(node, 'l2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__foo__bar__l2, child_l2)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -115,6 +134,12 @@ class foo__foo(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
+    yang.gdata.maybe_add(children, 'bar', from_xml_foo__foo__bar, child_bar)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -169,6 +194,12 @@ class root(yang.adata.MNode):
             return root(foo=foo__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__foo, child_foo)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -70,7 +70,7 @@ mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'bar:l1', from_xml_foo__foo__bar__bar_l1, child_bar_l1)
     child_l2 = yang.gdata.from_xml_str(node, 'l2', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'l2', from_xml_foo__foo__bar__l2, child_l2)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -100,7 +100,7 @@ mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'bar:l1', from_json_foo__foo__bar__bar_l1, child_bar_l1)
     child_l2 = yang.gdata.take_json_str(jd, 'l2', 'bar')
     yang.gdata.maybe_add(children, 'l2', from_json_foo__foo__bar__l2, child_l2)
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
@@ -138,7 +138,7 @@ mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_xml_foo__foo__bar, child_bar)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -161,7 +161,7 @@ mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_bar = yang.gdata.take_json_opt_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__foo__bar, child_bar)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 class root(yang.adata.MNode):
     foo: ?foo__foo

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -55,12 +55,6 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(foo_l1=n.get_str('foo:l1'), bar_l1=n.get_str('bar:l1'), l2=n.get_str('l2'))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__foo__bar:
-        if n != None:
-            return foo__foo__bar(foo_l1=yang.gdata.from_xml_str(n, 'l1'), bar_l1=yang.gdata.from_xml_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_str(n, 'l2', 'http://example.com/bar'))
-        return None
-
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -127,12 +121,6 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__foo:
-        if n != None:
-            return foo__foo(bar=foo__foo__bar.from_xml(yang.gdata.get_xml_opt_child(n, 'bar')))
-        return None
-
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -186,12 +174,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(foo=foo__foo.from_gdata(n.get_opt_container('foo')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(foo=foo__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -33,12 +33,6 @@ class bar__c1(yang.adata.MNode):
             return bar__c1(l1=n.get_opt_str('l1'))
         return bar__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> bar__c1:
-        if n != None:
-            return bar__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return bar__c1()
-
 
 mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -94,12 +88,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -152,12 +140,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(bar_c1=bar__c1.from_gdata(n.get_opt_container('bar:c1')), foo_c1=foo__c1.from_gdata(n.get_opt_container('foo:c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(bar_c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/bar')), foo_c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_bar__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_bar__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class bar__c1(yang.adata.MNode):
     l1: ?str
 
@@ -37,6 +40,12 @@ class bar__c1(yang.adata.MNode):
         return bar__c1()
 
 
+mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_bar__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
 mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -60,6 +69,9 @@ mut def from_json_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1(yang.adata.MNode):
@@ -88,6 +100,12 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
         return foo__c1()
 
+
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -142,6 +160,14 @@ class root(yang.adata.MNode):
             return root(bar_c1=bar__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/bar')), foo_c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bar_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:c1', from_xml_bar__c1, child_bar_c1)
+    child_foo_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'foo:c1', from_xml_foo__c1, child_foo_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
@@ -37,6 +40,12 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -60,6 +69,9 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__pc1__foo__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__pc1__foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__pc1__foo(yang.adata.MNode):
@@ -88,6 +100,12 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
         return foo__pc1__foo()
 
+
+mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__pc1__foo__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -137,6 +155,12 @@ class foo__pc1(yang.adata.MNode):
             return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo')))
         return None
 
+
+mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc1__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -197,6 +221,14 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    child_pc1 = yang.gdata.from_xml_opt_cnt(node, 'pc1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'pc1', from_xml_foo__pc1, child_pc1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -33,12 +33,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -94,12 +88,6 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_str('l1'))
         return foo__pc1__foo()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc1__foo:
-        if n != None:
-            return foo__pc1__foo(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__pc1__foo()
-
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -147,12 +135,6 @@ class foo__pc1(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container('foo')))
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
-        if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo')))
         return None
 
 
@@ -213,12 +195,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -160,7 +160,7 @@ mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc1__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -183,7 +183,7 @@ mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_opt_cnt(jd, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_json_foo__pc1__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 class root(yang.adata.MNode):
     c1: foo__c1

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -10,10 +10,19 @@ import yang.gdata
 mut def from_json_foo__c1__l1__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l1__k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l1__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_foo__c1__l1__k2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_foo__c1__l1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__l1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__l1_entry(yang.adata.MNode):
@@ -101,6 +110,22 @@ class foo__c1__l1(yang.adata.MNode):
             res.append(foo__c1__l1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__c1__l1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_k1 = yang.gdata.from_xml_str(node, 'k1')
+    yang.gdata.maybe_add(children, 'k1', from_xml_foo__c1__l1__k1, child_k1)
+    child_k2 = yang.gdata.from_xml_value(node, 'k2')
+    yang.gdata.maybe_add(children, 'k2', from_xml_foo__c1__l1__k2, child_k2)
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1__l1, child_l1)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2)])
+
+mut def from_xml_foo__c1__l1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__c1__l1_element(e))
+    return yang.gdata.List(keys=['k1', 'k2'], elements=elements)
 
 mut def from_json_path_foo__c1__l1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -194,6 +219,12 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_list(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -243,6 +274,12 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -53,10 +53,6 @@ class foo__c1__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
         return foo__c1__l1_entry(k1=n.get_str('k1'), k2=n.get_value('k2'), l1=n.get_str('l1'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__c1__l1_entry:
-        return foo__c1__l1_entry(k1=yang.gdata.from_xml_str(n, 'k1'), k2=yang.gdata.from_xml_value(n, 'k2'), l1=yang.gdata.from_xml_str(n, 'l1'))
-
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -101,13 +97,6 @@ class foo__c1__l1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__c1__l1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__l1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__c1__l1_entry.from_xml(node))
         return res
 
 
@@ -212,12 +201,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=foo__c1__l1.from_gdata(n.get_opt_list('l1')))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(l1=foo__c1__l1.from_xml(yang.gdata.get_xml_children(n, 'l1')))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -266,12 +249,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')))
         return root()
 
 

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -66,12 +66,6 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_int('l1'), l2=n.get_opt_int('l2'), l3=n.get_opt_int('l3'), l4=n.get_opt_int('l4'))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(l1=yang.gdata.from_xml_opt_int(n, 'l1', 'http://example.com/foo'), l2=yang.gdata.from_xml_opt_int(n, 'l2', 'http://example.com/foo'), l3=yang.gdata.from_xml_opt_int(n, 'l3', 'http://example.com/foo'), l4=yang.gdata.from_xml_opt_int(n, 'l4', 'http://example.com/foo'))
-        return root()
-
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -10,13 +10,25 @@ import yang.gdata
 mut def from_json_foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
+mut def from_xml_foo__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
+
 mut def from_json_foo__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
+
+mut def from_xml_foo__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__l3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
+mut def from_xml_foo__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
+
 mut def from_json_foo__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
+
+mut def from_xml_foo__l4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
 class root(yang.adata.MNode):
@@ -60,6 +72,18 @@ class root(yang.adata.MNode):
             return root(l1=yang.gdata.from_xml_opt_int(n, 'l1', 'http://example.com/foo'), l2=yang.gdata.from_xml_opt_int(n, 'l2', 'http://example.com/foo'), l3=yang.gdata.from_xml_opt_int(n, 'l3', 'http://example.com/foo'), l4=yang.gdata.from_xml_opt_int(n, 'l4', 'http://example.com/foo'))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_int(node, 'l1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_int(node, 'l2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__l2, child_l2)
+    child_l3 = yang.gdata.from_xml_opt_int(node, 'l3', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l3', from_xml_foo__l3, child_l3)
+    child_l4 = yang.gdata.from_xml_opt_int(node, 'l4', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l4', from_xml_foo__l4, child_l4)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
+mut def from_xml_foo__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
+
 class root(yang.adata.MNode):
     l1: ?str
 
@@ -36,6 +39,12 @@ class root(yang.adata.MNode):
             return root(l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/foo'))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -33,12 +33,6 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_str('l1'))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/foo'))
-        return root()
-
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -10,6 +10,9 @@ import yang.gdata
 mut def from_json_foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
+mut def from_xml_foo__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
+
 class root(yang.adata.MNode):
     l1: value
 
@@ -36,6 +39,12 @@ class root(yang.adata.MNode):
             return root(l1=yang.gdata.from_xml_opt_value(n, 'l1', 'http://example.com/foo'))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_value(node, 'l1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -33,12 +33,6 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_value('l1'))
         return root()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(l1=yang.gdata.from_xml_opt_value(n, 'l1', 'http://example.com/foo'))
-        return root()
-
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -15,20 +15,20 @@ import yang_basics
 def _test_mandatory1():
     xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1></data>"""
     # This should work, because we provide a value for the mandatory leaf l1
-    r = yang_one.root.from_xml(xml.decode(xml_text))
+    r = yang_one.from_xml(xml.decode(xml_text))
     # This should not work
     try:
-        r = yang_one.root.from_xml(xml.decode(xml_text))
+        r = yang_one.from_xml(xml.decode(xml_text))
     except ValueError as e:
         pass
 
 def _test_mandatory2():
     # This should work, because we provide a value for the mandatory leaf l1
     xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1><li xmlns="http://example.com/foo"><name>foo</name><c1><l1>foo</l1></c1></li></data>"""
-    r = yang_one.root.from_xml(xml.decode(xml_text))
+    r = yang_one.from_xml(xml.decode(xml_text))
     # This should not work
     try:
-        r = yang_one.root.from_xml(xml.decode(xml_text))
+        r = yang_one.from_xml(xml.decode(xml_text))
     except ValueError as e:
         pass
 
@@ -152,21 +152,43 @@ xml_text_full = """<data>
 
 def _test_foo_from_xml_full():
     xml_in = xml.decode(xml_text_full)
-    d = yang_foo_root.from_xml(xml_in)
-    g = d.to_gdata()
-    print(g.prsrc(), err=True)
-    xml_out_text = g.to_xmlstr()
+    gd1 = yang_foo.from_xml(xml_in)
+    # In this test we also use the gdata to "fill in" the foo module adata
+    # classes and then compare the result of adata.to_gdata() with the input.
+    ad = yang_foo_root.from_gdata(gd1)
+    gd2 = ad.to_gdata()
+    print(gd1.prsrc(), err=True)
+    gdiff = yang.gdata.diff(gd1, gd2)
+    # TODO: (XML -> gdata) -> adata -> gdata differs from XML -> gdata in that
+    # it includes "default" (empty) containers and lists. We could improve
+    # adata.to_gdata() methods to skip empty subtrees ...
+    # testing.assertEqual(gd1, gd2)
+    if gdiff is not None:
+        diff = """Container({
+  'nested': Container({
+    'f:inner': Container({
+      'li1': List(['name'])
+    }),
+    'bar:inner': Container(ns='http://example.com/bar', module='bar')
+  }, ns='http://example.com/foo', module='foo'),
+  'state': Container({
+    'c1': Container()
+  }, ns='http://example.com/foo', module='foo')
+})"""
+        testing.assertEqual(gdiff.prsrc(), diff)
+    else:
+        testing.assertNotNone(gdiff)
+    xml_out_text = gd1.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
-    return d.to_gdata().prsrc()
+    return gd1.prsrc()
 
 def _test_gdata_source_roundtrip_xml_full(t: testing.EnvT):
     wfcap = file.WriteFileCap(file.FileCap(t.env.cap))
     xml_in = xml.decode(xml_text_full)
-    d = yang_foo_root.from_xml(xml_in)
-    g = d.to_gdata()
+    gd = yang_foo.from_xml(xml_in)
     wf = file.WriteFile(wfcap, "../test_gdata_source_roundtrip/src/xml_full.act")
-    await async wf.write(f"from yang.gdata import *\n\nxml_full = {g.prsrc()}".encode())
+    await async wf.write(f"from yang.gdata import *\n\nxml_full = {gd.prsrc()}".encode())
     await async wf.close()
     t.success()
 
@@ -180,8 +202,8 @@ def _test_foo_from_xml1():
 </pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    gd = yang_foo.from_xml(xml_in)
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
@@ -191,17 +213,18 @@ def _test_foo_from_xml_pc1():
 <pc1 xmlns="http://example.com/foo"></pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    pc1 = d.pc1
-    if pc1 is not None:
-        present = True
+    gd = yang_foo.from_xml(xml_in)
+    print(gd.prsrc(), err=True)
+    pc1_gdata = gd.get_opt_container("pc1")
+    if pc1_gdata is not None:
+        testing.assertTrue(pc1_gdata.presence)
     else:
-        present = False
-    testing.assertEqual(present, True)
-    g = d.to_gdata()
-    gc = g.prsrc()
-    print(gc, err=True)
-    xml_out_text = g.to_xmlstr()
+        testing.error("pc1 not found in gdata")
+    ad = yang_foo_root.from_gdata(gd)
+    pc1 = ad.pc1
+    if pc1 is None:
+        testing.error("pc1 not found in adata")
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
@@ -212,7 +235,7 @@ def _test_foo_from_xml_pc2():
 </data>"""
     xml_in = xml.decode(xml_text)
     try:
-        d = yang_foo_root.from_xml(xml_in)
+        gd = yang_foo.from_xml(xml_in)
         testing.error("Expected exception on missing mandatory leaf")
     except ValueError as e:
         if str(e) != "ValueError: Cannot find xml child with name foo":
@@ -227,17 +250,17 @@ def _test_foo_from_xml2():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    pc1 = d.pc1
+    gd = yang_foo.from_xml(xml_in)
+    print(gd.prsrc(), err=True)
+    # The sibling presence container pc1 must not appear here
+    pc1_gdata = gd.get_opt_container("pc1")
+    if pc1_gdata is not None:
+        testing.error("pc1 found in gdata")
+    ad = yang_foo_root.from_gdata(gd)
+    pc1 = ad.pc1
     if pc1 is not None:
-        present = True
-    else:
-        present = False
-    testing.assertEqual(present, False)
-    g = d.to_gdata()
-    gc = g.prsrc()
-    print(gc, err=True)
-    xml_out_text = g.to_xmlstr()
+        testing.error("pc1 found in adata")
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
@@ -249,8 +272,8 @@ def _test_foo_from_xml_leaf_ns():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    gd = yang_foo.from_xml(xml_in)
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
@@ -263,8 +286,8 @@ def _test_foo_from_xml_named_ns():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    gd = yang_foo.from_xml(xml_in)
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
@@ -277,8 +300,8 @@ def _test_foo_from_xml_dots():
 </c.dot>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    gd = yang_foo.from_xml(xml_in)
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
@@ -302,7 +325,8 @@ def _test_foo_from_xml_li_union():
 </li-union>
 </data>"""
     xml_in = xml.decode(xml_text)
-    root = yang_foo_root.from_xml(xml_in)
+    gd = yang_foo.from_xml(xml_in)
+    root = yang_foo_root.from_gdata(gd)
 
     li1 = root.li_union.elements[0]
     testing.assertEqual(li1.k1, "first")
@@ -342,9 +366,12 @@ def _test_foo_from_gdata_int():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    testing.assertEqual(d.c1.l3, 1337)
-    gd = d.to_gdata()
+    gd = yang_foo.from_xml(xml_in)
+    l3 = gd.get_container("c1").get_leaf("l3").val
+    if isinstance(l3, int):
+        testing.assertEqual(l3, 1337)
+    else:
+        testing.error("l3 in gdata is not an int")
     nr = yang_foo_root.from_gdata(gd)
     testing.assertEqual(nr.c1.l3, 1337)
 
@@ -416,7 +443,8 @@ def _test_leaf_defaults():
 def _test_leaf_default_from_xml():
     xml_text = """<data><c xmlns="http://example.com/basics"/></data>"""
     xml_in = xml.decode(xml_text)
-    r = yang_basics.root.from_xml(xml_in)
+    gd = yang_basics.from_xml(xml_in)
+    r = yang_basics.root.from_gdata(gd)
     basics_leaf_defaults(r)
 
 def _test_leaf_default_from_json():
@@ -444,8 +472,10 @@ def _test_union_default_other_type():
 def _test_empty_presence():
     xml_text = """<data><empty-presence xmlns="http://example.com/foo"/></data>"""
     xml_in = xml.decode(xml_text)
-    d = yang_foo_root.from_xml(xml_in)
-    xml_out_text = d.to_gdata().to_xmlstr()
+    gd = yang_foo.from_xml(xml_in)
+    ad = yang_foo_root.from_gdata(gd)
+    testing.assertNotNone(ad.empty_presence)
+    xml_out_text = gd.to_xmlstr()
     xml_out = xml.decode("<data>\n" + xml_out_text + "</data>")
     # testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -11,7 +11,13 @@ import yang.gdata
 mut def from_json_basics__c__l_str_def(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_basics__c__l_str_def(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_basics__c__l_str_def_quoted(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_basics__c__l_str_def_quoted(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_basics__c__l_uint64_def(val: value) -> yang.gdata.Leaf:
@@ -19,22 +25,43 @@ mut def from_json_basics__c__l_uint64_def(val: value) -> yang.gdata.Leaf:
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_basics__c__l_uint64_def(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_basics__c__l_union_def_str(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_basics__c__l_union_def_str(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 mut def from_json_basics__c__l_union_def_int(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_basics__c__l_union_def_int(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_basics__c__l_union_def_float(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
+mut def from_xml_basics__c__l_union_def_float(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
 mut def from_json_basics__c__l_union_def_bool(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_basics__c__l_union_def_bool(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_basics__c__l_union_def_enumeration(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_basics__c__l_union_def_enumeration(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_basics__c__l_binary_def(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('binary', val)
+
+mut def from_xml_basics__c__l_binary_def(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('binary', val)
 
 class basics__c(yang.adata.MNode):
@@ -103,6 +130,28 @@ class basics__c(yang.adata.MNode):
             return basics__c(l_str_def=yang.gdata.from_xml_opt_str(n, 'l_str_def'), l_str_def_quoted=yang.gdata.from_xml_opt_str(n, 'l_str_def_quoted'), l_uint64_def=yang.gdata.from_xml_opt_int(n, 'l_uint64_def'), l_union_def_str=yang.gdata.from_xml_opt_value(n, 'l_union_def_str'), l_union_def_int=yang.gdata.from_xml_opt_value(n, 'l_union_def_int'), l_union_def_float=yang.gdata.from_xml_opt_value(n, 'l_union_def_float'), l_union_def_bool=yang.gdata.from_xml_opt_value(n, 'l_union_def_bool'), l_union_def_enumeration=yang.gdata.from_xml_opt_value(n, 'l_union_def_enumeration'), l_binary_def=yang.gdata.from_xml_opt_bytes(n, 'l_binary_def'))
         return basics__c()
 
+
+mut def from_xml_basics__c(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l_str_def = yang.gdata.from_xml_opt_str(node, 'l_str_def')
+    yang.gdata.maybe_add(children, 'l_str_def', from_xml_basics__c__l_str_def, child_l_str_def)
+    child_l_str_def_quoted = yang.gdata.from_xml_opt_str(node, 'l_str_def_quoted')
+    yang.gdata.maybe_add(children, 'l_str_def_quoted', from_xml_basics__c__l_str_def_quoted, child_l_str_def_quoted)
+    child_l_uint64_def = yang.gdata.from_xml_opt_int(node, 'l_uint64_def')
+    yang.gdata.maybe_add(children, 'l_uint64_def', from_xml_basics__c__l_uint64_def, child_l_uint64_def)
+    child_l_union_def_str = yang.gdata.from_xml_opt_value(node, 'l_union_def_str')
+    yang.gdata.maybe_add(children, 'l_union_def_str', from_xml_basics__c__l_union_def_str, child_l_union_def_str)
+    child_l_union_def_int = yang.gdata.from_xml_opt_value(node, 'l_union_def_int')
+    yang.gdata.maybe_add(children, 'l_union_def_int', from_xml_basics__c__l_union_def_int, child_l_union_def_int)
+    child_l_union_def_float = yang.gdata.from_xml_opt_value(node, 'l_union_def_float')
+    yang.gdata.maybe_add(children, 'l_union_def_float', from_xml_basics__c__l_union_def_float, child_l_union_def_float)
+    child_l_union_def_bool = yang.gdata.from_xml_opt_value(node, 'l_union_def_bool')
+    yang.gdata.maybe_add(children, 'l_union_def_bool', from_xml_basics__c__l_union_def_bool, child_l_union_def_bool)
+    child_l_union_def_enumeration = yang.gdata.from_xml_opt_value(node, 'l_union_def_enumeration')
+    yang.gdata.maybe_add(children, 'l_union_def_enumeration', from_xml_basics__c__l_union_def_enumeration, child_l_union_def_enumeration)
+    child_l_binary_def = yang.gdata.from_xml_opt_bytes(node, 'l_binary_def')
+    yang.gdata.maybe_add(children, 'l_binary_def', from_xml_basics__c__l_binary_def, child_l_binary_def)
+    return yang.gdata.Container(children, ns='http://example.com/basics', module='basics')
 
 mut def from_json_path_basics__c(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -184,6 +233,12 @@ class root(yang.adata.MNode):
             return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, 'c', 'http://example.com/basics')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c = yang.gdata.from_xml_opt_cnt(node, 'c', 'http://example.com/basics')
+    yang.gdata.maybe_add(children, 'c', from_xml_basics__c, child_c)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -124,12 +124,6 @@ class basics__c(yang.adata.MNode):
             return basics__c(l_str_def=n.get_opt_str('l_str_def'), l_str_def_quoted=n.get_opt_str('l_str_def_quoted'), l_uint64_def=n.get_opt_int('l_uint64_def'), l_union_def_str=n.get_opt_value('l_union_def_str'), l_union_def_int=n.get_opt_value('l_union_def_int'), l_union_def_float=n.get_opt_value('l_union_def_float'), l_union_def_bool=n.get_opt_value('l_union_def_bool'), l_union_def_enumeration=n.get_opt_value('l_union_def_enumeration'), l_binary_def=n.get_opt_bytes('l_binary_def'))
         return basics__c()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> basics__c:
-        if n != None:
-            return basics__c(l_str_def=yang.gdata.from_xml_opt_str(n, 'l_str_def'), l_str_def_quoted=yang.gdata.from_xml_opt_str(n, 'l_str_def_quoted'), l_uint64_def=yang.gdata.from_xml_opt_int(n, 'l_uint64_def'), l_union_def_str=yang.gdata.from_xml_opt_value(n, 'l_union_def_str'), l_union_def_int=yang.gdata.from_xml_opt_value(n, 'l_union_def_int'), l_union_def_float=yang.gdata.from_xml_opt_value(n, 'l_union_def_float'), l_union_def_bool=yang.gdata.from_xml_opt_value(n, 'l_union_def_bool'), l_union_def_enumeration=yang.gdata.from_xml_opt_value(n, 'l_union_def_enumeration'), l_binary_def=yang.gdata.from_xml_opt_bytes(n, 'l_binary_def'))
-        return basics__c()
-
 
 mut def from_xml_basics__c(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -225,12 +219,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c=basics__c.from_gdata(n.get_opt_container('c')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c=basics__c.from_xml(yang.gdata.get_xml_opt_child(n, 'c', 'http://example.com/basics')))
         return root()
 
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -11,18 +11,33 @@ import yang.gdata
 mut def from_json_foo__c1__f_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__f_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l3(val: value) -> yang.gdata.Leaf:
     if isinstance(val, str):
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_foo__c1__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_foo__c1__l_empty(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_foo__c1__l_empty(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 mut def from_json_foo__c1__li__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__li__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__li__val(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__li__val(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__li_entry(yang.adata.MNode):
@@ -96,6 +111,20 @@ class foo__c1__li(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__c1__li_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__c1__li__name, child_name)
+    child_val = yang.gdata.from_xml_opt_str(node, 'val')
+    yang.gdata.maybe_add(children, 'val', from_xml_foo__c1__li__val, child_val)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__c1__li(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__c1__li_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+
 mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -167,16 +196,31 @@ mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
              int_vals.append(v)
     return yang.gdata.LeafList('uint64', int_vals)
 
+mut def from_xml_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('uint64', val)
+
 mut def from_json_foo__c1__ll_str(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_foo__c1__ll_str(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 mut def from_json_foo__c1__l4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__bar_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
+mut def from_xml_foo__c1__bar_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
 mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__c1(yang.adata.MNode):
@@ -242,6 +286,28 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_f_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'f:l1', from_xml_foo__c1__f_l1, child_f_l1)
+    child_l3 = yang.gdata.from_xml_opt_int(node, 'l3')
+    yang.gdata.maybe_add(children, 'l3', from_xml_foo__c1__l3, child_l3)
+    child_l_empty = yang.gdata.from_xml_opt_bool(node, 'l_empty')
+    yang.gdata.maybe_add(children, 'l_empty', from_xml_foo__c1__l_empty, child_l_empty)
+    child_li = yang.gdata.from_xml_opt_list(node, 'li')
+    yang.gdata.maybe_add(children, 'li', from_xml_foo__c1__li, child_li)
+    child_ll_uint64 = yang.gdata.from_xml_opt_ints(node, 'll_uint64')
+    yang.gdata.maybe_add(children, 'll_uint64', from_xml_foo__c1__ll_uint64, child_ll_uint64)
+    child_ll_str = yang.gdata.from_xml_opt_strs(node, 'll_str')
+    yang.gdata.maybe_add(children, 'll_str', from_xml_foo__c1__ll_str, child_ll_str)
+    child_l4 = yang.gdata.from_xml_opt_str(node, 'l4')
+    yang.gdata.maybe_add(children, 'l4', from_xml_foo__c1__l4, child_l4)
+    child_bar_l1 = yang.gdata.from_xml_opt_str(node, 'l1', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:l1', from_xml_foo__c1__bar_l1, child_bar_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -300,6 +366,9 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__pc1__foo__l1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('binary', val)
 
+mut def from_xml_foo__pc1__foo__l1(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('binary', val)
+
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
@@ -324,6 +393,12 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=yang.gdata.from_xml_opt_bytess(n, 'l1'))
         return foo__pc1__foo()
 
+
+mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_bytess(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__pc1__foo__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -374,6 +449,12 @@ class foo__pc1(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc1__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -398,6 +479,9 @@ mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__pc2__foo(yang.adata.MNode):
@@ -426,6 +510,12 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=yang.gdata.from_xml_str(n, 'l_mandatory'))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
+
+mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l_mandatory = yang.gdata.from_xml_str(node, 'l_mandatory')
+    yang.gdata.maybe_add(children, 'l_mandatory', from_xml_foo__pc2__foo__l_mandatory, child_l_mandatory)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -476,6 +566,12 @@ class foo__pc2(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_cnt(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc2__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -522,6 +618,10 @@ class foo__empty_presence(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__empty_presence(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -543,7 +643,13 @@ mut def from_json_foo__empty_presence(jd: dict[str, ?value]) -> yang.gdata.Conta
 mut def from_json_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c_dot__l_dot2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__c_dot__l_dot2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__c_dot(yang.adata.MNode):
@@ -578,6 +684,14 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot()
 
 
+mut def from_xml_foo__c_dot(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l_dot1 = yang.gdata.from_xml_opt_str(node, 'l.dot1')
+    yang.gdata.maybe_add(children, 'l.dot1', from_xml_foo__c_dot__l_dot1, child_l_dot1)
+    child_l_dot2 = yang.gdata.from_xml_opt_str(node, 'l.dot2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l.dot2', from_xml_foo__c_dot__l_dot2, child_l_dot2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c_dot(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -607,7 +721,13 @@ mut def from_json_foo__c_dot(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__cc__cake(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__cc__cake(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__cc__death__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__cc__death__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__cc__death_entry(yang.adata.MNode):
@@ -675,6 +795,18 @@ class foo__cc__death(yang.adata.MNode):
             res.append(foo__cc__death_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__cc__death_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__cc__death__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__cc__death(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__cc__death_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -766,6 +898,14 @@ class foo__cc(yang.adata.MNode):
         return foo__cc()
 
 
+mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cake = yang.gdata.from_xml_opt_str(node, 'cake')
+    yang.gdata.maybe_add(children, 'cake', from_xml_foo__cc__cake, child_cake)
+    child_death = yang.gdata.from_xml_opt_list(node, 'death')
+    yang.gdata.maybe_add(children, 'death', from_xml_foo__cc__death, child_death)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__cc(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -796,6 +936,9 @@ mut def from_json_foo__cc(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -819,6 +962,10 @@ class foo__conflict__f_inner(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
 mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -838,6 +985,9 @@ mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Co
     return yang.gdata.Container(children)
 
 mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__conflict__bar_inner(yang.adata.MNode):
@@ -862,6 +1012,10 @@ class foo__conflict__bar_inner(yang.adata.MNode):
             return foo__conflict__bar_inner()
         return None
 
+
+mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -933,6 +1087,18 @@ class foo__conflict(yang.adata.MNode):
         return foo__conflict()
 
 
+mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_f_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'f:foo', from_xml_foo__conflict__f_foo, child_f_foo)
+    child_f_inner = yang.gdata.from_xml_opt_cnt(node, 'inner')
+    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__conflict__f_inner, child_f_inner)
+    child_bar_foo = yang.gdata.from_xml_opt_str(node, 'foo', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:foo', from_xml_foo__conflict__bar_foo, child_bar_foo)
+    child_bar_inner = yang.gdata.from_xml_opt_cnt(node, 'inner', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__conflict__bar_inner, child_bar_inner)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -970,6 +1136,9 @@ mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__special__yes(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_foo__special__yes(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class foo__special_entry(yang.adata.MNode):
@@ -1038,6 +1207,18 @@ class foo__special(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__special_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_yes = yang.gdata.from_xml_bool(node, 'yes')
+    yang.gdata.maybe_add(children, 'yes', from_xml_foo__special__yes, child_yes)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+
+mut def from_xml_foo__special(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__special_element(e))
+    return yang.gdata.List(keys=['yes'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -1099,19 +1280,37 @@ mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
 mut def from_json_foo__nested__f_inner__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__f_inner__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__nested__f_inner__li1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__nested__f_inner__li1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__nested__f_inner__li1__f_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__f_inner__li1__f_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__nested__f_inner__li1__li2__key1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__nested__f_inner__li1__li2__key1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__nested__f_inner__li1__li2__key2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__f_inner__li1__li2__key2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__nested__f_inner__li1__li2__baz(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__nested__f_inner__li1__li2__baz(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
@@ -1193,6 +1392,22 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__nested__f_inner__li1__li2_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_key1 = yang.gdata.from_xml_str(node, 'key1')
+    yang.gdata.maybe_add(children, 'key1', from_xml_foo__nested__f_inner__li1__li2__key1, child_key1)
+    child_key2 = yang.gdata.from_xml_str(node, 'key2')
+    yang.gdata.maybe_add(children, 'key2', from_xml_foo__nested__f_inner__li1__li2__key2, child_key2)
+    child_baz = yang.gdata.from_xml_opt_str(node, 'baz')
+    yang.gdata.maybe_add(children, 'baz', from_xml_foo__nested__f_inner__li1__li2__baz, child_baz)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+
+mut def from_xml_foo__nested__f_inner__li1__li2(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__nested__f_inner__li1__li2_element(e))
+    return yang.gdata.List(keys=['key1', 'key2'], elements=elements)
+
 mut def from_json_path_foo__nested__f_inner__li1__li2_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -1259,6 +1474,9 @@ mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) ->
     return yang.gdata.List(keys=['key1', 'key2'], elements=elements)
 
 mut def from_json_foo__nested__f_inner__li1__bar_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__nested__f_inner__li1__bar_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__nested__f_inner__li1_entry(yang.adata.MNode):
@@ -1341,6 +1559,24 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
             res.append(foo__nested__f_inner__li1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__nested__f_inner__li1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__nested__f_inner__li1__name, child_name)
+    child_f_bar = yang.gdata.from_xml_opt_str(node, 'bar')
+    yang.gdata.maybe_add(children, 'f:bar', from_xml_foo__nested__f_inner__li1__f_bar, child_f_bar)
+    child_li2 = yang.gdata.from_xml_opt_list(node, 'li2')
+    yang.gdata.maybe_add(children, 'li2', from_xml_foo__nested__f_inner__li1__li2, child_li2)
+    child_bar_bar = yang.gdata.from_xml_opt_str(node, 'bar', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:bar', from_xml_foo__nested__f_inner__li1__bar_bar, child_bar_bar)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__nested__f_inner__li1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__nested__f_inner__li1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_foo__nested__f_inner__li1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1444,6 +1680,14 @@ class foo__nested__f_inner(yang.adata.MNode):
         return foo__nested__f_inner()
 
 
+mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__nested__f_inner__foo, child_foo)
+    child_li1 = yang.gdata.from_xml_opt_list(node, 'li1')
+    yang.gdata.maybe_add(children, 'li1', from_xml_foo__nested__f_inner__li1, child_li1)
+    return yang.gdata.Container(children)
+
 mut def from_json_path_foo__nested__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1474,6 +1718,9 @@ mut def from_json_foo__nested__f_inner(jd: dict[str, ?value]) -> yang.gdata.Cont
 mut def from_json_foo__nested__bar_inner__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__bar_inner__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
@@ -1500,6 +1747,12 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return foo__nested__bar_inner()
 
+
+mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__nested__bar_inner__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__nested__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1555,6 +1808,14 @@ class foo__nested(yang.adata.MNode):
         return foo__nested()
 
 
+mut def from_xml_foo__nested(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_f_inner = yang.gdata.from_xml_opt_cnt(node, 'inner')
+    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__nested__f_inner, child_f_inner)
+    child_bar_inner = yang.gdata.from_xml_opt_cnt(node, 'inner', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__nested__bar_inner, child_bar_inner)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__nested(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1586,10 +1847,19 @@ mut def from_json_foo__nested(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__li_union__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__li_union__k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__li_union__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_foo__li_union__k2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_foo__li_union__k3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('binary', val)
+
+mut def from_xml_foo__li_union__k3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('binary', val)
 
 class foo__li_union_entry(yang.adata.MNode):
@@ -1686,6 +1956,22 @@ class foo__li_union(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__li_union_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_k1 = yang.gdata.from_xml_str(node, 'k1')
+    yang.gdata.maybe_add(children, 'k1', from_xml_foo__li_union__k1, child_k1)
+    child_k2 = yang.gdata.from_xml_value(node, 'k2')
+    yang.gdata.maybe_add(children, 'k2', from_xml_foo__li_union__k2, child_k2)
+    child_k3 = yang.gdata.from_xml_bytes(node, 'k3')
+    yang.gdata.maybe_add(children, 'k3', from_xml_foo__li_union__k3, child_k3)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+
+mut def from_xml_foo__li_union(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__li_union_element(e))
+    return yang.gdata.List(keys=['k1', 'k2', 'k3'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -1753,7 +2039,13 @@ mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
 mut def from_json_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__state__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__state__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__state__c1(yang.adata.MNode):
@@ -1787,6 +2079,14 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
         return foo__state__c1()
 
+
+mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__state__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__state__c1__l2, child_l2)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1841,6 +2141,12 @@ class foo__state(yang.adata.MNode):
         return foo__state()
 
 
+mut def from_xml_foo__state(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__state__c1, child_c1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1865,6 +2171,9 @@ mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__c2__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c2__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c2(yang.adata.MNode):
@@ -1894,6 +2203,12 @@ class foo__c2(yang.adata.MNode):
         return foo__c2()
 
 
+mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c2__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1917,6 +2232,9 @@ mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class bar__conflict(yang.adata.MNode):
@@ -1945,6 +2263,12 @@ class bar__conflict(yang.adata.MNode):
             return bar__conflict(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return bar__conflict()
 
+
+mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_bar__conflict__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2069,6 +2393,36 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), f_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    child_pc1 = yang.gdata.from_xml_opt_cnt(node, 'pc1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'pc1', from_xml_foo__pc1, child_pc1)
+    child_pc2 = yang.gdata.from_xml_opt_cnt(node, 'pc2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'pc2', from_xml_foo__pc2, child_pc2)
+    child_empty_presence = yang.gdata.from_xml_opt_cnt(node, 'empty-presence', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'empty-presence', from_xml_foo__empty_presence, child_empty_presence)
+    child_c_dot = yang.gdata.from_xml_opt_cnt(node, 'c.dot', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c.dot', from_xml_foo__c_dot, child_c_dot)
+    child_cc = yang.gdata.from_xml_opt_cnt(node, 'cc', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'cc', from_xml_foo__cc, child_cc)
+    child_f_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'f:conflict', from_xml_foo__conflict, child_f_conflict)
+    child_special = yang.gdata.from_xml_opt_list(node, 'special', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'special', from_xml_foo__special, child_special)
+    child_nested = yang.gdata.from_xml_opt_cnt(node, 'nested', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'nested', from_xml_foo__nested, child_nested)
+    child_li_union = yang.gdata.from_xml_opt_list(node, 'li-union', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'li-union', from_xml_foo__li_union, child_li_union)
+    child_state = yang.gdata.from_xml_opt_cnt(node, 'state', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'state', from_xml_foo__state, child_state)
+    child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
+    child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -453,7 +453,7 @@ mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc1__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -476,7 +476,7 @@ mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_opt_cnt(jd, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_json_foo__pc1__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -570,7 +570,7 @@ mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_cnt(node, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc2__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -593,7 +593,7 @@ mut def from_json_foo__pc2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_cnt(jd, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_json_foo__pc2__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 class foo__empty_presence(yang.adata.MNode):
 
@@ -620,7 +620,7 @@ class foo__empty_presence(yang.adata.MNode):
 
 mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__empty_presence(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -638,7 +638,7 @@ mut def from_json_path_foo__empty_presence(jd: value, path: list[str]=[], op: ?s
 
 mut def from_json_foo__empty_presence(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -964,7 +964,7 @@ class foo__conflict__f_inner(yang.adata.MNode):
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -982,7 +982,7 @@ mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op:
 
 mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
@@ -1015,7 +1015,7 @@ class foo__conflict__bar_inner(yang.adata.MNode):
 
 mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1033,7 +1033,7 @@ mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], o
 
 mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
 class foo__conflict(yang.adata.MNode):
     f_foo: ?str

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -63,10 +63,6 @@ class foo__c1__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
         return foo__c1__li_entry(name=n.get_str('name'), val=n.get_opt_str('val'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=yang.gdata.from_xml_str(n, 'name'), val=yang.gdata.from_xml_opt_str(n, 'val'))
-
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
     mut def __init__(self, elements=[]):
@@ -101,13 +97,6 @@ class foo__c1__li(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__c1__li_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__li_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__c1__li_entry.from_xml(node))
         return res
 
 
@@ -279,12 +268,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(f_l1=yang.gdata.from_xml_opt_str(n, 'l1'), l3=yang.gdata.from_xml_opt_int(n, 'l3'), l_empty=yang.gdata.from_xml_opt_bool(n, 'l_empty'), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, 'li')), ll_uint64=yang.gdata.from_xml_opt_ints(n, 'll_uint64'), ll_str=yang.gdata.from_xml_opt_strs(n, 'll_str'), l4=yang.gdata.from_xml_opt_str(n, 'l4'), bar_l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -387,12 +370,6 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_bytess('l1'))
         return foo__pc1__foo()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc1__foo:
-        if n != None:
-            return foo__pc1__foo(l1=yang.gdata.from_xml_opt_bytess(n, 'l1'))
-        return foo__pc1__foo()
-
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -440,12 +417,6 @@ class foo__pc1(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container('foo')))
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
-        if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo')))
         return None
 
 
@@ -504,12 +475,6 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=n.get_str('l_mandatory'))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc2__foo:
-        if n != None:
-            return foo__pc2__foo(l_mandatory=yang.gdata.from_xml_str(n, 'l_mandatory'))
-        raise ValueError('Missing required subtree foo__pc2__foo')
-
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -559,12 +524,6 @@ class foo__pc2(yang.adata.MNode):
             return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_container('foo')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__pc2:
-        if n != None:
-            return foo__pc2(foo=foo__pc2__foo.from_xml(yang.gdata.get_xml_child(n, 'foo')))
-        return None
-
 
 mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -607,12 +566,6 @@ class foo__empty_presence(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__empty_presence:
-        if n != None:
-            return foo__empty_presence()
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__empty_presence:
         if n != None:
             return foo__empty_presence()
         return None
@@ -675,12 +628,6 @@ class foo__c_dot(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c_dot:
         if n != None:
             return foo__c_dot(l_dot1=n.get_opt_str('l.dot1'), l_dot2=n.get_opt_str('l.dot2'))
-        return foo__c_dot()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c_dot:
-        if n != None:
-            return foo__c_dot(l_dot1=yang.gdata.from_xml_opt_str(n, 'l.dot1'), l_dot2=yang.gdata.from_xml_opt_str(n, 'l.dot2', 'http://example.com/bar'))
         return foo__c_dot()
 
 
@@ -748,10 +695,6 @@ class foo__cc__death_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
         return foo__cc__death_entry(name=n.get_str('name'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__cc__death_entry:
-        return foo__cc__death_entry(name=yang.gdata.from_xml_str(n, 'name'))
-
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
     mut def __init__(self, elements=[]):
@@ -786,13 +729,6 @@ class foo__cc__death(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__cc__death_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__cc__death_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__cc__death_entry.from_xml(node))
         return res
 
 
@@ -891,12 +827,6 @@ class foo__cc(yang.adata.MNode):
             return foo__cc(cake=n.get_opt_str('cake'), death=foo__cc__death.from_gdata(n.get_opt_list('death')))
         return foo__cc()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__cc:
-        if n != None:
-            return foo__cc(cake=yang.gdata.from_xml_opt_str(n, 'cake'), death=foo__cc__death.from_xml(yang.gdata.get_xml_children(n, 'death')))
-        return foo__cc()
-
 
 mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -955,12 +885,6 @@ class foo__conflict__f_inner(yang.adata.MNode):
             return foo__conflict__f_inner()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__f_inner:
-        if n != None:
-            return foo__conflict__f_inner()
-        return None
-
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1002,12 +926,6 @@ class foo__conflict__bar_inner(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__bar_inner:
-        if n != None:
-            return foo__conflict__bar_inner()
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__bar_inner:
         if n != None:
             return foo__conflict__bar_inner()
         return None
@@ -1078,12 +996,6 @@ class foo__conflict(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
             return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
-        return foo__conflict()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__conflict:
-        if n != None:
-            return foo__conflict(f_foo=yang.gdata.from_xml_opt_str(n, 'foo'), f_inner=foo__conflict__f_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
         return foo__conflict()
 
 
@@ -1159,10 +1071,6 @@ class foo__special_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
         return foo__special_entry(yes=n.get_bool('yes'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__special_entry:
-        return foo__special_entry(yes=yang.gdata.from_xml_bool(n, 'yes'))
-
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
     mut def __init__(self, elements=[]):
@@ -1197,13 +1105,6 @@ class foo__special(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__special_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__special_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__special_entry.from_xml(node))
         return res
 
 
@@ -1341,10 +1242,6 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
         return foo__nested__f_inner__li1__li2_entry(key1=n.get_str('key1'), key2=n.get_str('key2'), baz=n.get_opt_str('baz'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__nested__f_inner__li1__li2_entry:
-        return foo__nested__f_inner__li1__li2_entry(key1=yang.gdata.from_xml_str(n, 'key1'), key2=yang.gdata.from_xml_str(n, 'key2'), baz=yang.gdata.from_xml_opt_str(n, 'baz'))
-
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -1382,13 +1279,6 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__nested__f_inner__li1__li2_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__nested__f_inner__li1__li2_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__nested__f_inner__li1__li2_entry.from_xml(node))
         return res
 
 
@@ -1512,10 +1402,6 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
         return foo__nested__f_inner__li1_entry(name=n.get_str('name'), f_bar=n.get_opt_str('f:bar'), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list('li2')), bar_bar=n.get_opt_str('bar:bar'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__nested__f_inner__li1_entry:
-        return foo__nested__f_inner__li1_entry(name=yang.gdata.from_xml_str(n, 'name'), f_bar=yang.gdata.from_xml_opt_str(n, 'bar'), li2=foo__nested__f_inner__li1__li2.from_xml(yang.gdata.get_xml_children(n, 'li2')), bar_bar=yang.gdata.from_xml_opt_str(n, 'bar', 'http://example.com/bar'))
-
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1550,13 +1436,6 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__nested__f_inner__li1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__nested__f_inner__li1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__nested__f_inner__li1_entry.from_xml(node))
         return res
 
 
@@ -1673,12 +1552,6 @@ class foo__nested__f_inner(yang.adata.MNode):
             return foo__nested__f_inner(foo=n.get_opt_str('foo'), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list('li1')))
         return foo__nested__f_inner()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__nested__f_inner:
-        if n != None:
-            return foo__nested__f_inner(foo=yang.gdata.from_xml_opt_str(n, 'foo'), li1=foo__nested__f_inner__li1.from_xml(yang.gdata.get_xml_children(n, 'li1')))
-        return foo__nested__f_inner()
-
 
 mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1741,12 +1614,6 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=n.get_opt_str('foo'))
         return foo__nested__bar_inner()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__nested__bar_inner:
-        if n != None:
-            return foo__nested__bar_inner(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
-        return foo__nested__bar_inner()
-
 
 mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1799,12 +1666,6 @@ class foo__nested(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested:
         if n != None:
             return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
-        return foo__nested()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__nested:
-        if n != None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_inner=foo__nested__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
         return foo__nested()
 
 
@@ -1890,10 +1751,6 @@ class foo__li_union_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
         return foo__li_union_entry(k1=n.get_str('k1'), k2=n.get_value('k2'), k3=n.get_bytes('k3'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__li_union_entry:
-        return foo__li_union_entry(k1=yang.gdata.from_xml_str(n, 'k1'), k2=yang.gdata.from_xml_value(n, 'k2'), k3=yang.gdata.from_xml_bytes(n, 'k3'))
-
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
     mut def __init__(self, elements=[]):
@@ -1946,13 +1803,6 @@ class foo__li_union(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__li_union_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__li_union_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__li_union_entry.from_xml(node))
         return res
 
 
@@ -2073,12 +1923,6 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__state__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__state__c1:
-        if n != None:
-            return foo__state__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        return foo__state__c1()
-
 
 mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2132,12 +1976,6 @@ class foo__state(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
         if n != None:
             return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_container('c1')))
-        return foo__state()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__state:
-        if n != None:
-            return foo__state(c1=foo__state__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1')))
         return foo__state()
 
 
@@ -2196,12 +2034,6 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l1=n.get_opt_str('l1'))
         return foo__c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c2:
-        if n != None:
-            return foo__c2(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__c2()
-
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2255,12 +2087,6 @@ class bar__conflict(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> bar__conflict:
         if n != None:
             return bar__conflict(foo=n.get_opt_str('foo'))
-        return bar__conflict()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> bar__conflict:
-        if n != None:
-            return bar__conflict(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return bar__conflict()
 
 
@@ -2385,12 +2211,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_container('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), c2=foo__c2.from_gdata(n.get_opt_container('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), f_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
         return root()
 
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -11,18 +11,33 @@ import yang.gdata
 mut def from_json_foo__c1__f_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__f_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__l3(val: value) -> yang.gdata.Leaf:
     if isinstance(val, str):
         return yang.gdata.Leaf('uint64', int(val))
     return yang.gdata.Leaf('uint64', val)
 
+mut def from_xml_foo__c1__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint64', val)
+
 mut def from_json_foo__c1__l_empty(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('empty', val)
+
+mut def from_xml_foo__c1__l_empty(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('empty', val)
 
 mut def from_json_foo__c1__li__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__li__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__li__val(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c1__li__val(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c1__li_entry(yang.adata.MNode):
@@ -96,6 +111,20 @@ class foo__c1__li(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__c1__li_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__c1__li__name, child_name)
+    child_val = yang.gdata.from_xml_opt_str(node, 'val')
+    yang.gdata.maybe_add(children, 'val', from_xml_foo__c1__li__val, child_val)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__c1__li(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__c1__li_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, user_order=True)
+
 mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -167,16 +196,31 @@ mut def from_json_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
              int_vals.append(v)
     return yang.gdata.LeafList('uint64', int_vals)
 
+mut def from_xml_foo__c1__ll_uint64(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('uint64', val)
+
 mut def from_json_foo__c1__ll_str(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_foo__c1__ll_str(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
 mut def from_json_foo__c1__l4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c1__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c1__bar_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
+mut def from_xml_foo__c1__bar_l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
 mut def from_json_foo__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__c1(yang.adata.MNode):
@@ -242,6 +286,28 @@ class foo__c1(yang.adata.MNode):
         return foo__c1()
 
 
+mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_f_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'f:l1', from_xml_foo__c1__f_l1, child_f_l1)
+    child_l3 = yang.gdata.from_xml_opt_int(node, 'l3')
+    yang.gdata.maybe_add(children, 'l3', from_xml_foo__c1__l3, child_l3)
+    child_l_empty = yang.gdata.from_xml_opt_bool(node, 'l_empty')
+    yang.gdata.maybe_add(children, 'l_empty', from_xml_foo__c1__l_empty, child_l_empty)
+    child_li = yang.gdata.from_xml_opt_list(node, 'li')
+    yang.gdata.maybe_add(children, 'li', from_xml_foo__c1__li, child_li)
+    child_ll_uint64 = yang.gdata.from_xml_opt_ints(node, 'll_uint64')
+    yang.gdata.maybe_add(children, 'll_uint64', from_xml_foo__c1__ll_uint64, child_ll_uint64)
+    child_ll_str = yang.gdata.from_xml_opt_strs(node, 'll_str')
+    yang.gdata.maybe_add(children, 'll_str', from_xml_foo__c1__ll_str, child_ll_str)
+    child_l4 = yang.gdata.from_xml_opt_str(node, 'l4')
+    yang.gdata.maybe_add(children, 'l4', from_xml_foo__c1__l4, child_l4)
+    child_bar_l1 = yang.gdata.from_xml_opt_str(node, 'l1', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:l1', from_xml_foo__c1__bar_l1, child_bar_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__c1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -300,6 +366,9 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__pc1__foo__l1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('binary', val)
 
+mut def from_xml_foo__pc1__foo__l1(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('binary', val)
+
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
@@ -324,6 +393,12 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=yang.gdata.from_xml_opt_bytess(n, 'l1'))
         return foo__pc1__foo()
 
+
+mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_bytess(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__pc1__foo__l1, child_l1)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__pc1__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -374,6 +449,12 @@ class foo__pc1(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc1__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -398,6 +479,9 @@ mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__pc2__foo(yang.adata.MNode):
@@ -426,6 +510,12 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=yang.gdata.from_xml_opt_str(n, 'l_mandatory'))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
+
+mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l_mandatory = yang.gdata.from_xml_str(node, 'l_mandatory')
+    yang.gdata.maybe_add(children, 'l_mandatory', from_xml_foo__pc2__foo__l_mandatory, child_l_mandatory)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -476,6 +566,12 @@ class foo__pc2(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc2__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -522,6 +618,10 @@ class foo__empty_presence(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__empty_presence(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -543,7 +643,13 @@ mut def from_json_foo__empty_presence(jd: dict[str, ?value]) -> yang.gdata.Conta
 mut def from_json_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__c_dot__l_dot2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__c_dot__l_dot2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__c_dot(yang.adata.MNode):
@@ -578,6 +684,14 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot()
 
 
+mut def from_xml_foo__c_dot(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l_dot1 = yang.gdata.from_xml_opt_str(node, 'l.dot1')
+    yang.gdata.maybe_add(children, 'l.dot1', from_xml_foo__c_dot__l_dot1, child_l_dot1)
+    child_l_dot2 = yang.gdata.from_xml_opt_str(node, 'l.dot2', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'l.dot2', from_xml_foo__c_dot__l_dot2, child_l_dot2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c_dot(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -607,7 +721,13 @@ mut def from_json_foo__c_dot(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__cc__cake(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__cc__cake(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__cc__death__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__cc__death__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__cc__death_entry(yang.adata.MNode):
@@ -675,6 +795,18 @@ class foo__cc__death(yang.adata.MNode):
             res.append(foo__cc__death_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__cc__death_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__cc__death__name, child_name)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__cc__death(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__cc__death_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -766,6 +898,14 @@ class foo__cc(yang.adata.MNode):
         return foo__cc()
 
 
+mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_cake = yang.gdata.from_xml_opt_str(node, 'cake')
+    yang.gdata.maybe_add(children, 'cake', from_xml_foo__cc__cake, child_cake)
+    child_death = yang.gdata.from_xml_opt_list(node, 'death')
+    yang.gdata.maybe_add(children, 'death', from_xml_foo__cc__death, child_death)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__cc(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -796,6 +936,9 @@ mut def from_json_foo__cc(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -819,6 +962,10 @@ class foo__conflict__f_inner(yang.adata.MNode):
         return None
 
 
+mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
 mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -838,6 +985,9 @@ mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Co
     return yang.gdata.Container(children)
 
 mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__conflict__bar_inner(yang.adata.MNode):
@@ -862,6 +1012,10 @@ class foo__conflict__bar_inner(yang.adata.MNode):
             return foo__conflict__bar_inner()
         return None
 
+
+mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -933,6 +1087,18 @@ class foo__conflict(yang.adata.MNode):
         return foo__conflict()
 
 
+mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_f_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'f:foo', from_xml_foo__conflict__f_foo, child_f_foo)
+    child_f_inner = yang.gdata.from_xml_opt_cnt(node, 'inner')
+    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__conflict__f_inner, child_f_inner)
+    child_bar_foo = yang.gdata.from_xml_opt_str(node, 'foo', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:foo', from_xml_foo__conflict__bar_foo, child_bar_foo)
+    child_bar_inner = yang.gdata.from_xml_opt_cnt(node, 'inner', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__conflict__bar_inner, child_bar_inner)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -970,6 +1136,9 @@ mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__special__yes(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_foo__special__yes(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
 class foo__special_entry(yang.adata.MNode):
@@ -1038,6 +1207,18 @@ class foo__special(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__special_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_yes = yang.gdata.from_xml_bool(node, 'yes')
+    yang.gdata.maybe_add(children, 'yes', from_xml_foo__special__yes, child_yes)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+
+mut def from_xml_foo__special(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__special_element(e))
+    return yang.gdata.List(keys=['yes'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -1099,19 +1280,37 @@ mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
 mut def from_json_foo__nested__f_inner__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__f_inner__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__nested__f_inner__li1__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__nested__f_inner__li1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__nested__f_inner__li1__f_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__f_inner__li1__f_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__nested__f_inner__li1__li2__key1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__nested__f_inner__li1__li2__key1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 mut def from_json_foo__nested__f_inner__li1__li2__key2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__f_inner__li1__li2__key2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__nested__f_inner__li1__li2__baz(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__nested__f_inner__li1__li2__baz(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
@@ -1193,6 +1392,22 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__nested__f_inner__li1__li2_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_key1 = yang.gdata.from_xml_str(node, 'key1')
+    yang.gdata.maybe_add(children, 'key1', from_xml_foo__nested__f_inner__li1__li2__key1, child_key1)
+    child_key2 = yang.gdata.from_xml_str(node, 'key2')
+    yang.gdata.maybe_add(children, 'key2', from_xml_foo__nested__f_inner__li1__li2__key2, child_key2)
+    child_baz = yang.gdata.from_xml_opt_str(node, 'baz')
+    yang.gdata.maybe_add(children, 'baz', from_xml_foo__nested__f_inner__li1__li2__baz, child_baz)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+
+mut def from_xml_foo__nested__f_inner__li1__li2(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__nested__f_inner__li1__li2_element(e))
+    return yang.gdata.List(keys=['key1', 'key2'], elements=elements)
+
 mut def from_json_path_foo__nested__f_inner__li1__li2_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -1259,6 +1474,9 @@ mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) ->
     return yang.gdata.List(keys=['key1', 'key2'], elements=elements)
 
 mut def from_json_foo__nested__f_inner__li1__bar_bar(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
+
+mut def from_xml_foo__nested__f_inner__li1__bar_bar(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
 class foo__nested__f_inner__li1_entry(yang.adata.MNode):
@@ -1341,6 +1559,24 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
             res.append(foo__nested__f_inner__li1_entry.from_xml(node))
         return res
 
+
+mut def from_xml_foo__nested__f_inner__li1_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__nested__f_inner__li1__name, child_name)
+    child_f_bar = yang.gdata.from_xml_opt_str(node, 'bar')
+    yang.gdata.maybe_add(children, 'f:bar', from_xml_foo__nested__f_inner__li1__f_bar, child_f_bar)
+    child_li2 = yang.gdata.from_xml_opt_list(node, 'li2')
+    yang.gdata.maybe_add(children, 'li2', from_xml_foo__nested__f_inner__li1__li2, child_li2)
+    child_bar_bar = yang.gdata.from_xml_opt_str(node, 'bar', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:bar', from_xml_foo__nested__f_inner__li1__bar_bar, child_bar_bar)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__nested__f_inner__li1(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__nested__f_inner__li1_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements)
 
 mut def from_json_path_foo__nested__f_inner__li1_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
@@ -1444,6 +1680,14 @@ class foo__nested__f_inner(yang.adata.MNode):
         return foo__nested__f_inner()
 
 
+mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__nested__f_inner__foo, child_foo)
+    child_li1 = yang.gdata.from_xml_opt_list(node, 'li1')
+    yang.gdata.maybe_add(children, 'li1', from_xml_foo__nested__f_inner__li1, child_li1)
+    return yang.gdata.Container(children)
+
 mut def from_json_path_foo__nested__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1474,6 +1718,9 @@ mut def from_json_foo__nested__f_inner(jd: dict[str, ?value]) -> yang.gdata.Cont
 mut def from_json_foo__nested__bar_inner__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__nested__bar_inner__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
@@ -1500,6 +1747,12 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return foo__nested__bar_inner()
 
+
+mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_foo__nested__bar_inner__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__nested__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1555,6 +1808,14 @@ class foo__nested(yang.adata.MNode):
         return foo__nested()
 
 
+mut def from_xml_foo__nested(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_f_inner = yang.gdata.from_xml_opt_cnt(node, 'inner')
+    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__nested__f_inner, child_f_inner)
+    child_bar_inner = yang.gdata.from_xml_opt_cnt(node, 'inner', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__nested__bar_inner, child_bar_inner)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__nested(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1586,10 +1847,19 @@ mut def from_json_foo__nested(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__li_union__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__li_union__k1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__li_union__k2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val)
 
+mut def from_xml_foo__li_union__k2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('union', val)
+
 mut def from_json_foo__li_union__k3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('binary', val)
+
+mut def from_xml_foo__li_union__k3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('binary', val)
 
 class foo__li_union_entry(yang.adata.MNode):
@@ -1686,6 +1956,22 @@ class foo__li_union(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__li_union_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_k1 = yang.gdata.from_xml_str(node, 'k1')
+    yang.gdata.maybe_add(children, 'k1', from_xml_foo__li_union__k1, child_k1)
+    child_k2 = yang.gdata.from_xml_value(node, 'k2')
+    yang.gdata.maybe_add(children, 'k2', from_xml_foo__li_union__k2, child_k2)
+    child_k3 = yang.gdata.from_xml_bytes(node, 'k3')
+    yang.gdata.maybe_add(children, 'k3', from_xml_foo__li_union__k3, child_k3)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+
+mut def from_xml_foo__li_union(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__li_union_element(e))
+    return yang.gdata.List(keys=['k1', 'k2', 'k3'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -1753,7 +2039,13 @@ mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
 mut def from_json_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__state__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__state__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__state__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__state__c1(yang.adata.MNode):
@@ -1787,6 +2079,14 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
         return foo__state__c1()
 
+
+mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__state__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__state__c1__l2, child_l2)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__state__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1841,6 +2141,12 @@ class foo__state(yang.adata.MNode):
         return foo__state()
 
 
+mut def from_xml_foo__state(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__state__c1, child_c1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__state(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1865,6 +2171,9 @@ mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__c2__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__c2__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__c2(yang.adata.MNode):
@@ -1894,6 +2203,12 @@ class foo__c2(yang.adata.MNode):
         return foo__c2()
 
 
+mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__c2__l1, child_l1)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__c2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -1917,6 +2232,9 @@ mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class bar__conflict(yang.adata.MNode):
@@ -1945,6 +2263,12 @@ class bar__conflict(yang.adata.MNode):
             return bar__conflict(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return bar__conflict()
 
+
+mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
+    yang.gdata.maybe_add(children, 'foo', from_xml_bar__conflict__foo, child_foo)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -2069,6 +2393,36 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), f_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
         return root()
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
+    child_pc1 = yang.gdata.from_xml_opt_cnt(node, 'pc1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'pc1', from_xml_foo__pc1, child_pc1)
+    child_pc2 = yang.gdata.from_xml_opt_cnt(node, 'pc2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'pc2', from_xml_foo__pc2, child_pc2)
+    child_empty_presence = yang.gdata.from_xml_opt_cnt(node, 'empty-presence', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'empty-presence', from_xml_foo__empty_presence, child_empty_presence)
+    child_c_dot = yang.gdata.from_xml_opt_cnt(node, 'c.dot', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c.dot', from_xml_foo__c_dot, child_c_dot)
+    child_cc = yang.gdata.from_xml_opt_cnt(node, 'cc', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'cc', from_xml_foo__cc, child_cc)
+    child_f_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'f:conflict', from_xml_foo__conflict, child_f_conflict)
+    child_special = yang.gdata.from_xml_opt_list(node, 'special', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'special', from_xml_foo__special, child_special)
+    child_nested = yang.gdata.from_xml_opt_cnt(node, 'nested', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'nested', from_xml_foo__nested, child_nested)
+    child_li_union = yang.gdata.from_xml_opt_list(node, 'li-union', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'li-union', from_xml_foo__li_union, child_li_union)
+    child_state = yang.gdata.from_xml_opt_cnt(node, 'state', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'state', from_xml_foo__state, child_state)
+    child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
+    child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -453,7 +453,7 @@ mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc1__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__pc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -476,7 +476,7 @@ mut def from_json_foo__pc1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_opt_cnt(jd, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_json_foo__pc1__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__pc2__foo__l_mandatory(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -570,7 +570,7 @@ mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_opt_cnt(node, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__pc2__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__pc2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -593,7 +593,7 @@ mut def from_json_foo__pc2(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_opt_cnt(jd, 'foo')
     yang.gdata.maybe_add(children, 'foo', from_json_foo__pc2__foo, child_foo)
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 class foo__empty_presence(yang.adata.MNode):
 
@@ -620,7 +620,7 @@ class foo__empty_presence(yang.adata.MNode):
 
 mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_path_foo__empty_presence(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -638,7 +638,7 @@ mut def from_json_path_foo__empty_presence(jd: value, path: list[str]=[], op: ?s
 
 mut def from_json_foo__empty_presence(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
 
 mut def from_json_foo__c_dot__l_dot1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -964,7 +964,7 @@ class foo__conflict__f_inner(yang.adata.MNode):
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -982,7 +982,7 @@ mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op:
 
 mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children)
+    return yang.gdata.Container(children, presence=True)
 
 mut def from_json_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
@@ -1015,7 +1015,7 @@ class foo__conflict__bar_inner(yang.adata.MNode):
 
 mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
 mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -1033,7 +1033,7 @@ mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], o
 
 mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+    return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
 class foo__conflict(yang.adata.MNode):
     f_foo: ?str

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -63,10 +63,6 @@ class foo__c1__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
         return foo__c1__li_entry(name=n.get_str('name'), val=n.get_opt_str('val'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=yang.gdata.from_xml_str(n, 'name'), val=yang.gdata.from_xml_opt_str(n, 'val'))
-
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
     mut def __init__(self, elements=[]):
@@ -101,13 +97,6 @@ class foo__c1__li(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__c1__li_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__c1__li_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__c1__li_entry.from_xml(node))
         return res
 
 
@@ -279,12 +268,6 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c1:
-        if n != None:
-            return foo__c1(f_l1=yang.gdata.from_xml_opt_str(n, 'l1'), l3=yang.gdata.from_xml_opt_int(n, 'l3'), l_empty=yang.gdata.from_xml_opt_bool(n, 'l_empty'), li=foo__c1__li.from_xml(yang.gdata.get_xml_children(n, 'li')), ll_uint64=yang.gdata.from_xml_opt_ints(n, 'll_uint64'), ll_str=yang.gdata.from_xml_opt_strs(n, 'll_str'), l4=yang.gdata.from_xml_opt_str(n, 'l4'), bar_l1=yang.gdata.from_xml_opt_str(n, 'l1', 'http://example.com/bar'), l2=yang.gdata.from_xml_opt_str(n, 'l2', 'http://example.com/bar'))
-        return foo__c1()
-
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -387,12 +370,6 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_bytess('l1'))
         return foo__pc1__foo()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc1__foo:
-        if n != None:
-            return foo__pc1__foo(l1=yang.gdata.from_xml_opt_bytess(n, 'l1'))
-        return foo__pc1__foo()
-
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -440,12 +417,6 @@ class foo__pc1(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container('foo')))
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__pc1:
-        if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo')))
         return None
 
 
@@ -504,12 +475,6 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=n.get_opt_str('l_mandatory'))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__pc2__foo:
-        if n != None:
-            return foo__pc2__foo(l_mandatory=yang.gdata.from_xml_opt_str(n, 'l_mandatory'))
-        raise ValueError('Missing required subtree foo__pc2__foo')
-
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -559,12 +524,6 @@ class foo__pc2(yang.adata.MNode):
             return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_container('foo')))
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__pc2:
-        if n != None:
-            return foo__pc2(foo=foo__pc2__foo.from_xml(yang.gdata.get_xml_opt_child(n, 'foo')))
-        return None
-
 
 mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -607,12 +566,6 @@ class foo__empty_presence(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__empty_presence:
-        if n != None:
-            return foo__empty_presence()
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__empty_presence:
         if n != None:
             return foo__empty_presence()
         return None
@@ -675,12 +628,6 @@ class foo__c_dot(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c_dot:
         if n != None:
             return foo__c_dot(l_dot1=n.get_opt_str('l.dot1'), l_dot2=n.get_opt_str('l.dot2'))
-        return foo__c_dot()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c_dot:
-        if n != None:
-            return foo__c_dot(l_dot1=yang.gdata.from_xml_opt_str(n, 'l.dot1'), l_dot2=yang.gdata.from_xml_opt_str(n, 'l.dot2', 'http://example.com/bar'))
         return foo__c_dot()
 
 
@@ -748,10 +695,6 @@ class foo__cc__death_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
         return foo__cc__death_entry(name=n.get_str('name'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__cc__death_entry:
-        return foo__cc__death_entry(name=yang.gdata.from_xml_str(n, 'name'))
-
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
     mut def __init__(self, elements=[]):
@@ -786,13 +729,6 @@ class foo__cc__death(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__cc__death_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__cc__death_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__cc__death_entry.from_xml(node))
         return res
 
 
@@ -891,12 +827,6 @@ class foo__cc(yang.adata.MNode):
             return foo__cc(cake=n.get_opt_str('cake'), death=foo__cc__death.from_gdata(n.get_opt_list('death')))
         return foo__cc()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__cc:
-        if n != None:
-            return foo__cc(cake=yang.gdata.from_xml_opt_str(n, 'cake'), death=foo__cc__death.from_xml(yang.gdata.get_xml_children(n, 'death')))
-        return foo__cc()
-
 
 mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -955,12 +885,6 @@ class foo__conflict__f_inner(yang.adata.MNode):
             return foo__conflict__f_inner()
         return None
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__f_inner:
-        if n != None:
-            return foo__conflict__f_inner()
-        return None
-
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1002,12 +926,6 @@ class foo__conflict__bar_inner(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__bar_inner:
-        if n != None:
-            return foo__conflict__bar_inner()
-        return None
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> ?foo__conflict__bar_inner:
         if n != None:
             return foo__conflict__bar_inner()
         return None
@@ -1078,12 +996,6 @@ class foo__conflict(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
             return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
-        return foo__conflict()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__conflict:
-        if n != None:
-            return foo__conflict(f_foo=yang.gdata.from_xml_opt_str(n, 'foo'), f_inner=foo__conflict__f_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_foo=yang.gdata.from_xml_opt_str(n, 'foo', 'http://example.com/bar'), bar_inner=foo__conflict__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
         return foo__conflict()
 
 
@@ -1159,10 +1071,6 @@ class foo__special_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
         return foo__special_entry(yes=n.get_bool('yes'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__special_entry:
-        return foo__special_entry(yes=yang.gdata.from_xml_bool(n, 'yes'))
-
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
     mut def __init__(self, elements=[]):
@@ -1197,13 +1105,6 @@ class foo__special(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__special_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__special_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__special_entry.from_xml(node))
         return res
 
 
@@ -1341,10 +1242,6 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
         return foo__nested__f_inner__li1__li2_entry(key1=n.get_str('key1'), key2=n.get_str('key2'), baz=n.get_opt_str('baz'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__nested__f_inner__li1__li2_entry:
-        return foo__nested__f_inner__li1__li2_entry(key1=yang.gdata.from_xml_str(n, 'key1'), key2=yang.gdata.from_xml_str(n, 'key2'), baz=yang.gdata.from_xml_opt_str(n, 'baz'))
-
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -1382,13 +1279,6 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__nested__f_inner__li1__li2_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__nested__f_inner__li1__li2_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__nested__f_inner__li1__li2_entry.from_xml(node))
         return res
 
 
@@ -1512,10 +1402,6 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
         return foo__nested__f_inner__li1_entry(name=n.get_str('name'), f_bar=n.get_opt_str('f:bar'), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list('li2')), bar_bar=n.get_opt_str('bar:bar'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__nested__f_inner__li1_entry:
-        return foo__nested__f_inner__li1_entry(name=yang.gdata.from_xml_str(n, 'name'), f_bar=yang.gdata.from_xml_opt_str(n, 'bar'), li2=foo__nested__f_inner__li1__li2.from_xml(yang.gdata.get_xml_children(n, 'li2')), bar_bar=yang.gdata.from_xml_opt_str(n, 'bar', 'http://example.com/bar'))
-
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1550,13 +1436,6 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__nested__f_inner__li1_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__nested__f_inner__li1_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__nested__f_inner__li1_entry.from_xml(node))
         return res
 
 
@@ -1673,12 +1552,6 @@ class foo__nested__f_inner(yang.adata.MNode):
             return foo__nested__f_inner(foo=n.get_opt_str('foo'), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list('li1')))
         return foo__nested__f_inner()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__nested__f_inner:
-        if n != None:
-            return foo__nested__f_inner(foo=yang.gdata.from_xml_opt_str(n, 'foo'), li1=foo__nested__f_inner__li1.from_xml(yang.gdata.get_xml_children(n, 'li1')))
-        return foo__nested__f_inner()
-
 
 mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1741,12 +1614,6 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=n.get_opt_str('foo'))
         return foo__nested__bar_inner()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__nested__bar_inner:
-        if n != None:
-            return foo__nested__bar_inner(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
-        return foo__nested__bar_inner()
-
 
 mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1799,12 +1666,6 @@ class foo__nested(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested:
         if n != None:
             return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
-        return foo__nested()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__nested:
-        if n != None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner')), bar_inner=foo__nested__bar_inner.from_xml(yang.gdata.get_xml_opt_child(n, 'inner', 'http://example.com/bar')))
         return foo__nested()
 
 
@@ -1890,10 +1751,6 @@ class foo__li_union_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
         return foo__li_union_entry(k1=n.get_str('k1'), k2=n.get_value('k2'), k3=n.get_bytes('k3'))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__li_union_entry:
-        return foo__li_union_entry(k1=yang.gdata.from_xml_str(n, 'k1'), k2=yang.gdata.from_xml_value(n, 'k2'), k3=yang.gdata.from_xml_bytes(n, 'k3'))
-
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
     mut def __init__(self, elements=[]):
@@ -1946,13 +1803,6 @@ class foo__li_union(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__li_union_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__li_union_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__li_union_entry.from_xml(node))
         return res
 
 
@@ -2073,12 +1923,6 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__state__c1()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__state__c1:
-        if n != None:
-            return foo__state__c1(l1=yang.gdata.from_xml_opt_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        return foo__state__c1()
-
 
 mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2132,12 +1976,6 @@ class foo__state(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
         if n != None:
             return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_container('c1')))
-        return foo__state()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__state:
-        if n != None:
-            return foo__state(c1=foo__state__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1')))
         return foo__state()
 
 
@@ -2196,12 +2034,6 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l1=n.get_opt_str('l1'))
         return foo__c2()
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__c2:
-        if n != None:
-            return foo__c2(l1=yang.gdata.from_xml_opt_str(n, 'l1'))
-        return foo__c2()
-
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2255,12 +2087,6 @@ class bar__conflict(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> bar__conflict:
         if n != None:
             return bar__conflict(foo=n.get_opt_str('foo'))
-        return bar__conflict()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> bar__conflict:
-        if n != None:
-            return bar__conflict(foo=yang.gdata.from_xml_opt_str(n, 'foo'))
         return bar__conflict()
 
 
@@ -2385,12 +2211,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_container('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), c2=foo__c2.from_gdata(n.get_opt_container('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
-        return root()
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(c1=foo__c1.from_xml(yang.gdata.get_xml_opt_child(n, 'c1', 'http://example.com/foo')), pc1=foo__pc1.from_xml(yang.gdata.get_xml_opt_child(n, 'pc1', 'http://example.com/foo')), pc2=foo__pc2.from_xml(yang.gdata.get_xml_opt_child(n, 'pc2', 'http://example.com/foo')), empty_presence=foo__empty_presence.from_xml(yang.gdata.get_xml_opt_child(n, 'empty-presence', 'http://example.com/foo')), c_dot=foo__c_dot.from_xml(yang.gdata.get_xml_opt_child(n, 'c.dot', 'http://example.com/foo')), cc=foo__cc.from_xml(yang.gdata.get_xml_opt_child(n, 'cc', 'http://example.com/foo')), f_conflict=foo__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/foo')), special=foo__special.from_xml(yang.gdata.get_xml_children(n, 'special', 'http://example.com/foo')), nested=foo__nested.from_xml(yang.gdata.get_xml_opt_child(n, 'nested', 'http://example.com/foo')), li_union=foo__li_union.from_xml(yang.gdata.get_xml_children(n, 'li-union', 'http://example.com/foo')), state=foo__state.from_xml(yang.gdata.get_xml_opt_child(n, 'state', 'http://example.com/foo')), c2=foo__c2.from_xml(yang.gdata.get_xml_opt_child(n, 'c2', 'http://example.com/foo')), bar_conflict=bar__conflict.from_xml(yang.gdata.get_xml_opt_child(n, 'conflict', 'http://example.com/bar')))
         return root()
 
 

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -11,7 +11,13 @@ import yang.gdata
 mut def from_json_foo__tc1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__tc1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__tc1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__tc1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__tc1(yang.adata.MNode):
@@ -46,6 +52,14 @@ class foo__tc1(yang.adata.MNode):
         raise ValueError('Missing required subtree foo__tc1')
 
 
+mut def from_xml_foo__tc1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__tc1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__tc1__l2, child_l2)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__tc1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -75,10 +89,19 @@ mut def from_json_foo__tc1(jd: dict[str, ?value]) -> yang.gdata.Container:
 mut def from_json_foo__li__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__li__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__li__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
+mut def from_xml_foo__li__c1__l1(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
 mut def from_json_foo__li__c1__l2(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__li__c1__l2(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
 class foo__li__c1(yang.adata.MNode):
@@ -112,6 +135,14 @@ class foo__li__c1(yang.adata.MNode):
             return foo__li__c1(l1=yang.gdata.from_xml_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
         raise ValueError('Missing required subtree foo__li__c1')
 
+
+mut def from_xml_foo__li__c1(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    yang.gdata.maybe_add(children, 'l1', from_xml_foo__li__c1__l1, child_l1)
+    child_l2 = yang.gdata.from_xml_opt_str(node, 'l2')
+    yang.gdata.maybe_add(children, 'l2', from_xml_foo__li__c1__l2, child_l2)
+    return yang.gdata.Container(children)
 
 mut def from_json_path_foo__li__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
@@ -210,6 +241,20 @@ class foo__li(yang.adata.MNode):
         return res
 
 
+mut def from_xml_foo__li_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_foo__li__name, child_name)
+    child_c1 = yang.gdata.from_xml_cnt(node, 'c1')
+    yang.gdata.maybe_add(children, 'c1', from_xml_foo__li__c1, child_c1)
+    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+
+mut def from_xml_foo__li(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = []
+    for e in nodes:
+        elements.append(from_xml_foo__li_element(e))
+    return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
 mut def from_json_path_foo__li_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     if len(path) == 1:
         point = path[0]
@@ -303,6 +348,14 @@ class root(yang.adata.MNode):
             return root(tc1=foo__tc1.from_xml(yang.gdata.get_xml_child(n, 'tc1', 'http://example.com/foo')), li=foo__li.from_xml(yang.gdata.get_xml_children(n, 'li', 'http://example.com/foo')))
         raise ValueError('Missing required subtree root')
 
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_tc1 = yang.gdata.from_xml_cnt(node, 'tc1', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'tc1', from_xml_foo__tc1, child_tc1)
+    child_li = yang.gdata.from_xml_opt_list(node, 'li', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'li', from_xml_foo__li, child_li)
+    return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -45,12 +45,6 @@ class foo__tc1(yang.adata.MNode):
             return foo__tc1(l1=n.get_str('l1'), l2=n.get_opt_str('l2'))
         raise ValueError('Missing required subtree foo__tc1')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__tc1:
-        if n != None:
-            return foo__tc1(l1=yang.gdata.from_xml_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        raise ValueError('Missing required subtree foo__tc1')
-
 
 mut def from_xml_foo__tc1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -129,12 +123,6 @@ class foo__li__c1(yang.adata.MNode):
             return foo__li__c1(l1=n.get_str('l1'), l2=n.get_opt_str('l2'))
         raise ValueError('Missing required subtree foo__li__c1')
 
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> foo__li__c1:
-        if n != None:
-            return foo__li__c1(l1=yang.gdata.from_xml_str(n, 'l1'), l2=yang.gdata.from_xml_opt_str(n, 'l2'))
-        raise ValueError('Missing required subtree foo__li__c1')
-
 
 mut def from_xml_foo__li__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -193,10 +181,6 @@ class foo__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_entry:
         return foo__li_entry(name=n.get_str('name'), c1=foo__li__c1.from_gdata(n.get_container('c1')))
 
-    @staticmethod
-    mut def from_xml(n: xml.Node) -> foo__li_entry:
-        return foo__li_entry(name=yang.gdata.from_xml_str(n, 'name'), c1=foo__li__c1.from_xml(yang.gdata.get_xml_child(n, 'c1')))
-
 class foo__li(yang.adata.MNode):
     elements: list[foo__li_entry]
     mut def __init__(self, elements=[]):
@@ -231,13 +215,6 @@ class foo__li(yang.adata.MNode):
         if n is not None:
             for e in n.elements:
                 res.append(foo__li_entry.from_gdata(e))
-        return res
-
-    @staticmethod
-    mut def from_xml(nodes: list[xml.Node]) -> list[foo__li_entry]:
-        res = []
-        for node in nodes:
-            res.append(foo__li_entry.from_xml(node))
         return res
 
 
@@ -340,12 +317,6 @@ class root(yang.adata.MNode):
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
             return root(tc1=foo__tc1.from_gdata(n.get_container('tc1')), li=foo__li.from_gdata(n.get_opt_list('li')))
-        raise ValueError('Missing required subtree root')
-
-    @staticmethod
-    mut def from_xml(n: ?xml.Node) -> root:
-        if n != None:
-            return root(tc1=foo__tc1.from_xml(yang.gdata.get_xml_child(n, 'tc1', 'http://example.com/foo')), li=foo__li.from_xml(yang.gdata.get_xml_children(n, 'li', 'http://example.com/foo')))
         raise ValueError('Missing required subtree root')
 
 

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -18,12 +18,12 @@ Container({
     'foo': Container({
       'l1': LeafList('binary', [b'Hello Acton \xf0\x9f\xab\xa1'])
     })
-  }, ns='http://example.com/foo', module='foo'),
+  }, presence=True, ns='http://example.com/foo', module='foo'),
   'pc2': Container({
     'foo': Container({
       'l_mandatory': Leaf('string', 'baz')
     })
-  }, ns='http://example.com/foo', module='foo'),
+  }, presence=True, ns='http://example.com/foo', module='foo'),
   'c.dot': Container({
     'l.dot1': Leaf('string', 'who put that here?!')
   }, ns='http://example.com/foo', module='foo'),
@@ -32,9 +32,9 @@ Container({
   }, ns='http://example.com/foo', module='foo'),
   'f:conflict': Container({
     'f:foo': Leaf('string', 'foo-foo'),
-    'f:inner': Container(),
+    'f:inner': Container(presence=True),
     'bar:foo': Leaf('string', 'foo-augmented-from-bar', ns='http://example.com/bar', module='bar'),
-    'bar:inner': Container(ns='http://example.com/bar', module='bar')
+    'bar:inner': Container(presence=True, ns='http://example.com/bar', module='bar')
   }, ns='http://example.com/foo', module='foo'),
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -42,12 +42,6 @@ Container({
       'yes': Leaf('boolean', True)
     }, ['true'])
   ]),
-  'nested': Container({
-    'f:inner': Container({
-      'li1': List(['name'])
-    }),
-    'bar:inner': Container(ns='http://example.com/bar', module='bar')
-  }, ns='http://example.com/foo', module='foo'),
   'li-union': List(['k1', 'k2', 'k3'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'k1': Leaf('string', 'first'),
@@ -65,9 +59,6 @@ Container({
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
     }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
   ]),
-  'state': Container({
-    'c1': Container()
-  }, ns='http://example.com/foo', module='foo'),
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')
   }, ns='http://example.com/foo', module='foo'),

--- a/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
@@ -21,7 +21,7 @@ Container({
     'foo': Container({
       'l1': LeafList('binary', [b'Hello Acton \xf0\x9f\xab\xa1'])
     })
-  }, ns='http://example.com/foo', module='foo'),
+  }, presence=True, ns='http://example.com/foo', module='foo'),
   'c.dot': Container({
     'l.dot1': Leaf('string', 'who put that here?!')
   }, ns='http://example.com/foo', module='foo'),

--- a/test/test_gdata_source_roundtrip/src/xml_full.act
+++ b/test/test_gdata_source_roundtrip/src/xml_full.act
@@ -44,12 +44,6 @@ xml_full = Container({
       'yes': Leaf('boolean', True)
     }, ['true'])
   ]),
-  'nested': Container({
-    'f:inner': Container({
-      'li1': List(['name'])
-    }),
-    'bar:inner': Container(ns='http://example.com/bar', module='bar')
-  }, ns='http://example.com/foo', module='foo'),
   'li-union': List(['k1', 'k2', 'k3'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'k1': Leaf('string', 'first'),
@@ -67,9 +61,6 @@ xml_full = Container({
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
     }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
   ]),
-  'state': Container({
-    'c1': Container()
-  }, ns='http://example.com/foo', module='foo'),
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')
   }, ns='http://example.com/foo', module='foo'),


### PR DESCRIPTION
Generate free `from_xml*(n: xml.Node) -> gdata.Node` functions that convert XML directly to gdata. This avoids mangling the input data in adata classes, where we handle non-optional values (like leaves with defaults) differently. 

The `from_xml` generator in schema.act is essentially a copypaste of the `from_json` codegen, the only changes are the input types and the value taker functions.

Closes #122 