### PR TITLE
Fix optional value takers for XML, JSON -> gdata

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1336,7 +1336,10 @@ def get_xml_children(n: xml.Node, name: str, ns: ?str) -> list[xml.Node]:
     return res
 
 def from_xml_opt_list(n: xml.Node, name: str, ns: ?str) -> ?list[xml.Node]:
-    return get_xml_children(n, name, ns)
+    r = get_xml_children(n, name, ns)
+    if len(r) == 0:
+        return None
+    return r
 
 def from_xml_list(n: xml.Node, name: str, ns: ?str) -> list[xml.Node]:
     r = from_xml_opt_list(n, name, ns)
@@ -1452,36 +1455,44 @@ def from_xml_strs(n: xml.Node, name: str, ns: ?str) -> list[str]:
         return r
     raise ValueError("Cannot find xml child with name " + name)
 
-def from_xml_opt_strs(n: xml.Node, name: str, ns: ?str) -> list[str]:
+def from_xml_opt_strs(n: xml.Node, name: str, ns: ?str) -> ?list[str]:
     res = []
     for child in get_xml_children(n, name, ns):
         ctext = child.text
         if ctext is not None:
             res.append(ctext)
+    if len(res) == 0:
+        return None
     return res
 
-def from_xml_opt_bytess(n: xml.Node, name: str, ns: ?str) -> list[bytes]:
+def from_xml_opt_bytess(n: xml.Node, name: str, ns: ?str) -> ?list[bytes]:
     res = []
     for child in get_xml_children(n, name, ns):
         ctext = child.text
         if ctext is not None:
             res.append(base64.decode(ctext.encode()))
+    if len(res) == 0:
+        return None
     return res
 
-def from_xml_opt_values(n: xml.Node, name: str, ns: ?str) -> list[value]:
+def from_xml_opt_values(n: xml.Node, name: str, ns: ?str) -> ?list[value]:
     res = []
     for child in get_xml_children(n, name, ns):
         ctext = child.text
         if isinstance(ctext, value):
             res.append(ctext)
+    if len(res) == 0:
+        return None
     return res
 
-def from_xml_opt_ints(n: xml.Node, name: str, ns: ?str) -> list[int]:
+def from_xml_opt_ints(n: xml.Node, name: str, ns: ?str) -> ?list[int]:
     res = []
     for child in get_xml_children(n, name, ns):
         ctext = child.text
         if ctext is not None:
             res.append(int(ctext))
+    if len(res) == 0:
+        return None
     return res
 
 #def from_xml_opt_u16(n: xml.Node, name: str) -> ?u16:
@@ -1712,7 +1723,7 @@ def take_json_opt_bytess(jd: dict[str, ?value], name: str, module: ?str=None) ->
                     raise ValueError(name + "is a list of wrong type, should be base64 encoded strings, not " + str(type(c)))
             return decoded
         raise ValueError(name + "is not a list of bytes")
-    return []
+    return None
 
 def take_json_bytess(jd: dict[str, ?value], name: str, module: ?str=None) -> list[bytes]:
     val = take_json_opt_bytess(jd, name, module)

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -401,6 +401,14 @@ def _test_foo_from_gdata_empty():
     d = yang_foo_root.from_gdata(gd)
     return d.to_gdata().prsrc()
 
+def _test_foo_from_xml_empty():
+    gd = yang_foo.from_xml(xml.decode("<data/>"))
+    return gd.prsrc()
+
+def _test_foo_from_json_empty():
+    gd = yang_foo.from_json(json.decode("{}"))
+    return gd.prsrc()
+
 def _test_foo_from_gdata_c1_l1():
     gd = yang.gdata.Container(children={
         "c1": yang.gdata.Container(children={

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -165,6 +165,9 @@ def _test_foo_from_xml_full():
     # testing.assertEqual(gd1, gd2)
     if gdiff is not None:
         diff = """Container({
+  'cc': Container({
+    'death': List(['name'])
+  }, ns='http://example.com/foo', module='foo'),
   'nested': Container({
     'f:inner': Container({
       'li1': List(['name'])

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_empty
@@ -1,0 +1,1 @@
+Container()

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_empty
@@ -1,0 +1,1 @@
+Container()

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -29,8 +29,7 @@ Container({
     'l.dot1': Leaf('string', 'who put that here?!')
   }, ns='http://example.com/foo', module='foo'),
   'cc': Container({
-    'cake': Leaf('string', 'cake'),
-    'death': List(['name'])
+    'cake': Leaf('string', 'cake')
   }, ns='http://example.com/foo', module='foo'),
   'f:conflict': Container({
     'f:foo': Leaf('string', 'foo-foo'),

--- a/test/test_gdata_source_roundtrip/src/xml_full.act
+++ b/test/test_gdata_source_roundtrip/src/xml_full.act
@@ -31,8 +31,7 @@ xml_full = Container({
     'l.dot1': Leaf('string', 'who put that here?!')
   }, ns='http://example.com/foo', module='foo'),
   'cc': Container({
-    'cake': Leaf('string', 'cake'),
-    'death': List(['name'])
+    'cake': Leaf('string', 'cake')
   }, ns='http://example.com/foo', module='foo'),
   'f:conflict': Container({
     'f:foo': Leaf('string', 'foo-foo'),


### PR DESCRIPTION
Gdata produced from deserializing XML, JSON should always be the minimum required to represent the
data. It should not include unnecessary empty Container (for
non-presence containers) or List nodes when they have no meaning.