### PR TITLE
Make mandatory leaves optional in loose mode again

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2041,7 +2041,7 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         return taker_prefix + optional_str + "list"
     if isinstance(n, DLeaf):
-        optional = is_optional_arg_yang_leaf(n)
+        optional = is_optional_arg_yang_leaf(n, loose)
         optional_str = "opt_" if optional else ""
         if n.type_.name == "empty":
             return taker_prefix + optional_str + "empty"

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2037,7 +2037,7 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         return taker_prefix + optional_str + "list"
     if isinstance(n, DLeaf):
-        optional = is_optional_arg_yang_leaf(n)
+        optional = is_optional_arg_yang_leaf(n, loose)
         optional_str = "opt_" if optional else ""
         if n.type_.name == "empty":
             return taker_prefix + optional_str + "empty"

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -27,7 +27,7 @@ class foo__foo__bar(yang.adata.MNode):
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__foo__bar__l1, child_l1)
     return yang.gdata.Container(children)
 
@@ -49,7 +49,7 @@ mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1 = yang.gdata.take_json_str(jd, 'l1')
+    child_l1 = yang.gdata.take_json_opt_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__foo__bar__l1, child_l1)
     return yang.gdata.Container(children)
 

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -27,7 +27,7 @@ class foo__foo__bar(yang.adata.MNode):
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_l1 = yang.gdata.from_xml_str(node, 'l1')
+    child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__foo__bar__l1, child_l1)
     return yang.gdata.Container(children, presence=True)
 
@@ -49,7 +49,7 @@ mut def from_json_path_foo__foo__bar(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__foo__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1 = yang.gdata.take_json_str(jd, 'l1')
+    child_l1 = yang.gdata.take_json_opt_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__foo__bar__l1, child_l1)
     return yang.gdata.Container(children, presence=True)
 

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -48,7 +48,7 @@ class foo__l1__bar(yang.adata.MNode):
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_hi = yang.gdata.from_xml_str(node, 'hi')
+    child_hi = yang.gdata.from_xml_opt_str(node, 'hi')
     yang.gdata.maybe_add(children, 'hi', from_xml_foo__l1__bar__hi, child_hi)
     return yang.gdata.Container(children)
 
@@ -70,7 +70,7 @@ mut def from_json_path_foo__l1__bar(jd: value, path: list[str]=[], op: ?str='mer
 
 mut def from_json_foo__l1__bar(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_hi = yang.gdata.take_json_str(jd, 'hi')
+    child_hi = yang.gdata.take_json_opt_str(jd, 'hi')
     yang.gdata.maybe_add(children, 'hi', from_json_foo__l1__bar__hi, child_hi)
     return yang.gdata.Container(children)
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -470,7 +470,7 @@ class foo__pc2__foo(yang.adata.MNode):
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_l_mandatory = yang.gdata.from_xml_str(node, 'l_mandatory')
+    child_l_mandatory = yang.gdata.from_xml_opt_str(node, 'l_mandatory')
     yang.gdata.maybe_add(children, 'l_mandatory', from_xml_foo__pc2__foo__l_mandatory, child_l_mandatory)
     return yang.gdata.Container(children)
 
@@ -492,7 +492,7 @@ mut def from_json_path_foo__pc2__foo(jd: value, path: list[str]=[], op: ?str='me
 
 mut def from_json_foo__pc2__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l_mandatory = yang.gdata.take_json_str(jd, 'l_mandatory')
+    child_l_mandatory = yang.gdata.take_json_opt_str(jd, 'l_mandatory')
     yang.gdata.maybe_add(children, 'l_mandatory', from_json_foo__pc2__foo__l_mandatory, child_l_mandatory)
     return yang.gdata.Container(children)
 


### PR DESCRIPTION
In #120 we changed the from_xml* value getters such that they allowed parsing NETCONF messages with partial config - mandatory leaves were made optional for the "loose" data classes because the constraints really apply to the datastore as a whole, not individual NETCONF messages. In the gen2 parser rewrite #156 I missed this, so this PR restores the previous correct behavior for both from_xml* and from_json* functions.