### PR TITLE
Replace gdata.Container.key attr with key_str() method

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -492,11 +492,9 @@ class DNodeInner(DNode):
                     res.append(f"            children['{uname(child)}'] = _{usname(child)}.to_gdata()")
 
         if isinstance(self, DList):
-            # keys contains a yang spec of the keys, like "k1 k2"
-            # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key()))
-            # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
-            res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
+            # List element is a Container, but it needs no namespace qualifiers
+            # because it must belong to the same module as the list
+            res.append("        return yang.gdata.Container(children)")
         elif isinstance(self, DRoot):
             # No namespace qualifiers for the artifical root node
             res.append(f"        return yang.gdata.{self.gname}(children)")
@@ -656,10 +654,9 @@ class DNodeInner(DNode):
                 res.append(f"    yang.gdata.maybe_add(children, '{uname(child)}', from_xml_{pname(child)}, child_{usname(child)})")
 
             if isinstance(self, DList):
-                # Collect keys leaf values in a list of strings by using the
-                # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
-                res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+                # List element is a Container, but it needs no namespace qualifiers
+                # because it must belong to the same module as the list
+                res.append("    return yang.gdata.Container(children)")
             elif isinstance(self, DContainer) and self.presence:
                 res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:
@@ -696,7 +693,7 @@ class DNodeInner(DNode):
                 res += ["        if op == \"merge\":"]
                 res += ["            return val"]
                 res += ["        elif op == \"remove\":"]
-                res += [f"            return yang.gdata.Absent(val.key)"]
+                res += [f"            return yang.gdata.Absent(val.key_children({repr(self.key)}))"]
                 res += ["        raise ValueError(\"Invalid operation\")"]
                 res += ["    elif len(path) > 1:"]
                 res += ["        keys = path[0].split(\",\")"]
@@ -716,7 +713,7 @@ class DNodeInner(DNode):
                             res += [f"            children['{uname(child)}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
                         else:
                             res += ["            raise ValueError(\"Invalid json path to non-inner node\")"]
-                res += [f"        return yang.gdata.Container(children, keys)"]
+                res += [f"        return yang.gdata.Container(children)"]
                 res += ["    raise ValueError(\"unreachable - no keys to list element\")"]
                 res += [""]
 
@@ -740,7 +737,7 @@ class DNodeInner(DNode):
                 res.append("        if op == \"merge\":")
                 res.append("            elements.append(element)")
                 res.append("        elif op == \"remove\":")
-                res.append("            elements.append(yang.gdata.Absent(element.key))")
+                res.append(f"            elements.append(yang.gdata.Absent(element.key_children({repr(self.key)})))")
                 res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    elif len(path) > 1:")
                 res.append(f"        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
@@ -794,10 +791,9 @@ class DNodeInner(DNode):
                 res.append(f"    yang.gdata.maybe_add(children, '{uname(child)}', from_json_{pname(child)}, child_{usname(child)})")
 
             if isinstance(self, DList):
-                # Collect keys leaf values in a list of strings by using the
-                # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
-                res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+                # List element is a Container, but it needs no namespace qualifiers
+                # because it must belong to the same module as the list
+                res.append("    return yang.gdata.Container(children)")
             elif isinstance(self, DContainer) and self.presence:
                 res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -222,13 +222,17 @@ empty_key = []
 class Node(value):
     ns: ?str
     module: ?str
-    key: list[str] # values of the key leafs
     children: dict[str, Node]
 
-    def key_str(self) -> str:
+    def key_str(self, key_names: list[str]) -> str:
         def escape_keys(key_val):
             return key_val.replace(",", "\\,")
-        return ",".join(map(escape_keys, self.key))
+        keys = map(lambda kn: str(self.get_leaf(kn).val), key_names)
+        return ",".join(map(escape_keys, keys))
+
+    def key_children(self, key_names: list[str]) -> dict[str, Leaf]:
+        keys = map(lambda kn: (kn, self.get_leaf(kn)), key_names)
+        return dict(keys)
 
     def prsrc(self, indent=0, name="") -> str:
         args = []
@@ -254,9 +258,21 @@ class Node(value):
                 args.append("user_order=True")
             return "LeafList(" + ", ".join(args) + ")"
         elif isinstance(self, Absent):
-            if self.key != []:
-                args.insert(0, str(self.key))
-            return "Absent(" + ", ".join(args) + ")"
+            sname = "Absent"
+            if len(self.children) == 0:
+                res.append(sname + "(" + ", ".join(args) + ")")
+            else:
+                child_res = []
+                for nm,child in self.children.items():
+                    child_res.append(_ind(indent+1) + "'" + nm + "': " + child.prsrc(indent+1, nm))
+                res.append(sname + "({")
+                res.append(",\n".join(child_res))
+
+                args_str = ""
+                if len(args) > 0:
+                    args_str = ", " + ", ".join(args)
+                res.append(_ind(indent) + "}" + args_str + ")")
+            return "\n".join(res)
         elif isinstance(self, List):
             args.insert(0, str(self.keys))
             if self.user_order:
@@ -267,7 +283,7 @@ class Node(value):
                 args.append("elements=[")
                 res.append("List(" + ", ".join(args))
                 child_res = []
-                for elem in self.elements if self.user_order else sorted(self.elements):
+                for elem in self.elements if self.user_order else sorted_elements(self.elements, self.keys):
                     child_res.append(_ind(indent+1) + elem.prsrc(indent+1))
                 res.append(",\n".join(child_res))
                 res.append(_ind(indent) + "])")
@@ -276,9 +292,6 @@ class Node(value):
             sname = "Container"
             if self.presence:
                 args.insert(0, "presence=True")
-            if self.key != []:
-                args.insert(0, str(self.key))
-
             if len(self.children) == 0:
                 res.append(sname + "(" + ", ".join(args) + ")")
             else:
@@ -325,7 +338,7 @@ class Node(value):
                     child_dict[fmt_json_name(nm, child.module)] = vals
                 elif isinstance(child, List):
                     elems = []
-                    for elem in child.elements if child.user_order else sorted(child.elements):
+                    for elem in child.elements if child.user_order else sorted_elements(child.elements, child.keys):
                         if isinstance(elem, Container):
                             elem_dict = {}
                             for k, v in dict(zip(child.keys, elem.key)).items():
@@ -376,7 +389,7 @@ class Node(value):
 
         elif isinstance(self, List):
             xml = ""
-            for elem in self.elements if self.user_order else sorted(self.elements):
+            for elem in self.elements if self.user_order else sorted_elements(self.elements, self.keys):
                 remove = isinstance(elem, Absent)
                 xml += _indent() + fmt_tag(name, either(self.ns, cns), attrs=remove_op if remove else []) + _nl()
                 # Print key leafs first
@@ -419,10 +432,10 @@ class Node(value):
         l = self.get_opt_leaf(name)
         if l != None:
             return l
-        raise ValueError("Cannot find leaf child with name: " + name)
+        raise ValueError(f"Cannot find leaf child in {self} with name: " + name)
 
     def get_opt_leaf(self, name) -> ?Leaf:
-        if isinstance(self, Container):
+        if isinstance(self, Container) or isinstance(self, Absent):
             for nm,child in self.children.items():
                 if isinstance(child, Leaf) and nm == name:
                     return child
@@ -592,14 +605,12 @@ class Node(value):
         except ValueError:
             return []
 
-extension Node(Ord):
+extension Node(Eq):
     def __eq__(self, other: Node) -> bool:
         if self.ns != other.ns:
             return False
 
         if isinstance(self, Container) and isinstance(other, Container):
-            if self.key != other.key:
-                return False
             if set(self.children.keys()) != set(other.children.keys()):
                 return False
             for key in self.children.keys():
@@ -621,21 +632,23 @@ extension Node(Ord):
             for i in range(len(self.elements)):
                 e1 = self.elements[i]
                 e2 = other.elements[i]
-                if not self.user_order and e1.key != e2.key:
+                if not self.user_order and e1.key_str(self.keys) != e2.key_str(other.keys):
                     for e2 in other.elements:
-                        if e1.key == e2.key:
+                        if e1.key_str(self.keys) == e2.key_str(other.keys):
                             break
                 if e1 != e2:
                     return False
             return True
 
         if isinstance(self, Absent) and isinstance(other, Absent):
-            return self.key == other.key
+            if set(self.children.keys()) != set(other.children.keys()):
+                return False
+            for key in self.children.keys():
+                if self.children[key] != other.children[key]:
+                    return False
+            return True
 
         return False
-
-    def __lt__(a, b):
-        return a.key_str() <= b.key_str()
 
 
 class List(Node):
@@ -652,9 +665,8 @@ class List(Node):
         self.module = module
 
 class Container(Node):
-    def __init__(self, children: dict[str, Node]={}, key: list[str]=[], presence: bool=False, ns: ?str=None, module: ?str=None):
+    def __init__(self, children: dict[str, Node]={}, presence: bool=False, ns: ?str=None, module: ?str=None):
         self.children = children
-        self.key = key
         self.presence = presence
         self.ns = ns
         self.module = module
@@ -691,11 +703,10 @@ class Absent(Node):
     Absent is declarative / idempotent, meaning that if the target to be removed
     / made absent is not present, no error is raised.
     """
-    def __init__(self, key: list[str]=[], ns: ?str=None, module: ?str=None):
-        self.key = key
+    def __init__(self, children: dict[str, Node]={}, ns: ?str=None, module: ?str=None):
         self.ns = ns
         self.module = module
-        self.children = {}
+        self.children = children
 
 class Delete(Node):
     """Imperative delete of a node
@@ -731,6 +742,14 @@ class Replace(Node):
         self.module = module
         self.children = children
 
+def sorted_elements(elements, key_names):
+    keys = list(map(lambda elem: elem.key_str(key_names), elements))
+    key_map = dict(zip(keys, elements))
+    sorted_keys = sorted(keys)
+    res = []
+    for key in sorted_keys:
+        res.append(key_map[key])
+    return res
 
 def vals_equal(a: value, b: value) -> bool:
     # Compare known leaf value types
@@ -908,11 +927,9 @@ def merge(a: Node, b: Node) -> Node:
         return result
 
     if isinstance(a, Container) and isinstance(b, Container):
-        if a.key != b.key:
-            raise ValueError("Cannot merge containers with different keys: %s vs %s" % (str(a.key), str(b.key)))
         # Merge keyed children similarly to Container
         new_children = merge_keyed_children(a.children, b.children)
-        return Container(children=new_children, key=a.key, presence=a.presence, ns=a.ns, module=a.module)
+        return Container(children=new_children, presence=a.presence, ns=a.ns, module=a.module)
 
     elif isinstance(a, Leaf) and isinstance(b, Leaf):
         if a.t != b.t:
@@ -942,14 +959,14 @@ def merge(a: Node, b: Node) -> Node:
 
             old_map = {}
             for e in a.elements:
-                old_map[e.key_str()] = e
+                old_map[e.key_str(a.keys)] = e
 
             # Start with elements from a, merge if present in b
             for a_elem in a.elements:
-                k = a_elem.key_str()
+                k = a_elem.key_str(a.keys)
                 found = False
                 for b_elem in b.elements:
-                    if b_elem.key == a_elem.key:
+                    if b_elem.key_str(b.keys) == a_elem.key_str(a.keys):
                         merged_elem = merge(a_elem, b_elem)
                         if isinstance(merged_elem, Container):
                             new_elements.append(merged_elem)
@@ -968,9 +985,9 @@ def merge(a: Node, b: Node) -> Node:
             # For now, we just append them at the end.
             existing_keys = {}
             for e in new_elements:
-                existing_keys[e.key_str()] = True
+                existing_keys[e.key_str(a.keys)] = True
             for b_elem in b.elements:
-                bk = b_elem.key_str()
+                bk = b_elem.key_str(b.keys)
                 if bk not in existing_keys:
                     new_elements.append(b_elem)
                     existing_keys[bk] = True
@@ -984,12 +1001,12 @@ def merge(a: Node, b: Node) -> Node:
             def escape_keys(key_val):
                 return key_val.replace(",", "\\,")
             for elem in a.elements:
-                key_str = ",".join(elem.key)
+                key_str = elem.key_str(a.keys)
                 if key_str not in all_elements:
                     all_elements[key_str] = []
                 all_elements[key_str].append(elem)
             for elem in b.elements:
-                key_str = ",".join(elem.key)
+                key_str = elem.key_str(b.keys)
                 if key_str not in all_elements:
                     all_elements[key_str] = []
                 all_elements[key_str].append(elem)
@@ -1047,6 +1064,19 @@ def diff(old: Node, new: Node) -> ?Node:
             return None
         return result
 
+    # Helper function for diffing list elements (specialized Container nodes)
+    # that *must* always include the key leaf children
+    def diff_list_element(old_element: Node, new_element: Node, keys: list[str]) -> ?Node:
+        # Diff of element Container nodes will only contain the actual
+        # differences, skipping keys which are equal in both
+        entry_diff = diff(old_element, new_element)
+        if entry_diff is not None:
+            # Update the entry to include key leaf children
+            for key in keys:
+                entry_diff.children[key] = old_element.get_leaf(key)
+            return entry_diff
+        return None
+
     # Helper function for diffing Lists which have ordered elements
     def diff_list_elements(old_list: List, new_list: List) -> ?list[Node]:
 
@@ -1057,14 +1087,14 @@ def diff(old: Node, new: Node) -> ?Node:
         old_map = {}
         old_key_order = []
         for e in old_list.elements:
-            k = e.key_str()
+            k = e.key_str(old_list.keys)
             old_map[k] = e
             old_key_order.append(k)
 
         new_map = {}
         new_key_order = []
         for e in new_list.elements:
-            nk = e.key_str()
+            nk = e.key_str(new_list.keys)
             new_map[nk] = e
             new_key_order.append(nk)
 
@@ -1079,12 +1109,9 @@ def diff(old: Node, new: Node) -> ?Node:
 
             if ok == nk:
                 # same element key
-                elem_diff = diff(old_map[ok], new_map[nk])
-                if elem_diff != None:
-                    if isinstance(elem_diff, Absent):
-                        raise ValueError("Absent returned from diff in list elements")
-                    elif isinstance(elem_diff, Container):
-                        result.append(elem_diff)
+                elem_diff = diff_list_element(old_map[ok], new_map[nk], old_list.keys)
+                if elem_diff is not None:
+                    result.append(elem_diff)
                 i += 1
                 j += 1
             else:
@@ -1094,7 +1121,7 @@ def diff(old: Node, new: Node) -> ?Node:
                 if not ok_in_new:
                     # old element not in new => absent
                     oe = old_map[ok]
-                    result.append(Absent(oe.key))
+                    result.append(Absent(oe.key_children(old_list.keys)))
                     i += 1
                 elif not nk_in_old:
                     # new element not in old => new element
@@ -1111,7 +1138,7 @@ def diff(old: Node, new: Node) -> ?Node:
             ok = old_key_order[i]
             if ok not in new_map:
                 oe = old_map[ok]
-                result.append(Absent(oe.key))
+                result.append(Absent(oe.key_children(old_list.keys)))
             i += 1
 
         # Remaining new elements are new
@@ -1129,12 +1156,10 @@ def diff(old: Node, new: Node) -> ?Node:
     # Diff logic for each node type
 
     if isinstance(old, Container) and isinstance(new, Container):
-        if old.key != new.key:
-            raise ValueError("Container keys differ: %s vs %s" % (str(old.key), str(new.key)))
         diff_children = diff_keyed_children(old.children, new.children)
         if diff_children is None:
             return None
-        return Container(children=diff_children, key=new.key, presence=new.presence, ns=new.ns, module=new.module)
+        return Container(children=diff_children, presence=new.presence, ns=new.ns, module=new.module)
 
     elif isinstance(old, List) and isinstance(new, List):
         # For lists, we have elements instead of children
@@ -1157,8 +1182,10 @@ def diff(old: Node, new: Node) -> ?Node:
         return new
 
     elif isinstance(old, Absent) and isinstance(new, Absent):
-        if old.key != new.key:
-            raise ValueError("Absent keys differ: %s vs %s" % (str(old.key), str(new.key)))
+        diff_children = diff_keyed_children(old.children, new.children)
+        if diff_children is not None:
+            # TODO: can't call key_str(list_keys) without our parent List node!?
+            raise ValueError("Absent keys differ: %s vs %s" % (str(old.children), str(new.children)))
         return None
 
     else:
@@ -1172,12 +1199,14 @@ def patch(old: Node, p: ?Node) -> ?Node:
 
     if isinstance(p, Absent):
         # Patch says remove this node
+        if isinstance(old, Absent):
+            # Both absent means node was removed
+            if p.children != old.children:
+                # TODO: can't call key_str(list_keys) without our parent List node!?
+                raise ValueError("Absent keys differ in patch: %s vs %s" % (str(old.children), str(p.children)))
         return None
 
     elif isinstance(old, Container) and isinstance(p, Container):
-        if old.key != p.key:
-            raise ValueError("Container keys differ in patch: %s vs %s" % (str(old.key), str(p.key)))
-
         # Start with old children
         new_children: dict[str, Node] = {}
         for key in old.children:
@@ -1205,7 +1234,7 @@ def patch(old: Node, p: ?Node) -> ?Node:
         # No need to remove unchanged nodes; they are already in new_children
         if len(new_children) == 0:
             return None
-        return Container(children=new_children, key=old.key, presence=old.presence, ns=old.ns, module=old.module)
+        return Container(children=new_children, presence=old.presence, ns=old.ns, module=old.module)
 
     elif isinstance(old, List) and isinstance(p, List):
         if old.keys != p.keys:
@@ -1213,7 +1242,7 @@ def patch(old: Node, p: ?Node) -> ?Node:
 
         old_map = {}
         for e in old.elements:
-            k = e.key_str()
+            k = e.key_str(old.keys)
             old_map[k] = e
 
         # Apply patch elements
@@ -1221,12 +1250,12 @@ def patch(old: Node, p: ?Node) -> ?Node:
         for pelem in patch_elems:
             if isinstance(pelem, Absent):
                 # Remove this element if it exists
-                k = pelem.key_str()
+                k = pelem.key_str(p.keys)
                 if k in old_map:
                     del old_map[k]
             else:
                 # pelem is a ListElement
-                k = pelem.key_str()
+                k = pelem.key_str(p.keys)
                 if k in old_map:
                     # Patch existing element
                     res = patch(old_map[k], pelem)
@@ -1244,7 +1273,7 @@ def patch(old: Node, p: ?Node) -> ?Node:
         final_key_order = []
         chosen = {}
         for e in old.elements:
-            k = e.key_str()
+            k = e.key_str(old.keys)
             if k in old_map:
                 final_key_order.append(k)
                 chosen[k] = True
@@ -1254,7 +1283,7 @@ def patch(old: Node, p: ?Node) -> ?Node:
         for pelem in patch_elems:
             if isinstance(pelem, Absent):
                 continue
-            k = pelem.key_str()
+            k = pelem.key_str(p.keys)
             if k in old_map and k not in chosen:
                 final_key_order.append(k)
                 chosen[k] = True
@@ -1279,8 +1308,6 @@ def patch(old: Node, p: ?Node) -> ?Node:
 
     elif isinstance(old, Absent) and isinstance(p, Absent):
         # Both absent means node was removed
-        if old.key != p.key:
-            raise ValueError("Absent keys differ in patch: %s vs %s" % (str(old.key), str(p.key)))
         return None
 
     else:
@@ -1764,12 +1791,14 @@ def _test_merge1():
         "a": Leaf("int", 1),
         "l1": List(["name"], [
             Container({
+                "name": Leaf("str", "k1"),
                 "n1": Leaf("int", 1),
                 "n2": Leaf("int", 2)
-            }, ["k1"]),
+            }),
             Container({
+                "name": Leaf("str", "k4"),
                 "n4": Leaf("int", 4),
-            }, ["k4"]),
+            }),
         ])
     }, ns="http://example.com/acme", module="acme")
 
@@ -1778,9 +1807,10 @@ def _test_merge1():
         "c": Leaf("int", 3),
         "l1": List(["name"], [
             Container({
+                "name": Leaf("str", "k2"),
                 "n1": Leaf("int", 1),
                 "n3": Leaf("int", 3)
-            }, ["k2"]),
+            }),
         ]),
         "d": LeafList("str", ["a", "b", "c"])
     }, ns="http://example.com/acme", module="acme")
@@ -1793,16 +1823,19 @@ def _test_merge1():
         "c": Leaf("int", 3),
         "l1": List(["name"], [
             Container({
+                "name": Leaf("str", "k1"),
                 "n1": Leaf("int", 1),
                 "n2": Leaf("int", 2)
-            }, ["k1"]),
+            }),
             Container({
+                "name": Leaf("str", "k2"),
                 "n1": Leaf("int", 1),
                 "n3": Leaf("int", 3)
-            }, ["k2"]),
+            }),
             Container({
+                "name": Leaf("str", "k4"),
                 "n4": Leaf("int", 4),
-            }, ["k4"]),
+            }),
         ]),
         "d": LeafList("str", ["a", "b", "c"])
     }, ns="http://example.com/acme", module="acme")
@@ -1812,59 +1845,78 @@ def _test_merge1():
 def _test_merge_list1():
     y1 = List(["name"], [
         Container({
+            "name": Leaf("str", "first"),
             "n1": Leaf("int", 1)
-        }, ["first"]),
+        }),
         Container({
+            "name": Leaf("str", "breaker"),
             "n1": Leaf("int", 1)
-        }, ["breaker"]),
+        }),
         Container({
+            "name": Leaf("str", "fourth"),
             "n1": Leaf("int", 1)
-        }, ["fourth"]),
+        }),
         Container({
+            "name": Leaf("str", "common"),
             "n2": Leaf("int", 2)
-        }, ["common"]),
+        }),
         Container({
+            "name": Leaf("str", "last"),
             "n1": Leaf("int", 1)
-        }, ["last"]),
+        }),
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
     y2 = List(["name"], [
-        Container({}, ["breaker"]),
         Container({
-            "n1": Leaf("int", 1)
-        }, ["second"]),
+            "name": Leaf("str", "breaker")
+        }),
         Container({
+            "name": Leaf("str", "second"),
             "n1": Leaf("int", 1)
-        }, ["third"]),
+        }),
         Container({
+            "name": Leaf("str", "third"),
             "n1": Leaf("int", 1)
-        }, ["common"]),
-        Container({}, ["last"])
+        }),
+        Container({
+            "name": Leaf("str", "common"),
+            "n1": Leaf("int", 1)
+        }),
+        Container({
+            "name": Leaf("str", "last")
+        })
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
     exp = List(["name"], [
         Container({
+            "name": Leaf("str", "first"),
             "n1": Leaf("int", 1)
-        }, ["first"]),
+        }),
         Container({
+            "name": Leaf("str", "breaker"),
             "n1": Leaf("int", 1)
-        }, ["breaker"]),
+        }),
         Container({
+            "name": Leaf("str", "fourth"),
             "n1": Leaf("int", 1)
-        }, ["fourth"]),
+        }),
         Container({
+            "name": Leaf("str", "common"),
             "n2": Leaf("int", 2),
             "n1": Leaf("int", 1)
-        }, ["common"]),
+        }),
         Container({
+            "name": Leaf("str", "last"),
             "n1": Leaf("int", 1)
-        }, ["last"]),
+        }),
         Container({
+            "name": Leaf("str", "second"),
             "n1": Leaf("int", 1)
-        }, ["second"]),
+        }),
         Container({
+            "name": Leaf("str", "third"),
             "n1": Leaf("int", 1)
-        }, ["third"]),
+        }),
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(exp, merge(y1, y2))
@@ -1872,19 +1924,23 @@ def _test_merge_list1():
 def _test_eq_list():
     l1 = List(["name"], [
         Container({
+            "name": Leaf("str", "a"),
             "x": Leaf("int", 1)
-        }, ["a"]),
+        }),
         Container({
+            "name": Leaf("str", "b"),
             "x": Leaf("int", 2)
-        }, ["b"])
+        })
     ])
     l2 = List(["name"], [
         Container({
+            "name": Leaf("str", "b"),
             "x": Leaf("int", 2)
-        }, ["b"]),
+        }),
         Container({
+            "name": Leaf("str", "a"),
             "x": Leaf("int", 1)
-        }, ["a"])
+        })
     ])
     testing.assertEqual(l1, l1)
     testing.assertEqual(l1, l2)
@@ -1893,18 +1949,18 @@ def _test_eq_list_user_order():
     l1 = List(["name"], user_order=True, elements=[
         Container({
             "x": Leaf("int", 1)
-        }, ["a"]),
+        }),
         Container({
             "x": Leaf("int", 2)
-        }, ["b"])
+        })
     ])
     l2 = List(["name"], user_order=True, elements=[
         Container({
             "x": Leaf("int", 2)
-        }, ["b"]),
+        }),
         Container({
             "x": Leaf("int", 1)
-        }, ["a"])
+        })
     ])
     testing.assertEqual(l1, l1)
     testing.assertNotEqual(l1, l2)
@@ -1985,30 +2041,35 @@ def _test_diff_node_removal():
     testing.assertEqual(d, exp)
 
 def _test_diff_elem_removal():
-    """A list element k1 is removed from old to new. We expect an Absent(["k1"])
+    """A list element k1 is removed from old to new. We expect an Absent("k1")
     node in the diff at the place where k1 was.
     """
     old = List(["name"], [
         Container({
+            "name": Leaf("str", "k1"),
             "n1": Leaf("int", 1),
-            "n2": Leaf("int", 2)
-        }, ["k1"]),
+            "n2": Leaf("int", 2),
+        }),
         Container({
+            "name": Leaf("str", "k4"),
             "n4": Leaf("int", 4),
-        }, ["k4"]),
+        }),
     ], ns="http://example.com/acme", module="acme")
 
     new = List(["name"], [
         Container({
+            "name": Leaf("str", "k4"),
             "n4": Leaf("int", 4),
-        }, ["k4"]),
+        }),
     ], ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
 
     # k1 is removed
     exp = List(["name"], [
-        Absent(["k1"]),
+        Absent({
+            "name": Leaf("str", "k1")
+        })
     ], ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
@@ -2135,25 +2196,30 @@ def _test_patch_node_removal():
 def _test_patch_elem_removal():
     old = List(["name"], [
         Container({
+            "name": Leaf("str", "k1"),
             "n1": Leaf("int", 1),
             "n2": Leaf("int", 2)
-        }, ["k1"]),
+        }),
         Container({
+            "name": Leaf("str", "k4"),
             "n4": Leaf("int", 4),
-        }, ["k4"]),
+        }),
     ], ns="http://example.com/acme", module="acme")
 
     # Suppose we remove 'k1'
     # patch would be:
     p = List(["name"], [
-        Absent(["k1"]),
+        Absent({
+            "name": Leaf("str", "k1")
+        })
     ], ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = List(["name"], [
         Container({
+            "name": Leaf("str", "k4"),
             "n4": Leaf("int", 4),
-        }, ["k4"]),
+        }),
     ], ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2162,9 +2228,11 @@ def _test_patch_elem_removal2():
     old = Container({
         "n1": Leaf("int", 1),
         "n2": Leaf("int", 2)
-    }, ["k1"])
+    })
 
-    p = Absent(["k1"])
+    p = Absent({
+        "name": Leaf("str", "k1")
+    })
 
     res = patch(old, p)
 
@@ -2241,13 +2309,15 @@ def _test_diff_and_patch_large_tree():
                 }),
                 "interfaces": List(["name"], elements=[
                     Container({
+                        "name": Leaf("str", "eth0"),
                         "desc": Leaf("str", "Uplink interface"),
                         "enabled": Leaf("bool", True)
-                    }, ["eth0"]),
+                    }),
                     Container({
+                        "name": Leaf("str", "eth1"),
                         "desc": Leaf("str", "Internal interface"),
                         "enabled": Leaf("bool", True)
-                    }, ["eth1"]),
+                    }),
                 ])
             }, ns="http://example.com/yang/mod1", module="mod1")
         }),
@@ -2255,15 +2325,17 @@ def _test_diff_and_patch_large_tree():
             "acl": Container(children={
                 "rules": List(["id"], elements=[
                     Container({
+                        "id": Leaf("int", 10),
                         "action": Leaf("str", "permit"),
                         "src": Leaf("str", "10.0.0.0/24"),
                         "dst": Leaf("str", "10.0.1.0/24"),
-                    }, ["10"]),
+                    }),
                     Container({
+                        "id": Leaf("int", 20),
                         "action": Leaf("str", "deny"),
                         "src": Leaf("str", "any"),
                         "dst": Leaf("str", "any"),
-                    }, ["20"]),
+                    }),
                 ])
             }, ns="http://example.com/yang/mod2", module="mod2")
         }),
@@ -2288,14 +2360,16 @@ def _test_diff_and_patch_large_tree():
                 }),
                 "interfaces": List(["name"], elements=[
                     Container({
+                        "name": Leaf("str", "eth0"),
                         "desc": Leaf("str", "Uplink interface"),
                         "enabled": Leaf("bool", True)
-                    }, ["eth0"]),
+                    }),
                     # eth1 removed
                     Container({
+                        "name": Leaf("str", "eth2"),
                         "desc": Leaf("str", "DMZ interface"),
                         "enabled": Leaf("bool", False)
-                    }, ["eth2"]),
+                    }),
                 ])
             }, ns="http://example.com/yang/mod1", module="mod1")
         }),
@@ -2303,27 +2377,35 @@ def _test_diff_and_patch_large_tree():
             "acl": Container(children={
                 "rules": List(["id"], elements=[
                     Container({
+                        "id": Leaf("int", 10),
                         "action": Leaf("str", "permit"),
                         "src": Leaf("str", "10.0.0.0/24"),
                         "dst": Leaf("str", "10.0.1.0/24"),
-                    }, ["10"]),
+                    }),
                     Container({
+                        "id": Leaf("int", 20),
                         "action": Leaf("str", "drop"),  # changed from deny
                         "src": Leaf("str", "any"),
                         "dst": Leaf("str", "any"),
-                    }, ["20"]),
+                    }),
                     Container({
+                        "id": Leaf("int", 30),
                         "action": Leaf("str", "permit"),
                         "src": Leaf("str", "192.0.2.0/24"),
                         "dst": Leaf("str", "198.51.100.0/24"),
-                    }, ["30"]),
+                    }),
                 ])
             }, ns="http://example.com/yang/mod2", module="mod2")
         })
     })
 
     # Compute diff
+    print("Old: ", old.prsrc())
     d = diff(old, new)
+    if d is not None:
+        print("Diff result: ", d.prsrc())
+    else:
+        print("Diff result: None")
 
     # Check that patching old with d results in new
     res = patch(old, d)
@@ -2342,12 +2424,14 @@ def _test_prsrc():
             "a": Leaf("int", 1),
             "l1": List(["name"], [
                 Container({
+                    "name": Leaf("str", "k1"),
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
-                }, ["k1"]),
+                }),
                 Container({
+                    "name": Leaf("str", "k4"),
                     "n4": Leaf("int", 4),
-                }, ["k4"]),
+                }),
             ])
         }, ns="http://example.com/acme", module="acme")
     })
@@ -2359,10 +2443,13 @@ def _test_prsrc_absent():
         "foo": Container({
             "a": Absent(),
             "l1": List(["name"], [
-                Absent(["k1"]),
+                Absent({
+                    "name": Leaf("str", "k1")
+                }),
                 Container({
+                    "name": Leaf("str", "k4"),
                     "n4": Leaf("int", 4),
-                }, ["k4"]),
+                }),
             ])
         }, ns="http://example.com/acme", module="acme")
     })
@@ -2397,10 +2484,10 @@ def _test_to_json():
                 Container({
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
-                }, ["k1", "k1a"]),
+                }),
                 Container({
                     "n4": Leaf("int", 4),
-                }, ["k4", "k4a"]),
+                }),
             ]),
             "b": Leaf("bool", False),
             "lb": Leaf("binary", b"Hello Acton \xf0\x9f\xab\xa1"),
@@ -2430,10 +2517,10 @@ def _test_to_xmlstr():
                 Container({
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
-                }, ["k1", "k1a"]),
+                }),
                 Container({
                     "n4": Leaf("int", 4),
-                }, ["k4", "k4a"]),
+                }),
             ]),
             "b": Leaf("bool", False),
             "lb": Leaf("binary", b"Hello Acton \xf0\x9f\xab\xa1"),
@@ -2486,14 +2573,14 @@ def _test_to_xmlstr_mixed():
                         "system-network-name": Leaf("str", "dev1")
                     }, ns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg")
                 }),
-            }, ["dev1"]),
+            }),
             Container({
                 "config": Container({
                     "hostname": Container({
                         "system-network-name": Leaf("str", "dev2")
                     }, ns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg")
                 }),
-            }, ["dev2"]),
+            }),
         ], ns="http://orchestron.org/yang/orchestron-device.yang")
     })
 

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -231,8 +231,10 @@ class Node(value):
         return ",".join(map(escape_keys, keys))
 
     def key_children(self, key_names: list[str]) -> dict[str, Leaf]:
-        keys = map(lambda kn: (kn, self.get_leaf(kn)), key_names)
-        return dict(keys)
+        children = {}
+        for kn in key_names:
+            children[kn] = self.get_leaf(kn)
+        return children
 
     def prsrc(self, indent=0, name="") -> str:
         args = []

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -191,7 +191,7 @@ def yang_str(v) -> str:
         s = s.lower()
     return s
 
-def json_val(yang_type: str, v: ?value) -> ?value:
+def json_val(yang_type: str, v: value) -> ?value:
     if isinstance(v, bytes):
         return base64.encode(v).decode()
     if yang_type == "int64" or yang_type == "uint64":
@@ -343,8 +343,8 @@ class Node(value):
                     for elem in child.elements if child.user_order else sorted_elements(child.elements, child.keys):
                         if isinstance(elem, Container):
                             elem_dict = {}
-                            for k, v in dict(zip(child.keys, elem.key)).items():
-                                elem_dict[k] = v
+                            for key_name, key_leaf in elem.key_children(child.keys).items():
+                                elem_dict[fmt_json_name(key_name)] = json_val(key_leaf.t, key_leaf.val)
                             elem_dict.update(elem.to_dict(pretty).items())
                             elems.append(elem_dict)
                         else:
@@ -395,8 +395,9 @@ class Node(value):
                 remove = isinstance(elem, Absent)
                 xml += _indent() + fmt_tag(name, either(self.ns, cns), attrs=remove_op if remove else []) + _nl()
                 # Print key leafs first
-                for key_idx, key_name in enumerate(self.keys):
-                    xml += _indent(1) + "<" + key_name + ">" + str(elem.key[key_idx]) + "</" + key_name + ">" + _nl()
+                for key_name, key_leaf in elem.key_children(self.keys).items():
+                    v = yang_str(key_leaf.val)
+                    xml += _indent(1) + fmt_tag(key_name) + v + fmt_tag(key_name, close=True) + _nl()
                 for nm,child in elem.children.items():
                     if nm in self.keys or remove:
                         continue
@@ -2484,10 +2485,14 @@ def _test_to_json():
             "a": Leaf("int", 1),
             "l1": List(["name", "name_two"], [
                 Container({
+                    "name": Leaf("str", "k1"),
+                    "name_two": Leaf("str", "k1a"),
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
                 }),
                 Container({
+                    "name": Leaf("str", "k4"),
+                    "name_two": Leaf("str", "k4a"),
                     "n4": Leaf("int", 4),
                 }),
             ]),
@@ -2517,10 +2522,14 @@ def _test_to_xmlstr():
             "a": Leaf("int", 1),
             "l1": List(["name", "name_two"], [
                 Container({
+                    "name": Leaf("str", "k1"),
+                    "name_two": Leaf("str", "k1a"),
                     "n1": Leaf("int", 1),
                     "n2": Leaf("int", 2)
                 }),
                 Container({
+                    "name": Leaf("str", "k4"),
+                    "name_two": Leaf("str", "k4a"),
                     "n4": Leaf("int", 4),
                 }),
             ]),
@@ -2570,6 +2579,7 @@ def _test_to_xmlstr_mixed():
     y1 = Container({
         "device": List(["name"], [
             Container({
+                "name": Leaf("str", "dev1"),
                 "config": Container({
                     "hostname": Container({
                         "system-network-name": Leaf("str", "dev1")
@@ -2577,6 +2587,7 @@ def _test_to_xmlstr_mixed():
                 }),
             }),
             Container({
+                "name": Leaf("str", "dev2"),
                 "config": Container({
                     "hostname": Container({
                         "system-network-name": Leaf("str", "dev2")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -488,11 +488,9 @@ class DNodeInner(DNode):
                     res.append(f"            children['{uname(child)}'] = _{usname(child)}.to_gdata()")
 
         if isinstance(self, DList):
-            # keys contains a yang spec of the keys, like "k1 k2"
-            # which are modeled as attributes of the list entry class and accessed via self.k1, self.k2
-            list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(self.{x})", us_list_key()))
-            # No namespace qualifiers for the list entry "container" node - it is the same as the parent list node
-            res.append(f"        return yang.gdata.Container(children, [{list_keys_str}])")
+            # List element is a Container, but it needs no namespace qualifiers
+            # because it must belong to the same module as the list
+            res.append("        return yang.gdata.Container(children)")
         elif isinstance(self, DRoot):
             # No namespace qualifiers for the artifical root node
             res.append(f"        return yang.gdata.{self.gname}(children)")
@@ -652,10 +650,9 @@ class DNodeInner(DNode):
                 res.append(f"    yang.gdata.maybe_add(children, '{uname(child)}', from_xml_{pname(child)}, child_{usname(child)})")
 
             if isinstance(self, DList):
-                # Collect keys leaf values in a list of strings by using the
-                # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
-                res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+                # List element is a Container, but it needs no namespace qualifiers
+                # because it must belong to the same module as the list
+                res.append("    return yang.gdata.Container(children)")
             elif isinstance(self, DContainer) and self.presence:
                 res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:
@@ -692,7 +689,7 @@ class DNodeInner(DNode):
                 res += ["        if op == \"merge\":"]
                 res += ["            return val"]
                 res += ["        elif op == \"remove\":"]
-                res += [f"            return yang.gdata.Absent(val.key)"]
+                res += [f"            return yang.gdata.Absent(val.key_children({repr(self.key)}))"]
                 res += ["        raise ValueError(\"Invalid operation\")"]
                 res += ["    elif len(path) > 1:"]
                 res += ["        keys = path[0].split(\",\")"]
@@ -712,7 +709,7 @@ class DNodeInner(DNode):
                             res += [f"            children['{uname(child)}'] = from_json_path_{pname(child)}(jd, rest_path, op)"]
                         else:
                             res += ["            raise ValueError(\"Invalid json path to non-inner node\")"]
-                res += [f"        return yang.gdata.Container(children, keys)"]
+                res += [f"        return yang.gdata.Container(children)"]
                 res += ["    raise ValueError(\"unreachable - no keys to list element\")"]
                 res += [""]
 
@@ -736,7 +733,7 @@ class DNodeInner(DNode):
                 res.append("        if op == \"merge\":")
                 res.append("            elements.append(element)")
                 res.append("        elif op == \"remove\":")
-                res.append("            elements.append(yang.gdata.Absent(element.key))")
+                res.append(f"            elements.append(yang.gdata.Absent(element.key_children({repr(self.key)})))")
                 res.append(f"        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    elif len(path) > 1:")
                 res.append(f"        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
@@ -790,10 +787,9 @@ class DNodeInner(DNode):
                 res.append(f"    yang.gdata.maybe_add(children, '{uname(child)}', from_json_{pname(child)}, child_{usname(child)})")
 
             if isinstance(self, DList):
-                # Collect keys leaf values in a list of strings by using the
-                # non-optional local variables defined above.
-                list_keys_str = ", ".join(map(lambda x: f"yang.gdata.yang_str(child_{x})", us_list_key()))
-                res.append(f"    return yang.gdata.Container(children, [{list_keys_str}])")
+                # List element is a Container, but it needs no namespace qualifiers
+                # because it must belong to the same module as the list
+                res.append("    return yang.gdata.Container(children)")
             elif isinstance(self, DContainer) and self.presence:
                 res.append(f"    return yang.gdata.{self.gname}(children, presence=True{gdata_nsq})")
             else:

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -36,7 +36,7 @@ class foo__c1__things_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('string', _id)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__things_entry:
@@ -85,7 +85,7 @@ mut def from_xml_foo__c1__things_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__c1__things__name, child_name)
     child_id = yang.gdata.from_xml_opt_str(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_foo__c1__things__id, child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__c1__things(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -102,7 +102,7 @@ mut def from_json_path_foo__c1__things_element(jd: value, path: list[str]=[], op
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -112,7 +112,7 @@ mut def from_json_path_foo__c1__things_element(jd: value, path: list[str]=[], op
         children['name'] = from_json_foo__c1__things__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__c1__things(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -134,7 +134,7 @@ mut def from_json_path_foo__c1__things(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__c1__things_element(jd, path, op)])
@@ -146,7 +146,7 @@ mut def from_json_foo__c1__things_element(jd: dict[str, ?value]) -> yang.gdata.N
     yang.gdata.maybe_add(children, 'name', from_json_foo__c1__things__name, child_name)
     child_id = yang.gdata.take_json_opt_str(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_foo__c1__things__id, child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__c1__things(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -25,7 +25,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> bar__c1__li1_entry:
@@ -72,7 +72,7 @@ mut def from_xml_bar__c1__li1_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_l1 = yang.gdata.from_xml_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_bar__c1__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_bar__c1__li1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -89,7 +89,7 @@ mut def from_json_path_bar__c1__li1_element(jd: value, path: list[str]=[], op: ?
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['l1']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -97,7 +97,7 @@ mut def from_json_path_bar__c1__li1_element(jd: value, path: list[str]=[], op: ?
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['l1'] = from_json_bar__c1__li1__l1(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_bar__c1__li1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -119,7 +119,7 @@ mut def from_json_path_bar__c1__li1(jd: value, path: list[str]=[], op: ?str='mer
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['l1'])))
         return yang.gdata.List(['l1'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['l1'], [from_json_path_bar__c1__li1_element(jd, path, op)])
@@ -129,7 +129,7 @@ mut def from_json_bar__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node
     children = {}
     child_l1 = yang.gdata.take_json_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_bar__c1__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_json_bar__c1__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -25,7 +25,7 @@ class foo__c1__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li1_entry:
@@ -72,7 +72,7 @@ mut def from_xml_foo__c1__li1_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_l1 = yang.gdata.from_xml_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__c1__li1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -89,7 +89,7 @@ mut def from_json_path_foo__c1__li1_element(jd: value, path: list[str]=[], op: ?
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['l1']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -97,7 +97,7 @@ mut def from_json_path_foo__c1__li1_element(jd: value, path: list[str]=[], op: ?
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['l1'] = from_json_foo__c1__li1__l1(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__c1__li1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -119,7 +119,7 @@ mut def from_json_path_foo__c1__li1(jd: value, path: list[str]=[], op: ?str='mer
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['l1'])))
         return yang.gdata.List(['l1'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['l1'], [from_json_path_foo__c1__li1_element(jd, path, op)])
@@ -129,7 +129,7 @@ mut def from_json_foo__c1__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node
     children = {}
     child_l1 = yang.gdata.take_json_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__c1__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__c1__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -87,7 +87,7 @@ class foo__c__li_entry(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c__li_entry:
@@ -138,7 +138,7 @@ mut def from_xml_foo__c__li_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__c__li__foo, child_foo)
     child_bar = yang.gdata.from_xml_cnt(node, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_xml_foo__c__li__bar, child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__c__li(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -155,7 +155,7 @@ mut def from_json_path_foo__c__li_element(jd: value, path: list[str]=[], op: ?st
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -167,7 +167,7 @@ mut def from_json_path_foo__c__li_element(jd: value, path: list[str]=[], op: ?st
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar':
             children['bar'] = from_json_path_foo__c__li__bar(jd, rest_path, op)
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__c__li(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -189,7 +189,7 @@ mut def from_json_path_foo__c__li(jd: value, path: list[str]=[], op: ?str='merge
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__c__li_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -203,7 +203,7 @@ mut def from_json_foo__c__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'foo', from_json_foo__c__li__foo, child_foo)
     child_bar = yang.gdata.take_json_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__c__li__bar, child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__c__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -27,7 +27,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         _foo_k1 = self.foo_k1
         if _foo_k1 is not None:
             children['foo:k1'] = yang.gdata.Leaf('string', _foo_k1, ns='http://example.com/foo', module='foo')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.base_k1)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
@@ -76,7 +76,7 @@ mut def from_xml_base__c1__base_l1_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'base:k1', from_xml_base__c1__base_l1__base_k1, child_base_k1)
     child_foo_k1 = yang.gdata.from_xml_str(node, 'k1', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'foo:k1', from_xml_base__c1__base_l1__foo_k1, child_foo_k1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_base_k1)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_base__c1__base_l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -93,7 +93,7 @@ mut def from_json_path_base__c1__base_l1_element(jd: value, path: list[str]=[], 
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['k1']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -102,7 +102,7 @@ mut def from_json_path_base__c1__base_l1_element(jd: value, path: list[str]=[], 
         children: dict[str, yang.gdata.Node] = {}
         children['base:k1'] = from_json_base__c1__base_l1__base_k1(keys[0])
         children['foo:k1'] = from_json_base__c1__base_l1__foo_k1(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_base__c1__base_l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -124,7 +124,7 @@ mut def from_json_path_base__c1__base_l1(jd: value, path: list[str]=[], op: ?str
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['k1'])))
         return yang.gdata.List(['k1'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['k1'], [from_json_path_base__c1__base_l1_element(jd, path, op)])
@@ -136,7 +136,7 @@ mut def from_json_base__c1__base_l1_element(jd: dict[str, ?value]) -> yang.gdata
     yang.gdata.maybe_add(children, 'base:k1', from_json_base__c1__base_l1__base_k1, child_base_k1)
     child_foo_k1 = yang.gdata.take_json_str(jd, 'k1', 'foo')
     yang.gdata.maybe_add(children, 'foo:k1', from_json_base__c1__base_l1__foo_k1, child_foo_k1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_base_k1)])
+    return yang.gdata.Container(children)
 
 mut def from_json_base__c1__base_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -163,7 +163,7 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
         _k2 = self.k2
         if _k2 is not None:
             children['k2'] = yang.gdata.Leaf('string', _k2)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k2)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__foo_l1_entry:
@@ -210,7 +210,7 @@ mut def from_xml_base__c1__foo_l1_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_k2 = yang.gdata.from_xml_str(node, 'k2')
     yang.gdata.maybe_add(children, 'k2', from_xml_base__c1__foo_l1__k2, child_k2)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k2)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_base__c1__foo_l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -227,7 +227,7 @@ mut def from_json_path_base__c1__foo_l1_element(jd: value, path: list[str]=[], o
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['k2']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -235,7 +235,7 @@ mut def from_json_path_base__c1__foo_l1_element(jd: value, path: list[str]=[], o
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['k2'] = from_json_base__c1__foo_l1__k2(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_base__c1__foo_l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -257,7 +257,7 @@ mut def from_json_path_base__c1__foo_l1(jd: value, path: list[str]=[], op: ?str=
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['k2'])))
         return yang.gdata.List(['k2'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['k2'], [from_json_path_base__c1__foo_l1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -267,7 +267,7 @@ mut def from_json_base__c1__foo_l1_element(jd: dict[str, ?value]) -> yang.gdata.
     children = {}
     child_k2 = yang.gdata.take_json_str(jd, 'k2')
     yang.gdata.maybe_add(children, 'k2', from_json_base__c1__foo_l1__k2, child_k2)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k2)])
+    return yang.gdata.Container(children)
 
 mut def from_json_base__c1__foo_l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -16,7 +16,7 @@ class foo__l1_entry(yang.adata.MNode):
         _name = self.name
         if _name is not None:
             children['name'] = yang.gdata.Leaf('string', _name)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -63,7 +63,7 @@ mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_name = yang.gdata.from_xml_str(node, 'name')
     yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -80,7 +80,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -88,7 +88,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_foo__l1__name(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -110,7 +110,7 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__l1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -120,7 +120,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
     child_name = yang.gdata.take_json_str(jd, 'name')
     yang.gdata.maybe_add(children, 'name', from_json_foo__l1__name, child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -27,7 +27,7 @@ class foo__l1_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('string', _id)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -76,7 +76,7 @@ mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
     child_id = yang.gdata.from_xml_opt_str(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_foo__l1__id, child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -93,7 +93,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -103,7 +103,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -125,7 +125,7 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__l1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -137,7 +137,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_json_foo__l1__name, child_name)
     child_id = yang.gdata.take_json_opt_str(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_foo__l1__id, child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -25,7 +25,7 @@ class foo__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
@@ -72,7 +72,7 @@ mut def from_xml_foo__li1_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_l1 = yang.gdata.from_xml_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__li1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -89,7 +89,7 @@ mut def from_json_path_foo__li1_element(jd: value, path: list[str]=[], op: ?str=
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['l1']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -97,7 +97,7 @@ mut def from_json_path_foo__li1_element(jd: value, path: list[str]=[], op: ?str=
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['l1'] = from_json_foo__li1__l1(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__li1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -119,7 +119,7 @@ mut def from_json_path_foo__li1(jd: value, path: list[str]=[], op: ?str='merge')
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['l1'])))
         return yang.gdata.List(['l1'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['l1'], [from_json_path_foo__li1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -129,7 +129,7 @@ mut def from_json_foo__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
     child_l1 = yang.gdata.take_json_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -25,7 +25,7 @@ class foo__li1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.l1)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
@@ -72,7 +72,7 @@ mut def from_xml_foo__li1_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_l1 = yang.gdata.from_xml_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__li1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -89,7 +89,7 @@ mut def from_json_path_foo__li1_element(jd: value, path: list[str]=[], op: ?str=
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['l1']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -97,7 +97,7 @@ mut def from_json_path_foo__li1_element(jd: value, path: list[str]=[], op: ?str=
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['l1'] = from_json_foo__li1__l1(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__li1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -119,7 +119,7 @@ mut def from_json_path_foo__li1(jd: value, path: list[str]=[], op: ?str='merge')
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['l1'])))
         return yang.gdata.List(['l1'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['l1'], [from_json_path_foo__li1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -129,7 +129,7 @@ mut def from_json_foo__li1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     children = {}
     child_l1 = yang.gdata.take_json_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__li1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_l1)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -96,7 +96,7 @@ class foo__l1_entry(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -147,7 +147,7 @@ mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'id', from_xml_foo__l1__id, child_id)
     child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_xml_foo__l1__bar, child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -164,7 +164,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -176,7 +176,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar':
             children['bar'] = from_json_path_foo__l1__bar(jd, rest_path, op)
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -198,7 +198,7 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__l1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -212,7 +212,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'id', from_json_foo__l1__id, child_id)
     child_bar = yang.gdata.take_json_opt_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__l1__bar, child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -27,7 +27,7 @@ class foo__l1_entry(yang.adata.MNode):
         _id = self.id
         if _id is not None:
             children['id'] = yang.gdata.Leaf('string', _id)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -76,7 +76,7 @@ mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
     child_id = yang.gdata.from_xml_str(node, 'id')
     yang.gdata.maybe_add(children, 'id', from_xml_foo__l1__id, child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -93,7 +93,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -103,7 +103,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'id':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -125,7 +125,7 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__l1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -137,7 +137,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_json_foo__l1__name, child_name)
     child_id = yang.gdata.take_json_str(jd, 'id')
     yang.gdata.maybe_add(children, 'id', from_json_foo__l1__id, child_id)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -81,7 +81,7 @@ class foo__l1_entry(yang.adata.MNode):
         _bar = self.bar
         if _bar is not None:
             children['bar'] = _bar.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
@@ -130,7 +130,7 @@ mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__l1__name, child_name)
     child_bar = yang.gdata.from_xml_opt_cnt(node, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_xml_foo__l1__bar, child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -147,7 +147,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -157,7 +157,7 @@ mut def from_json_path_foo__l1_element(jd: value, path: list[str]=[], op: ?str='
         children['name'] = from_json_foo__l1__name(keys[0])
         if point == 'bar':
             children['bar'] = from_json_path_foo__l1__bar(jd, rest_path, op)
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -179,7 +179,7 @@ mut def from_json_path_foo__l1(jd: value, path: list[str]=[], op: ?str='merge') 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__l1_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -191,7 +191,7 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_json_foo__l1__name, child_name)
     child_bar = yang.gdata.take_json_opt_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__l1__bar, child_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -47,7 +47,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
         _l1 = self.l1
         if _l1 is not None:
             children['l1'] = yang.gdata.Leaf('string', _l1)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1), yang.gdata.yang_str(self.k2)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
@@ -108,7 +108,7 @@ mut def from_xml_foo__c1__l1_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'k2', from_xml_foo__c1__l1__k2, child_k2)
     child_l1 = yang.gdata.from_xml_str(node, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__c1__l1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__c1__l1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -125,7 +125,7 @@ mut def from_json_path_foo__c1__l1_element(jd: value, path: list[str]=[], op: ?s
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['k1', 'k2']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -136,7 +136,7 @@ mut def from_json_path_foo__c1__l1_element(jd: value, path: list[str]=[], op: ?s
         children['k2'] = from_json_foo__c1__l1__k2(keys[1])
         if point == 'l1':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__c1__l1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -158,7 +158,7 @@ mut def from_json_path_foo__c1__l1(jd: value, path: list[str]=[], op: ?str='merg
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['k1', 'k2'])))
         return yang.gdata.List(['k1', 'k2'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['k1', 'k2'], [from_json_path_foo__c1__l1_element(jd, path, op)])
@@ -172,7 +172,7 @@ mut def from_json_foo__c1__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'k2', from_json_foo__c1__l1__k2, child_k2)
     child_l1 = yang.gdata.take_json_str(jd, 'l1')
     yang.gdata.maybe_add(children, 'l1', from_json_foo__c1__l1__l1, child_l1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__c1__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/golden/yang.gdata/prsrc
+++ b/test/golden/yang.gdata/prsrc
@@ -3,12 +3,14 @@ Container({
     'a': Leaf('int', 1),
     'l1': List(['name'], elements=[
       Container({
+        'name': Leaf('str', 'k1'),
         'n1': Leaf('int', 1),
         'n2': Leaf('int', 2)
-      }, ['k1']),
+      }),
       Container({
+        'name': Leaf('str', 'k4'),
         'n4': Leaf('int', 4)
-      }, ['k4'])
+      })
     ])
   }, ns='http://example.com/acme', module='acme')
 })

--- a/test/golden/yang.gdata/prsrc_absent
+++ b/test/golden/yang.gdata/prsrc_absent
@@ -2,10 +2,13 @@ Container({
   'foo': Container({
     'a': Absent(),
     'l1': List(['name'], elements=[
-      Absent(['k1']),
+      Absent({
+        'name': Leaf('str', 'k1')
+      }),
       Container({
+        'name': Leaf('str', 'k4'),
         'n4': Leaf('int', 4)
-      }, ['k4'])
+      })
     ])
   }, ns='http://example.com/acme', module='acme')
 })

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -55,7 +55,7 @@ class foo__c1__li_entry(yang.adata.MNode):
         _val = self.val
         if _val is not None:
             children['val'] = yang.gdata.Leaf('string', _val)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
@@ -104,7 +104,7 @@ mut def from_xml_foo__c1__li_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__c1__li__name, child_name)
     child_val = yang.gdata.from_xml_opt_str(node, 'val')
     yang.gdata.maybe_add(children, 'val', from_xml_foo__c1__li__val, child_val)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__c1__li(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -121,7 +121,7 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -131,7 +131,7 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         children['name'] = from_json_foo__c1__li__name(keys[0])
         if point == 'val':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -153,7 +153,7 @@ mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merg
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, user_order=True)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__c1__li_element(jd, path, op)], user_order=True)
@@ -165,7 +165,7 @@ mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_json_foo__c1__li__name, child_name)
     child_val = yang.gdata.take_json_opt_str(jd, 'val')
     yang.gdata.maybe_add(children, 'val', from_json_foo__c1__li__val, child_val)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -681,7 +681,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         _name = self.name
         if _name is not None:
             children['name'] = yang.gdata.Leaf('string', _name)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
@@ -728,7 +728,7 @@ mut def from_xml_foo__cc__death_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_name = yang.gdata.from_xml_str(node, 'name')
     yang.gdata.maybe_add(children, 'name', from_xml_foo__cc__death__name, child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__cc__death(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -745,7 +745,7 @@ mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op:
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -753,7 +753,7 @@ mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op:
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_foo__cc__death__name(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__cc__death(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -775,7 +775,7 @@ mut def from_json_path_foo__cc__death(jd: value, path: list[str]=[], op: ?str='m
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__cc__death_element(jd, path, op)])
@@ -785,7 +785,7 @@ mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.No
     children = {}
     child_name = yang.gdata.take_json_str(jd, 'name')
     yang.gdata.maybe_add(children, 'name', from_json_foo__cc__death__name, child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__cc__death(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1057,7 +1057,7 @@ class foo__special_entry(yang.adata.MNode):
         _yes = self.yes
         if _yes is not None:
             children['yes'] = yang.gdata.Leaf('boolean', _yes)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.yes)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
@@ -1104,7 +1104,7 @@ mut def from_xml_foo__special_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_yes = yang.gdata.from_xml_bool(node, 'yes')
     yang.gdata.maybe_add(children, 'yes', from_xml_foo__special__yes, child_yes)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__special(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1121,7 +1121,7 @@ mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['yes']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1129,7 +1129,7 @@ mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['yes'] = from_json_foo__special__yes(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__special(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1151,7 +1151,7 @@ mut def from_json_path_foo__special(jd: value, path: list[str]=[], op: ?str='mer
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['yes'])))
         return yang.gdata.List(['yes'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['yes'], [from_json_path_foo__special_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -1161,7 +1161,7 @@ mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node
     children = {}
     child_yes = yang.gdata.take_json_bool(jd, 'yes')
     yang.gdata.maybe_add(children, 'yes', from_json_foo__special__yes, child_yes)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1228,7 +1228,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         _baz = self.baz
         if _baz is not None:
             children['baz'] = yang.gdata.Leaf('string', _baz)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.key1), yang.gdata.yang_str(self.key2)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
@@ -1282,7 +1282,7 @@ mut def from_xml_foo__nested__f_inner__li1__li2_element(node: xml.Node) -> yang.
     yang.gdata.maybe_add(children, 'key2', from_xml_foo__nested__f_inner__li1__li2__key2, child_key2)
     child_baz = yang.gdata.from_xml_opt_str(node, 'baz')
     yang.gdata.maybe_add(children, 'baz', from_xml_foo__nested__f_inner__li1__li2__baz, child_baz)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__nested__f_inner__li1__li2(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1299,7 +1299,7 @@ mut def from_json_path_foo__nested__f_inner__li1__li2_element(jd: value, path: l
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['key1', 'key2']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1310,7 +1310,7 @@ mut def from_json_path_foo__nested__f_inner__li1__li2_element(jd: value, path: l
         children['key2'] = from_json_foo__nested__f_inner__li1__li2__key2(keys[1])
         if point == 'baz':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__nested__f_inner__li1__li2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1332,7 +1332,7 @@ mut def from_json_path_foo__nested__f_inner__li1__li2(jd: value, path: list[str]
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['key1', 'key2'])))
         return yang.gdata.List(['key1', 'key2'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['key1', 'key2'], [from_json_path_foo__nested__f_inner__li1__li2_element(jd, path, op)])
@@ -1346,7 +1346,7 @@ mut def from_json_foo__nested__f_inner__li1__li2_element(jd: dict[str, ?value]) 
     yang.gdata.maybe_add(children, 'key2', from_json_foo__nested__f_inner__li1__li2__key2, child_key2)
     child_baz = yang.gdata.take_json_opt_str(jd, 'baz')
     yang.gdata.maybe_add(children, 'baz', from_json_foo__nested__f_inner__li1__li2__baz, child_baz)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1388,7 +1388,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
             children['bar:bar'] = yang.gdata.Leaf('string', _bar_bar, ns='http://example.com/bar', module='bar')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
@@ -1441,7 +1441,7 @@ mut def from_xml_foo__nested__f_inner__li1_element(node: xml.Node) -> yang.gdata
     yang.gdata.maybe_add(children, 'li2', from_xml_foo__nested__f_inner__li1__li2, child_li2)
     child_bar_bar = yang.gdata.from_xml_opt_str(node, 'bar', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'bar:bar', from_xml_foo__nested__f_inner__li1__bar_bar, child_bar_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__nested__f_inner__li1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1458,7 +1458,7 @@ mut def from_json_path_foo__nested__f_inner__li1_element(jd: value, path: list[s
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1472,7 +1472,7 @@ mut def from_json_path_foo__nested__f_inner__li1_element(jd: value, path: list[s
             children['li2'] = from_json_path_foo__nested__f_inner__li1__li2(jd, rest_path, op)
         if point == 'bar:bar':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__nested__f_inner__li1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1494,7 +1494,7 @@ mut def from_json_path_foo__nested__f_inner__li1(jd: value, path: list[str]=[], 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__nested__f_inner__li1_element(jd, path, op)])
@@ -1510,7 +1510,7 @@ mut def from_json_foo__nested__f_inner__li1_element(jd: dict[str, ?value]) -> ya
     yang.gdata.maybe_add(children, 'li2', from_json_foo__nested__f_inner__li1__li2, child_li2)
     child_bar_bar = yang.gdata.take_json_opt_str(jd, 'bar', 'bar')
     yang.gdata.maybe_add(children, 'bar:bar', from_json_foo__nested__f_inner__li1__bar_bar, child_bar_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__nested__f_inner__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1737,7 +1737,7 @@ class foo__li_union_entry(yang.adata.MNode):
         _k3 = self.k3
         if _k3 is not None:
             children['k3'] = yang.gdata.Leaf('binary', _k3)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1), yang.gdata.yang_str(self.k2), yang.gdata.yang_str(self.k3)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
@@ -1806,7 +1806,7 @@ mut def from_xml_foo__li_union_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'k2', from_xml_foo__li_union__k2, child_k2)
     child_k3 = yang.gdata.from_xml_bytes(node, 'k3')
     yang.gdata.maybe_add(children, 'k3', from_xml_foo__li_union__k3, child_k3)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__li_union(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1823,7 +1823,7 @@ mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: 
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['k1', 'k2', 'k3']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1833,7 +1833,7 @@ mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: 
         children['k1'] = from_json_foo__li_union__k1(keys[0])
         children['k2'] = from_json_foo__li_union__k2(keys[1])
         children['k3'] = from_json_foo__li_union__k3(keys[2])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__li_union(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1855,7 +1855,7 @@ mut def from_json_path_foo__li_union(jd: value, path: list[str]=[], op: ?str='me
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['k1', 'k2', 'k3'])))
         return yang.gdata.List(['k1', 'k2', 'k3'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['k1', 'k2', 'k3'], [from_json_path_foo__li_union_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -1869,7 +1869,7 @@ mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Nod
     yang.gdata.maybe_add(children, 'k2', from_json_foo__li_union__k2, child_k2)
     child_k3 = yang.gdata.take_json_bytes(jd, 'k3')
     yang.gdata.maybe_add(children, 'k3', from_json_foo__li_union__k3, child_k3)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -55,7 +55,7 @@ class foo__c1__li_entry(yang.adata.MNode):
         _val = self.val
         if _val is not None:
             children['val'] = yang.gdata.Leaf('string', _val)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
@@ -104,7 +104,7 @@ mut def from_xml_foo__c1__li_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__c1__li__name, child_name)
     child_val = yang.gdata.from_xml_opt_str(node, 'val')
     yang.gdata.maybe_add(children, 'val', from_xml_foo__c1__li__val, child_val)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__c1__li(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -121,7 +121,7 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -131,7 +131,7 @@ mut def from_json_path_foo__c1__li_element(jd: value, path: list[str]=[], op: ?s
         children['name'] = from_json_foo__c1__li__name(keys[0])
         if point == 'val':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -153,7 +153,7 @@ mut def from_json_path_foo__c1__li(jd: value, path: list[str]=[], op: ?str='merg
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, user_order=True)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__c1__li_element(jd, path, op)], user_order=True)
@@ -165,7 +165,7 @@ mut def from_json_foo__c1__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_json_foo__c1__li__name, child_name)
     child_val = yang.gdata.take_json_opt_str(jd, 'val')
     yang.gdata.maybe_add(children, 'val', from_json_foo__c1__li__val, child_val)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__c1__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -681,7 +681,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         _name = self.name
         if _name is not None:
             children['name'] = yang.gdata.Leaf('string', _name)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
@@ -728,7 +728,7 @@ mut def from_xml_foo__cc__death_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_name = yang.gdata.from_xml_str(node, 'name')
     yang.gdata.maybe_add(children, 'name', from_xml_foo__cc__death__name, child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__cc__death(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -745,7 +745,7 @@ mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op:
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -753,7 +753,7 @@ mut def from_json_path_foo__cc__death_element(jd: value, path: list[str]=[], op:
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['name'] = from_json_foo__cc__death__name(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__cc__death(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -775,7 +775,7 @@ mut def from_json_path_foo__cc__death(jd: value, path: list[str]=[], op: ?str='m
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__cc__death_element(jd, path, op)])
@@ -785,7 +785,7 @@ mut def from_json_foo__cc__death_element(jd: dict[str, ?value]) -> yang.gdata.No
     children = {}
     child_name = yang.gdata.take_json_str(jd, 'name')
     yang.gdata.maybe_add(children, 'name', from_json_foo__cc__death__name, child_name)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__cc__death(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1057,7 +1057,7 @@ class foo__special_entry(yang.adata.MNode):
         _yes = self.yes
         if _yes is not None:
             children['yes'] = yang.gdata.Leaf('boolean', _yes)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.yes)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
@@ -1104,7 +1104,7 @@ mut def from_xml_foo__special_element(node: xml.Node) -> yang.gdata.Node:
     children = {}
     child_yes = yang.gdata.from_xml_bool(node, 'yes')
     yang.gdata.maybe_add(children, 'yes', from_xml_foo__special__yes, child_yes)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__special(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1121,7 +1121,7 @@ mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['yes']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1129,7 +1129,7 @@ mut def from_json_path_foo__special_element(jd: value, path: list[str]=[], op: ?
         rest_path = path[2:]
         children: dict[str, yang.gdata.Node] = {}
         children['yes'] = from_json_foo__special__yes(keys[0])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__special(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1151,7 +1151,7 @@ mut def from_json_path_foo__special(jd: value, path: list[str]=[], op: ?str='mer
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['yes'])))
         return yang.gdata.List(['yes'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['yes'], [from_json_path_foo__special_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -1161,7 +1161,7 @@ mut def from_json_foo__special_element(jd: dict[str, ?value]) -> yang.gdata.Node
     children = {}
     child_yes = yang.gdata.take_json_bool(jd, 'yes')
     yang.gdata.maybe_add(children, 'yes', from_json_foo__special__yes, child_yes)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_yes)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__special(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1228,7 +1228,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         _baz = self.baz
         if _baz is not None:
             children['baz'] = yang.gdata.Leaf('string', _baz)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.key1), yang.gdata.yang_str(self.key2)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
@@ -1282,7 +1282,7 @@ mut def from_xml_foo__nested__f_inner__li1__li2_element(node: xml.Node) -> yang.
     yang.gdata.maybe_add(children, 'key2', from_xml_foo__nested__f_inner__li1__li2__key2, child_key2)
     child_baz = yang.gdata.from_xml_opt_str(node, 'baz')
     yang.gdata.maybe_add(children, 'baz', from_xml_foo__nested__f_inner__li1__li2__baz, child_baz)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__nested__f_inner__li1__li2(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1299,7 +1299,7 @@ mut def from_json_path_foo__nested__f_inner__li1__li2_element(jd: value, path: l
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['key1', 'key2']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1310,7 +1310,7 @@ mut def from_json_path_foo__nested__f_inner__li1__li2_element(jd: value, path: l
         children['key2'] = from_json_foo__nested__f_inner__li1__li2__key2(keys[1])
         if point == 'baz':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__nested__f_inner__li1__li2(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1332,7 +1332,7 @@ mut def from_json_path_foo__nested__f_inner__li1__li2(jd: value, path: list[str]
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['key1', 'key2'])))
         return yang.gdata.List(['key1', 'key2'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['key1', 'key2'], [from_json_path_foo__nested__f_inner__li1__li2_element(jd, path, op)])
@@ -1346,7 +1346,7 @@ mut def from_json_foo__nested__f_inner__li1__li2_element(jd: dict[str, ?value]) 
     yang.gdata.maybe_add(children, 'key2', from_json_foo__nested__f_inner__li1__li2__key2, child_key2)
     child_baz = yang.gdata.take_json_opt_str(jd, 'baz')
     yang.gdata.maybe_add(children, 'baz', from_json_foo__nested__f_inner__li1__li2__baz, child_baz)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_key1), yang.gdata.yang_str(child_key2)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__nested__f_inner__li1__li2(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1388,7 +1388,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
             children['bar:bar'] = yang.gdata.Leaf('string', _bar_bar, ns='http://example.com/bar', module='bar')
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
@@ -1441,7 +1441,7 @@ mut def from_xml_foo__nested__f_inner__li1_element(node: xml.Node) -> yang.gdata
     yang.gdata.maybe_add(children, 'li2', from_xml_foo__nested__f_inner__li1__li2, child_li2)
     child_bar_bar = yang.gdata.from_xml_opt_str(node, 'bar', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'bar:bar', from_xml_foo__nested__f_inner__li1__bar_bar, child_bar_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__nested__f_inner__li1(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1458,7 +1458,7 @@ mut def from_json_path_foo__nested__f_inner__li1_element(jd: value, path: list[s
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1472,7 +1472,7 @@ mut def from_json_path_foo__nested__f_inner__li1_element(jd: value, path: list[s
             children['li2'] = from_json_path_foo__nested__f_inner__li1__li2(jd, rest_path, op)
         if point == 'bar:bar':
             raise ValueError("Invalid json path to non-inner node")
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__nested__f_inner__li1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1494,7 +1494,7 @@ mut def from_json_path_foo__nested__f_inner__li1(jd: value, path: list[str]=[], 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements)
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__nested__f_inner__li1_element(jd, path, op)])
@@ -1510,7 +1510,7 @@ mut def from_json_foo__nested__f_inner__li1_element(jd: dict[str, ?value]) -> ya
     yang.gdata.maybe_add(children, 'li2', from_json_foo__nested__f_inner__li1__li2, child_li2)
     child_bar_bar = yang.gdata.take_json_opt_str(jd, 'bar', 'bar')
     yang.gdata.maybe_add(children, 'bar:bar', from_json_foo__nested__f_inner__li1__bar_bar, child_bar_bar)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__nested__f_inner__li1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []
@@ -1737,7 +1737,7 @@ class foo__li_union_entry(yang.adata.MNode):
         _k3 = self.k3
         if _k3 is not None:
             children['k3'] = yang.gdata.Leaf('binary', _k3)
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.k1), yang.gdata.yang_str(self.k2), yang.gdata.yang_str(self.k3)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
@@ -1806,7 +1806,7 @@ mut def from_xml_foo__li_union_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'k2', from_xml_foo__li_union__k2, child_k2)
     child_k3 = yang.gdata.from_xml_bytes(node, 'k3')
     yang.gdata.maybe_add(children, 'k3', from_xml_foo__li_union__k3, child_k3)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__li_union(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -1823,7 +1823,7 @@ mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: 
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['k1', 'k2', 'k3']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -1833,7 +1833,7 @@ mut def from_json_path_foo__li_union_element(jd: value, path: list[str]=[], op: 
         children['k1'] = from_json_foo__li_union__k1(keys[0])
         children['k2'] = from_json_foo__li_union__k2(keys[1])
         children['k3'] = from_json_foo__li_union__k3(keys[2])
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__li_union(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -1855,7 +1855,7 @@ mut def from_json_path_foo__li_union(jd: value, path: list[str]=[], op: ?str='me
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['k1', 'k2', 'k3'])))
         return yang.gdata.List(['k1', 'k2', 'k3'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['k1', 'k2', 'k3'], [from_json_path_foo__li_union_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -1869,7 +1869,7 @@ mut def from_json_foo__li_union_element(jd: dict[str, ?value]) -> yang.gdata.Nod
     yang.gdata.maybe_add(children, 'k2', from_json_foo__li_union__k2, child_k2)
     child_k3 = yang.gdata.take_json_bytes(jd, 'k3')
     yang.gdata.maybe_add(children, 'k3', from_json_foo__li_union__k3, child_k3)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_k1), yang.gdata.yang_str(child_k2), yang.gdata.yang_str(child_k3)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__li_union(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -175,7 +175,7 @@ class foo__li_entry(yang.adata.MNode):
         _c1 = self.c1
         if _c1 is not None:
             children['c1'] = _c1.to_gdata()
-        return yang.gdata.Container(children, [yang.gdata.yang_str(self.name)])
+        return yang.gdata.Container(children)
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_entry:
@@ -224,7 +224,7 @@ mut def from_xml_foo__li_element(node: xml.Node) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_xml_foo__li__name, child_name)
     child_c1 = yang.gdata.from_xml_cnt(node, 'c1')
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__li__c1, child_c1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_xml_foo__li(nodes: list[xml.Node]) -> yang.gdata.List:
     elements = []
@@ -241,7 +241,7 @@ mut def from_json_path_foo__li_element(jd: value, path: list[str]=[], op: ?str='
         if op == "merge":
             return val
         elif op == "remove":
-            return yang.gdata.Absent(val.key)
+            return yang.gdata.Absent(val.key_children(['name']))
         raise ValueError("Invalid operation")
     elif len(path) > 1:
         keys = path[0].split(",")
@@ -251,7 +251,7 @@ mut def from_json_path_foo__li_element(jd: value, path: list[str]=[], op: ?str='
         children['name'] = from_json_foo__li__name(keys[0])
         if point == 'c1':
             children['c1'] = from_json_path_foo__li__c1(jd, rest_path, op)
-        return yang.gdata.Container(children, keys)
+        return yang.gdata.Container(children)
     raise ValueError("unreachable - no keys to list element")
 
 mut def from_json_path_foo__li(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
@@ -273,7 +273,7 @@ mut def from_json_path_foo__li(jd: value, path: list[str]=[], op: ?str='merge') 
         if op == "merge":
             elements.append(element)
         elif op == "remove":
-            elements.append(yang.gdata.Absent(element.key))
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
         return yang.gdata.List(['name'], elements, ns='http://example.com/foo', module='foo')
     elif len(path) > 1:
         return yang.gdata.List(['name'], [from_json_path_foo__li_element(jd, path, op)], ns='http://example.com/foo', module='foo')
@@ -285,7 +285,7 @@ mut def from_json_foo__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
     yang.gdata.maybe_add(children, 'name', from_json_foo__li__name, child_name)
     child_c1 = yang.gdata.take_json_cnt(jd, 'c1')
     yang.gdata.maybe_add(children, 'c1', from_json_foo__li__c1, child_c1)
-    return yang.gdata.Container(children, [yang.gdata.yang_str(child_name)])
+    return yang.gdata.Container(children)
 
 mut def from_json_foo__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = []

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -6,7 +6,7 @@ Container({
       Container({
         'name': Leaf('string', 'tuta'),
         'val': Leaf('string', 'baba')
-      }, ['tuta'])
+      })
     ]),
     'll_uint64': LeafList('uint64', [4, 42]),
     'll_str': LeafList('string', ['kava', 'čaj']),
@@ -39,7 +39,7 @@ Container({
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'yes': Leaf('boolean', True)
-    }, ['true'])
+    })
   ]),
   'nested': Container({
     'f:inner': Container({
@@ -53,9 +53,9 @@ Container({
               'key1': Leaf('string', 'BBB'),
               'key2': Leaf('string', 'CCC'),
               'baz': Leaf('string', 'WINNING')
-            }, ['BBB', 'CCC'])
+            })
           ])
-        }, ['AAA'])
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo'),
@@ -64,17 +64,17 @@ Container({
       'k1': Leaf('string', 'first'),
       'k2': Leaf('union', 4),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['first', '4', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }),
     Container({
       'k1': Leaf('string', 'second'),
       'k2': Leaf('union', 'unlimited'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['second', 'unlimited', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }),
     Container({
       'k1': Leaf('string', 'third'),
       'k2': Leaf('union', 'aGk='),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
+    })
   ]),
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -7,7 +7,7 @@ Container({
       Container({
         'name': Leaf('string', 'tuta'),
         'val': Leaf('string', 'baba')
-      }, ['tuta'])
+      })
     ]),
     'll_uint64': LeafList('uint64', [4, 42]),
     'll_str': LeafList('string', ['kava', 'čaj']),
@@ -40,24 +40,24 @@ Container({
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'yes': Leaf('boolean', True)
-    }, ['true'])
+    })
   ]),
   'li-union': List(['k1', 'k2', 'k3'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'k1': Leaf('string', 'first'),
       'k2': Leaf('union', '4'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['first', '4', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }),
     Container({
       'k1': Leaf('string', 'second'),
       'k2': Leaf('union', 'unlimited'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['second', 'unlimited', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }),
     Container({
       'k1': Leaf('string', 'third'),
       'k2': Leaf('union', 'aGk='),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
+    })
   ]),
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')

--- a/test/test_data_classes/test/golden/test_data_classes/json_ops
+++ b/test/test_data_classes/test/golden/test_data_classes/json_ops
@@ -5,7 +5,7 @@ Container({
         Container({
           'name': Leaf('string', 'BBB'),
           'f:bar': Leaf('string', 'p2')
-        }, ['BBB'])
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo')

--- a/test/test_data_classes/test/golden/test_data_classes/json_path_conflict
+++ b/test/test_data_classes/test/golden/test_data_classes/json_path_conflict
@@ -6,7 +6,7 @@ Container({
           'name': Leaf('string', 'AAA'),
           'f:bar': Leaf('string', 'WINNING'),
           'bar:bar': Leaf('string', 'WINNING2', ns='http://example.com/bar', module='bar')
-        }, ['AAA'])
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo')

--- a/test/test_data_classes/test/golden/test_data_classes/json_path_nested
+++ b/test/test_data_classes/test/golden/test_data_classes/json_path_nested
@@ -9,9 +9,9 @@ Container({
               'key1': Leaf('string', 'BBB'),
               'key2': Leaf('string', 'CCC'),
               'baz': Leaf('string', 'WINNING')
-            }, ['BBB', 'CCC'])
+            })
           ])
-        }, ['AAA'])
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo')

--- a/test/test_data_classes/test/golden/test_data_classes/json_path_nested_key_in_payload
+++ b/test/test_data_classes/test/golden/test_data_classes/json_path_nested_key_in_payload
@@ -5,7 +5,7 @@ Container({
         Container({
           'name': Leaf('string', 'AAA'),
           'f:bar': Leaf('string', 'WINNING')
-        }, ['AAA'])
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo')

--- a/test/test_data_classes/test/golden/test_data_classes/json_path_nested_no_key_in_payload
+++ b/test/test_data_classes/test/golden/test_data_classes/json_path_nested_no_key_in_payload
@@ -5,7 +5,7 @@ Container({
         Container({
           'name': Leaf('string', 'AAA'),
           'f:bar': Leaf('string', 'WINNING')
-        }, ['AAA'])
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo')

--- a/test/test_data_classes/test/golden/test_data_classes/json_path_remove_list_element
+++ b/test/test_data_classes/test/golden/test_data_classes/json_path_remove_list_element
@@ -2,7 +2,9 @@ Container({
   'nested': Container({
     'f:inner': Container({
       'li1': List(['name'], elements=[
-        Absent(['AAA'])
+        Absent({
+          'name': Leaf('string', 'AAA')
+        })
       ])
     })
   }, ns='http://example.com/foo', module='foo')

--- a/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
@@ -6,11 +6,11 @@ Container({
       Container({
         'name': Leaf('string', 'tuta'),
         'val': Leaf('string', 'baba')
-      }, ['tuta']),
+      }),
       Container({
         'name': Leaf('string', 'tata'),
         'val': Leaf('string', 'baba')
-      }, ['tata'])
+      })
     ]),
     'll_uint64': LeafList('uint64', [4, 42]),
     'll_str': LeafList('string', ['kava', 'čaj']),

--- a/test/test_gdata_source_roundtrip/src/xml_full.act
+++ b/test/test_gdata_source_roundtrip/src/xml_full.act
@@ -9,7 +9,7 @@ xml_full = Container({
       Container({
         'name': Leaf('string', 'tuta'),
         'val': Leaf('string', 'baba')
-      }, ['tuta'])
+      })
     ]),
     'll_uint64': LeafList('uint64', [4, 42]),
     'll_str': LeafList('string', ['kava', 'čaj']),
@@ -42,24 +42,24 @@ xml_full = Container({
   'special': List(['yes'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'yes': Leaf('boolean', True)
-    }, ['true'])
+    })
   ]),
   'li-union': List(['k1', 'k2', 'k3'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'k1': Leaf('string', 'first'),
       'k2': Leaf('union', '4'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['first', '4', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }),
     Container({
       'k1': Leaf('string', 'second'),
       'k2': Leaf('union', 'unlimited'),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['second', 'unlimited', 'SGVsbG8gQWN0b24g8J+roQ==']),
+    }),
     Container({
       'k1': Leaf('string', 'third'),
       'k2': Leaf('union', 'aGk='),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
-    }, ['third', 'aGk=', 'SGVsbG8gQWN0b24g8J+roQ=='])
+    })
   ]),
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')


### PR DESCRIPTION
A gdata.Container node for a list element already has all the data it needs to produce a key for itself (list entry). We replace the key attribute with a method that looks up the key leaf values directly from the child nodes.