### PR TITLE
P-container is a barrier for non-optional subtree

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -454,7 +454,7 @@ class DNodeInner(DNode):
                         if cchild.mandatory:
                             pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                     elif isinstance(cchild, DContainer):
-                        if not (loose or optional_subtree(cchild)):
+                        if not (loose or optional_subtree(cchild) or cchild.presence):
                             pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                 pc_args_str = ", ".join(pc_args)
                 pc_args_str1 = ", ".join(pc_args[1:])
@@ -567,7 +567,7 @@ class DNodeInner(DNode):
                     if child.mandatory:
                         list_key_args.append(usname(child))
                 elif isinstance(child, DContainer):
-                    if not (loose or optional_subtree(child)):
+                    if not (loose or optional_subtree(child) or child.presence):
                         list_key_args.append(usname(child))
             list_create_args_str = ", ".join(["self"] + list_key_args)
             res.append(f"    mut def create({list_create_args_str}):")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -450,7 +450,7 @@ class DNodeInner(DNode):
                         if cchild.mandatory:
                             pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                     elif isinstance(cchild, DContainer):
-                        if not (loose or optional_subtree(cchild)):
+                        if not (loose or optional_subtree(cchild) or cchild.presence):
                             pc_args.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
                 pc_args_str = ", ".join(pc_args)
                 pc_args_str1 = ", ".join(pc_args[1:])
@@ -563,7 +563,7 @@ class DNodeInner(DNode):
                     if child.mandatory:
                         list_key_args.append(usname(child))
                 elif isinstance(child, DContainer):
-                    if not (loose or optional_subtree(child)):
+                    if not (loose or optional_subtree(child) or child.presence):
                         list_key_args.append(usname(child))
             list_create_args_str = ", ".join(["self"] + list_key_args)
             res.append(f"    mut def create({list_create_args_str}):")

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -94,7 +94,7 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name, bar):
+    mut def create(self, name):
         for e in self.elements:
             match = True
             if e.name != name:
@@ -103,7 +103,7 @@ class foo__l1(yang.adata.MNode):
             if match:
                 return e
 
-        res = foo__l1_entry(name, bar)
+        res = foo__l1_entry(name)
         self.elements.append(res)
         return res
 

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -158,8 +158,8 @@ class root(yang.adata.MNode):
         self._ns = ''
         self.foo = foo
 
-    mut def create_foo(self, bar):
-        res = foo__foo(bar)
+    mut def create_foo(self):
+        res = foo__foo()
         self.foo = res
         return res
 


### PR DESCRIPTION
In the generated `.create_XXX()` methods for P-containers and `.create()` for list elements, we include non-optional children as non-optional arguments. The generated code required a P-container with a non-optional child, which is incorrect because non-optional requirements within a P-container only apply if the container is present.