### PR TITLE
Remove explicit f-string prefix from inner string

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -590,7 +590,7 @@ class DNodeInner(DNode):
 
                         if sub_args:
                             sub_args_str = ", ".join(sub_args)
-                            non_optional_containers.append("            res.append(f'{mcchild_var} = {pname(cchild)}({sub_args_str})')")
+                            non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}({sub_args_str})')")
                         else:
                             non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}()')")
 
@@ -614,7 +614,7 @@ class DNodeInner(DNode):
         res.append("    def prsrc(self, self_name='ad', top=True, list_element=False):")
         res.append("        res = []")
         res.append("        if top:")
-        res.append("            res.append(f'# Top node: {get_path(self)}')")
+        res.append("            res.append('# Top node: {get_path(self)}')")
         # Build constructor arguments for non-optional children (same logic as in __init__)
         constructor_args, constructor_containers = find_non_optional_subtree(self, ["self"], local_prefix="")
 
@@ -625,9 +625,9 @@ class DNodeInner(DNode):
             # Since find_non_optional_subtree() builds the list depth-first, we reverse it.
             res.extend(list(reversed(constructor_containers)))
             args_str = ", ".join(constructor_args)
-            res.append("            res.append(f'{{self_name}} = {pname(self)}({args_str})')")
+            res.append("            res.append('{{self_name}} = {pname(self)}({args_str})')")
         else:
-            res.append("            res.append(f'{{self_name}} = {pname(self)}()')")
+            res.append("            res.append('{{self_name}} = {pname(self)}()')")
         res.append("        leaves = []")
         for child in self.children:
             if isinstance(child, DNodeLeaf):
@@ -638,7 +638,7 @@ class DNodeInner(DNode):
                 # DLeaf and DLeafList are both copied verbatim
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        if _{usname(child)} is not None:")
-                res.append("            leaves.append(f'{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
+                res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
             elif isinstance(child, DContainer):
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        if _{usname(child)} is not None:")
@@ -654,14 +654,14 @@ class DNodeInner(DNode):
                     child_accessor = _safe_name(child.name)
                     pc_args_str = ", ".join(pc_args)
                     if pc_args_str:
-                        res.append("            res.append(f'{child_accessor} = {{self_name}}.create_{usname(child)}({pc_args_str})')")
+                        res.append("            res.append('{child_accessor} = {{self_name}}.create_{usname(child)}({pc_args_str})')")
                     else:
-                        res.append("            res.append(f'{child_accessor} = {{self_name}}.create_{usname(child)}()')")
+                        res.append("            res.append('{child_accessor} = {{self_name}}.create_{usname(child)}()')")
                     # Recursive call to prsrc() for the P-container, to fill in the rest of the optional children
                     res.append("            res.extend(_{usname(child)}.prsrc('{usname(child)}', False).splitlines())")
                 else:
                     # Build .prsrc() code for this container
-                    res.append("            res.extend(_{usname(child)}.prsrc(f'{{self_name}}.{usname(child)}', False).splitlines())")
+                    res.append("            res.extend(_{usname(child)}.prsrc('{{self_name}}.{usname(child)}', False).splitlines())")
             elif isinstance(child, DList):
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        for _element in _{usname(child)}.elements:")
@@ -679,12 +679,12 @@ class DNodeInner(DNode):
 
                 create_args_str = ", ".join(list_create_args)
                 if create_args_str:
-                    res.append("            list_elem = f'{usname(child)}_element = {{self_name}}.{usname(child)}.create({create_args_str})'")
+                    res.append("            list_elem = '{usname(child)}_element = {{self_name}}.{usname(child)}.create({create_args_str})'")
                 else:
-                    res.append("            list_elem = f'{usname(child)}_element = {{self_name}}.{usname(child)}.create()'")
+                    res.append("            list_elem = '{usname(child)}_element = {{self_name}}.{usname(child)}.create()'")
                 res.append("            res.append(list_elem)")
                 # Recursive call to prsrc() for the list element
-                res.append("            res.extend(_element.prsrc(f'{usname(child)}_element', False, list_element=True).splitlines())")
+                res.append("            res.extend(_element.prsrc('{usname(child)}_element', False, list_element=True).splitlines())")
             else:
                 raise ValueError("Unhandled child type in .prsrc(): {type(child)}")
         # Add the leaves as a single group at the beginning of the section,
@@ -1452,7 +1452,7 @@ class SchemaNode(object):
         raise NotImplementedError('SchemaNode pdc')
 
     mut def to_dnode(self) -> DNode:
-        raise NotImplementedError(f'SchemaNode to_dschema not implemented for {type(self)}')
+        raise NotImplementedError('SchemaNode to_dschema not implemented for {type(self)}')
 
     def get_dnode_children(self, in_choice: bool=False):
         mut def unset_mandatory(node):
@@ -1789,7 +1789,7 @@ class SchemaNode(object):
             raise ValueError("expand_children() called on non-inner node {type(self)}")
 
     mut def apply_refine(self, refine: Refine):
-        raise NotImplementedError(f'SchemaNode apply_refine not implemented for {type(self)}')
+        raise NotImplementedError('SchemaNode apply_refine not implemented for {type(self)}')
 
     def get_module_by_prefix(self, prefix: str, context: Context) -> Module:
         """Get a Module from the import prefix in the local module"""

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -586,7 +586,7 @@ class DNodeInner(DNode):
 
                         if sub_args:
                             sub_args_str = ", ".join(sub_args)
-                            non_optional_containers.append("            res.append(f'{mcchild_var} = {pname(cchild)}({sub_args_str})')")
+                            non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}({sub_args_str})')")
                         else:
                             non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}()')")
 
@@ -610,7 +610,7 @@ class DNodeInner(DNode):
         res.append("    def prsrc(self, self_name='ad', top=True, list_element=False):")
         res.append("        res = []")
         res.append("        if top:")
-        res.append("            res.append(f'# Top node: {get_path(self)}')")
+        res.append("            res.append('# Top node: {get_path(self)}')")
         # Build constructor arguments for non-optional children (same logic as in __init__)
         constructor_args, constructor_containers = find_non_optional_subtree(self, ["self"], local_prefix="")
 
@@ -621,9 +621,9 @@ class DNodeInner(DNode):
             # Since find_non_optional_subtree() builds the list depth-first, we reverse it.
             res.extend(list(reversed(constructor_containers)))
             args_str = ", ".join(constructor_args)
-            res.append("            res.append(f'{{self_name}} = {pname(self)}({args_str})')")
+            res.append("            res.append('{{self_name}} = {pname(self)}({args_str})')")
         else:
-            res.append("            res.append(f'{{self_name}} = {pname(self)}()')")
+            res.append("            res.append('{{self_name}} = {pname(self)}()')")
         res.append("        leaves = []")
         for child in self.children:
             if isinstance(child, DNodeLeaf):
@@ -634,7 +634,7 @@ class DNodeInner(DNode):
                 # DLeaf and DLeafList are both copied verbatim
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        if _{usname(child)} is not None:")
-                res.append("            leaves.append(f'{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
+                res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
             elif isinstance(child, DContainer):
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        if _{usname(child)} is not None:")
@@ -650,14 +650,14 @@ class DNodeInner(DNode):
                     child_accessor = _safe_name(child.name)
                     pc_args_str = ", ".join(pc_args)
                     if pc_args_str:
-                        res.append("            res.append(f'{child_accessor} = {{self_name}}.create_{usname(child)}({pc_args_str})')")
+                        res.append("            res.append('{child_accessor} = {{self_name}}.create_{usname(child)}({pc_args_str})')")
                     else:
-                        res.append("            res.append(f'{child_accessor} = {{self_name}}.create_{usname(child)}()')")
+                        res.append("            res.append('{child_accessor} = {{self_name}}.create_{usname(child)}()')")
                     # Recursive call to prsrc() for the P-container, to fill in the rest of the optional children
                     res.append("            res.extend(_{usname(child)}.prsrc('{usname(child)}', False).splitlines())")
                 else:
                     # Build .prsrc() code for this container
-                    res.append("            res.extend(_{usname(child)}.prsrc(f'{{self_name}}.{usname(child)}', False).splitlines())")
+                    res.append("            res.extend(_{usname(child)}.prsrc('{{self_name}}.{usname(child)}', False).splitlines())")
             elif isinstance(child, DList):
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        for _element in _{usname(child)}.elements:")
@@ -675,12 +675,12 @@ class DNodeInner(DNode):
 
                 create_args_str = ", ".join(list_create_args)
                 if create_args_str:
-                    res.append("            list_elem = f'{usname(child)}_element = {{self_name}}.{usname(child)}.create({create_args_str})'")
+                    res.append("            list_elem = '{usname(child)}_element = {{self_name}}.{usname(child)}.create({create_args_str})'")
                 else:
-                    res.append("            list_elem = f'{usname(child)}_element = {{self_name}}.{usname(child)}.create()'")
+                    res.append("            list_elem = '{usname(child)}_element = {{self_name}}.{usname(child)}.create()'")
                 res.append("            res.append(list_elem)")
                 # Recursive call to prsrc() for the list element
-                res.append("            res.extend(_element.prsrc(f'{usname(child)}_element', False, list_element=True).splitlines())")
+                res.append("            res.extend(_element.prsrc('{usname(child)}_element', False, list_element=True).splitlines())")
             else:
                 raise ValueError("Unhandled child type in .prsrc(): {type(child)}")
         # Add the leaves as a single group at the beginning of the section,
@@ -1448,7 +1448,7 @@ class SchemaNode(object):
         raise NotImplementedError('SchemaNode pdc')
 
     mut def to_dnode(self) -> DNode:
-        raise NotImplementedError(f'SchemaNode to_dschema not implemented for {type(self)}')
+        raise NotImplementedError('SchemaNode to_dschema not implemented for {type(self)}')
 
     def get_dnode_children(self, in_choice: bool=False):
         mut def unset_mandatory(node):
@@ -1785,7 +1785,7 @@ class SchemaNode(object):
             raise ValueError("expand_children() called on non-inner node {type(self)}")
 
     mut def apply_refine(self, refine: Refine):
-        raise NotImplementedError(f'SchemaNode apply_refine not implemented for {type(self)}')
+        raise NotImplementedError('SchemaNode apply_refine not implemented for {type(self)}')
 
     def get_module_by_prefix(self, prefix: str, context: Context) -> Module:
         """Get a Module from the import prefix in the local module"""

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -47,15 +47,15 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -121,12 +121,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -26,8 +26,8 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         if leaves:
             if not list_element:
@@ -82,12 +82,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -47,15 +47,15 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -121,12 +121,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -53,15 +53,15 @@ class foo__c1__c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/c2')
-            res.append(f'{self_name} = foo__c1__c2()')
+            res.append('# Top node: /c1/c2')
+            res.append('{self_name} = foo__c1__c2()')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append(f'{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/c2'] + leaves + res
@@ -132,15 +132,15 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _c2 = self.c2
         if _c2 is not None:
-            res.extend(_c2.prsrc(f'{self_name}.c2', False).splitlines())
+            res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -207,12 +207,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -53,15 +53,15 @@ class foo__c1__c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/c2')
-            res.append(f'{self_name} = foo__c1__c2()')
+            res.append('# Top node: /c1/c2')
+            res.append('{self_name} = foo__c1__c2()')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append(f'{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/c2'] + leaves + res
@@ -132,15 +132,15 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _c2 = self.c2
         if _c2 is not None:
-            res.extend(_c2.prsrc(f'{self_name}.c2', False).splitlines())
+            res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -207,12 +207,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -36,12 +36,12 @@ class foo__c1__c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/c2')
-            res.append(f'{self_name} = foo__c1__c2()')
+            res.append('# Top node: /c1/c2')
+            res.append('{self_name} = foo__c1__c2()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/c2'] + leaves + res
@@ -101,12 +101,12 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _c2 = self.c2
         if _c2 is not None:
-            res.extend(_c2.prsrc(f'{self_name}.c2', False).splitlines())
+            res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -167,12 +167,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -47,15 +47,15 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -121,12 +121,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -45,12 +45,12 @@ class foo__c1__things_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/things')
-            res.append(f'{self_name} = foo__c1__things({repr(self.name)})')
+            res.append('# Top node: /c1/things')
+            res.append('{self_name} = foo__c1__things({repr(self.name)})')
         leaves = []
         _id = self.id
         if _id is not None:
-            leaves.append(f'{self_name}.id = {repr(_id)}')
+            leaves.append('{self_name}.id = {repr(_id)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/things'] + leaves + res
@@ -187,16 +187,16 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _things = self.things
         for _element in _things.elements:
             res.append('')
             res.append("# List /c1/things element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'things_element = {self_name}.things.create({repr(_element.name)})'
+            list_elem = 'things_element = {self_name}.things.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'things_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('things_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -257,12 +257,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -36,12 +36,12 @@ class acme_foo_bar__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = acme_foo_bar__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = acme_foo_bar__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -101,12 +101,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -34,8 +34,8 @@ class bar__c1__li1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/li1')
-            res.append(f'{self_name} = bar__c1__li1({repr(self.l1)})')
+            res.append('# Top node: /c1/li1')
+            res.append('{self_name} = bar__c1__li1({repr(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -167,16 +167,16 @@ class bar__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = bar__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = bar__c1()')
         leaves = []
         _li1 = self.li1
         for _element in _li1.elements:
             res.append('')
             res.append("# List /c1/li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = f'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -237,12 +237,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -34,12 +34,12 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -99,12 +99,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -36,12 +36,12 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -107,12 +107,12 @@ class foo__c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c2')
-            res.append(f'{self_name} = foo__c2()')
+            res.append('# Top node: /c2')
+            res.append('{self_name} = foo__c2()')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c2'] + leaves + res
@@ -177,15 +177,15 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         _c2 = self.c2
         if _c2 is not None:
-            res.extend(_c2.prsrc(f'{self_name}.c2', False).splitlines())
+            res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -34,8 +34,8 @@ class foo__c1__li1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/li1')
-            res.append(f'{self_name} = foo__c1__li1({repr(self.l1)})')
+            res.append('# Top node: /c1/li1')
+            res.append('{self_name} = foo__c1__li1({repr(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -167,16 +167,16 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _li1 = self.li1
         for _element in _li1.elements:
             res.append('')
             res.append("# List /c1/li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = f'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -237,12 +237,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -47,15 +47,15 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -121,12 +121,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -39,8 +39,8 @@ class foo__c__li__bar(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c/li/bar')
-            res.append(f'{self_name} = foo__c__li__bar({repr(self.man)})')
+            res.append('# Top node: /c/li/bar')
+            res.append('{self_name} = foo__c__li__bar({repr(self.man)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -109,16 +109,16 @@ class foo__c__li_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c/li')
-            res.append(f'self_bar = foo__c__li__bar({repr(self.bar.man)})')
-            res.append(f'{self_name} = foo__c__li({repr(self.name)}, self_bar)')
+            res.append('# Top node: /c/li')
+            res.append('self_bar = foo__c__li__bar({repr(self.bar.man)})')
+            res.append('{self_name} = foo__c__li({repr(self.name)}, self_bar)')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         _bar = self.bar
         if _bar is not None:
-            res.extend(_bar.prsrc(f'{self_name}.bar', False).splitlines())
+            res.extend(_bar.prsrc('{self_name}.bar', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c/li'] + leaves + res

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -36,8 +36,8 @@ class base__c1__base_l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/base:l1')
-            res.append(f'{self_name} = base__c1__base_l1({repr(self.base_k1)}, {repr(self.foo_k1)})')
+            res.append('# Top node: /c1/base:l1')
+            res.append('{self_name} = base__c1__base_l1({repr(self.base_k1)}, {repr(self.foo_k1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -178,8 +178,8 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/foo:l1')
-            res.append(f'{self_name} = base__c1__foo_l1({repr(self.k2)})')
+            res.append('# Top node: /c1/foo:l1')
+            res.append('{self_name} = base__c1__foo_l1({repr(self.k2)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -316,23 +316,23 @@ class base__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = base__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = base__c1()')
         leaves = []
         _base_l1 = self.base_l1
         for _element in _base_l1.elements:
             res.append('')
             res.append("# List /c1/base:l1 element: {_element.to_gdata().key_str(['k1'])}")
-            list_elem = f'base_l1_element = {self_name}.base_l1.create({repr(_element.base_k1)}, {repr(_element.foo_k1)})'
+            list_elem = 'base_l1_element = {self_name}.base_l1.create({repr(_element.base_k1)}, {repr(_element.foo_k1)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'base_l1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('base_l1_element', False, list_element=True).splitlines())
         _foo_l1 = self.foo_l1
         for _element in _foo_l1.elements:
             res.append('')
             res.append("# List /c1/foo:l1 element: {_element.to_gdata().key_str(['k2'])}")
-            list_elem = f'foo_l1_element = {self_name}.foo_l1.create({repr(_element.k2)})'
+            list_elem = 'foo_l1_element = {self_name}.foo_l1.create({repr(_element.k2)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'foo_l1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('foo_l1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -400,12 +400,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -27,12 +27,12 @@ class base__c1__base_c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/base:c2')
-            res.append(f'{self_name} = base__c1__base_c2()')
+            res.append('# Top node: /c1/base:c2')
+            res.append('{self_name} = base__c1__base_c2()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/base:c2'] + leaves + res
@@ -98,12 +98,12 @@ class base__c1__foo_c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/foo:c2')
-            res.append(f'{self_name} = base__c1__foo_c2()')
+            res.append('# Top node: /c1/foo:c2')
+            res.append('{self_name} = base__c1__foo_c2()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/foo:c2'] + leaves + res
@@ -168,15 +168,15 @@ class base__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = base__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = base__c1()')
         leaves = []
         _base_c2 = self.base_c2
         if _base_c2 is not None:
-            res.extend(_base_c2.prsrc(f'{self_name}.base_c2', False).splitlines())
+            res.extend(_base_c2.prsrc('{self_name}.base_c2', False).splitlines())
         _foo_c2 = self.foo_c2
         if _foo_c2 is not None:
-            res.extend(_foo_c2.prsrc(f'{self_name}.foo_c2', False).splitlines())
+            res.extend(_foo_c2.prsrc('{self_name}.foo_c2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -244,12 +244,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -38,15 +38,15 @@ class base__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = base__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = base__c1()')
         leaves = []
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
-            leaves.append(f'{self_name}.bar_foo = {repr(_bar_foo)}')
+            leaves.append('{self_name}.bar_foo = {repr(_bar_foo)}')
         _foo_foo = self.foo_foo
         if _foo_foo is not None:
-            leaves.append(f'{self_name}.foo_foo = {repr(_foo_foo)}')
+            leaves.append('{self_name}.foo_foo = {repr(_foo_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -36,12 +36,12 @@ class foo__ieee_802_3(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /ieee-802.3')
-            res.append(f'{self_name} = foo__ieee_802_3()')
+            res.append('# Top node: /ieee-802.3')
+            res.append('{self_name} = foo__ieee_802_3()')
         leaves = []
         _ieee_802_3 = self.ieee_802_3
         if _ieee_802_3 is not None:
-            leaves.append(f'{self_name}.ieee_802_3 = {repr(_ieee_802_3)}')
+            leaves.append('{self_name}.ieee_802_3 = {repr(_ieee_802_3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /ieee-802.3'] + leaves + res
@@ -101,12 +101,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _ieee_802_3 = self.ieee_802_3
         if _ieee_802_3 is not None:
-            res.extend(_ieee_802_3.prsrc(f'{self_name}.ieee_802_3', False).splitlines())
+            res.extend(_ieee_802_3.prsrc('{self_name}.ieee_802_3', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -71,24 +71,24 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _as_ = self.as_
         if _as_ is not None:
-            leaves.append(f'{self_name}.as_ = {repr(_as_)}')
+            leaves.append('{self_name}.as_ = {repr(_as_)}')
         _for_ = self.for_
         if _for_ is not None:
-            leaves.append(f'{self_name}.for_ = {repr(_for_)}')
+            leaves.append('{self_name}.for_ = {repr(_for_)}')
         _import_ = self.import_
         if _import_ is not None:
-            leaves.append(f'{self_name}.import_ = {repr(_import_)}')
+            leaves.append('{self_name}.import_ = {repr(_import_)}')
         _in_ = self.in_
         if _in_ is not None:
-            leaves.append(f'{self_name}.in_ = {repr(_in_)}')
+            leaves.append('{self_name}.in_ = {repr(_in_)}')
         _with_ = self.with_
         if _with_ is not None:
-            leaves.append(f'{self_name}.with_ = {repr(_with_)}')
+            leaves.append('{self_name}.with_ = {repr(_with_)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -25,8 +25,8 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1')
-            res.append(f'{self_name} = foo__l1({repr(self.name)})')
+            res.append('# Top node: /l1')
+            res.append('{self_name} = foo__l1({repr(self.name)})')
         leaves = []
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -36,12 +36,12 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1')
-            res.append(f'{self_name} = foo__l1({repr(self.name)})')
+            res.append('# Top node: /l1')
+            res.append('{self_name} = foo__l1({repr(self.name)})')
         leaves = []
         _id = self.id
         if _id is not None:
-            leaves.append(f'{self_name}.id = {repr(_id)}')
+            leaves.append('{self_name}.id = {repr(_id)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /l1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -27,12 +27,12 @@ class foo__foo__bar(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /foo/bar')
-            res.append(f'{self_name} = foo__foo__bar()')
+            res.append('# Top node: /foo/bar')
+            res.append('{self_name} = foo__foo__bar()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/bar'] + leaves + res
@@ -92,12 +92,12 @@ class foo__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /foo')
-            res.append(f'{self_name} = foo__foo()')
+            res.append('# Top node: /foo')
+            res.append('{self_name} = foo__foo()')
         leaves = []
         _bar = self.bar
         if _bar is not None:
-            res.extend(_bar.prsrc(f'{self_name}.bar', False).splitlines())
+            res.extend(_bar.prsrc('{self_name}.bar', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo'] + leaves + res

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -27,12 +27,12 @@ class foo__foo__bar(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /foo/bar')
-            res.append(f'{self_name} = foo__foo__bar()')
+            res.append('# Top node: /foo/bar')
+            res.append('{self_name} = foo__foo__bar()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/bar'] + leaves + res
@@ -97,14 +97,14 @@ class foo__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /foo')
-            res.append(f'{self_name} = foo__foo()')
+            res.append('# Top node: /foo')
+            res.append('{self_name} = foo__foo()')
         leaves = []
         _bar = self.bar
         if _bar is not None:
             res.append('')
             res.append('# P-container: /foo/bar')
-            res.append(f'bar = {self_name}.create_bar()')
+            res.append('bar = {self_name}.create_bar()')
             res.extend(_bar.prsrc('bar', False).splitlines())
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -34,8 +34,8 @@ class foo__li1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /li1')
-            res.append(f'{self_name} = foo__li1({repr(self.l1)})')
+            res.append('# Top node: /li1')
+            res.append('{self_name} = foo__li1({repr(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -176,19 +176,19 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _li1 = self.li1
         for _element in _li1.elements:
             res.append('')
             res.append("# List /li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = f'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         _ll1 = self.ll1
         if _ll1 is not None:
-            leaves.append(f'{self_name}.ll1 = {repr(_ll1)}')
+            leaves.append('{self_name}.ll1 = {repr(_ll1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -34,8 +34,8 @@ class foo__li1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /li1')
-            res.append(f'{self_name} = foo__li1({repr(self.l1)})')
+            res.append('# Top node: /li1')
+            res.append('{self_name} = foo__li1({repr(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -176,19 +176,19 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _li1 = self.li1
         for _element in _li1.elements:
             res.append('')
             res.append("# List /li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = f'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         _ll1 = self.ll1
         if _ll1 is not None:
-            leaves.append(f'{self_name}.ll1 = {repr(_ll1)}')
+            leaves.append('{self_name}.ll1 = {repr(_ll1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -48,12 +48,12 @@ class foo__l1__bar(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1/bar')
-            res.append(f'{self_name} = foo__l1__bar()')
+            res.append('# Top node: /l1/bar')
+            res.append('{self_name} = foo__l1__bar()')
         leaves = []
         _hi = self.hi
         if _hi is not None:
-            leaves.append(f'{self_name}.hi = {repr(_hi)}')
+            leaves.append('{self_name}.hi = {repr(_hi)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /l1/bar'] + leaves + res
@@ -121,15 +121,15 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1')
-            res.append(f'{self_name} = foo__l1({repr(self.name)})')
+            res.append('# Top node: /l1')
+            res.append('{self_name} = foo__l1({repr(self.name)})')
         leaves = []
         _id = self.id
         if _id is not None:
-            leaves.append(f'{self_name}.id = {repr(_id)}')
+            leaves.append('{self_name}.id = {repr(_id)}')
         _bar = self.bar
         if _bar is not None:
-            res.extend(_bar.prsrc(f'{self_name}.bar', False).splitlines())
+            res.extend(_bar.prsrc('{self_name}.bar', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /l1'] + leaves + res
@@ -272,16 +272,16 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _l1 = self.l1
         for _element in _l1.elements:
             res.append('')
             res.append("# List /l1 element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'l1_element = {self_name}.l1.create({repr(_element.name)})'
+            list_elem = 'l1_element = {self_name}.l1.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'l1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('l1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -36,8 +36,8 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1')
-            res.append(f'{self_name} = foo__l1({repr(self.name)}, {repr(self.id)})')
+            res.append('# Top node: /l1')
+            res.append('{self_name} = foo__l1({repr(self.name)}, {repr(self.id)})')
         leaves = []
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -33,8 +33,8 @@ class foo__l1__bar(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1/bar')
-            res.append(f'{self_name} = foo__l1__bar({repr(self.hi)})')
+            res.append('# Top node: /l1/bar')
+            res.append('{self_name} = foo__l1__bar({repr(self.hi)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -103,14 +103,14 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /l1')
-            res.append(f'{self_name} = foo__l1({repr(self.name)})')
+            res.append('# Top node: /l1')
+            res.append('{self_name} = foo__l1({repr(self.name)})')
         leaves = []
         _bar = self.bar
         if _bar is not None:
             res.append('')
             res.append('# P-container: /l1/bar')
-            res.append(f'bar = {self_name}.create_bar({repr(_bar.hi)})')
+            res.append('bar = {self_name}.create_bar({repr(_bar.hi)})')
             res.extend(_bar.prsrc('bar', False).splitlines())
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -58,8 +58,8 @@ class foo__foo__bar(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /foo/bar')
-            res.append(f'{self_name} = foo__foo__bar({repr(self.foo_l1)}, {repr(self.bar_l1)}, {repr(self.l2)})')
+            res.append('# Top node: /foo/bar')
+            res.append('{self_name} = foo__foo__bar({repr(self.foo_l1)}, {repr(self.bar_l1)}, {repr(self.l2)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -137,14 +137,14 @@ class foo__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /foo')
-            res.append(f'{self_name} = foo__foo()')
+            res.append('# Top node: /foo')
+            res.append('{self_name} = foo__foo()')
         leaves = []
         _bar = self.bar
         if _bar is not None:
             res.append('')
             res.append('# P-container: /foo/bar')
-            res.append(f'bar = {self_name}.create_bar({repr(_bar.foo_l1)}, {repr(_bar.bar_l1)}, {repr(_bar.l2)})')
+            res.append('bar = {self_name}.create_bar({repr(_bar.foo_l1)}, {repr(_bar.bar_l1)}, {repr(_bar.l2)})')
             res.extend(_bar.prsrc('bar', False).splitlines())
         if leaves:
             if not list_element:
@@ -211,14 +211,14 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
             res.append('')
             res.append('# P-container: /foo')
-            res.append(f'foo = {self_name}.create_foo()')
+            res.append('foo = {self_name}.create_foo()')
             res.extend(_foo.prsrc('foo', False).splitlines())
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -36,12 +36,12 @@ class bar__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = bar__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = bar__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -107,12 +107,12 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -177,15 +177,15 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _bar_c1 = self.bar_c1
         if _bar_c1 is not None:
-            res.extend(_bar_c1.prsrc(f'{self_name}.bar_c1', False).splitlines())
+            res.extend(_bar_c1.prsrc('{self_name}.bar_c1', False).splitlines())
         _foo_c1 = self.foo_c1
         if _foo_c1 is not None:
-            res.extend(_foo_c1.prsrc(f'{self_name}.foo_c1', False).splitlines())
+            res.extend(_foo_c1.prsrc('{self_name}.foo_c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -36,12 +36,12 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -107,12 +107,12 @@ class foo__pc1__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc1/foo')
-            res.append(f'{self_name} = foo__pc1__foo()')
+            res.append('# Top node: /pc1/foo')
+            res.append('{self_name} = foo__pc1__foo()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1/foo'] + leaves + res
@@ -172,12 +172,12 @@ class foo__pc1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc1')
-            res.append(f'{self_name} = foo__pc1()')
+            res.append('# Top node: /pc1')
+            res.append('{self_name} = foo__pc1()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            res.extend(_foo.prsrc(f'{self_name}.foo', False).splitlines())
+            res.extend(_foo.prsrc('{self_name}.foo', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1'] + leaves + res
@@ -248,17 +248,17 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         _pc1 = self.pc1
         if _pc1 is not None:
             res.append('')
             res.append('# P-container: /pc1')
-            res.append(f'pc1 = {self_name}.create_pc1()')
+            res.append('pc1 = {self_name}.create_pc1()')
             res.extend(_pc1.prsrc('pc1', False).splitlines())
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -56,8 +56,8 @@ class foo__c1__l1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/l1')
-            res.append(f'{self_name} = foo__c1__l1({repr(self.k1)}, {repr(self.k2)}, {repr(self.l1)})')
+            res.append('# Top node: /c1/l1')
+            res.append('{self_name} = foo__c1__l1({repr(self.k1)}, {repr(self.k2)}, {repr(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -210,16 +210,16 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
         for _element in _l1.elements:
             res.append('')
             res.append("# List /c1/l1 element: {_element.to_gdata().key_str(['k1', 'k2'])}")
-            list_elem = f'l1_element = {self_name}.l1.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.l1)})'
+            list_elem = 'l1_element = {self_name}.l1.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.l1)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'l1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('l1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -280,12 +280,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -69,21 +69,21 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append(f'{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append(f'{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr(_l4)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -36,12 +36,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -36,12 +36,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -125,36 +125,36 @@ class basics__c(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c')
-            res.append(f'{self_name} = basics__c()')
+            res.append('# Top node: /c')
+            res.append('{self_name} = basics__c()')
         leaves = []
         _l_str_def = self.l_str_def
         if _l_str_def is not None:
-            leaves.append(f'{self_name}.l_str_def = {repr(_l_str_def)}')
+            leaves.append('{self_name}.l_str_def = {repr(_l_str_def)}')
         _l_str_def_quoted = self.l_str_def_quoted
         if _l_str_def_quoted is not None:
-            leaves.append(f'{self_name}.l_str_def_quoted = {repr(_l_str_def_quoted)}')
+            leaves.append('{self_name}.l_str_def_quoted = {repr(_l_str_def_quoted)}')
         _l_uint64_def = self.l_uint64_def
         if _l_uint64_def is not None:
-            leaves.append(f'{self_name}.l_uint64_def = {repr(_l_uint64_def)}')
+            leaves.append('{self_name}.l_uint64_def = {repr(_l_uint64_def)}')
         _l_union_def_str = self.l_union_def_str
         if _l_union_def_str is not None:
-            leaves.append(f'{self_name}.l_union_def_str = {repr(_l_union_def_str)}')
+            leaves.append('{self_name}.l_union_def_str = {repr(_l_union_def_str)}')
         _l_union_def_int = self.l_union_def_int
         if _l_union_def_int is not None:
-            leaves.append(f'{self_name}.l_union_def_int = {repr(_l_union_def_int)}')
+            leaves.append('{self_name}.l_union_def_int = {repr(_l_union_def_int)}')
         _l_union_def_float = self.l_union_def_float
         if _l_union_def_float is not None:
-            leaves.append(f'{self_name}.l_union_def_float = {repr(_l_union_def_float)}')
+            leaves.append('{self_name}.l_union_def_float = {repr(_l_union_def_float)}')
         _l_union_def_bool = self.l_union_def_bool
         if _l_union_def_bool is not None:
-            leaves.append(f'{self_name}.l_union_def_bool = {repr(_l_union_def_bool)}')
+            leaves.append('{self_name}.l_union_def_bool = {repr(_l_union_def_bool)}')
         _l_union_def_enumeration = self.l_union_def_enumeration
         if _l_union_def_enumeration is not None:
-            leaves.append(f'{self_name}.l_union_def_enumeration = {repr(_l_union_def_enumeration)}')
+            leaves.append('{self_name}.l_union_def_enumeration = {repr(_l_union_def_enumeration)}')
         _l_binary_def = self.l_binary_def
         if _l_binary_def is not None:
-            leaves.append(f'{self_name}.l_binary_def = {repr(_l_binary_def)}')
+            leaves.append('{self_name}.l_binary_def = {repr(_l_binary_def)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c'] + leaves + res
@@ -262,12 +262,12 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c = self.c
         if _c is not None:
-            res.extend(_c.prsrc(f'{self_name}.c', False).splitlines())
+            res.extend(_c.prsrc('{self_name}.c', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -64,12 +64,12 @@ class foo__c1__li_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/li')
-            res.append(f'{self_name} = foo__c1__li({repr(self.name)})')
+            res.append('# Top node: /c1/li')
+            res.append('{self_name} = foo__c1__li({repr(self.name)})')
         leaves = []
         _val = self.val
         if _val is not None:
-            leaves.append(f'{self_name}.val = {repr(_val)}')
+            leaves.append('{self_name}.val = {repr(_val)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/li'] + leaves + res
@@ -272,40 +272,40 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _f_l1 = self.f_l1
         if _f_l1 is not None:
-            leaves.append(f'{self_name}.f_l1 = {repr(_f_l1)}')
+            leaves.append('{self_name}.f_l1 = {repr(_f_l1)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append(f'{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
         _l_empty = self.l_empty
         if _l_empty is not None:
-            leaves.append(f'{self_name}.l_empty = {repr(_l_empty)}')
+            leaves.append('{self_name}.l_empty = {repr(_l_empty)}')
         _li = self.li
         for _element in _li.elements:
             res.append('')
             res.append("# List /c1/li element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'li_element = {self_name}.li.create({repr(_element.name)})'
+            list_elem = 'li_element = {self_name}.li.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         _ll_uint64 = self.ll_uint64
         if _ll_uint64 is not None:
-            leaves.append(f'{self_name}.ll_uint64 = {repr(_ll_uint64)}')
+            leaves.append('{self_name}.ll_uint64 = {repr(_ll_uint64)}')
         _ll_str = self.ll_str
         if _ll_str is not None:
-            leaves.append(f'{self_name}.ll_str = {repr(_ll_str)}')
+            leaves.append('{self_name}.ll_str = {repr(_ll_str)}')
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append(f'{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr(_l4)}')
         _bar_l1 = self.bar_l1
         if _bar_l1 is not None:
-            leaves.append(f'{self_name}.bar_l1 = {repr(_bar_l1)}')
+            leaves.append('{self_name}.bar_l1 = {repr(_bar_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -418,12 +418,12 @@ class foo__pc1__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc1/foo')
-            res.append(f'{self_name} = foo__pc1__foo()')
+            res.append('# Top node: /pc1/foo')
+            res.append('{self_name} = foo__pc1__foo()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1/foo'] + leaves + res
@@ -483,12 +483,12 @@ class foo__pc1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc1')
-            res.append(f'{self_name} = foo__pc1()')
+            res.append('# Top node: /pc1')
+            res.append('{self_name} = foo__pc1()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            res.extend(_foo.prsrc(f'{self_name}.foo', False).splitlines())
+            res.extend(_foo.prsrc('{self_name}.foo', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1'] + leaves + res
@@ -555,8 +555,8 @@ class foo__pc2__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc2/foo')
-            res.append(f'{self_name} = foo__pc2__foo({repr(self.l_mandatory)})')
+            res.append('# Top node: /pc2/foo')
+            res.append('{self_name} = foo__pc2__foo({repr(self.l_mandatory)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -617,13 +617,13 @@ class foo__pc2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc2')
-            res.append(f'self_foo = foo__pc2__foo({repr(self.foo.l_mandatory)})')
-            res.append(f'{self_name} = foo__pc2(self_foo)')
+            res.append('# Top node: /pc2')
+            res.append('self_foo = foo__pc2__foo({repr(self.foo.l_mandatory)})')
+            res.append('{self_name} = foo__pc2(self_foo)')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            res.extend(_foo.prsrc(f'{self_name}.foo', False).splitlines())
+            res.extend(_foo.prsrc('{self_name}.foo', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc2'] + leaves + res
@@ -725,12 +725,12 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3/level1/level2/level3')
-            res.append(f'{self_name} = foo__pc3__level1__level2__level3({repr(self.l3)})')
+            res.append('# Top node: /pc3/level1/level2/level3')
+            res.append('{self_name} = foo__pc3__level1__level2__level3({repr(self.l3)})')
         leaves = []
         _l3_optional = self.l3_optional
         if _l3_optional is not None:
-            leaves.append(f'{self_name}.l3_optional = {repr(_l3_optional)}')
+            leaves.append('{self_name}.l3_optional = {repr(_l3_optional)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1/level2/level3'] + leaves + res
@@ -806,16 +806,16 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3/level1/level2')
-            res.append(f'self_level3 = foo__pc3__level1__level2__level3({repr(self.level3.l3)})')
-            res.append(f'{self_name} = foo__pc3__level1__level2({repr(self.l2)}, self_level3)')
+            res.append('# Top node: /pc3/level1/level2')
+            res.append('self_level3 = foo__pc3__level1__level2__level3({repr(self.level3.l3)})')
+            res.append('{self_name} = foo__pc3__level1__level2({repr(self.l2)}, self_level3)')
         leaves = []
         _l2_optional = self.l2_optional
         if _l2_optional is not None:
-            leaves.append(f'{self_name}.l2_optional = {repr(_l2_optional)}')
+            leaves.append('{self_name}.l2_optional = {repr(_l2_optional)}')
         _level3 = self.level3
         if _level3 is not None:
-            res.extend(_level3.prsrc(f'{self_name}.level3', False).splitlines())
+            res.extend(_level3.prsrc('{self_name}.level3', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1/level2'] + leaves + res
@@ -898,17 +898,17 @@ class foo__pc3__level1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3/level1')
-            res.append(f'self_level2_level3 = foo__pc3__level1__level2__level3({repr(self.level2.level3.l3)})')
-            res.append(f'self_level2 = foo__pc3__level1__level2({repr(self.level2.l2)}, self_level2_level3)')
-            res.append(f'{self_name} = foo__pc3__level1({repr(self.l1)}, self_level2)')
+            res.append('# Top node: /pc3/level1')
+            res.append('self_level2_level3 = foo__pc3__level1__level2__level3({repr(self.level2.level3.l3)})')
+            res.append('self_level2 = foo__pc3__level1__level2({repr(self.level2.l2)}, self_level2_level3)')
+            res.append('{self_name} = foo__pc3__level1({repr(self.l1)}, self_level2)')
         leaves = []
         _l1_optional = self.l1_optional
         if _l1_optional is not None:
-            leaves.append(f'{self_name}.l1_optional = {repr(_l1_optional)}')
+            leaves.append('{self_name}.l1_optional = {repr(_l1_optional)}')
         _level2 = self.level2
         if _level2 is not None:
-            res.extend(_level2.prsrc(f'{self_name}.level2', False).splitlines())
+            res.extend(_level2.prsrc('{self_name}.level2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1'] + leaves + res
@@ -981,15 +981,15 @@ class foo__pc3(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3')
-            res.append(f'self_level1_level2_level3 = foo__pc3__level1__level2__level3({repr(self.level1.level2.level3.l3)})')
-            res.append(f'self_level1_level2 = foo__pc3__level1__level2({repr(self.level1.level2.l2)}, self_level1_level2_level3)')
-            res.append(f'self_level1 = foo__pc3__level1({repr(self.level1.l1)}, self_level1_level2)')
-            res.append(f'{self_name} = foo__pc3(self_level1)')
+            res.append('# Top node: /pc3')
+            res.append('self_level1_level2_level3 = foo__pc3__level1__level2__level3({repr(self.level1.level2.level3.l3)})')
+            res.append('self_level1_level2 = foo__pc3__level1__level2({repr(self.level1.level2.l2)}, self_level1_level2_level3)')
+            res.append('self_level1 = foo__pc3__level1({repr(self.level1.l1)}, self_level1_level2)')
+            res.append('{self_name} = foo__pc3(self_level1)')
         leaves = []
         _level1 = self.level1
         if _level1 is not None:
-            res.extend(_level1.prsrc(f'{self_name}.level1', False).splitlines())
+            res.extend(_level1.prsrc('{self_name}.level1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3'] + leaves + res
@@ -1046,8 +1046,8 @@ class foo__empty_presence(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /empty-presence')
-            res.append(f'{self_name} = foo__empty_presence()')
+            res.append('# Top node: /empty-presence')
+            res.append('{self_name} = foo__empty_presence()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1119,15 +1119,15 @@ class foo__c_dot(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c.dot')
-            res.append(f'{self_name} = foo__c_dot()')
+            res.append('# Top node: /c.dot')
+            res.append('{self_name} = foo__c_dot()')
         leaves = []
         _l_dot1 = self.l_dot1
         if _l_dot1 is not None:
-            leaves.append(f'{self_name}.l_dot1 = {repr(_l_dot1)}')
+            leaves.append('{self_name}.l_dot1 = {repr(_l_dot1)}')
         _l_dot2 = self.l_dot2
         if _l_dot2 is not None:
-            leaves.append(f'{self_name}.l_dot2 = {repr(_l_dot2)}')
+            leaves.append('{self_name}.l_dot2 = {repr(_l_dot2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c.dot'] + leaves + res
@@ -1203,8 +1203,8 @@ class foo__cc__death_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /cc/death')
-            res.append(f'{self_name} = foo__cc__death({repr(self.name)})')
+            res.append('# Top node: /cc/death')
+            res.append('{self_name} = foo__cc__death({repr(self.name)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1341,19 +1341,19 @@ class foo__cc(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /cc')
-            res.append(f'{self_name} = foo__cc()')
+            res.append('# Top node: /cc')
+            res.append('{self_name} = foo__cc()')
         leaves = []
         _cake = self.cake
         if _cake is not None:
-            leaves.append(f'{self_name}.cake = {repr(_cake)}')
+            leaves.append('{self_name}.cake = {repr(_cake)}')
         _death = self.death
         for _element in _death.elements:
             res.append('')
             res.append("# List /cc/death element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'death_element = {self_name}.death.create({repr(_element.name)})'
+            list_elem = 'death_element = {self_name}.death.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'death_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('death_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /cc'] + leaves + res
@@ -1422,8 +1422,8 @@ class foo__conflict__f_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict/f:inner')
-            res.append(f'{self_name} = foo__conflict__f_inner()')
+            res.append('# Top node: /conflict/f:inner')
+            res.append('{self_name} = foo__conflict__f_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1480,8 +1480,8 @@ class foo__conflict__bar_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict/bar:inner')
-            res.append(f'{self_name} = foo__conflict__bar_inner()')
+            res.append('# Top node: /conflict/bar:inner')
+            res.append('{self_name} = foo__conflict__bar_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1561,26 +1561,26 @@ class foo__conflict(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict')
-            res.append(f'{self_name} = foo__conflict()')
+            res.append('# Top node: /conflict')
+            res.append('{self_name} = foo__conflict()')
         leaves = []
         _f_foo = self.f_foo
         if _f_foo is not None:
-            leaves.append(f'{self_name}.f_foo = {repr(_f_foo)}')
+            leaves.append('{self_name}.f_foo = {repr(_f_foo)}')
         _f_inner = self.f_inner
         if _f_inner is not None:
             res.append('')
             res.append('# P-container: /conflict/f:inner')
-            res.append(f'inner = {self_name}.create_f_inner()')
+            res.append('inner = {self_name}.create_f_inner()')
             res.extend(_f_inner.prsrc('f_inner', False).splitlines())
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
-            leaves.append(f'{self_name}.bar_foo = {repr(_bar_foo)}')
+            leaves.append('{self_name}.bar_foo = {repr(_bar_foo)}')
         _bar_inner = self.bar_inner
         if _bar_inner is not None:
             res.append('')
             res.append('# P-container: /conflict/bar:inner')
-            res.append(f'inner = {self_name}.create_bar_inner()')
+            res.append('inner = {self_name}.create_bar_inner()')
             res.extend(_bar_inner.prsrc('bar_inner', False).splitlines())
         if leaves:
             if not list_element:
@@ -1665,8 +1665,8 @@ class foo__special_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /special')
-            res.append(f'{self_name} = foo__special({repr(self.yes)})')
+            res.append('# Top node: /special')
+            res.append('{self_name} = foo__special({repr(self.yes)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1842,12 +1842,12 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/f:inner/li1/li2')
-            res.append(f'{self_name} = foo__nested__f_inner__li1__li2({repr(self.key1)}, {repr(self.key2)})')
+            res.append('# Top node: /nested/f:inner/li1/li2')
+            res.append('{self_name} = foo__nested__f_inner__li1__li2({repr(self.key1)}, {repr(self.key2)})')
         leaves = []
         _baz = self.baz
         if _baz is not None:
-            leaves.append(f'{self_name}.baz = {repr(_baz)}')
+            leaves.append('{self_name}.baz = {repr(_baz)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1/li2'] + leaves + res
@@ -2011,22 +2011,22 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/f:inner/li1')
-            res.append(f'{self_name} = foo__nested__f_inner__li1({repr(self.name)})')
+            res.append('# Top node: /nested/f:inner/li1')
+            res.append('{self_name} = foo__nested__f_inner__li1({repr(self.name)})')
         leaves = []
         _f_bar = self.f_bar
         if _f_bar is not None:
-            leaves.append(f'{self_name}.f_bar = {repr(_f_bar)}')
+            leaves.append('{self_name}.f_bar = {repr(_f_bar)}')
         _li2 = self.li2
         for _element in _li2.elements:
             res.append('')
             res.append("# List /nested/f:inner/li1/li2 element: {_element.to_gdata().key_str(['key1', 'key2'])}")
-            list_elem = f'li2_element = {self_name}.li2.create({repr(_element.key1)}, {repr(_element.key2)})'
+            list_elem = 'li2_element = {self_name}.li2.create({repr(_element.key1)}, {repr(_element.key2)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li2_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li2_element', False, list_element=True).splitlines())
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
-            leaves.append(f'{self_name}.bar_bar = {repr(_bar_bar)}')
+            leaves.append('{self_name}.bar_bar = {repr(_bar_bar)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1'] + leaves + res
@@ -2180,19 +2180,19 @@ class foo__nested__f_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/f:inner')
-            res.append(f'{self_name} = foo__nested__f_inner()')
+            res.append('# Top node: /nested/f:inner')
+            res.append('{self_name} = foo__nested__f_inner()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         _li1 = self.li1
         for _element in _li1.elements:
             res.append('')
             res.append("# List /nested/f:inner/li1 element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'li1_element = {self_name}.li1.create({repr(_element.name)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner'] + leaves + res
@@ -2265,12 +2265,12 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/bar:inner')
-            res.append(f'{self_name} = foo__nested__bar_inner()')
+            res.append('# Top node: /nested/bar:inner')
+            res.append('{self_name} = foo__nested__bar_inner()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/bar:inner'] + leaves + res
@@ -2335,15 +2335,15 @@ class foo__nested(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested')
-            res.append(f'{self_name} = foo__nested()')
+            res.append('# Top node: /nested')
+            res.append('{self_name} = foo__nested()')
         leaves = []
         _f_inner = self.f_inner
         if _f_inner is not None:
-            res.extend(_f_inner.prsrc(f'{self_name}.f_inner', False).splitlines())
+            res.extend(_f_inner.prsrc('{self_name}.f_inner', False).splitlines())
         _bar_inner = self.bar_inner
         if _bar_inner is not None:
-            res.extend(_bar_inner.prsrc(f'{self_name}.bar_inner', False).splitlines())
+            res.extend(_bar_inner.prsrc('{self_name}.bar_inner', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested'] + leaves + res
@@ -2437,8 +2437,8 @@ class foo__li_union_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /li-union')
-            res.append(f'{self_name} = foo__li_union({repr(self.k1)}, {repr(self.k2)}, {repr(self.k3)})')
+            res.append('# Top node: /li-union')
+            res.append('{self_name} = foo__li_union({repr(self.k1)}, {repr(self.k2)}, {repr(self.k3)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -2615,15 +2615,15 @@ class foo__state__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /state/c1')
-            res.append(f'{self_name} = foo__state__c1()')
+            res.append('# Top node: /state/c1')
+            res.append('{self_name} = foo__state__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /state/c1'] + leaves + res
@@ -2689,12 +2689,12 @@ class foo__state(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /state')
-            res.append(f'{self_name} = foo__state()')
+            res.append('# Top node: /state')
+            res.append('{self_name} = foo__state()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /state'] + leaves + res
@@ -2761,12 +2761,12 @@ class foo__c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c2')
-            res.append(f'{self_name} = foo__c2()')
+            res.append('# Top node: /c2')
+            res.append('{self_name} = foo__c2()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c2'] + leaves + res
@@ -2832,12 +2832,12 @@ class bar__conflict(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict')
-            res.append(f'{self_name} = bar__conflict()')
+            res.append('# Top node: /conflict')
+            res.append('{self_name} = bar__conflict()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /conflict'] + leaves + res
@@ -2982,75 +2982,75 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         _pc1 = self.pc1
         if _pc1 is not None:
             res.append('')
             res.append('# P-container: /pc1')
-            res.append(f'pc1 = {self_name}.create_pc1()')
+            res.append('pc1 = {self_name}.create_pc1()')
             res.extend(_pc1.prsrc('pc1', False).splitlines())
         _pc2 = self.pc2
         if _pc2 is not None:
             res.append('')
             res.append('# P-container: /pc2')
-            res.append(f'pc2_foo = foo__pc2__foo({repr(_pc2.foo.l_mandatory)})')
-            res.append(f'pc2 = {self_name}.create_pc2(pc2_foo)')
+            res.append('pc2_foo = foo__pc2__foo({repr(_pc2.foo.l_mandatory)})')
+            res.append('pc2 = {self_name}.create_pc2(pc2_foo)')
             res.extend(_pc2.prsrc('pc2', False).splitlines())
         _pc3 = self.pc3
         if _pc3 is not None:
             res.append('')
             res.append('# P-container: /pc3')
-            res.append(f'pc3_level1_level2_level3 = foo__pc3__level1__level2__level3({repr(_pc3.level1.level2.level3.l3)})')
-            res.append(f'pc3_level1_level2 = foo__pc3__level1__level2({repr(_pc3.level1.level2.l2)}, pc3_level1_level2_level3)')
-            res.append(f'pc3_level1 = foo__pc3__level1({repr(_pc3.level1.l1)}, pc3_level1_level2)')
-            res.append(f'pc3 = {self_name}.create_pc3(pc3_level1)')
+            res.append('pc3_level1_level2_level3 = foo__pc3__level1__level2__level3({repr(_pc3.level1.level2.level3.l3)})')
+            res.append('pc3_level1_level2 = foo__pc3__level1__level2({repr(_pc3.level1.level2.l2)}, pc3_level1_level2_level3)')
+            res.append('pc3_level1 = foo__pc3__level1({repr(_pc3.level1.l1)}, pc3_level1_level2)')
+            res.append('pc3 = {self_name}.create_pc3(pc3_level1)')
             res.extend(_pc3.prsrc('pc3', False).splitlines())
         _empty_presence = self.empty_presence
         if _empty_presence is not None:
             res.append('')
             res.append('# P-container: /empty-presence')
-            res.append(f'empty_presence = {self_name}.create_empty_presence()')
+            res.append('empty_presence = {self_name}.create_empty_presence()')
             res.extend(_empty_presence.prsrc('empty_presence', False).splitlines())
         _c_dot = self.c_dot
         if _c_dot is not None:
-            res.extend(_c_dot.prsrc(f'{self_name}.c_dot', False).splitlines())
+            res.extend(_c_dot.prsrc('{self_name}.c_dot', False).splitlines())
         _cc = self.cc
         if _cc is not None:
-            res.extend(_cc.prsrc(f'{self_name}.cc', False).splitlines())
+            res.extend(_cc.prsrc('{self_name}.cc', False).splitlines())
         _f_conflict = self.f_conflict
         if _f_conflict is not None:
-            res.extend(_f_conflict.prsrc(f'{self_name}.f_conflict', False).splitlines())
+            res.extend(_f_conflict.prsrc('{self_name}.f_conflict', False).splitlines())
         _special = self.special
         for _element in _special.elements:
             res.append('')
             res.append("# List /special element: {_element.to_gdata().key_str(['yes'])}")
-            list_elem = f'special_element = {self_name}.special.create({repr(_element.yes)})'
+            list_elem = 'special_element = {self_name}.special.create({repr(_element.yes)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'special_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('special_element', False, list_element=True).splitlines())
         _nested = self.nested
         if _nested is not None:
-            res.extend(_nested.prsrc(f'{self_name}.nested', False).splitlines())
+            res.extend(_nested.prsrc('{self_name}.nested', False).splitlines())
         _li_union = self.li_union
         for _element in _li_union.elements:
             res.append('')
             res.append("# List /li-union element: {_element.to_gdata().key_str(['k1', 'k2', 'k3'])}")
-            list_elem = f'li_union_element = {self_name}.li_union.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.k3)})'
+            list_elem = 'li_union_element = {self_name}.li_union.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.k3)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li_union_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li_union_element', False, list_element=True).splitlines())
         _state = self.state
         if _state is not None:
-            res.extend(_state.prsrc(f'{self_name}.state', False).splitlines())
+            res.extend(_state.prsrc('{self_name}.state', False).splitlines())
         _c2 = self.c2
         if _c2 is not None:
-            res.extend(_c2.prsrc(f'{self_name}.c2', False).splitlines())
+            res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
-            res.extend(_bar_conflict.prsrc(f'{self_name}.bar_conflict', False).splitlines())
+            res.extend(_bar_conflict.prsrc('{self_name}.bar_conflict', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -64,12 +64,12 @@ class foo__c1__li_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1/li')
-            res.append(f'{self_name} = foo__c1__li({repr(self.name)})')
+            res.append('# Top node: /c1/li')
+            res.append('{self_name} = foo__c1__li({repr(self.name)})')
         leaves = []
         _val = self.val
         if _val is not None:
-            leaves.append(f'{self_name}.val = {repr(_val)}')
+            leaves.append('{self_name}.val = {repr(_val)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/li'] + leaves + res
@@ -272,40 +272,40 @@ class foo__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c1')
-            res.append(f'{self_name} = foo__c1()')
+            res.append('# Top node: /c1')
+            res.append('{self_name} = foo__c1()')
         leaves = []
         _f_l1 = self.f_l1
         if _f_l1 is not None:
-            leaves.append(f'{self_name}.f_l1 = {repr(_f_l1)}')
+            leaves.append('{self_name}.f_l1 = {repr(_f_l1)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append(f'{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
         _l_empty = self.l_empty
         if _l_empty is not None:
-            leaves.append(f'{self_name}.l_empty = {repr(_l_empty)}')
+            leaves.append('{self_name}.l_empty = {repr(_l_empty)}')
         _li = self.li
         for _element in _li.elements:
             res.append('')
             res.append("# List /c1/li element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'li_element = {self_name}.li.create({repr(_element.name)})'
+            list_elem = 'li_element = {self_name}.li.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         _ll_uint64 = self.ll_uint64
         if _ll_uint64 is not None:
-            leaves.append(f'{self_name}.ll_uint64 = {repr(_ll_uint64)}')
+            leaves.append('{self_name}.ll_uint64 = {repr(_ll_uint64)}')
         _ll_str = self.ll_str
         if _ll_str is not None:
-            leaves.append(f'{self_name}.ll_str = {repr(_ll_str)}')
+            leaves.append('{self_name}.ll_str = {repr(_ll_str)}')
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append(f'{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr(_l4)}')
         _bar_l1 = self.bar_l1
         if _bar_l1 is not None:
-            leaves.append(f'{self_name}.bar_l1 = {repr(_bar_l1)}')
+            leaves.append('{self_name}.bar_l1 = {repr(_bar_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -418,12 +418,12 @@ class foo__pc1__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc1/foo')
-            res.append(f'{self_name} = foo__pc1__foo()')
+            res.append('# Top node: /pc1/foo')
+            res.append('{self_name} = foo__pc1__foo()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1/foo'] + leaves + res
@@ -483,12 +483,12 @@ class foo__pc1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc1')
-            res.append(f'{self_name} = foo__pc1()')
+            res.append('# Top node: /pc1')
+            res.append('{self_name} = foo__pc1()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            res.extend(_foo.prsrc(f'{self_name}.foo', False).splitlines())
+            res.extend(_foo.prsrc('{self_name}.foo', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1'] + leaves + res
@@ -555,12 +555,12 @@ class foo__pc2__foo(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc2/foo')
-            res.append(f'{self_name} = foo__pc2__foo()')
+            res.append('# Top node: /pc2/foo')
+            res.append('{self_name} = foo__pc2__foo()')
         leaves = []
         _l_mandatory = self.l_mandatory
         if _l_mandatory is not None:
-            leaves.append(f'{self_name}.l_mandatory = {repr(_l_mandatory)}')
+            leaves.append('{self_name}.l_mandatory = {repr(_l_mandatory)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc2/foo'] + leaves + res
@@ -620,12 +620,12 @@ class foo__pc2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc2')
-            res.append(f'{self_name} = foo__pc2()')
+            res.append('# Top node: /pc2')
+            res.append('{self_name} = foo__pc2()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            res.extend(_foo.prsrc(f'{self_name}.foo', False).splitlines())
+            res.extend(_foo.prsrc('{self_name}.foo', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc2'] + leaves + res
@@ -727,15 +727,15 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3/level1/level2/level3')
-            res.append(f'{self_name} = foo__pc3__level1__level2__level3()')
+            res.append('# Top node: /pc3/level1/level2/level3')
+            res.append('{self_name} = foo__pc3__level1__level2__level3()')
         leaves = []
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append(f'{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
         _l3_optional = self.l3_optional
         if _l3_optional is not None:
-            leaves.append(f'{self_name}.l3_optional = {repr(_l3_optional)}')
+            leaves.append('{self_name}.l3_optional = {repr(_l3_optional)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1/level2/level3'] + leaves + res
@@ -811,18 +811,18 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3/level1/level2')
-            res.append(f'{self_name} = foo__pc3__level1__level2()')
+            res.append('# Top node: /pc3/level1/level2')
+            res.append('{self_name} = foo__pc3__level1__level2()')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         _l2_optional = self.l2_optional
         if _l2_optional is not None:
-            leaves.append(f'{self_name}.l2_optional = {repr(_l2_optional)}')
+            leaves.append('{self_name}.l2_optional = {repr(_l2_optional)}')
         _level3 = self.level3
         if _level3 is not None:
-            res.extend(_level3.prsrc(f'{self_name}.level3', False).splitlines())
+            res.extend(_level3.prsrc('{self_name}.level3', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1/level2'] + leaves + res
@@ -905,18 +905,18 @@ class foo__pc3__level1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3/level1')
-            res.append(f'{self_name} = foo__pc3__level1()')
+            res.append('# Top node: /pc3/level1')
+            res.append('{self_name} = foo__pc3__level1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l1_optional = self.l1_optional
         if _l1_optional is not None:
-            leaves.append(f'{self_name}.l1_optional = {repr(_l1_optional)}')
+            leaves.append('{self_name}.l1_optional = {repr(_l1_optional)}')
         _level2 = self.level2
         if _level2 is not None:
-            res.extend(_level2.prsrc(f'{self_name}.level2', False).splitlines())
+            res.extend(_level2.prsrc('{self_name}.level2', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1'] + leaves + res
@@ -989,12 +989,12 @@ class foo__pc3(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /pc3')
-            res.append(f'{self_name} = foo__pc3()')
+            res.append('# Top node: /pc3')
+            res.append('{self_name} = foo__pc3()')
         leaves = []
         _level1 = self.level1
         if _level1 is not None:
-            res.extend(_level1.prsrc(f'{self_name}.level1', False).splitlines())
+            res.extend(_level1.prsrc('{self_name}.level1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3'] + leaves + res
@@ -1051,8 +1051,8 @@ class foo__empty_presence(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /empty-presence')
-            res.append(f'{self_name} = foo__empty_presence()')
+            res.append('# Top node: /empty-presence')
+            res.append('{self_name} = foo__empty_presence()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1124,15 +1124,15 @@ class foo__c_dot(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c.dot')
-            res.append(f'{self_name} = foo__c_dot()')
+            res.append('# Top node: /c.dot')
+            res.append('{self_name} = foo__c_dot()')
         leaves = []
         _l_dot1 = self.l_dot1
         if _l_dot1 is not None:
-            leaves.append(f'{self_name}.l_dot1 = {repr(_l_dot1)}')
+            leaves.append('{self_name}.l_dot1 = {repr(_l_dot1)}')
         _l_dot2 = self.l_dot2
         if _l_dot2 is not None:
-            leaves.append(f'{self_name}.l_dot2 = {repr(_l_dot2)}')
+            leaves.append('{self_name}.l_dot2 = {repr(_l_dot2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c.dot'] + leaves + res
@@ -1208,8 +1208,8 @@ class foo__cc__death_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /cc/death')
-            res.append(f'{self_name} = foo__cc__death({repr(self.name)})')
+            res.append('# Top node: /cc/death')
+            res.append('{self_name} = foo__cc__death({repr(self.name)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1346,19 +1346,19 @@ class foo__cc(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /cc')
-            res.append(f'{self_name} = foo__cc()')
+            res.append('# Top node: /cc')
+            res.append('{self_name} = foo__cc()')
         leaves = []
         _cake = self.cake
         if _cake is not None:
-            leaves.append(f'{self_name}.cake = {repr(_cake)}')
+            leaves.append('{self_name}.cake = {repr(_cake)}')
         _death = self.death
         for _element in _death.elements:
             res.append('')
             res.append("# List /cc/death element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'death_element = {self_name}.death.create({repr(_element.name)})'
+            list_elem = 'death_element = {self_name}.death.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'death_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('death_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /cc'] + leaves + res
@@ -1427,8 +1427,8 @@ class foo__conflict__f_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict/f:inner')
-            res.append(f'{self_name} = foo__conflict__f_inner()')
+            res.append('# Top node: /conflict/f:inner')
+            res.append('{self_name} = foo__conflict__f_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1485,8 +1485,8 @@ class foo__conflict__bar_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict/bar:inner')
-            res.append(f'{self_name} = foo__conflict__bar_inner()')
+            res.append('# Top node: /conflict/bar:inner')
+            res.append('{self_name} = foo__conflict__bar_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1566,26 +1566,26 @@ class foo__conflict(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict')
-            res.append(f'{self_name} = foo__conflict()')
+            res.append('# Top node: /conflict')
+            res.append('{self_name} = foo__conflict()')
         leaves = []
         _f_foo = self.f_foo
         if _f_foo is not None:
-            leaves.append(f'{self_name}.f_foo = {repr(_f_foo)}')
+            leaves.append('{self_name}.f_foo = {repr(_f_foo)}')
         _f_inner = self.f_inner
         if _f_inner is not None:
             res.append('')
             res.append('# P-container: /conflict/f:inner')
-            res.append(f'inner = {self_name}.create_f_inner()')
+            res.append('inner = {self_name}.create_f_inner()')
             res.extend(_f_inner.prsrc('f_inner', False).splitlines())
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
-            leaves.append(f'{self_name}.bar_foo = {repr(_bar_foo)}')
+            leaves.append('{self_name}.bar_foo = {repr(_bar_foo)}')
         _bar_inner = self.bar_inner
         if _bar_inner is not None:
             res.append('')
             res.append('# P-container: /conflict/bar:inner')
-            res.append(f'inner = {self_name}.create_bar_inner()')
+            res.append('inner = {self_name}.create_bar_inner()')
             res.extend(_bar_inner.prsrc('bar_inner', False).splitlines())
         if leaves:
             if not list_element:
@@ -1670,8 +1670,8 @@ class foo__special_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /special')
-            res.append(f'{self_name} = foo__special({repr(self.yes)})')
+            res.append('# Top node: /special')
+            res.append('{self_name} = foo__special({repr(self.yes)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1847,12 +1847,12 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/f:inner/li1/li2')
-            res.append(f'{self_name} = foo__nested__f_inner__li1__li2({repr(self.key1)}, {repr(self.key2)})')
+            res.append('# Top node: /nested/f:inner/li1/li2')
+            res.append('{self_name} = foo__nested__f_inner__li1__li2({repr(self.key1)}, {repr(self.key2)})')
         leaves = []
         _baz = self.baz
         if _baz is not None:
-            leaves.append(f'{self_name}.baz = {repr(_baz)}')
+            leaves.append('{self_name}.baz = {repr(_baz)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1/li2'] + leaves + res
@@ -2016,22 +2016,22 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/f:inner/li1')
-            res.append(f'{self_name} = foo__nested__f_inner__li1({repr(self.name)})')
+            res.append('# Top node: /nested/f:inner/li1')
+            res.append('{self_name} = foo__nested__f_inner__li1({repr(self.name)})')
         leaves = []
         _f_bar = self.f_bar
         if _f_bar is not None:
-            leaves.append(f'{self_name}.f_bar = {repr(_f_bar)}')
+            leaves.append('{self_name}.f_bar = {repr(_f_bar)}')
         _li2 = self.li2
         for _element in _li2.elements:
             res.append('')
             res.append("# List /nested/f:inner/li1/li2 element: {_element.to_gdata().key_str(['key1', 'key2'])}")
-            list_elem = f'li2_element = {self_name}.li2.create({repr(_element.key1)}, {repr(_element.key2)})'
+            list_elem = 'li2_element = {self_name}.li2.create({repr(_element.key1)}, {repr(_element.key2)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li2_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li2_element', False, list_element=True).splitlines())
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
-            leaves.append(f'{self_name}.bar_bar = {repr(_bar_bar)}')
+            leaves.append('{self_name}.bar_bar = {repr(_bar_bar)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1'] + leaves + res
@@ -2185,19 +2185,19 @@ class foo__nested__f_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/f:inner')
-            res.append(f'{self_name} = foo__nested__f_inner()')
+            res.append('# Top node: /nested/f:inner')
+            res.append('{self_name} = foo__nested__f_inner()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         _li1 = self.li1
         for _element in _li1.elements:
             res.append('')
             res.append("# List /nested/f:inner/li1 element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = f'li1_element = {self_name}.li1.create({repr(_element.name)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.name)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li1_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner'] + leaves + res
@@ -2270,12 +2270,12 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested/bar:inner')
-            res.append(f'{self_name} = foo__nested__bar_inner()')
+            res.append('# Top node: /nested/bar:inner')
+            res.append('{self_name} = foo__nested__bar_inner()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/bar:inner'] + leaves + res
@@ -2340,15 +2340,15 @@ class foo__nested(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /nested')
-            res.append(f'{self_name} = foo__nested()')
+            res.append('# Top node: /nested')
+            res.append('{self_name} = foo__nested()')
         leaves = []
         _f_inner = self.f_inner
         if _f_inner is not None:
-            res.extend(_f_inner.prsrc(f'{self_name}.f_inner', False).splitlines())
+            res.extend(_f_inner.prsrc('{self_name}.f_inner', False).splitlines())
         _bar_inner = self.bar_inner
         if _bar_inner is not None:
-            res.extend(_bar_inner.prsrc(f'{self_name}.bar_inner', False).splitlines())
+            res.extend(_bar_inner.prsrc('{self_name}.bar_inner', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested'] + leaves + res
@@ -2442,8 +2442,8 @@ class foo__li_union_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /li-union')
-            res.append(f'{self_name} = foo__li_union({repr(self.k1)}, {repr(self.k2)}, {repr(self.k3)})')
+            res.append('# Top node: /li-union')
+            res.append('{self_name} = foo__li_union({repr(self.k1)}, {repr(self.k2)}, {repr(self.k3)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -2620,15 +2620,15 @@ class foo__state__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /state/c1')
-            res.append(f'{self_name} = foo__state__c1()')
+            res.append('# Top node: /state/c1')
+            res.append('{self_name} = foo__state__c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /state/c1'] + leaves + res
@@ -2694,12 +2694,12 @@ class foo__state(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /state')
-            res.append(f'{self_name} = foo__state()')
+            res.append('# Top node: /state')
+            res.append('{self_name} = foo__state()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /state'] + leaves + res
@@ -2766,12 +2766,12 @@ class foo__c2(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /c2')
-            res.append(f'{self_name} = foo__c2()')
+            res.append('# Top node: /c2')
+            res.append('{self_name} = foo__c2()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append(f'{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c2'] + leaves + res
@@ -2837,12 +2837,12 @@ class bar__conflict(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /conflict')
-            res.append(f'{self_name} = bar__conflict()')
+            res.append('# Top node: /conflict')
+            res.append('{self_name} = bar__conflict()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append(f'{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /conflict'] + leaves + res
@@ -2987,71 +2987,71 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'{self_name} = root()')
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         _pc1 = self.pc1
         if _pc1 is not None:
             res.append('')
             res.append('# P-container: /pc1')
-            res.append(f'pc1 = {self_name}.create_pc1()')
+            res.append('pc1 = {self_name}.create_pc1()')
             res.extend(_pc1.prsrc('pc1', False).splitlines())
         _pc2 = self.pc2
         if _pc2 is not None:
             res.append('')
             res.append('# P-container: /pc2')
-            res.append(f'pc2 = {self_name}.create_pc2()')
+            res.append('pc2 = {self_name}.create_pc2()')
             res.extend(_pc2.prsrc('pc2', False).splitlines())
         _pc3 = self.pc3
         if _pc3 is not None:
             res.append('')
             res.append('# P-container: /pc3')
-            res.append(f'pc3 = {self_name}.create_pc3()')
+            res.append('pc3 = {self_name}.create_pc3()')
             res.extend(_pc3.prsrc('pc3', False).splitlines())
         _empty_presence = self.empty_presence
         if _empty_presence is not None:
             res.append('')
             res.append('# P-container: /empty-presence')
-            res.append(f'empty_presence = {self_name}.create_empty_presence()')
+            res.append('empty_presence = {self_name}.create_empty_presence()')
             res.extend(_empty_presence.prsrc('empty_presence', False).splitlines())
         _c_dot = self.c_dot
         if _c_dot is not None:
-            res.extend(_c_dot.prsrc(f'{self_name}.c_dot', False).splitlines())
+            res.extend(_c_dot.prsrc('{self_name}.c_dot', False).splitlines())
         _cc = self.cc
         if _cc is not None:
-            res.extend(_cc.prsrc(f'{self_name}.cc', False).splitlines())
+            res.extend(_cc.prsrc('{self_name}.cc', False).splitlines())
         _f_conflict = self.f_conflict
         if _f_conflict is not None:
-            res.extend(_f_conflict.prsrc(f'{self_name}.f_conflict', False).splitlines())
+            res.extend(_f_conflict.prsrc('{self_name}.f_conflict', False).splitlines())
         _special = self.special
         for _element in _special.elements:
             res.append('')
             res.append("# List /special element: {_element.to_gdata().key_str(['yes'])}")
-            list_elem = f'special_element = {self_name}.special.create({repr(_element.yes)})'
+            list_elem = 'special_element = {self_name}.special.create({repr(_element.yes)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'special_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('special_element', False, list_element=True).splitlines())
         _nested = self.nested
         if _nested is not None:
-            res.extend(_nested.prsrc(f'{self_name}.nested', False).splitlines())
+            res.extend(_nested.prsrc('{self_name}.nested', False).splitlines())
         _li_union = self.li_union
         for _element in _li_union.elements:
             res.append('')
             res.append("# List /li-union element: {_element.to_gdata().key_str(['k1', 'k2', 'k3'])}")
-            list_elem = f'li_union_element = {self_name}.li_union.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.k3)})'
+            list_elem = 'li_union_element = {self_name}.li_union.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.k3)})'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li_union_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li_union_element', False, list_element=True).splitlines())
         _state = self.state
         if _state is not None:
-            res.extend(_state.prsrc(f'{self_name}.state', False).splitlines())
+            res.extend(_state.prsrc('{self_name}.state', False).splitlines())
         _c2 = self.c2
         if _c2 is not None:
-            res.extend(_c2.prsrc(f'{self_name}.c2', False).splitlines())
+            res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
-            res.extend(_bar_conflict.prsrc(f'{self_name}.bar_conflict', False).splitlines())
+            res.extend(_bar_conflict.prsrc('{self_name}.bar_conflict', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -48,12 +48,12 @@ class foo__tc1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /tc1')
-            res.append(f'{self_name} = foo__tc1({repr(self.l1)})')
+            res.append('# Top node: /tc1')
+            res.append('{self_name} = foo__tc1({repr(self.l1)})')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /tc1'] + leaves + res
@@ -142,12 +142,12 @@ class foo__li__c1(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /li/c1')
-            res.append(f'{self_name} = foo__li__c1({repr(self.l1)})')
+            res.append('# Top node: /li/c1')
+            res.append('{self_name} = foo__li__c1({repr(self.l1)})')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append(f'{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /li/c1'] + leaves + res
@@ -216,13 +216,13 @@ class foo__li_entry(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /li')
-            res.append(f'self_c1 = foo__li__c1({repr(self.c1.l1)})')
-            res.append(f'{self_name} = foo__li({repr(self.name)}, self_c1)')
+            res.append('# Top node: /li')
+            res.append('self_c1 = foo__li__c1({repr(self.c1.l1)})')
+            res.append('{self_name} = foo__li({repr(self.name)}, self_c1)')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
-            res.extend(_c1.prsrc(f'{self_name}.c1', False).splitlines())
+            res.extend(_c1.prsrc('{self_name}.c1', False).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /li'] + leaves + res
@@ -364,21 +364,21 @@ class root(yang.adata.MNode):
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
-            res.append(f'# Top node: /root')
-            res.append(f'self_tc1 = foo__tc1({repr(self.tc1.l1)})')
-            res.append(f'{self_name} = root(self_tc1)')
+            res.append('# Top node: /root')
+            res.append('self_tc1 = foo__tc1({repr(self.tc1.l1)})')
+            res.append('{self_name} = root(self_tc1)')
         leaves = []
         _tc1 = self.tc1
         if _tc1 is not None:
-            res.extend(_tc1.prsrc(f'{self_name}.tc1', False).splitlines())
+            res.extend(_tc1.prsrc('{self_name}.tc1', False).splitlines())
         _li = self.li
         for _element in _li.elements:
             res.append('')
             res.append("# List /li element: {_element.to_gdata().key_str(['name'])}")
-            res.append(f'element_c1 = foo__li__c1({repr(_element.c1.l1)})')
-            list_elem = f'li_element = {self_name}.li.create({repr(_element.name)}, element_c1)'
+            res.append('element_c1 = foo__li__c1({repr(_element.c1.l1)})')
+            list_elem = 'li_element = {self_name}.li.create({repr(_element.name)}, element_c1)'
             res.append(list_elem)
-            res.extend(_element.prsrc(f'li_element', False, list_element=True).splitlines())
+            res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         if leaves:
             if not list_element:
                res = ['', '# Container: /root'] + leaves + res


### PR DESCRIPTION
In the adata.prsrc() method generator we use interpolated strings that themselves contain interpolated strings. The "f" prefix is no longer necessary, even for the inner string.