### PR TITLE
Harmonize gdata "takers" with XML, JSON

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -508,10 +508,8 @@ class DNodeInner(DNode):
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
         for child in self.children:
-            if isinstance(child, DLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}('{uname(child)}')")
-            elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}s('{uname(child)}')")
+            if isinstance(child, DNodeLeaf):
+                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}')")
             else:
                 from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}'))")
         from_gdata_args = ", ".join(from_gdata_args_list)
@@ -2211,12 +2209,6 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
             return taker_prefix + optional_str + "int64s"
         return taker_prefix + optional_str + yang_type_to_acton_type(n.type_) + "s"
     raise ValueError("unreachable - unknown node type {type(n)}")
-
-def yang_leaf_to_getval(leaf: DNodeLeaf, loose: bool) -> str:
-    optional = is_optional_arg_yang_leaf(leaf, loose)
-    optional_str = "opt_" if optional else ""
-    t = yang_type_to_acton_type(leaf.type_)
-    return optional_str + t
 
 def yang_leaflist_to_acton_type(leaf: DLeafList) -> str:
     t = yang_type_to_acton_type(leaf.type_)

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -512,13 +512,8 @@ class DNodeInner(DNode):
                 from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}('{uname(child)}')")
             elif isinstance(child, DLeafList):
                 from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}s('{uname(child)}')")
-            elif isinstance(child, DContainer):
-                if loose or child.presence or optional_subtree(child):
-                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.get_opt_container('{uname(child)}'))")
-                else:
-                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.get_container('{uname(child)}'))")
-            elif isinstance(child, DList):
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.get_opt_list('{uname(child)}'))")
+            else:
+                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}'))")
         from_gdata_args = ", ".join(from_gdata_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
@@ -2189,6 +2184,8 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         taker_prefix = "from_xml_"
     elif input_format == "json":
         taker_prefix = "take_json_"
+    elif input_format == "gdata":
+        taker_prefix = "get_"
     else:
         raise ValueError("Unknown input format {input_format}")
     if isinstance(n, DContainer):

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -479,6 +479,9 @@ class Node(value):
             if isinstance(childval, bool):
                 return childval
 
+    def get_opt_empty(self, name) -> ?bool:
+        return self.get_opt_bool(name)
+
     def get_float(self, name) -> float:
         child = self.get_leaf(name)
         childval = child.val

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -439,17 +439,17 @@ class Node(value):
 
     #--
 
-    def get_container(self, name) -> Container:
+    def get_cnt(self, name) -> Container:
         if isinstance(self, Container):
             for nm,child in self.children.items():
                 if isinstance(child, Container) and nm == name:
                     return child
         raise ValueError("Cannot find container child with name {name}")
 
-    def get_opt_container(self, name) -> ?Container:
+    def get_opt_cnt(self, name) -> ?Container:
         """This is for P-container"""
         try:
-            return self.get_container(name)
+            return self.get_cnt(name)
         except ValueError:
             return None
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -508,13 +508,8 @@ class DNodeInner(DNode):
                 from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}('{uname(child)}')")
             elif isinstance(child, DLeafList):
                 from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}s('{uname(child)}')")
-            elif isinstance(child, DContainer):
-                if loose or child.presence or optional_subtree(child):
-                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.get_opt_container('{uname(child)}'))")
-                else:
-                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.get_container('{uname(child)}'))")
-            elif isinstance(child, DList):
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.get_opt_list('{uname(child)}'))")
+            else:
+                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}'))")
         from_gdata_args = ", ".join(from_gdata_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
@@ -2185,6 +2180,8 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         taker_prefix = "from_xml_"
     elif input_format == "json":
         taker_prefix = "take_json_"
+    elif input_format == "gdata":
+        taker_prefix = "get_"
     else:
         raise ValueError("Unknown input format {input_format}")
     if isinstance(n, DContainer):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -504,10 +504,8 @@ class DNodeInner(DNode):
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
         for child in self.children:
-            if isinstance(child, DLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}('{uname(child)}')")
-            elif isinstance(child, DLeafList):
-                from_gdata_args_list.append("{usname(child)}=n.get_{yang_leaf_to_getval(child, loose)}s('{uname(child)}')")
+            if isinstance(child, DNodeLeaf):
+                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}')")
             else:
                 from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}'))")
         from_gdata_args = ", ".join(from_gdata_args_list)
@@ -2207,12 +2205,6 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
             return taker_prefix + optional_str + "int64s"
         return taker_prefix + optional_str + yang_type_to_acton_type(n.type_) + "s"
     raise ValueError("unreachable - unknown node type {type(n)}")
-
-def yang_leaf_to_getval(leaf: DNodeLeaf, loose: bool) -> str:
-    optional = is_optional_arg_yang_leaf(leaf, loose)
-    optional_str = "opt_" if optional else ""
-    t = yang_type_to_acton_type(leaf.type_)
-    return optional_str + t
 
 def yang_leaflist_to_acton_type(leaf: DLeafList) -> str:
     t = yang_type_to_acton_type(leaf.type_)

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -115,7 +115,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -76,7 +76,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -115,7 +115,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -126,7 +126,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_container('c2')))
+            return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_cnt('c2')))
         return foo__c1()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -201,7 +201,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -126,7 +126,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_container('c2')))
+            return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_cnt('c2')))
         return foo__c1()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -201,7 +201,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -95,7 +95,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(c2=foo__c1__c2.from_gdata(n.get_opt_container('c2')))
+            return foo__c1(c2=foo__c1__c2.from_gdata(n.get_opt_cnt('c2')))
         return foo__c1()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -161,7 +161,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -115,7 +115,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -251,7 +251,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -95,7 +95,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=acme_foo_bar__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=acme_foo_bar__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -231,7 +231,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=bar__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=bar__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -93,7 +93,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -171,7 +171,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), c2=foo__c2.from_gdata(n.get_opt_container('c2')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -231,7 +231,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -115,7 +115,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -104,7 +104,7 @@ class foo__c__li_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__c__li_entry:
-        return foo__c__li_entry(name=n.get_str('name'), foo=n.get_opt_str('foo'), bar=foo__c__li__bar.from_gdata(n.get_container('bar')))
+        return foo__c__li_entry(name=n.get_str('name'), foo=n.get_opt_str('foo'), bar=foo__c__li__bar.from_gdata(n.get_cnt('bar')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -394,7 +394,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=base__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=base__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -162,7 +162,7 @@ class base__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__c1:
         if n != None:
-            return base__c1(base_c2=base__c1__base_c2.from_gdata(n.get_opt_container('base:c2')), foo_c2=base__c1__foo_c2.from_gdata(n.get_opt_container('foo:c2')))
+            return base__c1(base_c2=base__c1__base_c2.from_gdata(n.get_opt_cnt('base:c2')), foo_c2=base__c1__foo_c2.from_gdata(n.get_opt_cnt('foo:c2')))
         return base__c1()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -238,7 +238,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=base__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=base__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -95,7 +95,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(ieee_802_3=foo__ieee_802_3.from_gdata(n.get_opt_container('ieee-802.3')))
+            return root(ieee_802_3=foo__ieee_802_3.from_gdata(n.get_opt_cnt('ieee-802.3')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -86,7 +86,7 @@ class foo__foo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo:
         if n != None:
-            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
+            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt('bar')))
         raise ValueError('Missing required subtree foo__foo')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -91,7 +91,7 @@ class foo__foo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo:
         if n != None:
-            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
+            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt('bar')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -170,7 +170,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(li1=foo__li1.from_gdata(n.get_opt_list('li1')), ll1=n.get_strs('ll1'))
+            return root(li1=foo__li1.from_gdata(n.get_list('li1')), ll1=n.get_strs('ll1'))
         raise ValueError('Missing required subtree root')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -116,7 +116,7 @@ class foo__l1_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=n.get_str('name'), id=n.get_opt_str('id'), bar=foo__l1__bar.from_gdata(n.get_opt_container('bar')))
+        return foo__l1_entry(name=n.get_str('name'), id=n.get_opt_str('id'), bar=foo__l1__bar.from_gdata(n.get_opt_cnt('bar')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -98,7 +98,7 @@ class foo__l1_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
-        return foo__l1_entry(name=n.get_str('name'), bar=foo__l1__bar.from_gdata(n.get_opt_container('bar')))
+        return foo__l1_entry(name=n.get_str('name'), bar=foo__l1__bar.from_gdata(n.get_opt_cnt('bar')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -131,7 +131,7 @@ class foo__foo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__foo:
         if n != None:
-            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_container('bar')))
+            return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt('bar')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -205,7 +205,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(foo=foo__foo.from_gdata(n.get_opt_container('foo')))
+            return root(foo=foo__foo.from_gdata(n.get_opt_cnt('foo')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -171,7 +171,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(bar_c1=bar__c1.from_gdata(n.get_opt_container('bar:c1')), foo_c1=foo__c1.from_gdata(n.get_opt_container('foo:c1')))
+            return root(bar_c1=bar__c1.from_gdata(n.get_opt_cnt('bar:c1')), foo_c1=foo__c1.from_gdata(n.get_opt_cnt('foo:c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -166,7 +166,7 @@ class foo__pc1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container('foo')))
+            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -242,7 +242,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -274,7 +274,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -274,7 +274,7 @@ def _test_foo_from_xml_pc1():
     xml_in = xml.decode(xml_text)
     gd = yang_foo.from_xml(xml_in)
     print(gd.prsrc(), err=True)
-    pc1_gdata = gd.get_opt_container("pc1")
+    pc1_gdata = gd.get_opt_cnt("pc1")
     if pc1_gdata is not None:
         testing.assertTrue(pc1_gdata.presence)
     else:
@@ -312,7 +312,7 @@ def _test_foo_from_xml2():
     gd = yang_foo.from_xml(xml_in)
     print(gd.prsrc(), err=True)
     # The sibling presence container pc1 must not appear here
-    pc1_gdata = gd.get_opt_container("pc1")
+    pc1_gdata = gd.get_opt_cnt("pc1")
     if pc1_gdata is not None:
         testing.error("pc1 found in gdata")
     ad = yang_foo_root.from_gdata(gd)
@@ -444,7 +444,7 @@ def _test_foo_from_gdata_int():
 </data>"""
     xml_in = xml.decode(xml_text)
     gd = yang_foo.from_xml(xml_in)
-    l3 = gd.get_container("c1").get_leaf("l3").val
+    l3 = gd.get_cnt("c1").get_leaf("l3").val
     if isinstance(l3, int):
         testing.assertEqual(l3, 1337)
     else:

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -256,7 +256,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c=basics__c.from_gdata(n.get_opt_container('c')))
+            return root(c=basics__c.from_gdata(n.get_opt_cnt('c')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -266,7 +266,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
+            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -477,7 +477,7 @@ class foo__pc1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container('foo')))
+            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -611,7 +611,7 @@ class foo__pc2(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc2:
         if n != None:
-            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_container('foo')))
+            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt('foo')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -800,7 +800,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1__level2:
         if n != None:
-            return foo__pc3__level1__level2(l2=n.get_str('l2'), l2_optional=n.get_opt_str('l2-optional'), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_container('level3')))
+            return foo__pc3__level1__level2(l2=n.get_str('l2'), l2_optional=n.get_opt_str('l2-optional'), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt('level3')))
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -892,7 +892,7 @@ class foo__pc3__level1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1:
         if n != None:
-            return foo__pc3__level1(l1=n.get_str('l1'), l1_optional=n.get_opt_str('l1-optional'), level2=foo__pc3__level1__level2.from_gdata(n.get_container('level2')))
+            return foo__pc3__level1(l1=n.get_str('l1'), l1_optional=n.get_opt_str('l1-optional'), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt('level2')))
         raise ValueError('Missing required subtree foo__pc3__level1')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -975,7 +975,7 @@ class foo__pc3(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc3:
         if n != None:
-            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_container('level1')))
+            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt('level1')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -1555,7 +1555,7 @@ class foo__conflict(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
+            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__conflict()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -2329,7 +2329,7 @@ class foo__nested(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested:
         if n != None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
+            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__nested()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -2683,7 +2683,7 @@ class foo__state(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
         if n != None:
-            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_container('c1')))
+            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt('c1')))
         return foo__state()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -2976,7 +2976,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_container('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_container('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), c2=foo__c2.from_gdata(n.get_opt_container('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -266,7 +266,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n != None:
-            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_bool('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
+            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -477,7 +477,7 @@ class foo__pc1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
         if n != None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_container('foo')))
+            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -614,7 +614,7 @@ class foo__pc2(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc2:
         if n != None:
-            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_container('foo')))
+            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -805,7 +805,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1__level2:
         if n != None:
-            return foo__pc3__level1__level2(l2=n.get_opt_str('l2'), l2_optional=n.get_opt_str('l2-optional'), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_container('level3')))
+            return foo__pc3__level1__level2(l2=n.get_opt_str('l2'), l2_optional=n.get_opt_str('l2-optional'), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt('level3')))
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -899,7 +899,7 @@ class foo__pc3__level1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1:
         if n != None:
-            return foo__pc3__level1(l1=n.get_opt_str('l1'), l1_optional=n.get_opt_str('l1-optional'), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_container('level2')))
+            return foo__pc3__level1(l1=n.get_opt_str('l1'), l1_optional=n.get_opt_str('l1-optional'), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt('level2')))
         raise ValueError('Missing required subtree foo__pc3__level1')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -983,7 +983,7 @@ class foo__pc3(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc3:
         if n != None:
-            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_container('level1')))
+            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt('level1')))
         return None
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -1560,7 +1560,7 @@ class foo__conflict(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
         if n != None:
-            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
+            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__conflict()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -2334,7 +2334,7 @@ class foo__nested(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested:
         if n != None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_container('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_container('bar:inner')))
+            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__nested()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -2688,7 +2688,7 @@ class foo__state(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
         if n != None:
-            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_container('c1')))
+            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt('c1')))
         return foo__state()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -2981,7 +2981,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_container('c1')), pc1=foo__pc1.from_gdata(n.get_opt_container('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_container('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_container('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_container('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_container('c.dot')), cc=foo__cc.from_gdata(n.get_opt_container('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_container('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_container('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_container('state')), c2=foo__c2.from_gdata(n.get_opt_container('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_container('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -211,7 +211,7 @@ class foo__li_entry(yang.adata.MNode):
 
     @staticmethod
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_entry:
-        return foo__li_entry(name=n.get_str('name'), c1=foo__li__c1.from_gdata(n.get_container('c1')))
+        return foo__li_entry(name=n.get_str('name'), c1=foo__li__c1.from_gdata(n.get_cnt('c1')))
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -358,7 +358,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n != None:
-            return root(tc1=foo__tc1.from_gdata(n.get_container('tc1')), li=foo__li.from_gdata(n.get_opt_list('li')))
+            return root(tc1=foo__tc1.from_gdata(n.get_cnt('tc1')), li=foo__li.from_gdata(n.get_opt_list('li')))
         raise ValueError('Missing required subtree root')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):


### PR DESCRIPTION
Refactor the `from_gdata()` generator to harmonize with `from_xml()` and `from_json()`. This allows us to consolidate the edge cases for (non-)optional in one place - the `taker_name()` function.