### PR TITLE
Cleanup common.act

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -438,14 +438,11 @@ class DNodeInner(DNode):
                 child_default = child.default
                 if not loose and child_default is not None:
                     if child.type_.name == "identityref":
-                        parts = child_default.split(":")
-                        if len(parts) == 1:
-                            prefix = child.prefix
-                            name = parts[0]
+                        prefix, name = split_prefix_name(child_default)
+                        if prefix is None or prefix == child.prefix:
+                            child_default = "Identityref('{name}')"
                         else:
-                            prefix = parts[0]
-                            name = parts[1]
-                        child_default = """Identityref('{name}', mod_to_ns[prefix_to_mod["{prefix}"]], prefix_to_mod["{prefix}"])"""
+                            child_default = """Identityref('{name}', mod_to_ns[prefix_to_mod["{prefix}"]], prefix_to_mod["{prefix}"])"""
                     res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {prsrc_literal(child.type_.name, child_default)}")
                 else:
                     res.append("        self.{usname(child)} = {usname(child)}")

--- a/src/yang/common.act
+++ b/src/yang/common.act
@@ -16,7 +16,6 @@ class Identityref:
 
     @staticmethod
     def complete(partial: Identityref, ns_to_mod, mod_to_ns):
-        print(partial, ns_to_mod, mod_to_ns, err=True)
         partial_ns = partial.ns
         partial_mod = partial.mod
         if partial_ns is not None and partial_mod is None:

--- a/src/yang/common.act
+++ b/src/yang/common.act
@@ -6,7 +6,7 @@ def maybe_str(s):
         return "None"
 
 class Identityref:
-    val: value
+    val: str
     ns: ?str
     mod: ?str
 
@@ -62,77 +62,7 @@ extension Identityref (Ord):
         self_mod = self.mod
         other_ns = other.ns
         other_mod = other.mod
-        return vals_equal(self.val, other.val)
-
-       # return self.name == other.name and (self_arg is None and other_arg is None or (self_arg is not None and other_arg is not None and self_arg == other_arg))
+        return self.val == other.val and self_ns == other_ns and self_mod == other_mod
 
     def __lt__(self, other: Identityref) -> bool:
-        return vals_less_than(self.val, other.val)
-
-def vals_equal(a: value, b: value) -> bool:
-    # Compare known leaf value types
-    if isinstance(a, int) and isinstance(b, int):
-        return a == b
-    if isinstance(a, bool) and isinstance(b, bool):
-        return a == b
-    if isinstance(a, float) and isinstance(b, float):
-        return a == b
-    if isinstance(a, str) and isinstance(b, str):
-        return a == b
-    if isinstance(a, bytes) and isinstance(b, bytes):
-        return a == b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, u8) and isinstance(b, u8):
-    #    return a == b
-    if isinstance(a, u16) and isinstance(b, u16):
-        return a == b
-    if isinstance(a, u32) and isinstance(b, u32):
-        return a == b
-    if isinstance(a, u64) and isinstance(b, u64):
-        return a == b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, i8) and isinstance(b, i8):
-    #    return a == b
-    if isinstance(a, i16) and isinstance(b, i16):
-        return a == b
-    if isinstance(a, i32) and isinstance(b, i32):
-        return a == b
-    if isinstance(a, i64) and isinstance(b, i64):
-        return a == b
-    if isinstance(a, Identityref) and isinstance(b, Identityref):
-        return a == b
-    raise ValueError("Unsupported value type or mismatch in comparison: {type(a)}, {type(b)}")
-
-def vals_less_than(a: value, b: value) -> bool:
-    # Compare known leaf value types
-    if isinstance(a, int) and isinstance(b, int):
-        return a < b
-    if isinstance(a, bool) and isinstance(b, bool):
-        return not a  # False (0) before True (1)
-    if isinstance(a, float) and isinstance(b, float):
-        return a < b
-    if isinstance(a, str) and isinstance(b, str):
-        return a < b
-    if isinstance(a, bytes) and isinstance(b, bytes):
-        return a < b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, u8) and isinstance(b, u8):
-    #    return a < b
-    if isinstance(a, u16) and isinstance(b, u16):
-        return a < b
-    if isinstance(a, u32) and isinstance(b, u32):
-        return a < b
-    if isinstance(a, u64) and isinstance(b, u64):
-        return a < b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, i8) and isinstance(b, i8):
-    #    return a < b
-    if isinstance(a, i16) and isinstance(b, i16):
-        return a < b
-    if isinstance(a, i32) and isinstance(b, i32):
-        return a < b
-    if isinstance(a, i64) and isinstance(b, i64):
-        return a < b
-    if isinstance(a, Identityref) and isinstance(b, Identityref):
-        return a < b
-    raise ValueError("Unsupported value type or mismatch in comparison: {type(a)}, {type(b)}")
+        return self.val < other.val

--- a/src/yang/common.act
+++ b/src/yang/common.act
@@ -1,10 +1,3 @@
-
-def maybe_str(s):
-    if s is not None:
-        return "'{s}'"
-    else:
-        return "None"
-
 class Identityref:
     val: str
     ns: ?str
@@ -16,7 +9,7 @@ class Identityref:
         self.mod = mod
 
     def __str__(self):
-        return "Identityref('{self.val}', {maybe_str(self.ns)}, {maybe_str(self.mod)})"
+        return "Identityref({repr(self.val)}, {repr(self.ns)}, {repr(self.mod)})"
 
     def __repr__(self):
         return str(self)

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -434,14 +434,11 @@ class DNodeInner(DNode):
                 child_default = child.default
                 if not loose and child_default is not None:
                     if child.type_.name == "identityref":
-                        parts = child_default.split(":")
-                        if len(parts) == 1:
-                            prefix = child.prefix
-                            name = parts[0]
+                        prefix, name = split_prefix_name(child_default)
+                        if prefix is None or prefix == child.prefix:
+                            child_default = "Identityref('{name}')"
                         else:
-                            prefix = parts[0]
-                            name = parts[1]
-                        child_default = """Identityref('{name}', mod_to_ns[prefix_to_mod["{prefix}"]], prefix_to_mod["{prefix}"])"""
+                            child_default = """Identityref('{name}', mod_to_ns[prefix_to_mod["{prefix}"]], prefix_to_mod["{prefix}"])"""
                     res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {prsrc_literal(child.type_.name, child_default)}")
                 else:
                     res.append("        self.{usname(child)} = {usname(child)}")

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -498,7 +498,7 @@ def basics_leaf_defaults(r):
     testing.assertEqual(r.c.l_uint64_def, 1234567890)
     testing.assertEqual(r.c.l_str_def_quoted, '"foo"')
     testing.assertEqual(r.c.l_binary_def, "Hello Acton 🫡".encode())
-    testing.assertEqual(r.c.l_identityref_def, Identityref("id1", None, None))
+    testing.assertEqual(r.c.l_identityref_def, Identityref("id1"))
 
     # union types
     uds = r.c.l_union_def_str

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -99,7 +99,7 @@ class basics__c(yang.adata.MNode):
         self.l_union_def_bool = l_union_def_bool if l_union_def_bool is not None else False
         self.l_union_def_enumeration = l_union_def_enumeration if l_union_def_enumeration is not None else "unlimited"
         self.l_binary_def = l_binary_def if l_binary_def is not None else base64.decode('SGVsbG8gQWN0b24g8J+roQ=='.encode())
-        self.l_identityref_def = l_identityref_def if l_identityref_def is not None else Identityref('id1', mod_to_ns[prefix_to_mod["b"]], prefix_to_mod["b"])
+        self.l_identityref_def = l_identityref_def if l_identityref_def is not None else Identityref('id1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}


### PR DESCRIPTION
We can simplify the `Identityref` by storing the value (name) as a string ...