### PR TITLE
Submodule shares parent identifier namespace

### DIFF
--- a/src/yang.act
+++ b/src/yang.act
@@ -118,9 +118,11 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
 
                 for c in submod.children:
                     # TODO: Align submodule-local import prefixes to parent module imports
-                    # Attach subtree to parent module
+                    # Attach subtree to parent module, inherit identifier namespace from parent module
                     c.parent = m
                     c.ns = m.get_namespace()
+                    c.pfx = m.get_prefix()
+                    c.mod = m.get_module_name()
                     m.children.append(c)
 
                 m.augment.extend(submod.augment)


### PR DESCRIPTION
Submodule child nodes share the identifier namespace from the parent module they belong to.