### PR TITLE
Support eq on different types

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -846,7 +846,12 @@ def vals_equal(a: value, b: value) -> bool:
         return a == b
     if isinstance(a, Identityref) and isinstance(b, Identityref):
         return a == b
-    raise ValueError("Unsupported value type or mismatch in eq comparison: {type(a)}, {type(b)}")
+    if type(a) != type(b):
+        # It is valid to compare values of different type, which happens if
+        # leaves are of type union and value a and b happen to be of different
+        # type.
+        return False
+    raise ValueError("Unsupported value type in eq comparison")
 
 # For leaf-lists we need to compare a list of values
 def vals_list_equal(a: list[value], b: list[value]) -> bool:


### PR DESCRIPTION
For YANG leaf union types, the concrete values we get might be of different types, like a string and some integer. It is valid to compare them, for example for the purpose of computing a diff, and the result is always False. For diff computation this means that the values are always seen as different and thus the resulting diff will overwrite it - which is what we want.

Previously we considered comparing different types a sort of developer bug that should probably warrant more investigation. We loose that ability now. Not sure how useful it was / is. An alternative would be to thread through the supposed type of yang leafs, so we would see "union" and thus only allow the equality check of different concrete types when the leaf is a union... but meh, keep it simple for now.