### PR TITLE
Fix taker_name() for int64

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2557,13 +2557,13 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         if n.type_.name == "empty":
             return taker_prefix + optional_str + "empty"
-        if input_format == "json" and n.type_.name == "uint64" or n.type_.name == "int64":
+        if input_format == "json" and (n.type_.name == "uint64" or n.type_.name == "int64"):
             return taker_prefix + optional_str + "int64"
         return taker_prefix + optional_str + yang_type_to_acton_type(n.type_)
     if isinstance(n, DLeafList):
         optional = loose or n.min_elements == 0
         optional_str = "opt_" if optional else ""
-        if input_format == "json" and n.type_.name == "uint64" or n.type_.name == "int64":
+        if input_format == "json" and (n.type_.name == "uint64" or n.type_.name == "int64"):
             return taker_prefix + optional_str + "int64s"
         return taker_prefix + optional_str + yang_type_to_acton_type(n.type_) + "s"
     raise ValueError("unreachable - unknown node type {type(n)}")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2553,13 +2553,13 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         if n.type_.name == "empty":
             return taker_prefix + optional_str + "empty"
-        if input_format == "json" and n.type_.name == "uint64" or n.type_.name == "int64":
+        if input_format == "json" and (n.type_.name == "uint64" or n.type_.name == "int64"):
             return taker_prefix + optional_str + "int64"
         return taker_prefix + optional_str + yang_type_to_acton_type(n.type_)
     if isinstance(n, DLeafList):
         optional = loose or n.min_elements == 0
         optional_str = "opt_" if optional else ""
-        if input_format == "json" and n.type_.name == "uint64" or n.type_.name == "int64":
+        if input_format == "json" and (n.type_.name == "uint64" or n.type_.name == "int64"):
             return taker_prefix + optional_str + "int64s"
         return taker_prefix + optional_str + yang_type_to_acton_type(n.type_) + "s"
     raise ValueError("unreachable - unknown node type {type(n)}")


### PR DESCRIPTION
A missing parenthesis in the condition caused int64 YANG to use incorrect value taker.