### PR TITLE
Generate adata, rpc_root wrapper for RPC

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1090,6 +1090,80 @@ class DNodeInner(DNode):
             res.append("    return yang.gen3.from_json_path(s, jd, path, op, loose={loose})")
             res.append("")
 
+        if isinstance(self, DRoot) and len(self.rpcs) > 0:
+            # First generate data classes for RPC input/output
+            for rpc in self.rpcs:
+                # Generate adata classes for DInput, DOutput, but override:
+                # - set_ns: from DRpc (=True)
+                # - include_state=True
+                for child in rpc.children:
+                    child_class_src = child.prdaclass(schema_yang=schema_yang, loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
+                    res.append(child_class_src)
+
+            # TODO: unique safe name for RPC function!
+            # Generate rpc_handler actor
+            res.append("actor rpc_handler(tp: yang.gdata.TreeProvider):")
+            for rpc in self.rpcs:
+                input_node = rpc.input
+                output_node = rpc.output
+
+                # Get the actual generated class names using get_path_name
+                input_class_name = get_path_name(input_node) if input_node is not None else None
+                output_class_name = get_path_name(output_node) if output_node is not None else None
+
+
+                if input_node is not None:
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}):")
+                else:
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None):")
+                res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
+                res.append("            if res is not None:")
+                if output_node is not None:
+                    res.append("                gdata_res = from_xml_{output_class_name}(res)")
+                    res.append("                adata_res = {output_class_name}.from_gdata(gdata_res)")
+                    res.append("                cb(adata_res, err)")
+                else:
+                    res.append("                cb(None, err)")
+                res.append("            else:")
+                res.append("                cb(None, err)")
+                res.append("")
+                if input_node is not None:
+                    res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
+                else:
+                    res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
+                res.append("        print(xmlstr, err=True)")
+                res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
+                res.append("")
+            res.append("")
+
+            # Generate rpc_root class
+            # TODO: this wrapper class is not needed! We need an actor
+            # (currently rpc_handler) because we pass callback references, but
+            # we could instantiate it directly instead
+            res.append("class rpc_root(yang.adata.RpcRoot):")
+            res.append("    _handler: rpc_handler")
+            res.append("")
+            res.append("    def __init__(self, tp: yang.gdata.TreeProvider):")
+            res.append("        yang.adata.RpcRoot.__init__(self, tp)")
+            res.append("        self._handler = rpc_handler(tp)")
+            res.append("")
+            for rpc in self.rpcs:
+                input_node = rpc.input
+                output_node = rpc.output
+
+                # Get the actual generated class names using get_path_name
+                input_class_name = get_path_name(input_node) if input_node is not None else None
+                output_class_name = get_path_name(output_node) if output_node is not None else None
+
+                if input_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp)")
+                else:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb)")
+                res.append("")
+            res.append("")
+
         if top:
             res.append("schema_namespaces: set[str] = {{")
             for ns in sorted(schema_ns):
@@ -1292,7 +1366,7 @@ class DInput(DNodeInner):
         self.namespace = namespace
         self.prefix = prefix
         self.name = "input"
-        self.gname = "Input"
+        self.gname = "Container"
         self.config = False
         self.must = must
         self.exts = exts
@@ -1539,7 +1613,7 @@ class DOutput(DNodeInner):
         self.namespace = namespace
         self.prefix = prefix
         self.name = "output"
-        self.gname = "Output"
+        self.gname = "Container"
         self.config = False
         self.must = must
         self.exts = exts
@@ -1552,7 +1626,8 @@ class DRoot(DNodeInner):
         self.name = "root"
         self.gname = "Container"
         self.config = True
-        self.children=[]
+        self.children = []
+        self.rpcs = []
         self.identities = []
 
         # Build a global identity map from all modules
@@ -1560,7 +1635,10 @@ class DRoot(DNodeInner):
         for module in modules:
             if isinstance(module, DModule):
                 for child in module.children:
-                    self.children.append(child)
+                    if isinstance(child, DRpc):
+                        self.rpcs.append(child)
+                    else:
+                        self.children.append(child)
 
                 # Add identities to global map
                 for identity in module.identity:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1113,13 +1113,16 @@ class DNodeInner(DNode):
 
 
                 if input_node is not None:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False):")
                 else:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False):")
                 res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
                 res.append("            if res is not None:")
                 if output_node is not None:
-                    res.append("                gdata_res = from_xml_{output_class_name}(res)")
+                    res.append("                if gen3:")
+                    res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
+                    res.append("                else:")
+                    res.append("                    gdata_res = from_xml_{output_class_name}(res)")
                     res.append("                adata_res = {output_class_name}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                 else:
@@ -1156,11 +1159,11 @@ class DNodeInner(DNode):
                 output_class_name = get_path_name(output_node) if output_node is not None else None
 
                 if input_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp)")
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
                 else:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb)")
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, gen3)")
                 res.append("")
             res.append("")
 

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1871,18 +1871,24 @@ class SchemaNode(object):
     def is_config(self) -> bool:
         n = self
         for i in range(RECURSION_LIMIT+1):
-            if (isinstance(n, Anydata)
+            if (isinstance(n, Action)
+                or isinstance(n, Anydata)
                 or isinstance(n, Anyxml)
                 or isinstance(n, Case)
                 or isinstance(n, Choice)
                 or isinstance(n, Container)
+                or isinstance(n, Input)
                 or isinstance(n, Module)
-                or isinstance(n, Notification)
                 or isinstance(n, Leaf)
                 or isinstance(n, LeafList)
-                or isinstance(n, List)):
+                or isinstance(n, List)
+                or isinstance(n, Notification)
+                or isinstance(n, Output)
+                or isinstance(n, Rpc)):
                 found_config = True
-                if isinstance(n, Anydata):
+                if isinstance(n, Action):
+                    return False
+                elif isinstance(n, Anydata):
                     nconfig = n.config
                     if nconfig is not None:
                         return nconfig
@@ -1904,9 +1910,7 @@ class SchemaNode(object):
                     if nconfig is not None:
                         return nconfig
                     found_config = False
-                elif isinstance(n, Module):
-                    return True
-                elif isinstance(n, Notification):
+                elif isinstance(n, Input):
                     return False
                 elif isinstance(n, Leaf):
                     nconfig = n.config
@@ -1923,6 +1927,14 @@ class SchemaNode(object):
                     if nconfig is not None:
                         return nconfig
                     found_config = False
+                elif isinstance(n, Module):
+                    return True
+                elif isinstance(n, Notification):
+                    return False
+                elif isinstance(n, Output):
+                    return False
+                elif isinstance(n, Rpc):
+                    return False
 
                 if not found_config:
                     nparent = n.parent

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1109,23 +1109,25 @@ class DNodeInner(DNode):
                 input_node = rpc.input
                 output_node = rpc.output
 
-                # Get the actual generated class names using get_path_name
-                input_class_name = get_path_name(input_node) if input_node is not None else None
-                output_class_name = get_path_name(output_node) if output_node is not None else None
-
-
                 if input_node is not None:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False):")
+                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
                 else:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False):")
+                    input_param = "inp: ?None"
+
+                if output_node is not None:
+                    output_type = get_path_name(output_node)
+                else:
+                    output_type = None
+
+                res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False):")
                 res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
                 res.append("            if res is not None:")
-                if output_node is not None:
+                if output_type is not None:
                     res.append("                if gen3:")
                     res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                else:")
-                    res.append("                    gdata_res = from_xml_{output_class_name}(res)")
-                    res.append("                adata_res = {output_class_name}.from_gdata(gdata_res)")
+                    res.append("                    gdata_res = from_xml_{output_type}(res)")
+                    res.append("                adata_res = {output_type}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                 else:
                     res.append("                cb(None, err)")
@@ -1133,11 +1135,14 @@ class DNodeInner(DNode):
                 res.append("                cb(None, err)")
                 res.append("")
                 if input_node is not None:
-                    res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
+                    res.append("        if inp is not None:")
+                    res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
+                    res.append("        else:")
+                    res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
+                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 else:
                     res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
-                res.append("        print(xmlstr, err=True)")
-                res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
+                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 res.append("")
             res.append("")
 
@@ -1156,16 +1161,28 @@ class DNodeInner(DNode):
                 input_node = rpc.input
                 output_node = rpc.output
 
-                # Get the actual generated class names using get_path_name
-                input_class_name = get_path_name(input_node) if input_node is not None else None
-                output_class_name = get_path_name(output_node) if output_node is not None else None
-
                 if input_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
+                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
                 else:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, gen3)")
+                    input_param = ""
+
+                if output_node is not None:
+                    output_type = get_path_name(output_node)
+                else:
+                    output_type = ""
+
+                if input_node is not None and output_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
+                elif input_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), inp, gen3)")
+                elif output_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, None, gen3)")
+                else:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), None, gen3)")
                 res.append("")
             res.append("")
 

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -406,6 +406,8 @@ class DNodeInner(DNode):
         for child in self.children:
             if include_state == False and child.config == False:
                 continue
+            elif isinstance(child, DRpc):
+                continue
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
@@ -1640,8 +1642,7 @@ class DRoot(DNodeInner):
                 for child in module.children:
                     if isinstance(child, DRpc):
                         self.rpcs.append(child)
-                    else:
-                        self.children.append(child)
+                    self.children.append(child)
 
                 # Add identities to global map
                 for identity in module.identity:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1627,10 +1627,11 @@ class DRoot(DNodeInner):
 
 class DRpc(DNodeInner):
     if_feature: list[str]
-    must: list[Must]
+    input: ?DInput
+    output: ?DOutput
     status: ?str
 
-    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], input: ?DInput=None, output: ?DOutput=None, reference=None, status=None, exts=[], children=[]):
         self.module = module
         self.namespace = namespace
         self.prefix = prefix
@@ -1639,6 +1640,8 @@ class DRpc(DNodeInner):
         self.config = False
         self.description = description
         self.if_feature = if_feature
+        self.input = input
+        self.output = output
         self.reference = reference
         self.status = status
         self.exts = exts

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -331,6 +331,16 @@ snode_methods = {
 
 """,
         "to_dnode": """    def to_dnode(self) -> DAction:
+        dnode_children = []
+        self_input = self.input
+        if self_input is not None:
+            input_dnode = self_input.to_dnode()
+            dnode_children.append(input_dnode)
+        self_output = self.output
+        if self_output is not None:
+            output_dnode = self_output.to_dnode()
+            dnode_children.append(output_dnode)
+
         new_dnode = DAction(
             module=self.get_module_name(),
             namespace=self.get_namespace(),
@@ -341,7 +351,7 @@ snode_methods = {
             reference=self.reference,
             status=self.status,
             exts=self.exts,
-            children=self.get_dnode_children()
+            children=dnode_children
         )
         for child in new_dnode.children:
             child.parent = new_dnode
@@ -786,6 +796,23 @@ snode_methods = {
 
 """,
         "to_dnode": """    def to_dnode(self) -> DRpc:
+        # Convert SchemaNode Rpc.input/output to DRpc.input/output and add to
+        # its children, but only if Input and Output actually contain data
+        # nodes.
+        dnode_children = []
+        self_input = self.input
+        if self_input is not None and len(self_input.children) > 0:
+            input_dnode = self_input.to_dnode()
+            dnode_children.append(input_dnode)
+        else:
+            input_dnode = None
+        self_output = self.output
+        if self_output is not None and len(self_output.children) > 0:
+            output_dnode = self_output.to_dnode()
+            dnode_children.append(output_dnode)
+        else:
+            output_dnode = None
+
         new_dnode = DRpc(
             module=self.get_module_name(),
             namespace=self.get_namespace(),
@@ -793,10 +820,12 @@ snode_methods = {
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
+            input=input_dnode if isinstance(input_dnode, DInput) else None,
+            output=output_dnode if isinstance(output_dnode, DOutput) else None,
             reference=self.reference,
             status=self.status,
             exts=self.exts,
-            children=self.get_dnode_children()
+            children=dnode_children
         )
         for child in new_dnode.children:
             child.parent = new_dnode

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2240,6 +2240,27 @@ def _test_prdaclass_dot():
     src = root.prdaclass()
     return src
 
+def _test_prdaclass_rpc():
+    ys = r"""module yangrpc {
+  yang-version "1.1";
+  namespace "http://example.com/yangrpc";
+  prefix "yrpc";
+  rpc foo {
+    input {
+      leaf a { type string; }
+      container woo {
+        leaf woo_b { type int64; }
+      }
+    }
+    output {
+      leaf outoo { type string; }
+    }
+  }
+}"""
+    root = yang.compile([ys])
+    src = root.prdaclass()
+    return src
+
 def _test_identityref():
     # Base module with base identity and a leaf that references it
     ys_base = r"""module base {

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2256,6 +2256,7 @@ def _test_prdaclass_rpc():
       leaf outoo { type string; }
     }
   }
+  rpc silent;
 }"""
     root = yang.compile([ys])
     src = root.prdaclass()

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -16,3 +16,8 @@ class MNode(object):
     # TODO: remove mut effect once the compiler is fixed to not leak mut effect out of functions
     mut def prsrc(self, self_name='ad', top=False, list_element=False) -> str:
         raise NotImplementedError("prsrc not implemented for {self._name}")
+
+
+class RpcRoot(object):
+    def __init__(self, tp: yang.gdata.TreeProvider):
+        self._tp = tp

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1422,6 +1422,12 @@ def patch(old: Node, p: ?Node) -> ?Node:
         if p is not None:
             raise ValueError("Unhandled node type in patch: {str(type(p))}")
 
+
+class TreeProvider(object):
+    rpc: proc(action(?Node, ?Exception) -> None, Node) -> None
+    rpc_xml: proc(action(?xml.Node, ?Exception) -> None, xml.Node) -> None
+
+
 def _node_match(n: xml.Node, name: str, ns: ?str) -> bool:
     """Check if an XML node matches the given name and namespace
 

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -487,6 +487,8 @@ def _from_data[A(YangData[A])](s: yang.schema.DNodeInner, global_identity, data:
         # When processing a list element, return it as a Container
         # The List wrapper is created by the parent when processing all elements
         return yang.gdata.Container(children)
+    elif isinstance(s, yang.schema.DOutput):
+        return yang.gdata.Container(children)
     else:
         raise ValueError(f"Unknown schema node type: {s.gname} for {s}")
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -402,6 +402,8 @@ class DNodeInner(DNode):
         for child in self.children:
             if include_state == False and child.config == False:
                 continue
+            elif isinstance(child, DRpc):
+                continue
             if isinstance(child, DLeaf) and child.is_key():
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
@@ -1636,8 +1638,7 @@ class DRoot(DNodeInner):
                 for child in module.children:
                     if isinstance(child, DRpc):
                         self.rpcs.append(child)
-                    else:
-                        self.children.append(child)
+                    self.children.append(child)
 
                 # Add identities to global map
                 for identity in module.identity:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1623,10 +1623,11 @@ class DRoot(DNodeInner):
 
 class DRpc(DNodeInner):
     if_feature: list[str]
-    must: list[Must]
+    input: ?DInput
+    output: ?DOutput
     status: ?str
 
-    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], reference=None, status=None, exts=[], children=[]):
+    def __init__(self, module: str, namespace: str, prefix: str, name: str, description: ?str=None, if_feature=[], input: ?DInput=None, output: ?DOutput=None, reference=None, status=None, exts=[], children=[]):
         self.module = module
         self.namespace = namespace
         self.prefix = prefix
@@ -1635,6 +1636,8 @@ class DRpc(DNodeInner):
         self.config = False
         self.description = description
         self.if_feature = if_feature
+        self.input = input
+        self.output = output
         self.reference = reference
         self.status = status
         self.exts = exts
@@ -3219,6 +3222,16 @@ class Action(SchemaNodeInner):
         return new
 
     def to_dnode(self) -> DAction:
+        dnode_children = []
+        self_input = self.input
+        if self_input is not None:
+            input_dnode = self_input.to_dnode()
+            dnode_children.append(input_dnode)
+        self_output = self.output
+        if self_output is not None:
+            output_dnode = self_output.to_dnode()
+            dnode_children.append(output_dnode)
+
         new_dnode = DAction(
             module=self.get_module_name(),
             namespace=self.get_namespace(),
@@ -3229,7 +3242,7 @@ class Action(SchemaNodeInner):
             reference=self.reference,
             status=self.status,
             exts=self.exts,
-            children=self.get_dnode_children()
+            children=dnode_children
         )
         for child in new_dnode.children:
             child.parent = new_dnode
@@ -6631,6 +6644,23 @@ class Rpc(SchemaNodeInner):
         return new
 
     def to_dnode(self) -> DRpc:
+        # Convert SchemaNode Rpc.input/output to DRpc.input/output and add to
+        # its children, but only if Input and Output actually contain data
+        # nodes.
+        dnode_children = []
+        self_input = self.input
+        if self_input is not None and len(self_input.children) > 0:
+            input_dnode = self_input.to_dnode()
+            dnode_children.append(input_dnode)
+        else:
+            input_dnode = None
+        self_output = self.output
+        if self_output is not None and len(self_output.children) > 0:
+            output_dnode = self_output.to_dnode()
+            dnode_children.append(output_dnode)
+        else:
+            output_dnode = None
+
         new_dnode = DRpc(
             module=self.get_module_name(),
             namespace=self.get_namespace(),
@@ -6638,10 +6668,12 @@ class Rpc(SchemaNodeInner):
             name=self.name,
             description=self.description,
             if_feature=self.if_feature,
+            input=input_dnode if isinstance(input_dnode, DInput) else None,
+            output=output_dnode if isinstance(output_dnode, DOutput) else None,
             reference=self.reference,
             status=self.status,
             exts=self.exts,
-            children=self.get_dnode_children()
+            children=dnode_children
         )
         for child in new_dnode.children:
             child.parent = new_dnode

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1867,18 +1867,24 @@ class SchemaNode(object):
     def is_config(self) -> bool:
         n = self
         for i in range(RECURSION_LIMIT+1):
-            if (isinstance(n, Anydata)
+            if (isinstance(n, Action)
+                or isinstance(n, Anydata)
                 or isinstance(n, Anyxml)
                 or isinstance(n, Case)
                 or isinstance(n, Choice)
                 or isinstance(n, Container)
+                or isinstance(n, Input)
                 or isinstance(n, Module)
-                or isinstance(n, Notification)
                 or isinstance(n, Leaf)
                 or isinstance(n, LeafList)
-                or isinstance(n, List)):
+                or isinstance(n, List)
+                or isinstance(n, Notification)
+                or isinstance(n, Output)
+                or isinstance(n, Rpc)):
                 found_config = True
-                if isinstance(n, Anydata):
+                if isinstance(n, Action):
+                    return False
+                elif isinstance(n, Anydata):
                     nconfig = n.config
                     if nconfig is not None:
                         return nconfig
@@ -1900,9 +1906,7 @@ class SchemaNode(object):
                     if nconfig is not None:
                         return nconfig
                     found_config = False
-                elif isinstance(n, Module):
-                    return True
-                elif isinstance(n, Notification):
+                elif isinstance(n, Input):
                     return False
                 elif isinstance(n, Leaf):
                     nconfig = n.config
@@ -1919,6 +1923,14 @@ class SchemaNode(object):
                     if nconfig is not None:
                         return nconfig
                     found_config = False
+                elif isinstance(n, Module):
+                    return True
+                elif isinstance(n, Notification):
+                    return False
+                elif isinstance(n, Output):
+                    return False
+                elif isinstance(n, Rpc):
+                    return False
 
                 if not found_config:
                     nparent = n.parent

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1109,13 +1109,16 @@ class DNodeInner(DNode):
 
 
                 if input_node is not None:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False):")
                 else:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False):")
                 res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
                 res.append("            if res is not None:")
                 if output_node is not None:
-                    res.append("                gdata_res = from_xml_{output_class_name}(res)")
+                    res.append("                if gen3:")
+                    res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
+                    res.append("                else:")
+                    res.append("                    gdata_res = from_xml_{output_class_name}(res)")
                     res.append("                adata_res = {output_class_name}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                 else:
@@ -1152,11 +1155,11 @@ class DNodeInner(DNode):
                 output_class_name = get_path_name(output_node) if output_node is not None else None
 
                 if input_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp)")
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
                 else:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb)")
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, gen3)")
                 res.append("")
             res.append("")
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1105,23 +1105,25 @@ class DNodeInner(DNode):
                 input_node = rpc.input
                 output_node = rpc.output
 
-                # Get the actual generated class names using get_path_name
-                input_class_name = get_path_name(input_node) if input_node is not None else None
-                output_class_name = get_path_name(output_node) if output_node is not None else None
-
-
                 if input_node is not None:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False):")
+                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
                 else:
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False):")
+                    input_param = "inp: ?None"
+
+                if output_node is not None:
+                    output_type = get_path_name(output_node)
+                else:
+                    output_type = None
+
+                res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False):")
                 res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
                 res.append("            if res is not None:")
-                if output_node is not None:
+                if output_type is not None:
                     res.append("                if gen3:")
                     res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                else:")
-                    res.append("                    gdata_res = from_xml_{output_class_name}(res)")
-                    res.append("                adata_res = {output_class_name}.from_gdata(gdata_res)")
+                    res.append("                    gdata_res = from_xml_{output_type}(res)")
+                    res.append("                adata_res = {output_type}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                 else:
                     res.append("                cb(None, err)")
@@ -1129,11 +1131,14 @@ class DNodeInner(DNode):
                 res.append("                cb(None, err)")
                 res.append("")
                 if input_node is not None:
-                    res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
+                    res.append("        if inp is not None:")
+                    res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
+                    res.append("        else:")
+                    res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
+                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 else:
                     res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
-                res.append("        print(xmlstr, err=True)")
-                res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
+                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 res.append("")
             res.append("")
 
@@ -1152,16 +1157,28 @@ class DNodeInner(DNode):
                 input_node = rpc.input
                 output_node = rpc.output
 
-                # Get the actual generated class names using get_path_name
-                input_class_name = get_path_name(input_node) if input_node is not None else None
-                output_class_name = get_path_name(output_node) if output_node is not None else None
-
                 if input_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
+                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
                 else:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, gen3)")
+                    input_param = ""
+
+                if output_node is not None:
+                    output_type = get_path_name(output_node)
+                else:
+                    output_type = ""
+
+                if input_node is not None and output_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
+                elif input_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), inp, gen3)")
+                elif output_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, None, gen3)")
+                else:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), None, gen3)")
                 res.append("")
             res.append("")
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1086,6 +1086,80 @@ class DNodeInner(DNode):
             res.append("    return yang.gen3.from_json_path(s, jd, path, op, loose={loose})")
             res.append("")
 
+        if isinstance(self, DRoot) and len(self.rpcs) > 0:
+            # First generate data classes for RPC input/output
+            for rpc in self.rpcs:
+                # Generate adata classes for DInput, DOutput, but override:
+                # - set_ns: from DRpc (=True)
+                # - include_state=True
+                for child in rpc.children:
+                    child_class_src = child.prdaclass(schema_yang=schema_yang, loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
+                    res.append(child_class_src)
+
+            # TODO: unique safe name for RPC function!
+            # Generate rpc_handler actor
+            res.append("actor rpc_handler(tp: yang.gdata.TreeProvider):")
+            for rpc in self.rpcs:
+                input_node = rpc.input
+                output_node = rpc.output
+
+                # Get the actual generated class names using get_path_name
+                input_class_name = get_path_name(input_node) if input_node is not None else None
+                output_class_name = get_path_name(output_node) if output_node is not None else None
+
+
+                if input_node is not None:
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}):")
+                else:
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_class_name}, ?Exception) -> None):")
+                res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
+                res.append("            if res is not None:")
+                if output_node is not None:
+                    res.append("                gdata_res = from_xml_{output_class_name}(res)")
+                    res.append("                adata_res = {output_class_name}.from_gdata(gdata_res)")
+                    res.append("                cb(adata_res, err)")
+                else:
+                    res.append("                cb(None, err)")
+                res.append("            else:")
+                res.append("                cb(None, err)")
+                res.append("")
+                if input_node is not None:
+                    res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
+                else:
+                    res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
+                res.append("        print(xmlstr, err=True)")
+                res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
+                res.append("")
+            res.append("")
+
+            # Generate rpc_root class
+            # TODO: this wrapper class is not needed! We need an actor
+            # (currently rpc_handler) because we pass callback references, but
+            # we could instantiate it directly instead
+            res.append("class rpc_root(yang.adata.RpcRoot):")
+            res.append("    _handler: rpc_handler")
+            res.append("")
+            res.append("    def __init__(self, tp: yang.gdata.TreeProvider):")
+            res.append("        yang.adata.RpcRoot.__init__(self, tp)")
+            res.append("        self._handler = rpc_handler(tp)")
+            res.append("")
+            for rpc in self.rpcs:
+                input_node = rpc.input
+                output_node = rpc.output
+
+                # Get the actual generated class names using get_path_name
+                input_class_name = get_path_name(input_node) if input_node is not None else None
+                output_class_name = get_path_name(output_node) if output_node is not None else None
+
+                if input_node is not None:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None, inp: {input_class_name}) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp)")
+                else:
+                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_class_name}, ?Exception) -> None) -> None:")
+                    res.append("        self._handler.{_safe_name(rpc.name)}(cb)")
+                res.append("")
+            res.append("")
+
         if top:
             res.append("schema_namespaces: set[str] = {{")
             for ns in sorted(schema_ns):
@@ -1288,7 +1362,7 @@ class DInput(DNodeInner):
         self.namespace = namespace
         self.prefix = prefix
         self.name = "input"
-        self.gname = "Input"
+        self.gname = "Container"
         self.config = False
         self.must = must
         self.exts = exts
@@ -1535,7 +1609,7 @@ class DOutput(DNodeInner):
         self.namespace = namespace
         self.prefix = prefix
         self.name = "output"
-        self.gname = "Output"
+        self.gname = "Container"
         self.config = False
         self.must = must
         self.exts = exts
@@ -1548,7 +1622,8 @@ class DRoot(DNodeInner):
         self.name = "root"
         self.gname = "Container"
         self.config = True
-        self.children=[]
+        self.children = []
+        self.rpcs = []
         self.identities = []
 
         # Build a global identity map from all modules
@@ -1556,7 +1631,10 @@ class DRoot(DNodeInner):
         for module in modules:
             if isinstance(module, DModule):
                 for child in module.children:
-                    self.children.append(child)
+                    if isinstance(child, DRpc):
+                        self.rpcs.append(child)
+                    else:
+                        self.children.append(child)
 
                 # Add identities to global map
                 for identity in module.identity:

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -353,10 +353,13 @@ mut def from_json_foo__r1__output(jd: dict[str, ?value]) -> yang.gdata.Container
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 actor rpc_handler(tp: yang.gdata.TreeProvider):
-    def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input):
+    def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
-                gdata_res = from_xml_foo__r1__output(res)
+                if gen3:
+                    gdata_res = from_xml_gen3(res, ["foo:r1", "output"])
+                else:
+                    gdata_res = from_xml_foo__r1__output(res)
                 adata_res = foo__r1__output.from_gdata(gdata_res)
                 cb(adata_res, err)
             else:
@@ -374,8 +377,8 @@ class rpc_root(yang.adata.RpcRoot):
         yang.adata.RpcRoot.__init__(self, tp)
         self._handler = rpc_handler(tp)
 
-    proc def r1(self, cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input) -> None:
-        self._handler.r1(cb, inp)
+    proc def r1(self, cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input, gen3: bool=False) -> None:
+        self._handler.r1(cb, inp, gen3)
 
 
 schema_namespaces: set[str] = {

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -353,7 +353,7 @@ mut def from_json_foo__r1__output(jd: dict[str, ?value]) -> yang.gdata.Container
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 actor rpc_handler(tp: yang.gdata.TreeProvider):
-    def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input, gen3: bool=False):
+    def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
                 if gen3:
@@ -365,8 +365,10 @@ actor rpc_handler(tp: yang.gdata.TreeProvider):
             else:
                 cb(None, err)
 
-        xmlstr = '<r1 xmlns="http://example.com/foo">{inp.to_gdata().to_xmlstr()}</r1>'
-        print(xmlstr, err=True)
+        if inp is not None:
+            xmlstr = '<r1 xmlns="http://example.com/foo">{inp.to_gdata().to_xmlstr()}</r1>'
+        else:
+            xmlstr = '<r1 xmlns="http://example.com/foo" />'
         tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
 
 
@@ -377,7 +379,7 @@ class rpc_root(yang.adata.RpcRoot):
         yang.adata.RpcRoot.__init__(self, tp)
         self._handler = rpc_handler(tp)
 
-    proc def r1(self, cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input, gen3: bool=False) -> None:
+    proc def r1(self, cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input, gen3: bool=False) -> None:
         self._handler.r1(cb, inp, gen3)
 
 

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -144,6 +144,240 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
+mut def from_json_foo__r1__input__c3__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__r1__input__c3__l3(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class foo__r1__input__c3(yang.adata.MNode):
+    l3: ?str
+
+    mut def __init__(self, l3: ?str):
+        self._ns = 'http://example.com/foo'
+        self.l3 = l3
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l3 = self.l3
+        if _l3 is not None:
+            children['l3'] = yang.gdata.Leaf('string', _l3)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__r1__input__c3:
+        if n is not None:
+            return foo__r1__input__c3(l3=n.get_opt_str('l3'))
+        return foo__r1__input__c3()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /r1/input/c3')
+            res.append('{self_name} = foo__r1__input__c3()')
+        leaves = []
+        _l3 = self.l3
+        if _l3 is not None:
+            leaves.append('{self_name}.l3 = {repr(_l3)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /r1/input/c3'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_foo__r1__input__c3(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l3 = yang.gdata.from_xml_opt_str(node, 'l3')
+    yang.gdata.maybe_add(children, 'l3', from_xml_foo__r1__input__c3__l3, child_l3)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_foo__r1__input__c3(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'l3':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__r1__input__c3(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__r1__input__c3(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l3 = yang.gdata.take_json_opt_str(jd, 'l3')
+    yang.gdata.maybe_add(children, 'l3', from_json_foo__r1__input__c3__l3, child_l3)
+    return yang.gdata.Container(children)
+
+class foo__r1__input(yang.adata.MNode):
+    c3: foo__r1__input__c3
+
+    mut def __init__(self, c3: ?foo__r1__input__c3=None):
+        self._ns = 'http://example.com/foo'
+        self.c3 = c3 if c3 is not None else foo__r1__input__c3()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _c3 = self.c3
+        if _c3 is not None:
+            children['c3'] = _c3.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__r1__input:
+        if n is not None:
+            return foo__r1__input(c3=foo__r1__input__c3.from_gdata(n.get_opt_cnt('c3')))
+        return foo__r1__input()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /r1/input')
+            res.append('{self_name} = foo__r1__input()')
+        leaves = []
+        _c3 = self.c3
+        if _c3 is not None:
+            res.extend(_c3.prsrc('{self_name}.c3', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /r1/input'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_foo__r1__input(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_c3 = yang.gdata.from_xml_opt_cnt(node, 'c3')
+    yang.gdata.maybe_add(children, 'c3', from_xml_foo__r1__input__c3, child_c3)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+mut def from_json_path_foo__r1__input(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'c3':
+            child = {'c3': from_json_path_foo__r1__input__c3(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/foo', module='foo')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__r1__input(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__r1__input(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_c3 = yang.gdata.take_json_opt_cnt(jd, 'c3')
+    yang.gdata.maybe_add(children, 'c3', from_json_foo__r1__input__c3, child_c3)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+mut def from_json_foo__r1__output__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_foo__r1__output__l4(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class foo__r1__output(yang.adata.MNode):
+    l4: ?str
+
+    mut def __init__(self, l4: ?str):
+        self._ns = 'http://example.com/foo'
+        self.l4 = l4
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _l4 = self.l4
+        if _l4 is not None:
+            children['l4'] = yang.gdata.Leaf('string', _l4)
+        return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__r1__output:
+        if n is not None:
+            return foo__r1__output(l4=n.get_opt_str('l4'))
+        return foo__r1__output()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /r1/output')
+            res.append('{self_name} = foo__r1__output()')
+        leaves = []
+        _l4 = self.l4
+        if _l4 is not None:
+            leaves.append('{self_name}.l4 = {repr(_l4)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /r1/output'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_foo__r1__output(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_l4 = yang.gdata.from_xml_opt_str(node, 'l4')
+    yang.gdata.maybe_add(children, 'l4', from_xml_foo__r1__output__l4, child_l4)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+mut def from_json_path_foo__r1__output(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'l4':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_foo__r1__output(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_foo__r1__output(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_l4 = yang.gdata.take_json_opt_str(jd, 'l4')
+    yang.gdata.maybe_add(children, 'l4', from_json_foo__r1__output__l4, child_l4)
+    return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+actor rpc_handler(tp: yang.gdata.TreeProvider):
+    def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input):
+        def cb_wrap(res: ?xml.Node, err: ?Exception):
+            if res is not None:
+                gdata_res = from_xml_foo__r1__output(res)
+                adata_res = foo__r1__output.from_gdata(gdata_res)
+                cb(adata_res, err)
+            else:
+                cb(None, err)
+
+        xmlstr = '<r1 xmlns="http://example.com/foo">{inp.to_gdata().to_xmlstr()}</r1>'
+        print(xmlstr, err=True)
+        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+
+
+class rpc_root(yang.adata.RpcRoot):
+    _handler: rpc_handler
+
+    def __init__(self, tp: yang.gdata.TreeProvider):
+        yang.adata.RpcRoot.__init__(self, tp)
+        self._handler = rpc_handler(tp)
+
+    proc def r1(self, cb: action(?foo__r1__output, ?Exception) -> None, inp: foo__r1__input) -> None:
+        self._handler.r1(cb, inp)
+
+
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -307,10 +307,13 @@ mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Cont
     return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
 
 actor rpc_handler(tp: yang.gdata.TreeProvider):
-    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input):
+    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
-                gdata_res = from_xml_yangrpc__foo__output(res)
+                if gen3:
+                    gdata_res = from_xml_gen3(res, ["yangrpc:foo", "output"])
+                else:
+                    gdata_res = from_xml_yangrpc__foo__output(res)
                 adata_res = yangrpc__foo__output.from_gdata(gdata_res)
                 cb(adata_res, err)
             else:
@@ -328,8 +331,8 @@ class rpc_root(yang.adata.RpcRoot):
         yang.adata.RpcRoot.__init__(self, tp)
         self._handler = rpc_handler(tp)
 
-    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input) -> None:
-        self._handler.foo(cb, inp)
+    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False) -> None:
+        self._handler.foo(cb, inp, gen3)
 
 
 schema_namespaces: set[str] = {

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -307,7 +307,7 @@ mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Cont
     return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
 
 actor rpc_handler(tp: yang.gdata.TreeProvider):
-    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False):
+    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
                 if gen3:
@@ -319,8 +319,20 @@ actor rpc_handler(tp: yang.gdata.TreeProvider):
             else:
                 cb(None, err)
 
-        xmlstr = '<foo xmlns="http://example.com/yangrpc">{inp.to_gdata().to_xmlstr()}</foo>'
-        print(xmlstr, err=True)
+        if inp is not None:
+            xmlstr = '<foo xmlns="http://example.com/yangrpc">{inp.to_gdata().to_xmlstr()}</foo>'
+        else:
+            xmlstr = '<foo xmlns="http://example.com/yangrpc" />'
+        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+
+    def silent(cb: action(?None, ?Exception) -> None, inp: ?None, gen3: bool=False):
+        def cb_wrap(res: ?xml.Node, err: ?Exception):
+            if res is not None:
+                cb(None, err)
+            else:
+                cb(None, err)
+
+        xmlstr = '<silent xmlns="http://example.com/yangrpc" />'
         tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
 
 
@@ -331,8 +343,11 @@ class rpc_root(yang.adata.RpcRoot):
         yang.adata.RpcRoot.__init__(self, tp)
         self._handler = rpc_handler(tp)
 
-    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False) -> None:
+    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False) -> None:
         self._handler.foo(cb, inp, gen3)
+
+    proc def silent(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:
+        self._handler.silent(lambda _, err: cb(err), None, gen3)
 
 
 schema_namespaces: set[str] = {

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -1,0 +1,337 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+class root(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = ''
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root()
+        return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+mut def from_json_yangrpc__foo__input__a(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_yangrpc__foo__input__a(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_yangrpc__foo__input__woo__woo_b(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('int64', val)
+
+mut def from_xml_yangrpc__foo__input__woo__woo_b(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('int64', val)
+
+class yangrpc__foo__input__woo(yang.adata.MNode):
+    woo_b: ?int
+
+    mut def __init__(self, woo_b: ?int):
+        self._ns = 'http://example.com/yangrpc'
+        self.woo_b = woo_b
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _woo_b = self.woo_b
+        if _woo_b is not None:
+            children['woo_b'] = yang.gdata.Leaf('int64', _woo_b)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input__woo:
+        if n is not None:
+            return yangrpc__foo__input__woo(woo_b=n.get_opt_int('woo_b'))
+        return yangrpc__foo__input__woo()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /foo/input/woo')
+            res.append('{self_name} = yangrpc__foo__input__woo()')
+        leaves = []
+        _woo_b = self.woo_b
+        if _woo_b is not None:
+            leaves.append('{self_name}.woo_b = {repr(_woo_b)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /foo/input/woo'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_woo_b = yang.gdata.from_xml_opt_int(node, 'woo_b')
+    yang.gdata.maybe_add(children, 'woo_b', from_xml_yangrpc__foo__input__woo__woo_b, child_woo_b)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_yangrpc__foo__input__woo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'woo_b':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_yangrpc__foo__input__woo(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_yangrpc__foo__input__woo(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_woo_b = yang.gdata.take_json_opt_int64(jd, 'woo_b')
+    yang.gdata.maybe_add(children, 'woo_b', from_json_yangrpc__foo__input__woo__woo_b, child_woo_b)
+    return yang.gdata.Container(children)
+
+class yangrpc__foo__input(yang.adata.MNode):
+    a: ?str
+    woo: yangrpc__foo__input__woo
+
+    mut def __init__(self, a: ?str, woo: ?yangrpc__foo__input__woo=None):
+        self._ns = 'http://example.com/yangrpc'
+        self.a = a
+        self.woo = woo if woo is not None else yangrpc__foo__input__woo()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _a = self.a
+        if _a is not None:
+            children['a'] = yang.gdata.Leaf('string', _a)
+        _woo = self.woo
+        if _woo is not None:
+            children['woo'] = _woo.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input:
+        if n is not None:
+            return yangrpc__foo__input(a=n.get_opt_str('a'), woo=yangrpc__foo__input__woo.from_gdata(n.get_opt_cnt('woo')))
+        return yangrpc__foo__input()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /foo/input')
+            res.append('{self_name} = yangrpc__foo__input()')
+        leaves = []
+        _a = self.a
+        if _a is not None:
+            leaves.append('{self_name}.a = {repr(_a)}')
+        _woo = self.woo
+        if _woo is not None:
+            res.extend(_woo.prsrc('{self_name}.woo', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /foo/input'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_yangrpc__foo__input(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_a = yang.gdata.from_xml_opt_str(node, 'a')
+    yang.gdata.maybe_add(children, 'a', from_xml_yangrpc__foo__input__a, child_a)
+    child_woo = yang.gdata.from_xml_opt_cnt(node, 'woo')
+    yang.gdata.maybe_add(children, 'woo', from_xml_yangrpc__foo__input__woo, child_woo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+mut def from_json_path_yangrpc__foo__input(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'a':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'woo':
+            child = {'woo': from_json_path_yangrpc__foo__input__woo(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/yangrpc', module='yangrpc')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_yangrpc__foo__input(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_yangrpc__foo__input(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_a = yang.gdata.take_json_opt_str(jd, 'a')
+    yang.gdata.maybe_add(children, 'a', from_json_yangrpc__foo__input__a, child_a)
+    child_woo = yang.gdata.take_json_opt_cnt(jd, 'woo')
+    yang.gdata.maybe_add(children, 'woo', from_json_yangrpc__foo__input__woo, child_woo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+mut def from_json_yangrpc__foo__output__outoo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_yangrpc__foo__output__outoo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class yangrpc__foo__output(yang.adata.MNode):
+    outoo: ?str
+
+    mut def __init__(self, outoo: ?str):
+        self._ns = 'http://example.com/yangrpc'
+        self.outoo = outoo
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _outoo = self.outoo
+        if _outoo is not None:
+            children['outoo'] = yang.gdata.Leaf('string', _outoo)
+        return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__output:
+        if n is not None:
+            return yangrpc__foo__output(outoo=n.get_opt_str('outoo'))
+        return yangrpc__foo__output()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /foo/output')
+            res.append('{self_name} = yangrpc__foo__output()')
+        leaves = []
+        _outoo = self.outoo
+        if _outoo is not None:
+            leaves.append('{self_name}.outoo = {repr(_outoo)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /foo/output'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_yangrpc__foo__output(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_outoo = yang.gdata.from_xml_opt_str(node, 'outoo')
+    yang.gdata.maybe_add(children, 'outoo', from_xml_yangrpc__foo__output__outoo, child_outoo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+mut def from_json_path_yangrpc__foo__output(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'outoo':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_yangrpc__foo__output(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_outoo = yang.gdata.take_json_opt_str(jd, 'outoo')
+    yang.gdata.maybe_add(children, 'outoo', from_json_yangrpc__foo__output__outoo, child_outoo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+actor rpc_handler(tp: yang.gdata.TreeProvider):
+    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input):
+        def cb_wrap(res: ?xml.Node, err: ?Exception):
+            if res is not None:
+                gdata_res = from_xml_yangrpc__foo__output(res)
+                adata_res = yangrpc__foo__output.from_gdata(gdata_res)
+                cb(adata_res, err)
+            else:
+                cb(None, err)
+
+        xmlstr = '<foo xmlns="http://example.com/yangrpc">{inp.to_gdata().to_xmlstr()}</foo>'
+        print(xmlstr, err=True)
+        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+
+
+class rpc_root(yang.adata.RpcRoot):
+    _handler: rpc_handler
+
+    def __init__(self, tp: yang.gdata.TreeProvider):
+        yang.adata.RpcRoot.__init__(self, tp)
+        self._handler = rpc_handler(tp)
+
+    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input) -> None:
+        self._handler.foo(cb, inp)
+
+
+schema_namespaces: set[str] = {
+    'http://example.com/yangrpc',
+}

--- a/test/test_data_classes/src/test_rpc_exec.act
+++ b/test/test_data_classes/src/test_rpc_exec.act
@@ -1,0 +1,274 @@
+import testing
+import xml
+import yang.adata
+import yang.gdata
+import yangrpc
+
+
+class MockTreeProviderSuccess(yang.gdata.TreeProvider):
+    """Mock TreeProvider that returns a successful RPC response"""
+    def __init__(self):
+        pass
+
+    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
+        # Return a successful response with output data
+        xml_response = xml.Node("rpc-reply", [(None, "urn:ietf:params:xml:ns:netconf:base:1.0")], children=[
+            xml.Node("outoo", [(None, "http://example.com/yangrpc")], text="Hello from RPC!")
+        ])
+        cb(xml_response, None)
+
+    proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
+        output_gdata = yang.gdata.Container({
+            "outoo": yang.gdata.Leaf("string", "Hello from RPC!")
+        }, ns="http://example.com/yangrpc", module="yangrpc")
+        cb(output_gdata, None)
+
+
+class MockTreeProviderError(yang.gdata.TreeProvider):
+    """Mock TreeProvider that returns an error"""
+    def __init__(self):
+        pass
+
+    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
+        # Return an error
+        cb(None, ValueError("RPC execution failed"))
+
+    proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
+        cb(None, ValueError("RPC execution failed"))
+
+
+class MockTreeProviderEmpty(yang.gdata.TreeProvider):
+    """Mock TreeProvider that returns empty output"""
+    def __init__(self):
+        pass
+
+    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
+        # Return a response with no output data
+        xml_response = xml.Node("rpc-reply", [(None, "urn:ietf:params:xml:ns:netconf:base:1.0")], children=[
+            xml.Node("ok")
+        ])
+        cb(xml_response, None)
+
+    proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
+        output_gdata = yang.gdata.Container({}, ns="http://example.com/yangrpc", module="yangrpc")
+        cb(output_gdata, None)
+
+
+actor _test_rpc_foo_success(t: testing.AsyncT):
+    """Test successful RPC execution with valid input/output"""
+    def on_reply(r: ?yangrpc.yangrpc__foo__output, err: ?Exception):
+        if err is not None:
+            t.failure(err)
+            return
+
+        if r is not None:
+            # Verify the output data
+            testing.assertEqual(r.outoo, "Hello from RPC!", "Expected correct output message")
+            t.success()
+        else:
+            t.failure(ValueError("Got no result when one was expected"))
+
+    tp = MockTreeProviderSuccess()
+    root = yangrpc.rpc_root(tp)
+
+    # Create input data
+    woo = yangrpc.yangrpc__foo__input__woo(1337)
+    foo_input = yangrpc.yangrpc__foo__input("test_input", woo)
+
+    # Execute the RPC
+    root.foo(on_reply, foo_input)
+
+
+actor _test_rpc_foo_error(t: testing.AsyncT):
+    """Test RPC error handling"""
+    def on_reply(r: ?yangrpc.yangrpc__foo__output, err: ?Exception):
+        if err is not None:
+            # We expect an error in this test
+            testing.assertTrue(isinstance(err, ValueError), "Expected ValueError")
+            testing.assertEqual(str(err), "ValueError: RPC execution failed", "Expected correct error message")
+            t.success()
+        else:
+            t.failure(ValueError("Expected an error but got success"))
+
+    tp = MockTreeProviderError()
+    root = yangrpc.rpc_root(tp)
+
+    # Create input data
+    woo = yangrpc.yangrpc__foo__input__woo(42)
+    foo_input = yangrpc.yangrpc__foo__input("error_test", woo)
+
+    # Execute the RPC (should fail)
+    root.foo(on_reply, foo_input)
+
+
+actor _test_rpc_foo_empty_output(t: testing.AsyncT):
+    """Test RPC with empty output fields"""
+    def on_reply(r: ?yangrpc.yangrpc__foo__output, err: ?Exception):
+        if err is not None:
+            t.failure(err)
+            return
+
+        if r is not None:
+            # The outoo field should be None for empty output
+            testing.assertEqual(r.outoo, None, "Expected None for empty output field")
+            t.success()
+        else:
+            t.failure(ValueError("Got no result when one was expected"))
+
+    tp = MockTreeProviderEmpty()
+    root = yangrpc.rpc_root(tp)
+
+    # Create input data
+    woo = yangrpc.yangrpc__foo__input__woo(999)
+    foo_input = yangrpc.yangrpc__foo__input("empty_test", woo)
+
+    # Execute the RPC
+    root.foo(on_reply, foo_input)
+
+
+actor _test_rpc_foo_complex_input(t: testing.AsyncT):
+    """Test RPC with complex nested input data"""
+    def on_reply(r: ?yangrpc.yangrpc__foo__output, err: ?Exception):
+        if err is not None:
+            t.failure(err)
+            return
+
+        if r is not None:
+            # Just verify we got a response - the main test here is that
+            # the complex input was properly serialized
+            testing.assertNotNone(r, "Got a response")
+            t.success()
+        else:
+            t.failure(ValueError("Got no result when one was expected"))
+
+    tp = MockTreeProviderSuccess()
+    root = yangrpc.rpc_root(tp)
+
+    # Create complex input data with all fields populated
+    woo = yangrpc.yangrpc__foo__input__woo(9876543210)
+#    foo_input = yangrpc.yangrpc__foo__input("Complex input with special chars: <>&\"'", woo)
+    foo_input = yangrpc.yangrpc__foo__input("Full input", woo)
+
+    # Execute the RPC
+    root.foo(on_reply, foo_input)
+
+
+def _test_rpc_input_serialization():
+    """Test that RPC input data is properly serialized to gdata"""
+    # Create input data
+    woo = yangrpc.yangrpc__foo__input__woo(123)
+    foo_input = yangrpc.yangrpc__foo__input("test_string", woo)
+
+    # Convert to gdata
+    gdata = foo_input.to_gdata()
+
+    # Verify structure
+    testing.assertTrue(isinstance(gdata, yang.gdata.Container), "Should be a Container")
+    testing.assertEqual(gdata.get_str("a"), "test_string", "Leaf 'a' should have correct value")
+
+    # Check nested container
+    woo_gdata = gdata.get_cnt("woo")
+    testing.assertNotNone(woo_gdata, "Container 'woo' should exist")
+    testing.assertEqual(woo_gdata.get_int("woo_b"), 123, "Leaf 'woo_b' should have correct value")
+
+    # Convert to XML string
+    xml_str = gdata.to_xmlstr()
+    testing.assertTrue("<a>test_string</a>" in xml_str, "XML should contain leaf 'a'")
+    testing.assertTrue("<woo>" in xml_str, "XML should contain container 'woo'")
+    testing.assertTrue("<woo_b>123</woo_b>" in xml_str, "XML should contain leaf 'woo_b'")
+
+
+def _test_rpc_output_deserialization():
+    """Test that RPC output data is properly deserialized from gdata"""
+    # Create a gdata representation of output
+    output_gdata = yang.gdata.Container({
+        "outoo": yang.gdata.Leaf("string", "Test output value")
+    }, ns="http://example.com/yangrpc", module="yangrpc")
+
+    # Convert to adata
+    output_adata = yangrpc.yangrpc__foo__output.from_gdata(output_gdata)
+
+    # Verify the output
+    testing.assertEqual(output_adata.outoo, "Test output value", "Output should have correct value")
+
+    # Test with None value
+    empty_gdata = yang.gdata.Container({}, ns="http://example.com/yangrpc", module="yangrpc")
+    empty_output = yangrpc.yangrpc__foo__output.from_gdata(empty_gdata)
+    testing.assertEqual(empty_output.outoo, None, "Empty output should have None value")
+
+
+actor _test_rpc_foo_with_gen3(t: testing.AsyncT):
+    """Test RPC execution using gen3 parser"""
+    def on_reply(r: ?yangrpc.yangrpc__foo__output, err: ?Exception):
+        if err is not None:
+            t.failure(err)
+            return
+
+        if r is not None:
+            # Verify the output data
+            testing.assertEqual(r.outoo, "Hello from RPC!", "Expected correct output message from gen3 parser")
+            t.success()
+        else:
+            t.failure(ValueError("Got no result when one was expected"))
+
+    tp = MockTreeProviderSuccess()
+    root = yangrpc.rpc_root(tp)
+
+    # Create input data
+    woo = yangrpc.yangrpc__foo__input__woo(2024)
+    foo_input = yangrpc.yangrpc__foo__input("gen3_test", woo)
+
+    # Execute the RPC with gen3=True
+    root.foo(on_reply, foo_input, gen3=True)
+
+
+actor _test_rpc_silent_no_input_output(t: testing.AsyncT):
+    """Test RPC with no input and no output (silent RPC)"""
+    def on_reply(err: ?Exception):
+        if err is not None:
+            t.failure(err)
+            return
+
+        # For silent RPC, we expect no error (successful completion)
+        t.success()
+
+    tp = MockTreeProviderSuccess()
+    root = yangrpc.rpc_root(tp)
+
+    # Execute the silent RPC - no input parameter needed
+    root.silent(on_reply)
+
+
+actor _test_rpc_silent_with_gen3(t: testing.AsyncT):
+    """Test silent RPC using gen3 parser"""
+    def on_reply(err: ?Exception):
+        if err is not None:
+            t.failure(err)
+            return
+
+        # For silent RPC with gen3, we still expect successful completion
+        t.success()
+
+    tp = MockTreeProviderSuccess()
+    root = yangrpc.rpc_root(tp)
+
+    # Execute the silent RPC with gen3=True
+    root.silent(on_reply, gen3=True)
+
+
+actor _test_rpc_silent_error_handling(t: testing.AsyncT):
+    """Test silent RPC error handling"""
+    def on_reply(err: ?Exception):
+        if err is not None:
+            # We expect an error in this test
+            testing.assertTrue(isinstance(err, ValueError), "Expected ValueError for silent RPC error")
+            testing.assertEqual(str(err), "ValueError: RPC execution failed", "Expected correct error message")
+            t.success()
+        else:
+            t.failure(ValueError("Expected an error but got success"))
+
+    tp = MockTreeProviderError()
+    root = yangrpc.rpc_root(tp)
+
+    # Execute the silent RPC (should fail with error provider)
+    root.silent(on_reply)

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -1,0 +1,386 @@
+from yang.schema import *
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+def src_yang():
+    res = []
+    res.append(r"""module yangrpc {
+  yang-version "1.1";
+  namespace "http://example.com/yangrpc";
+  prefix "yrpc";
+  rpc foo {
+    input {
+      leaf a { type string; }
+      container woo {
+        leaf woo_b { type int64; }
+      }
+    }
+    output {
+      leaf outoo { type string; }
+    }
+  }
+}""")
+    return res
+
+
+class root(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = ''
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root()
+        return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+mut def from_json_yangrpc__foo__input__a(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_yangrpc__foo__input__a(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_yangrpc__foo__input__woo__woo_b(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('int64', val)
+
+mut def from_xml_yangrpc__foo__input__woo__woo_b(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('int64', val)
+
+class yangrpc__foo__input__woo(yang.adata.MNode):
+    woo_b: ?int
+
+    mut def __init__(self, woo_b: ?int):
+        self._ns = 'http://example.com/yangrpc'
+        self.woo_b = woo_b
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _woo_b = self.woo_b
+        if _woo_b is not None:
+            children['woo_b'] = yang.gdata.Leaf('int64', _woo_b)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input__woo:
+        if n is not None:
+            return yangrpc__foo__input__woo(woo_b=n.get_opt_int('woo_b'))
+        return yangrpc__foo__input__woo()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /foo/input/woo')
+            res.append('{self_name} = yangrpc__foo__input__woo()')
+        leaves = []
+        _woo_b = self.woo_b
+        if _woo_b is not None:
+            leaves.append('{self_name}.woo_b = {repr(_woo_b)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /foo/input/woo'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_woo_b = yang.gdata.from_xml_opt_int(node, 'woo_b')
+    yang.gdata.maybe_add(children, 'woo_b', from_xml_yangrpc__foo__input__woo__woo_b, child_woo_b)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_yangrpc__foo__input__woo(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'woo_b':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_yangrpc__foo__input__woo(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_yangrpc__foo__input__woo(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_woo_b = yang.gdata.take_json_opt_int64(jd, 'woo_b')
+    yang.gdata.maybe_add(children, 'woo_b', from_json_yangrpc__foo__input__woo__woo_b, child_woo_b)
+    return yang.gdata.Container(children)
+
+class yangrpc__foo__input(yang.adata.MNode):
+    a: ?str
+    woo: yangrpc__foo__input__woo
+
+    mut def __init__(self, a: ?str, woo: ?yangrpc__foo__input__woo=None):
+        self._ns = 'http://example.com/yangrpc'
+        self.a = a
+        self.woo = woo if woo is not None else yangrpc__foo__input__woo()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _a = self.a
+        if _a is not None:
+            children['a'] = yang.gdata.Leaf('string', _a)
+        _woo = self.woo
+        if _woo is not None:
+            children['woo'] = _woo.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input:
+        if n is not None:
+            return yangrpc__foo__input(a=n.get_opt_str('a'), woo=yangrpc__foo__input__woo.from_gdata(n.get_opt_cnt('woo')))
+        return yangrpc__foo__input()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /foo/input')
+            res.append('{self_name} = yangrpc__foo__input()')
+        leaves = []
+        _a = self.a
+        if _a is not None:
+            leaves.append('{self_name}.a = {repr(_a)}')
+        _woo = self.woo
+        if _woo is not None:
+            res.extend(_woo.prsrc('{self_name}.woo', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /foo/input'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_yangrpc__foo__input(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_a = yang.gdata.from_xml_opt_str(node, 'a')
+    yang.gdata.maybe_add(children, 'a', from_xml_yangrpc__foo__input__a, child_a)
+    child_woo = yang.gdata.from_xml_opt_cnt(node, 'woo')
+    yang.gdata.maybe_add(children, 'woo', from_xml_yangrpc__foo__input__woo, child_woo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+mut def from_json_path_yangrpc__foo__input(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'a':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'woo':
+            child = {'woo': from_json_path_yangrpc__foo__input__woo(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/yangrpc', module='yangrpc')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_yangrpc__foo__input(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_yangrpc__foo__input(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_a = yang.gdata.take_json_opt_str(jd, 'a')
+    yang.gdata.maybe_add(children, 'a', from_json_yangrpc__foo__input__a, child_a)
+    child_woo = yang.gdata.take_json_opt_cnt(jd, 'woo')
+    yang.gdata.maybe_add(children, 'woo', from_json_yangrpc__foo__input__woo, child_woo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+mut def from_json_yangrpc__foo__output__outoo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_yangrpc__foo__output__outoo(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class yangrpc__foo__output(yang.adata.MNode):
+    outoo: ?str
+
+    mut def __init__(self, outoo: ?str):
+        self._ns = 'http://example.com/yangrpc'
+        self.outoo = outoo
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _outoo = self.outoo
+        if _outoo is not None:
+            children['outoo'] = yang.gdata.Leaf('string', _outoo)
+        return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__output:
+        if n is not None:
+            return yangrpc__foo__output(outoo=n.get_opt_str('outoo'))
+        return yangrpc__foo__output()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /foo/output')
+            res.append('{self_name} = yangrpc__foo__output()')
+        leaves = []
+        _outoo = self.outoo
+        if _outoo is not None:
+            leaves.append('{self_name}.outoo = {repr(_outoo)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /foo/output'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+
+mut def from_xml_yangrpc__foo__output(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_outoo = yang.gdata.from_xml_opt_str(node, 'outoo')
+    yang.gdata.maybe_add(children, 'outoo', from_xml_yangrpc__foo__output__outoo, child_outoo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+mut def from_json_path_yangrpc__foo__output(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'outoo':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_yangrpc__foo__output(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_outoo = yang.gdata.take_json_opt_str(jd, 'outoo')
+    yang.gdata.maybe_add(children, 'outoo', from_json_yangrpc__foo__output__outoo, child_outoo)
+    return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
+
+actor rpc_handler(tp: yang.gdata.TreeProvider):
+    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input):
+        def cb_wrap(res: ?xml.Node, err: ?Exception):
+            if res is not None:
+                gdata_res = from_xml_yangrpc__foo__output(res)
+                adata_res = yangrpc__foo__output.from_gdata(gdata_res)
+                cb(adata_res, err)
+            else:
+                cb(None, err)
+
+        xmlstr = '<foo xmlns="http://example.com/yangrpc">{inp.to_gdata().to_xmlstr()}</foo>'
+        print(xmlstr, err=True)
+        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+
+
+class rpc_root(yang.adata.RpcRoot):
+    _handler: rpc_handler
+
+    def __init__(self, tp: yang.gdata.TreeProvider):
+        yang.adata.RpcRoot.__init__(self, tp)
+        self._handler = rpc_handler(tp)
+
+    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input) -> None:
+        self._handler.foo(cb, inp)
+
+
+schema_namespaces: set[str] = {
+    'http://example.com/yangrpc',
+}
+def src_schema():
+    res = {}
+    res["yangrpc"] = Module('yangrpc', yang_version=1.1, namespace='http://example.com/yangrpc', prefix='yrpc', children=[
+    Rpc('foo', input=Input(children=[
+    Leaf('a', type_=Type('string')),
+    Container('woo', children=[
+        Leaf('woo_b', type_=Type('int64'))
+    ])
+]), output=Output(children=[
+    Leaf('outoo', type_=Type('string'))
+]))
+])
+    return res
+
+def src_schema_compiled():
+    res = {}
+    res["yangrpc"] = Module('yangrpc', yang_version=1.1, namespace='http://example.com/yangrpc', prefix='yrpc', children=[
+    Rpc('foo', input=Input(children=[
+    Leaf('a', type_=Type('string')),
+    Container('woo', children=[
+        Leaf('woo_b', type_=Type('int64'))
+    ])
+]), output=Output(children=[
+    Leaf('outoo', type_=Type('string'))
+]))
+])
+    return res

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -30,6 +30,7 @@ def src_yang():
       leaf outoo { type string; }
     }
   }
+  rpc silent;
 }""")
     return res
 
@@ -329,7 +330,7 @@ mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Cont
     return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
 
 actor rpc_handler(tp: yang.gdata.TreeProvider):
-    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False):
+    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
                 if gen3:
@@ -341,8 +342,20 @@ actor rpc_handler(tp: yang.gdata.TreeProvider):
             else:
                 cb(None, err)
 
-        xmlstr = '<foo xmlns="http://example.com/yangrpc">{inp.to_gdata().to_xmlstr()}</foo>'
-        print(xmlstr, err=True)
+        if inp is not None:
+            xmlstr = '<foo xmlns="http://example.com/yangrpc">{inp.to_gdata().to_xmlstr()}</foo>'
+        else:
+            xmlstr = '<foo xmlns="http://example.com/yangrpc" />'
+        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+
+    def silent(cb: action(?None, ?Exception) -> None, inp: ?None, gen3: bool=False):
+        def cb_wrap(res: ?xml.Node, err: ?Exception):
+            if res is not None:
+                cb(None, err)
+            else:
+                cb(None, err)
+
+        xmlstr = '<silent xmlns="http://example.com/yangrpc" />'
         tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
 
 
@@ -353,8 +366,11 @@ class rpc_root(yang.adata.RpcRoot):
         yang.adata.RpcRoot.__init__(self, tp)
         self._handler = rpc_handler(tp)
 
-    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False) -> None:
+    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False) -> None:
         self._handler.foo(cb, inp, gen3)
+
+    proc def silent(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:
+        self._handler.silent(lambda _, err: cb(err), None, gen3)
 
 
 schema_namespaces: set[str] = {
@@ -370,7 +386,8 @@ def src_schema():
     ])
 ]), output=Output(children=[
     Leaf('outoo', type_=Type('string'))
-]))
+])),
+    Rpc('silent')
 ])
     return res
 
@@ -384,6 +401,7 @@ def src_schema_compiled():
     ])
 ]), output=Output(children=[
     Leaf('outoo', type_=Type('string'))
-]))
+])),
+    Rpc('silent', input=Input(), output=Output())
 ])
     return res

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -329,10 +329,13 @@ mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Cont
     return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
 
 actor rpc_handler(tp: yang.gdata.TreeProvider):
-    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input):
+    def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
-                gdata_res = from_xml_yangrpc__foo__output(res)
+                if gen3:
+                    gdata_res = from_xml_gen3(res, ["yangrpc:foo", "output"])
+                else:
+                    gdata_res = from_xml_yangrpc__foo__output(res)
                 adata_res = yangrpc__foo__output.from_gdata(gdata_res)
                 cb(adata_res, err)
             else:
@@ -350,8 +353,8 @@ class rpc_root(yang.adata.RpcRoot):
         yang.adata.RpcRoot.__init__(self, tp)
         self._handler = rpc_handler(tp)
 
-    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input) -> None:
-        self._handler.foo(cb, inp)
+    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: yangrpc__foo__input, gen3: bool=False) -> None:
+        self._handler.foo(cb, inp, gen3)
 
 
 schema_namespaces: set[str] = {

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -415,6 +415,7 @@ ys_yangrpc = r"""module yangrpc {
       leaf outoo { type string; }
     }
   }
+  rpc silent;
 }"""
 
 

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -400,6 +400,23 @@ ys_basics = r"""module basics {
     }
 }"""
 
+ys_yangrpc = r"""module yangrpc {
+  yang-version "1.1";
+  namespace "http://example.com/yangrpc";
+  prefix "yrpc";
+  rpc foo {
+    input {
+      leaf a { type string; }
+      container woo {
+        leaf woo_b { type int64; }
+      }
+    }
+    output {
+      leaf outoo { type string; }
+    }
+  }
+}"""
+
 
 actor main(env: Env):
     wfcap = file.WriteFileCap(file.FileCap(env.cap))
@@ -407,4 +424,5 @@ actor main(env: Env):
     yang_to_act(wfcap, yangs=[ys_foo, ys_qux, ys_bar], filename="../test_data_classes/src/yang_foo.act")
     yang_to_act(wfcap, yangs=[ys_foo, ys_qux, ys_bar], filename="../test_data_classes/src/yang_foo_loose.act", loose=True)
     yang_to_act(wfcap, yangs=[ys_basics], filename="../test_data_classes/src/yang_basics.act")
+    yang_to_act(wfcap, yangs=[ys_yangrpc], filename="../test_data_classes/src/yangrpc.act")
     env.exit(0)


### PR DESCRIPTION
This is the materialization of the sketch for RPC support in #197. A couple of deviations:
- There is now a "handler" (name??) actor placed between the user-facing method in `rpc_root` and the `TreeProvider` because a callback we pass to another actor must be an *action* in an actor.
- The user-facing method in `rpc_root` has a different signature if RPC input or output is undefined.
- The adata class names for input and output are a bit different, just because `get_path_name()` was convenient to use.

Closes #197.