### PR TITLE
Add schema-driven adata printer

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -801,6 +801,11 @@ class DNodeInner(DNode):
         res.append("                res = leaves + res")
         res.append("        return '\\n'.join(res)")
         res.append("")
+        res.append("    def prsrc_gen3(self, self_name='ad'):")
+        res.append("        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!")
+        res.append("        s = yang.compile(src_yang())")
+        res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose})")
+        res.append("")
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -740,9 +740,14 @@ class DNodeInner(DNode):
                     # Do not print non-optional leafs if not top level, because
                     # they are implicitly set with .create*()
                     continue
-                # DLeaf and DLeafList are both copied verbatim
+                # DLeaf and DLeafList are both copied verbatim, except for empty
+                # leaf-list. The gdata takers for leaf-list return an empty list
+                # as default: (see yang.gdata.get_opt_*s)
                 res.append("        _{usname(child)} = self.{usname(child)}")
-                res.append("        if _{usname(child)} is not None:")
+                if isinstance(child, DLeafList):
+                    res.append("        if len(_{usname(child)}) != 0:")
+                else:
+                    res.append("        if _{usname(child)} is not None:")
                 res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
             elif isinstance(child, DContainer):
                 res.append("        _{usname(child)} = self.{usname(child)}")

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -804,7 +804,15 @@ class DNodeInner(DNode):
         res.append("    def prsrc_gen3(self, self_name='ad'):")
         res.append("        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!")
         res.append("        s = yang.compile(src_yang())")
-        res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose})")
+        if isinstance(self, DRoot):
+            res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose})")
+        else:
+            # TODO: refactor prdaclass to accumulate the nodes (DNode) it traverses into a path parameter!
+            root_path = get_path(self).split("/")[1:]
+            # TODO: use a common function that takes a list[DNode] and builds a
+            # string path, obeying the rules for mandatory and optional qualifiers
+            root_path[0] = "{self.module}:{root_path[0]}"
+            res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose}, root_path={repr(root_path)})")
         res.append("")
 
         if isinstance(self, DList):
@@ -1196,6 +1204,11 @@ class DNodeInner(DNode):
             for ns in sorted(schema_ns):
                 res.append("    '{ns}',")
             res.append("}}")
+            res.append("")
+            res.append("def prsrc_gen3(data, self_name='ad'):")
+            res.append("    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.pradata(s, data, self_name, loose={loose})")
             res.append("")
 
         return "\n".join(res)

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -610,6 +610,40 @@ class Node(value):
         except ValueError:
             return []
 
+    def get_floats(self, name) -> list[float]:
+        if isinstance(self, Container):
+            for nm,child in self.children.items():
+                if isinstance(child, LeafList) and nm == name:
+                    cvals = []
+                    for v in child.vals:
+                        if isinstance(v, float):
+                            cvals.append(v)
+                    return cvals
+        raise ValueError("Cannot find leaf-list child with name {name}")
+
+    def get_opt_floats(self, name) -> list[float]:
+        try:
+            return self.get_floats(name)
+        except ValueError:
+            return []
+
+    def get_bools(self, name) -> list[bool]:
+        if isinstance(self, Container):
+            for nm,child in self.children.items():
+                if isinstance(child, LeafList) and nm == name:
+                    cvals = []
+                    for v in child.vals:
+                        if isinstance(v, bool):
+                            cvals.append(v)
+                    return cvals
+        raise ValueError("Cannot find leaf-list child with name {name}")
+
+    def get_opt_bools(self, name) -> list[bool]:
+        try:
+            return self.get_bools(name)
+        except ValueError:
+            return []
+
     def get_value(self, name) -> value:
         child = self.get_leaf(name)
         return child.val

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -433,7 +433,7 @@ def _from_data[A(YangData[A])](s: yang.schema.DNodeInner, global_identity, data:
     for child in s.children:
         # Only process data nodes
         if not (isinstance(child, yang.schema.DNodeLeaf) or isinstance(child, yang.schema.DContainer) or isinstance(child, yang.schema.DList)):
-            print("Skipping chilld: {child.name} of type {type(child)}", err=True)
+            print("Skipping child: {child.name} of type {type(child)}", err=True)
             continue
         # Get the appropriate taker function name
         taker_name = yang.schema.taker_name(child, data.format_name(), loose)
@@ -597,6 +597,8 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
         unique_namer = yang.schema._UniqueNamer(container)
 
         for cchild in container.children:
+            if not (isinstance(cchild, yang.schema.DNodeLeaf) or isinstance(cchild, yang.schema.DContainer) or isinstance(cchild, yang.schema.DList)):
+                continue
             if isinstance(cchild, yang.schema.DLeaf):
                 # The list of children is already sorted so that key leaves
                 # come first in the correct order.
@@ -652,9 +654,14 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
             res.append("{self_name} = {pname(s)}()")
     leaves = []
     for child in s.children:
+        # Only process data nodes
+        if not (isinstance(child, yang.schema.DNodeLeaf) or isinstance(child, yang.schema.DContainer) or isinstance(child, yang.schema.DList)):
+            print("Skipping child: {child.name} of type {type(child)}", err=True)
+            continue
+        taker_name = yang.schema.taker_name(child, "gdata", loose)
+        print("Processing child: {child.name} with taker {taker_name}", err=True)
         taken_nodes = None
         try:
-            taker_name = yang.schema.taker_name(child, "gdata", loose)
             taken_nodes = GDATA_TAKERS[taker_name](node, uname(child))
         except ValueError as err:
             raise ValueError("Error reading {yang.schema.get_path(child)}: {err.error_message}")

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -546,11 +546,20 @@ def from_json(root: yang.schema.DRoot, node: dict[str, ?value], loose: bool=Fals
     return _from_data(root, root.identities, json_data, loose, root_path=root_path)
 
 
-def pradata(root: yang.schema.DRoot, node: yang.gdata.Node, self_name: str="ad", loose: bool=False):
-    return _pradata_recursive(root, node, self_name, loose, top=True)
+def pradata(root: yang.schema.DRoot, node: yang.gdata.Node, self_name: str="ad", loose: bool=False, root_path: list[str]=[]):
+    return _pradata_recursive(root, node, self_name, loose, top=True, root_path=root_path)
 
 
-def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_name: str, loose: bool=False, top: bool=False, list_element: bool=False):
+def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_name: str, loose: bool=False, top: bool=False, list_element: bool=False, root_path: list[str]=[], path: list[str]=[]):
+    # Navigate to root path if specified
+    if root_path != [] and len(path) < len(root_path):
+        next = root_path[len(path)]
+        local_name, module = _parse_qualified_name(next)
+        child = s.get(local_name, module, allow_unqualified=False)
+        if isinstance(child, yang.schema.DNodeInner):
+            return _pradata_recursive(child, node, self_name, loose, top, list_element, root_path, path + [next])
+        raise ValueError("Node on path {path} is not inner")
+
     def pname(n):
         return yang.schema.get_path_name(n)
 
@@ -673,9 +682,9 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     pc_args_str = ", ".join(pc_args)
                     res.append("{child_accessor} = {self_name}.create_{usname(child)}({pc_args_str})")
                     # Recursive call to pradata() for the P-container, to fill in the rest of the optional children
-                    res.extend(_pradata_recursive(child, taken_nodes, usname(child), loose).splitlines())
+                    res.extend(_pradata_recursive(child, taken_nodes, usname(child), loose, root_path=root_path, path=path).splitlines())
                 else:
-                    res.extend(_pradata_recursive(child, taken_nodes, "{self_name}.{usname(child)}", loose).splitlines())
+                    res.extend(_pradata_recursive(child, taken_nodes, "{self_name}.{usname(child)}", loose, root_path=root_path, path=path).splitlines())
             elif isinstance(child, yang.schema.DList) and isinstance(taken_nodes, yang.gdata.List):
                 child_unique_namer = yang.schema._UniqueNamer(child)
                 for element in taken_nodes.elements:
@@ -693,7 +702,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     create_args_str = ", ".join(list_create_args)
                     res.append("{usname(child)}_element = {self_name}.{usname(child)}.create({create_args_str})")
                     # Recursive call to pradata() for the list element
-                    res.extend(_pradata_recursive(child, element, "{usname(child)}_element", loose, list_element=True).splitlines())
+                    res.extend(_pradata_recursive(child, element, "{usname(child)}_element", loose, list_element=True, root_path=root_path, path=path).splitlines())
             else:
                 raise ValueError("Unhandled child type in .pradata(): {type(child)}")
 
@@ -1198,6 +1207,44 @@ def _test_pradata():
     })
 
     result = pradata(s, gdata_tree)
+    return result
+
+
+def _test_pradata_root_path():
+    schema_str = r"""module test {
+      namespace "urn:example:test";
+      prefix test;
+
+      container outer {
+        container middle {
+          leaf value1 {
+            type string;
+          }
+          container inner {
+            leaf value2 {
+              type int32;
+            }
+          }
+        }
+      }
+    }"""
+
+    s = yang.compile([schema_str])
+
+    gdata_tree = yang.gdata.Container({
+        "outer": yang.gdata.Container({
+            "middle": yang.gdata.Container({
+                "value1": yang.gdata.Leaf("string", "test value"),
+                "inner": yang.gdata.Container({
+                    "value2": yang.gdata.Leaf("int32", 42)
+                })
+            })
+        })
+    })
+
+    middle_node = gdata_tree.get_cnt("outer").get_cnt("middle")
+    result = pradata(s, middle_node, root_path=["test:outer", "middle"])
+
     return result
 
 

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -665,8 +665,11 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     # Do not print non-optional leafs if not top level, because
                     # they are implicitly set with .create*()
                     continue
-                # DLeaf and DLeafList are both copied verbatim
-                # TODO: what about identityref?
+                # DLeaf and DLeafList are both copied verbatim, except for empty
+                # leaf-list. The gdata takers for leaf-list return an empty list
+                # as default: (see yang.gdata.get_opt_*s)
+                if isinstance(child, yang.schema.DLeafList) and isinstance(taken_nodes, list) and len(taken_nodes) == 0:
+                    continue
                 leaves.append("{self_name}.{usname(child)} = {repr(taken_nodes)}")
             elif isinstance(child, yang.schema.DContainer) and isinstance(taken_nodes, yang.gdata.Container):
                 if child.presence:
@@ -1179,6 +1182,10 @@ def _test_pradata():
           leaf value {
             type int32;
           }
+        }
+        leaf-list always-empty {
+          // Leave this empty, we check that empty leaf-list is not printed
+          type string;
         }
       }
     }"""

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -100,6 +100,47 @@ JSON_TAKERS = {
     "take_json_opt_Identityrefs": yang.gdata.take_json_opt_Identityrefs,
 }
 
+# Map of gdata getter method names to actual methods
+GDATA_TAKERS = {
+    # Container getters
+    "get_cnt": yang.gdata.Node.get_cnt,
+    "get_opt_cnt": yang.gdata.Node.get_opt_cnt,
+    # List getters
+    "get_list": yang.gdata.Node.get_list,
+    "get_opt_list": yang.gdata.Node.get_opt_list,
+    # Leaf getters
+    "get_str": yang.gdata.Node.get_str,
+    "get_opt_str": yang.gdata.Node.get_opt_str,
+    "get_int": yang.gdata.Node.get_int,
+    "get_opt_int": yang.gdata.Node.get_opt_int,
+    "get_float": yang.gdata.Node.get_float,
+    "get_opt_float": yang.gdata.Node.get_opt_float,
+    "get_bool": yang.gdata.Node.get_bool,
+    "get_opt_bool": yang.gdata.Node.get_opt_bool,
+    "get_opt_empty": yang.gdata.Node.get_opt_empty,
+    "get_bytes": yang.gdata.Node.get_bytes,
+    "get_opt_bytes": yang.gdata.Node.get_opt_bytes,
+    "get_value": yang.gdata.Node.get_value,
+    "get_opt_value": yang.gdata.Node.get_opt_value,
+    "get_Identityref": yang.gdata.Node.get_Identityref,
+    "get_opt_Identityref": yang.gdata.Node.get_opt_Identityref,
+    # LeafList getters
+    "get_strs": yang.gdata.Node.get_strs,
+    "get_opt_strs": yang.gdata.Node.get_opt_strs,
+    "get_ints": yang.gdata.Node.get_ints,
+    "get_opt_ints": yang.gdata.Node.get_opt_ints,
+    "get_floats": yang.gdata.Node.get_floats,
+    "get_opt_floats": yang.gdata.Node.get_opt_floats,
+    "get_bools": yang.gdata.Node.get_bools,
+    "get_opt_bools": yang.gdata.Node.get_opt_bools,
+    "get_bytess": yang.gdata.Node.get_bytess,
+    "get_opt_bytess": yang.gdata.Node.get_opt_bytess,
+    "get_values": yang.gdata.Node.get_values,
+    "get_opt_values": yang.gdata.Node.get_opt_values,
+    "get_Identityrefs": yang.gdata.Node.get_Identityrefs,
+    "get_opt_Identityrefs": yang.gdata.Node.get_opt_Identityrefs,
+}
+
 
 # TODO: implement this protocol on the actual data types instead of the wrapper classes:
 # - XML: xml.Node, list[xml.Node]
@@ -504,6 +545,166 @@ def from_json(root: yang.schema.DRoot, node: dict[str, ?value], loose: bool=Fals
     json_data = JsonYangData(node)
     return _from_data(root, root.identities, json_data, loose, root_path=root_path)
 
+
+def pradata(root: yang.schema.DRoot, node: yang.gdata.Node, self_name: str="ad", loose: bool=False):
+    return _pradata_recursive(root, node, self_name, loose, top=True)
+
+
+def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_name: str, loose: bool=False, top: bool=False, list_element: bool=False):
+    def pname(n):
+        return yang.schema.get_path_name(n)
+
+    def _find_non_optional_subtree(container: yang.schema.DNodeInner, node: yang.gdata.Node, path: list[str], local_prefix="_") -> (list[str], list[str]):
+        r"""Discover the non-optional descendants of a container
+
+        The container here is either a DContainer or a DList (representing
+        a list element). We recursively traverse the child nodes of the
+        container, looking for non-optional leaves and containers. A
+        container is non-optional if it is not a presence container and it
+        contains other non-optional nodes.
+
+        As we traverse the tree, we build intermediate container objects
+        using their non-optional arguments.
+
+        Args:
+            container: The container node to analyze
+            path: List of attribute names representing the path from the root
+                    to the current container (e.g. ['self', 'child1', 'child2'])
+            local_prefix: Prefix used for variable access in generated code,
+                            typically "_" for local variables or "" for self references
+
+        The function returns a tuple of two lists:
+        - non_optional_args: list of non-optional arguments for the outer container
+        - non_optional_containers: list of code lines that declare the
+        intermediate containers and their arguments
+
+        Note on f-string evaluation timing:
+        This function uses nested f-strings with two evaluation phases:
+        1. Generation-time: Outer f-strings resolve class names, paths, variable names
+        2. Runtime: Inner f-strings ({{...}}) become {...} and evaluate when pradata() executes.
+        """
+        non_optional_args = []
+        non_optional_containers = []
+        unique_namer = yang.schema._UniqueNamer(container)
+
+        for cchild in container.children:
+            if isinstance(cchild, yang.schema.DLeaf):
+                # The list of children is already sorted so that key leaves
+                # come first in the correct order.
+                if not yang.schema.is_optional_arg_yang_leaf(cchild, loose):
+                    taker_name = yang.schema.taker_name(cchild, "gdata", loose)
+                    taken_node = GDATA_TAKERS[taker_name](node, unique_namer.unique_name(cchild.name, cchild.prefix))
+                    if taken_node is not None:
+                        non_optional_args.append("{repr(taken_node)}")
+                    else:
+                        raise ValueError("Missing non-optional leaf {pname(cchild)}")
+            elif isinstance(cchild, yang.schema.DContainer):
+                if not (cchild.presence or loose or yang.schema.optional_subtree(cchild)):
+                    cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
+
+                    # Recursively build subtree for non-optional children
+                    sub_args, sub_containers = _find_non_optional_subtree(cchild, node.get_cnt(cchild.name), path + [cchild_safe_name], local_prefix)
+
+                    # Create variable declaration for this container
+                    mcchild_var = "{'_'.join(path)}_{cchild_safe_name}"
+
+                    if sub_args:
+                        sub_args_str = ", ".join(sub_args)
+                        non_optional_containers.append("{mcchild_var} = {pname(cchild)}({sub_args_str})")
+                    else:
+                        non_optional_containers.append("{mcchild_var} = {pname(cchild)}()")
+
+                    # Add nested variable declarations
+                    non_optional_containers.extend(sub_containers)
+
+                    non_optional_args.append(mcchild_var)
+
+        return non_optional_args, non_optional_containers
+
+    unique_namer = yang.schema._UniqueNamer(s)
+    def usname(n) -> str:
+        return unique_namer.unique_safe_name(n.name, n.prefix)
+    def uname(n) -> str:
+        return unique_namer.unique_name(n.name, n.prefix)
+    res = []
+    if top:
+        res.append('# Top node: {yang.schema.get_path(s)}')
+        # Build constructor arguments for non-optional children (same logic as in __init__)
+        constructor_args, constructor_containers = _find_non_optional_subtree(s, node, ["self"], local_prefix="")
+        if constructor_args:
+            # Add variable declarations in reverse order to ensure dependencies are declared before use.
+            # For example, if container C needs argument from container B, which needs argument from A,
+            # we must generate: A_var = ..., B_var = ..., C_var = ... in that order.
+            # Since find_non_optional_subtree() builds the list depth-first, we reverse it.
+            res.extend(list(reversed(constructor_containers)))
+            args_str = ", ".join(constructor_args)
+            res.append("{self_name} = {pname(s)}({args_str})")
+        else:
+            res.append("{self_name} = {pname(s)}()")
+    leaves = []
+    for child in s.children:
+        taken_nodes = None
+        try:
+            taker_name = yang.schema.taker_name(child, "gdata", loose)
+            taken_nodes = GDATA_TAKERS[taker_name](node, uname(child))
+        except ValueError as err:
+            raise ValueError("Error reading {yang.schema.get_path(child)}: {err.error_message}")
+
+        if taken_nodes is not None:
+            if isinstance(child, yang.schema.DNodeLeaf):
+                if not top and not yang.schema.is_optional_arg_yang_leaf(child, loose):
+                    # Do not print non-optional leafs if not top level, because
+                    # they are implicitly set with .create*()
+                    continue
+                # DLeaf and DLeafList are both copied verbatim
+                # TODO: what about identityref?
+                leaves.append("{self_name}.{usname(child)} = {repr(taken_nodes)}")
+            elif isinstance(child, yang.schema.DContainer) and isinstance(taken_nodes, yang.gdata.Container):
+                if child.presence:
+                    res.append("")
+                    res.append("# P-container: {yang.schema.get_path(child)}")
+                    # Build .pradata() code for this P-container
+                    pc_args, pc_var_declarations = _find_non_optional_subtree(child, taken_nodes, [usname(child)])
+
+                    # Add variable declarations in reverse order to ensure the prerequisites are met
+                    res.extend(list(reversed(pc_var_declarations)))
+
+                    child_accessor = yang.schema._safe_name(child.name)
+                    pc_args_str = ", ".join(pc_args)
+                    res.append("{child_accessor} = {self_name}.create_{usname(child)}({pc_args_str})")
+                    # Recursive call to pradata() for the P-container, to fill in the rest of the optional children
+                    res.extend(_pradata_recursive(child, taken_nodes, usname(child), loose).splitlines())
+                else:
+                    res.extend(_pradata_recursive(child, taken_nodes, "{self_name}.{usname(child)}", loose).splitlines())
+            elif isinstance(child, yang.schema.DList) and isinstance(taken_nodes, yang.gdata.List):
+                child_unique_namer = yang.schema._UniqueNamer(child)
+                for element in taken_nodes.elements:
+                    res.append("")
+                    res.append("# List {yang.schema.get_path(child)} element: {element.key_str(child.key)}")
+
+                    # Build the list of arguments for create() method
+                    list_create_args = []
+
+                    non_optional_args, non_optional_containers = _find_non_optional_subtree(child, element, ["element"])
+
+                    res.extend(list(reversed(non_optional_containers)))
+                    list_create_args.extend(non_optional_args)
+
+                    create_args_str = ", ".join(list_create_args)
+                    res.append("{usname(child)}_element = {self_name}.{usname(child)}.create({create_args_str})")
+                    # Recursive call to pradata() for the list element
+                    res.extend(_pradata_recursive(child, element, "{usname(child)}_element", loose, list_element=True).splitlines())
+            else:
+                raise ValueError("Unhandled child type in .pradata(): {type(child)}")
+
+    # Add the leaves as a single group at the beginning of the section,
+    # optionally add container header if we're not printing a list element
+    if leaves:
+        if not list_element:
+            res = ["", "# Container: {yang.schema.get_path(s)}"] + leaves + res
+        else:
+            res = leaves + res
+    return "\n".join(res)
 
 def _test_y1_xml():
     y1 = r"""module y1 {
@@ -935,6 +1136,69 @@ def _test_json_path_nested_lists():
         }, ns='urn:example:y1', module='y1')
     })
     testing.assertEqual(gd3.prsrc(), expected3.prsrc())
+
+
+def _test_pradata():
+    schema_str = r"""module test {
+      namespace "urn:example:test";
+      prefix test;
+
+      leaf top-level-leaf {
+        type string;
+        description "A leaf at the module root level";
+      }
+
+      container c1 {
+        leaf optional-leaf {
+          type int32;
+        }
+        container c2 {
+          presence "This is a presence container";
+          leaf l1 {
+            type string;
+          }
+          leaf mandatory-leaf {
+            type string;
+            mandatory true;
+          }
+        }
+        list mylist {
+          key name;
+          leaf name {
+            type string;
+          }
+          leaf value {
+            type int32;
+          }
+        }
+      }
+    }"""
+
+    s = yang.compile([schema_str])
+
+    gdata_tree = yang.gdata.Container({
+        "top-level-leaf": yang.gdata.Leaf("string", "root value"),
+        "c1": yang.gdata.Container({
+            "optional-leaf": yang.gdata.Leaf("int32", 42),
+            "c2": yang.gdata.Container({
+                "l1": yang.gdata.Leaf("string", "inner value"),
+                "mandatory-leaf": yang.gdata.Leaf("string", "required value")
+            }, presence=True),
+            "mylist": yang.gdata.List(["name"], [
+                yang.gdata.Container({
+                    "name": yang.gdata.Leaf("string", "item1"),
+                    "value": yang.gdata.Leaf("int32", 100)
+                }),
+                yang.gdata.Container({
+                    "name": yang.gdata.Leaf("string", "item2"),
+                    "value": yang.gdata.Leaf("int32", 200)
+                })
+            ])
+        })
+    })
+
+    result = pradata(s, gdata_tree)
+    return result
 
 
 def _test_json_path_container_list_container():

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -797,6 +797,11 @@ class DNodeInner(DNode):
         res.append("                res = leaves + res")
         res.append("        return '\\n'.join(res)")
         res.append("")
+        res.append("    def prsrc_gen3(self, self_name='ad'):")
+        res.append("        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!")
+        res.append("        s = yang.compile(src_yang())")
+        res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose})")
+        res.append("")
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -736,9 +736,14 @@ class DNodeInner(DNode):
                     # Do not print non-optional leafs if not top level, because
                     # they are implicitly set with .create*()
                     continue
-                # DLeaf and DLeafList are both copied verbatim
+                # DLeaf and DLeafList are both copied verbatim, except for empty
+                # leaf-list. The gdata takers for leaf-list return an empty list
+                # as default: (see yang.gdata.get_opt_*s)
                 res.append("        _{usname(child)} = self.{usname(child)}")
-                res.append("        if _{usname(child)} is not None:")
+                if isinstance(child, DLeafList):
+                    res.append("        if len(_{usname(child)}) != 0:")
+                else:
+                    res.append("        if _{usname(child)} is not None:")
                 res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
             elif isinstance(child, DContainer):
                 res.append("        _{usname(child)} = self.{usname(child)}")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -800,7 +800,15 @@ class DNodeInner(DNode):
         res.append("    def prsrc_gen3(self, self_name='ad'):")
         res.append("        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!")
         res.append("        s = yang.compile(src_yang())")
-        res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose})")
+        if isinstance(self, DRoot):
+            res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose})")
+        else:
+            # TODO: refactor prdaclass to accumulate the nodes (DNode) it traverses into a path parameter!
+            root_path = get_path(self).split("/")[1:]
+            # TODO: use a common function that takes a list[DNode] and builds a
+            # string path, obeying the rules for mandatory and optional qualifiers
+            root_path[0] = "{self.module}:{root_path[0]}"
+            res.append("        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose={loose}, root_path={repr(root_path)})")
         res.append("")
 
         if isinstance(self, DList):
@@ -1192,6 +1200,11 @@ class DNodeInner(DNode):
             for ns in sorted(schema_ns):
                 res.append("    '{ns}',")
             res.append("}}")
+            res.append("")
+            res.append("def prsrc_gen3(data, self_name='ad'):")
+            res.append("    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.pradata(s, data, self_name, loose={loose})")
             res.append("")
 
         return "\n".join(res)

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -196,3 +196,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -68,6 +68,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -138,6 +143,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -44,7 +44,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -199,7 +199,7 @@ class foo__r1__input__c3(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:r1', 'input', 'c3'])
 
 
 mut def from_xml_foo__r1__input__c3(node: xml.Node) -> yang.gdata.Container:
@@ -269,7 +269,7 @@ class foo__r1__input(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:r1', 'input'])
 
 
 mut def from_xml_foo__r1__input(node: xml.Node) -> yang.gdata.Container:
@@ -346,7 +346,7 @@ class foo__r1__output(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:r1', 'output'])
 
 
 mut def from_xml_foo__r1__output(node: xml.Node) -> yang.gdata.Container:
@@ -411,3 +411,8 @@ class rpc_root(yang.adata.RpcRoot):
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -41,6 +41,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -99,6 +104,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
@@ -186,6 +196,11 @@ class foo__r1__input__c3(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__r1__input__c3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -250,6 +265,11 @@ class foo__r1__input(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__r1__input(node: xml.Node) -> yang.gdata.Container:
@@ -322,6 +342,11 @@ class foo__r1__output(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__r1__output(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -197,3 +197,8 @@ schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -68,6 +68,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -138,6 +143,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -77,7 +77,7 @@ class foo__c1__c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'c2'])
 
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
@@ -161,7 +161,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -287,3 +287,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -74,6 +74,11 @@ class foo__c1__c2(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -153,6 +158,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -224,6 +234,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -77,7 +77,7 @@ class foo__c1__c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:c1', 'c2'])
 
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
@@ -161,7 +161,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -289,3 +289,8 @@ schema_namespaces: set[str] = {
     'http://example.com/baz',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -74,6 +74,11 @@ class foo__c1__c2(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -153,6 +158,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -224,6 +234,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -57,7 +57,7 @@ class foo__c1__c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'c2'])
 
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
@@ -127,7 +127,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -247,3 +247,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -54,6 +54,11 @@ class foo__c1__c2(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -118,6 +123,11 @@ class foo__c1(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -184,6 +194,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -197,3 +197,8 @@ schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -68,6 +68,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -138,6 +143,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -63,6 +63,11 @@ class foo__c1__things_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__c1__things(yang.adata.MNode):
     elements: list[foo__c1__things_entry]
     mut def __init__(self, elements=[]):
@@ -209,6 +214,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -274,6 +284,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -66,7 +66,7 @@ class foo__c1__things_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'things'])
 
 class foo__c1__things(yang.adata.MNode):
     elements: list[foo__c1__things_entry]
@@ -217,7 +217,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -337,3 +337,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -54,6 +54,11 @@ class acme_foo_bar__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_acme_foo_bar__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -118,6 +123,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -57,7 +57,7 @@ class acme_foo_bar__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['acme_foo-bar:c1'])
 
 
 mut def from_xml_acme_foo_bar__c1(node: xml.Node) -> yang.gdata.Container:
@@ -176,3 +176,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -49,6 +49,11 @@ class bar__c1__li1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -189,6 +194,11 @@ class bar__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -254,6 +264,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -52,7 +52,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:c1', 'li1'])
 
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
@@ -197,7 +197,7 @@ class bar__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:c1'])
 
 
 mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
@@ -317,3 +317,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/bar',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -54,6 +54,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -118,6 +123,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -45,7 +45,7 @@ class foo__c1(yang.adata.MNode):
             res.append('{self_name} = foo__c1()')
         leaves = []
         _l1 = self.l1
-        if _l1 is not None:
+        if len(_l1) != 0:
             leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -57,7 +57,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -176,3 +176,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -57,7 +57,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -133,7 +133,7 @@ class foo__c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c2'])
 
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
@@ -267,3 +267,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -54,6 +54,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -124,6 +129,11 @@ class foo__c2(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
@@ -197,6 +207,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -52,7 +52,7 @@ class foo__c1__li1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'li1'])
 
 class foo__c1__li1(yang.adata.MNode):
     elements: list[foo__c1__li1_entry]
@@ -197,7 +197,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -317,3 +317,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -49,6 +49,11 @@ class foo__c1__li1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__c1__li1(yang.adata.MNode):
     elements: list[foo__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -189,6 +194,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -254,6 +264,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -196,3 +196,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -68,6 +68,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -138,6 +143,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/identityref
+++ b/test/golden/test_yang/identityref
@@ -85,6 +85,11 @@ class base__config(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_base__config(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -149,6 +154,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/identityref
+++ b/test/golden/test_yang/identityref
@@ -88,7 +88,7 @@ class base__config(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:config'])
 
 
 mut def from_xml_base__config(node: xml.Node) -> yang.gdata.Container:
@@ -207,3 +207,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/base',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -49,6 +49,11 @@ class foo__c__li__bar(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c__li__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -125,6 +130,11 @@ class foo__c__li_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class foo__c__li(yang.adata.MNode):
     elements: list[foo__c__li_entry]

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -52,7 +52,7 @@ class foo__c__li__bar(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c', 'li', 'bar'])
 
 
 mut def from_xml_foo__c__li__bar(node: xml.Node) -> yang.gdata.Container:
@@ -134,7 +134,7 @@ class foo__c__li_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c', 'li'])
 
 class foo__c__li(yang.adata.MNode):
     elements: list[foo__c__li_entry]

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -46,6 +46,11 @@ class base__c1__base_l1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
     mut def __init__(self, elements=[]):
@@ -187,6 +192,11 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class base__c1__foo_l1(yang.adata.MNode):
     elements: list[base__c1__foo_l1_entry]
@@ -340,6 +350,11 @@ class base__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -412,6 +427,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_root(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -49,7 +49,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:c1', 'base:l1'])
 
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
@@ -196,7 +196,7 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'foo:l1'])
 
 class base__c1__foo_l1(yang.adata.MNode):
     elements: list[base__c1__foo_l1_entry]
@@ -353,7 +353,7 @@ class base__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:c1'])
 
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -40,6 +40,11 @@ class base__c1__base_c2(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_base__c1__base_c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -110,6 +115,11 @@ class base__c1__foo_c2(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_base__c1__foo_c2(node: xml.Node) -> yang.gdata.Container:
@@ -184,6 +194,11 @@ class base__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -256,6 +271,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_root(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -43,7 +43,7 @@ class base__c1__base_c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:c1', 'base:c2'])
 
 
 mut def from_xml_base__c1__base_c2(node: xml.Node) -> yang.gdata.Container:
@@ -119,7 +119,7 @@ class base__c1__foo_c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'foo:c2'])
 
 
 mut def from_xml_base__c1__foo_c2(node: xml.Node) -> yang.gdata.Container:
@@ -197,7 +197,7 @@ class base__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:c1'])
 
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -54,6 +54,11 @@ class base__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -57,7 +57,7 @@ class base__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:c1'])
 
 
 mut def from_xml_base__c1(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -57,7 +57,7 @@ class foo__ieee_802_3(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:ieee-802.3'])
 
 
 mut def from_xml_foo__ieee_802_3(node: xml.Node) -> yang.gdata.Container:
@@ -176,3 +176,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -54,6 +54,11 @@ class foo__ieee_802_3(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__ieee_802_3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -118,6 +123,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_identityref_list_key
+++ b/test/golden/test_yang/prdaclass_identityref_list_key
@@ -88,7 +88,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'l1'])
 
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
@@ -241,7 +241,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -361,3 +361,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_identityref_list_key
+++ b/test/golden/test_yang/prdaclass_identityref_list_key
@@ -85,6 +85,11 @@ class foo__c1__l1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -233,6 +238,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -298,6 +308,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -96,6 +96,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -99,7 +99,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -35,6 +35,11 @@ class foo__l1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -38,7 +38,7 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -49,6 +49,11 @@ class foo__l1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -52,7 +52,7 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -40,6 +40,11 @@ class foo__foo__bar(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -104,6 +109,11 @@ class foo__foo(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -43,7 +43,7 @@ class foo__foo__bar(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:foo', 'bar'])
 
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
@@ -113,7 +113,7 @@ class foo__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:foo'])
 
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -43,7 +43,7 @@ class foo__foo__bar(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:foo', 'bar'])
 
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
@@ -121,7 +121,7 @@ class foo__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:foo'])
 
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -40,6 +40,11 @@ class foo__foo__bar(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -112,6 +117,11 @@ class foo__foo(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -49,6 +49,11 @@ class foo__li1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -202,6 +207,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -52,7 +52,7 @@ class foo__li1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:li1'])
 
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
@@ -266,3 +266,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -199,7 +199,7 @@ class root(yang.adata.MNode):
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         _ll1 = self.ll1
-        if _ll1 is not None:
+        if len(_ll1) != 0:
             leaves.append('{self_name}.ll1 = {repr(_ll1)}')
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -49,6 +49,11 @@ class foo__li1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -202,6 +207,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -52,7 +52,7 @@ class foo__li1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:li1'])
 
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
@@ -266,3 +266,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -199,7 +199,7 @@ class root(yang.adata.MNode):
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         _ll1 = self.ll1
-        if _ll1 is not None:
+        if len(_ll1) != 0:
             leaves.append('{self_name}.ll1 = {repr(_ll1)}')
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -66,6 +66,11 @@ class foo__l1__bar(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -141,6 +146,11 @@ class foo__l1_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
@@ -293,6 +303,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -69,7 +69,7 @@ class foo__l1__bar(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:l1', 'bar'])
 
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
@@ -150,7 +150,7 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
@@ -356,3 +356,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=True)

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -134,7 +134,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
 
 
 mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
@@ -212,7 +212,7 @@ class yangrpc__foo__input(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input'])
 
 
 mut def from_xml_yangrpc__foo__input(node: xml.Node) -> yang.gdata.Container:
@@ -295,7 +295,7 @@ class yangrpc__foo__output(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'output'])
 
 
 mut def from_xml_yangrpc__foo__output(node: xml.Node) -> yang.gdata.Container:
@@ -373,3 +373,8 @@ class rpc_root(yang.adata.RpcRoot):
 schema_namespaces: set[str] = {
     'http://example.com/yangrpc',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -41,6 +41,11 @@ class root(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -126,6 +131,11 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -198,6 +208,11 @@ class yangrpc__foo__input(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_yangrpc__foo__input(node: xml.Node) -> yang.gdata.Container:
@@ -276,6 +291,11 @@ class yangrpc__foo__output(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_yangrpc__foo__output(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -46,6 +46,11 @@ class foo__l1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -49,7 +49,7 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -43,6 +43,11 @@ class foo__l1__bar(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -118,6 +123,11 @@ class foo__l1_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -46,7 +46,7 @@ class foo__l1__bar(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:l1', 'bar'])
 
 
 mut def from_xml_foo__l1__bar(node: xml.Node) -> yang.gdata.Container:
@@ -127,7 +127,7 @@ class foo__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -76,7 +76,7 @@ class foo__foo__bar(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:foo', 'bar'])
 
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
@@ -166,7 +166,7 @@ class foo__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:foo'])
 
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
@@ -295,3 +295,8 @@ schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -73,6 +73,11 @@ class foo__foo__bar(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__foo__bar(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -158,6 +163,11 @@ class foo__foo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -231,6 +241,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -54,6 +54,11 @@ class bar__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -124,6 +129,11 @@ class foo__c1(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -197,6 +207,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -57,7 +57,7 @@ class bar__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:c1'])
 
 
 mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
@@ -133,7 +133,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -268,3 +268,8 @@ schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -57,7 +57,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -133,7 +133,7 @@ class foo__pc1__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc1', 'foo'])
 
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
@@ -203,7 +203,7 @@ class foo__pc1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc1'])
 
 
 mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
@@ -346,3 +346,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -54,6 +54,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -125,6 +130,11 @@ class foo__pc1__foo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -189,6 +199,11 @@ class foo__pc1(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
@@ -271,6 +286,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -71,6 +71,11 @@ class foo__c1__l1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -232,6 +237,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -297,6 +307,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -74,7 +74,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'l1'])
 
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
@@ -240,7 +240,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -360,3 +360,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -96,6 +96,11 @@ class root(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -165,3 +165,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -105,3 +105,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -54,6 +54,11 @@ class root(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -105,3 +105,8 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -54,6 +54,11 @@ class root(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}

--- a/test/golden/yang.gen3/pradata
+++ b/test/golden/yang.gen3/pradata
@@ -1,0 +1,22 @@
+
+# Container: /root
+ad.top_level_leaf = 'root value'
+# Top node: /root
+ad = root()
+
+# Container: /c1
+ad.c1.optional_leaf = 42
+
+# P-container: /c1/c2
+c2 = ad.c1.create_c2('required value')
+
+# Container: /c1/c2
+c2.l1 = 'inner value'
+
+# List /c1/mylist element: item1
+mylist_element = ad.c1.mylist.create('item1')
+mylist_element.value = 100
+
+# List /c1/mylist element: item2
+mylist_element = ad.c1.mylist.create('item2')
+mylist_element.value = 200

--- a/test/golden/yang.gen3/pradata_root_path
+++ b/test/golden/yang.gen3/pradata_root_path
@@ -1,0 +1,8 @@
+
+# Container: /outer/middle
+ad.value1 = 'test value'
+# Top node: /outer/middle
+ad = test__outer__middle()
+
+# Container: /outer/middle/inner
+ad.inner.value2 = 42

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -246,6 +246,9 @@ def adata():
     return ad
 """.encode())
     await async wf.close()
+    # Print the adata source with gen3 schema-driven parser
+    # .. and it must match the gen2 prsrc output
+    testing.assertEqual(ad.prsrc(), ad.prsrc_gen3())
     t.success()
 
 actor _test_adata_source_roundtrip_xml_full_loose(t: testing.EnvT):
@@ -262,6 +265,9 @@ def adata():
     return ad
 """.encode())
     await async wf.close()
+    # Print the adata source with gen3 schema-driven parser
+    # .. and it must match the gen2 prsrc output
+    testing.assertEqual(ad.prsrc(), ad.prsrc_gen3())
     t.success()
 
 def _test_foo_from_xml1():

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -248,7 +248,7 @@ def adata():
     await async wf.close()
     # Print the adata source with gen3 schema-driven parser
     # .. and it must match the gen2 prsrc output
-    testing.assertEqual(ad.prsrc(), ad.prsrc_gen3())
+    testing.assertEqual(ad.prsrc(), yang_foo.prsrc_gen3(gd))
     t.success()
 
 actor _test_adata_source_roundtrip_xml_full_loose(t: testing.EnvT):
@@ -267,7 +267,7 @@ def adata():
     await async wf.close()
     # Print the adata source with gen3 schema-driven parser
     # .. and it must match the gen2 prsrc output
-    testing.assertEqual(ad.prsrc(), ad.prsrc_gen3())
+    testing.assertEqual(ad.prsrc(), yang_foo_loose.prsrc_gen3(gd))
     t.success()
 
 def _test_foo_from_xml1():

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -195,7 +195,8 @@ def _test_foo_from_xml_full():
   }, ns='http://example.com/foo', module='foo'),
   'state': Container({
     'c1': Container()
-  }, ns='http://example.com/foo', module='foo')
+  }, ns='http://example.com/foo', module='foo'),
+  'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo')
 })"""
         testing.assertEqual(gdiff.prsrc(), diff)
     else:

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -282,7 +282,7 @@ class basics__c(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['basics:c'])
 
 
 mut def from_xml_basics__c(node: xml.Node) -> yang.gdata.Container:
@@ -455,6 +455,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/basics',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
 def src_schema():
     res = {}
     res["basics"] = Module('basics', yang_version=1.1, namespace='http://example.com/basics', prefix='b', children=[

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -279,6 +279,11 @@ class basics__c(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_basics__c(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -397,6 +402,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -361,6 +361,11 @@ class foo__c1__li_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
     mut def __init__(self, elements=[]):
@@ -664,6 +669,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -796,6 +806,11 @@ class foo__pc1__foo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -860,6 +875,11 @@ class foo__pc1(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
@@ -930,6 +950,11 @@ class foo__pc2__foo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -995,6 +1020,11 @@ class foo__pc2(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
@@ -1103,6 +1133,11 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__pc3__level1__level2__level3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1187,6 +1222,11 @@ class foo__pc3__level1__level2(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__pc3__level1__level2(node: xml.Node) -> yang.gdata.Container:
@@ -1281,6 +1321,11 @@ class foo__pc3__level1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__pc3__level1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1362,6 +1407,11 @@ class foo__pc3(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__pc3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1420,6 +1470,11 @@ class foo__empty_presence(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
@@ -1500,6 +1555,11 @@ class foo__c_dot(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c_dot(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1577,6 +1637,11 @@ class foo__cc__death_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
@@ -1726,6 +1791,11 @@ class foo__cc(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1797,6 +1867,11 @@ class foo__conflict__f_inner(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1854,6 +1929,11 @@ class foo__conflict__bar_inner(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
@@ -1954,6 +2034,11 @@ class foo__conflict(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2039,6 +2124,11 @@ class foo__special_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
@@ -2220,6 +2310,11 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -2399,6 +2494,11 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -2565,6 +2665,11 @@ class foo__nested__f_inner(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2643,6 +2748,11 @@ class foo__nested__bar_inner(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2715,6 +2825,11 @@ class foo__nested(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__nested(node: xml.Node) -> yang.gdata.Container:
@@ -2811,6 +2926,11 @@ class foo__li_union_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
@@ -2996,6 +3116,11 @@ class foo__state__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3066,6 +3191,11 @@ class foo__state(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_foo__state(node: xml.Node) -> yang.gdata.Container:
@@ -3139,6 +3269,11 @@ class foo__c2(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3209,6 +3344,11 @@ class bar__conflict(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
@@ -3422,6 +3562,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -224,6 +224,11 @@ def src_yang():
             uses g1;
         }
     }
+    leaf-list ll-empty {
+        // Leave this empty, we check that empty leaf-list is not printed
+        type string;
+    }
+
 }""")
     res.append(r"""submodule qux {
     yang-version "1.1";
@@ -642,16 +647,16 @@ class foo__c1(yang.adata.MNode):
             res.append(list_elem)
             res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         _ll_uint64 = self.ll_uint64
-        if _ll_uint64 is not None:
+        if len(_ll_uint64) != 0:
             leaves.append('{self_name}.ll_uint64 = {repr(_ll_uint64)}')
         _ll_str = self.ll_str
-        if _ll_str is not None:
+        if len(_ll_str) != 0:
             leaves.append('{self_name}.ll_str = {repr(_ll_str)}')
         _l_identityref = self.l_identityref
         if _l_identityref is not None:
             leaves.append('{self_name}.l_identityref = {repr(_l_identityref)}')
         _ll_identityref = self.ll_identityref
-        if _ll_identityref is not None:
+        if len(_ll_identityref) != 0:
             leaves.append('{self_name}.ll_identityref = {repr(_ll_identityref)}')
         _l4 = self.l4
         if _l4 is not None:
@@ -797,7 +802,7 @@ class foo__pc1__foo(yang.adata.MNode):
             res.append('{self_name} = foo__pc1__foo()')
         leaves = []
         _l1 = self.l1
-        if _l1 is not None:
+        if len(_l1) != 0:
             leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
@@ -3227,6 +3232,12 @@ mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__state__c1, child_c1)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
+mut def from_json_foo__ll_empty(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, ns='http://example.com/foo', module='foo')
+
+mut def from_xml_foo__ll_empty(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, ns='http://example.com/foo', module='foo')
+
 mut def from_json_foo__c2__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -3392,10 +3403,11 @@ class root(yang.adata.MNode):
     nested: foo__nested
     li_union: foo__li_union
     state: foo__state
+    ll_empty: list[str]
     c2: foo__c2
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -3409,6 +3421,7 @@ class root(yang.adata.MNode):
         self.nested = nested if nested is not None else foo__nested()
         self.li_union = foo__li_union(elements=li_union)
         self.state = state if state is not None else foo__state()
+        self.ll_empty = ll_empty if ll_empty is not None else []
         self.c2 = c2 if c2 is not None else foo__c2()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
 
@@ -3470,6 +3483,9 @@ class root(yang.adata.MNode):
         _state = self.state
         if _state is not None:
             children['state'] = _state.to_gdata()
+        _ll_empty = self.ll_empty
+        if _ll_empty is not None:
+            children['ll-empty'] = yang.gdata.LeafList('string', _ll_empty, ns='http://example.com/foo', module='foo')
         _c2 = self.c2
         if _c2 is not None:
             children['c2'] = _c2.to_gdata()
@@ -3481,7 +3497,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -3550,6 +3566,9 @@ class root(yang.adata.MNode):
         _state = self.state
         if _state is not None:
             res.extend(_state.prsrc('{self_name}.state', False).splitlines())
+        _ll_empty = self.ll_empty
+        if len(_ll_empty) != 0:
+            leaves.append('{self_name}.ll_empty = {repr(_ll_empty)}')
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
@@ -3595,6 +3614,8 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'li-union', from_xml_foo__li_union, child_li_union)
     child_state = yang.gdata.from_xml_opt_cnt(node, 'state', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'state', from_xml_foo__state, child_state)
+    child_ll_empty = yang.gdata.from_xml_opt_strs(node, 'll-empty', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'll-empty', from_xml_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
     child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
@@ -3647,6 +3668,8 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         if point == 'foo:state':
             child = {'state': from_json_path_foo__state(jd, rest_path, op) }
             return yang.gdata.Container(child)
+        if point == 'foo:ll-empty':
+            raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:c2':
             child = {'c2': from_json_path_foo__c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
@@ -3688,6 +3711,8 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'li-union', from_json_foo__li_union, child_li_union)
     child_state = yang.gdata.take_json_opt_cnt(jd, 'state', 'foo')
     yang.gdata.maybe_add(children, 'state', from_json_foo__state, child_state)
+    child_ll_empty = yang.gdata.take_json_opt_strs(jd, 'll-empty', 'foo')
+    yang.gdata.maybe_add(children, 'll-empty', from_json_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.take_json_opt_cnt(jd, 'c2', 'foo')
     yang.gdata.maybe_add(children, 'c2', from_json_foo__c2, child_c2)
     child_bar_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'bar')
@@ -3811,7 +3836,8 @@ def src_schema():
         Container('c1', children=[
             Uses('g1')
         ])
-    ])
+    ]),
+    LeafList('ll-empty', type_=Type('string'))
 ])
     res["qux"] = Submodule('qux', yang_version=1.1, belongs_to=BelongsTo('foo', prefix='f'), augment=[
         Augment('/f:c1', children=[
@@ -3965,6 +3991,7 @@ def src_schema_compiled():
             Leaf('l2', type_=Type('string'))
         ])
     ]),
+    LeafList('ll-empty', type_=Type('string')),
     Identity('basey'),
     Container('c2', children=[
         Leaf('l1', type_=Type('string'))

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -364,7 +364,7 @@ class foo__c1__li_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'li'])
 
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
@@ -672,7 +672,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -809,7 +809,7 @@ class foo__pc1__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc1', 'foo'])
 
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
@@ -879,7 +879,7 @@ class foo__pc1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc1'])
 
 
 mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
@@ -953,7 +953,7 @@ class foo__pc2__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc2', 'foo'])
 
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
@@ -1024,7 +1024,7 @@ class foo__pc2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc2'])
 
 
 mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
@@ -1136,7 +1136,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
 
 mut def from_xml_foo__pc3__level1__level2__level3(node: xml.Node) -> yang.gdata.Container:
@@ -1226,7 +1226,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc3', 'level1', 'level2'])
 
 
 mut def from_xml_foo__pc3__level1__level2(node: xml.Node) -> yang.gdata.Container:
@@ -1324,7 +1324,7 @@ class foo__pc3__level1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc3', 'level1'])
 
 
 mut def from_xml_foo__pc3__level1(node: xml.Node) -> yang.gdata.Container:
@@ -1410,7 +1410,7 @@ class foo__pc3(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:pc3'])
 
 
 mut def from_xml_foo__pc3(node: xml.Node) -> yang.gdata.Container:
@@ -1474,7 +1474,7 @@ class foo__empty_presence(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:empty-presence'])
 
 
 mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
@@ -1558,7 +1558,7 @@ class foo__c_dot(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c.dot'])
 
 
 mut def from_xml_foo__c_dot(node: xml.Node) -> yang.gdata.Container:
@@ -1641,7 +1641,7 @@ class foo__cc__death_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:cc', 'death'])
 
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
@@ -1794,7 +1794,7 @@ class foo__cc(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:cc'])
 
 
 mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
@@ -1870,7 +1870,7 @@ class foo__conflict__f_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:conflict', 'f:inner'])
 
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
@@ -1933,7 +1933,7 @@ class foo__conflict__bar_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:conflict', 'bar:inner'])
 
 
 mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
@@ -2037,7 +2037,7 @@ class foo__conflict(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:conflict'])
 
 
 mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
@@ -2128,7 +2128,7 @@ class foo__special_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:special'])
 
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
@@ -2313,7 +2313,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'f:inner', 'li1', 'li2'])
 
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
@@ -2497,7 +2497,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'f:inner', 'li1'])
 
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
@@ -2668,7 +2668,7 @@ class foo__nested__f_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'f:inner'])
 
 
 mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
@@ -2751,7 +2751,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:nested', 'bar:inner'])
 
 
 mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
@@ -2829,7 +2829,7 @@ class foo__nested(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:nested'])
 
 
 mut def from_xml_foo__nested(node: xml.Node) -> yang.gdata.Container:
@@ -2930,7 +2930,7 @@ class foo__li_union_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:li-union'])
 
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
@@ -3119,7 +3119,7 @@ class foo__state__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:state', 'c1'])
 
 
 mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
@@ -3195,7 +3195,7 @@ class foo__state(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:state'])
 
 
 mut def from_xml_foo__state(node: xml.Node) -> yang.gdata.Container:
@@ -3272,7 +3272,7 @@ class foo__c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c2'])
 
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
@@ -3348,7 +3348,7 @@ class bar__conflict(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:conflict'])
 
 
 mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
@@ -3707,6 +3707,11 @@ schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -224,6 +224,11 @@ def src_yang():
             uses g1;
         }
     }
+    leaf-list ll-empty {
+        // Leave this empty, we check that empty leaf-list is not printed
+        type string;
+    }
+
 }""")
     res.append(r"""submodule qux {
     yang-version "1.1";
@@ -642,16 +647,16 @@ class foo__c1(yang.adata.MNode):
             res.append(list_elem)
             res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         _ll_uint64 = self.ll_uint64
-        if _ll_uint64 is not None:
+        if len(_ll_uint64) != 0:
             leaves.append('{self_name}.ll_uint64 = {repr(_ll_uint64)}')
         _ll_str = self.ll_str
-        if _ll_str is not None:
+        if len(_ll_str) != 0:
             leaves.append('{self_name}.ll_str = {repr(_ll_str)}')
         _l_identityref = self.l_identityref
         if _l_identityref is not None:
             leaves.append('{self_name}.l_identityref = {repr(_l_identityref)}')
         _ll_identityref = self.ll_identityref
-        if _ll_identityref is not None:
+        if len(_ll_identityref) != 0:
             leaves.append('{self_name}.ll_identityref = {repr(_ll_identityref)}')
         _l4 = self.l4
         if _l4 is not None:
@@ -797,7 +802,7 @@ class foo__pc1__foo(yang.adata.MNode):
             res.append('{self_name} = foo__pc1__foo()')
         leaves = []
         _l1 = self.l1
-        if _l1 is not None:
+        if len(_l1) != 0:
             leaves.append('{self_name}.l1 = {repr(_l1)}')
         if leaves:
             if not list_element:
@@ -3232,6 +3237,12 @@ mut def from_json_foo__state(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__state__c1, child_c1)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
+mut def from_json_foo__ll_empty(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, ns='http://example.com/foo', module='foo')
+
+mut def from_xml_foo__ll_empty(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val, ns='http://example.com/foo', module='foo')
+
 mut def from_json_foo__c2__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -3397,10 +3408,11 @@ class root(yang.adata.MNode):
     nested: foo__nested
     li_union: foo__li_union
     state: foo__state
+    ll_empty: list[str]
     c2: foo__c2
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -3414,6 +3426,7 @@ class root(yang.adata.MNode):
         self.nested = nested if nested is not None else foo__nested()
         self.li_union = foo__li_union(elements=li_union)
         self.state = state if state is not None else foo__state()
+        self.ll_empty = ll_empty if ll_empty is not None else []
         self.c2 = c2 if c2 is not None else foo__c2()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
 
@@ -3475,6 +3488,9 @@ class root(yang.adata.MNode):
         _state = self.state
         if _state is not None:
             children['state'] = _state.to_gdata()
+        _ll_empty = self.ll_empty
+        if _ll_empty is not None:
+            children['ll-empty'] = yang.gdata.LeafList('string', _ll_empty, ns='http://example.com/foo', module='foo')
         _c2 = self.c2
         if _c2 is not None:
             children['c2'] = _c2.to_gdata()
@@ -3486,7 +3502,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
@@ -3551,6 +3567,9 @@ class root(yang.adata.MNode):
         _state = self.state
         if _state is not None:
             res.extend(_state.prsrc('{self_name}.state', False).splitlines())
+        _ll_empty = self.ll_empty
+        if len(_ll_empty) != 0:
+            leaves.append('{self_name}.ll_empty = {repr(_ll_empty)}')
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
@@ -3596,6 +3615,8 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'li-union', from_xml_foo__li_union, child_li_union)
     child_state = yang.gdata.from_xml_opt_cnt(node, 'state', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'state', from_xml_foo__state, child_state)
+    child_ll_empty = yang.gdata.from_xml_opt_strs(node, 'll-empty', 'http://example.com/foo')
+    yang.gdata.maybe_add(children, 'll-empty', from_xml_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
     child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
@@ -3648,6 +3669,8 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         if point == 'foo:state':
             child = {'state': from_json_path_foo__state(jd, rest_path, op) }
             return yang.gdata.Container(child)
+        if point == 'foo:ll-empty':
+            raise ValueError("Invalid json path to non-inner node")
         if point == 'foo:c2':
             child = {'c2': from_json_path_foo__c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
@@ -3689,6 +3712,8 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'li-union', from_json_foo__li_union, child_li_union)
     child_state = yang.gdata.take_json_opt_cnt(jd, 'state', 'foo')
     yang.gdata.maybe_add(children, 'state', from_json_foo__state, child_state)
+    child_ll_empty = yang.gdata.take_json_opt_strs(jd, 'll-empty', 'foo')
+    yang.gdata.maybe_add(children, 'll-empty', from_json_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.take_json_opt_cnt(jd, 'c2', 'foo')
     yang.gdata.maybe_add(children, 'c2', from_json_foo__c2, child_c2)
     child_bar_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'bar')
@@ -3812,7 +3837,8 @@ def src_schema():
         Container('c1', children=[
             Uses('g1')
         ])
-    ])
+    ]),
+    LeafList('ll-empty', type_=Type('string'))
 ])
     res["qux"] = Submodule('qux', yang_version=1.1, belongs_to=BelongsTo('foo', prefix='f'), augment=[
         Augment('/f:c1', children=[
@@ -3966,6 +3992,7 @@ def src_schema_compiled():
             Leaf('l2', type_=Type('string'))
         ])
     ]),
+    LeafList('ll-empty', type_=Type('string')),
     Identity('basey'),
     Container('c2', children=[
         Leaf('l1', type_=Type('string'))

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -361,6 +361,11 @@ class foo__c1__li_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
     mut def __init__(self, elements=[]):
@@ -664,6 +669,11 @@ class foo__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -796,6 +806,11 @@ class foo__pc1__foo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -860,6 +875,11 @@ class foo__pc1(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
@@ -933,6 +953,11 @@ class foo__pc2__foo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -997,6 +1022,11 @@ class foo__pc2(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
@@ -1108,6 +1138,11 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__pc3__level1__level2__level3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1194,6 +1229,11 @@ class foo__pc3__level1__level2(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__pc3__level1__level2(node: xml.Node) -> yang.gdata.Container:
@@ -1289,6 +1329,11 @@ class foo__pc3__level1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__pc3__level1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1367,6 +1412,11 @@ class foo__pc3(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__pc3(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1425,6 +1475,11 @@ class foo__empty_presence(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
@@ -1505,6 +1560,11 @@ class foo__c_dot(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__c_dot(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1582,6 +1642,11 @@ class foo__cc__death_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
@@ -1731,6 +1796,11 @@ class foo__cc(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1802,6 +1872,11 @@ class foo__conflict__f_inner(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -1859,6 +1934,11 @@ class foo__conflict__bar_inner(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
@@ -1959,6 +2039,11 @@ class foo__conflict(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2044,6 +2129,11 @@ class foo__special_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
@@ -2225,6 +2315,11 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -2404,6 +2499,11 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -2570,6 +2670,11 @@ class foo__nested__f_inner(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2648,6 +2753,11 @@ class foo__nested__bar_inner(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -2720,6 +2830,11 @@ class foo__nested(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__nested(node: xml.Node) -> yang.gdata.Container:
@@ -2816,6 +2931,11 @@ class foo__li_union_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
@@ -3001,6 +3121,11 @@ class foo__state__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3071,6 +3196,11 @@ class foo__state(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_foo__state(node: xml.Node) -> yang.gdata.Container:
@@ -3144,6 +3274,11 @@ class foo__c2(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -3214,6 +3349,11 @@ class bar__conflict(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
@@ -3423,6 +3563,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -364,7 +364,7 @@ class foo__c1__li_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:c1', 'li'])
 
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
@@ -672,7 +672,7 @@ class foo__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:c1'])
 
 
 mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
@@ -809,7 +809,7 @@ class foo__pc1__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc1', 'foo'])
 
 
 mut def from_xml_foo__pc1__foo(node: xml.Node) -> yang.gdata.Container:
@@ -879,7 +879,7 @@ class foo__pc1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc1'])
 
 
 mut def from_xml_foo__pc1(node: xml.Node) -> yang.gdata.Container:
@@ -956,7 +956,7 @@ class foo__pc2__foo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc2', 'foo'])
 
 
 mut def from_xml_foo__pc2__foo(node: xml.Node) -> yang.gdata.Container:
@@ -1026,7 +1026,7 @@ class foo__pc2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc2'])
 
 
 mut def from_xml_foo__pc2(node: xml.Node) -> yang.gdata.Container:
@@ -1141,7 +1141,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
 
 mut def from_xml_foo__pc3__level1__level2__level3(node: xml.Node) -> yang.gdata.Container:
@@ -1233,7 +1233,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc3', 'level1', 'level2'])
 
 
 mut def from_xml_foo__pc3__level1__level2(node: xml.Node) -> yang.gdata.Container:
@@ -1332,7 +1332,7 @@ class foo__pc3__level1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc3', 'level1'])
 
 
 mut def from_xml_foo__pc3__level1(node: xml.Node) -> yang.gdata.Container:
@@ -1415,7 +1415,7 @@ class foo__pc3(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:pc3'])
 
 
 mut def from_xml_foo__pc3(node: xml.Node) -> yang.gdata.Container:
@@ -1479,7 +1479,7 @@ class foo__empty_presence(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:empty-presence'])
 
 
 mut def from_xml_foo__empty_presence(node: xml.Node) -> yang.gdata.Container:
@@ -1563,7 +1563,7 @@ class foo__c_dot(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:c.dot'])
 
 
 mut def from_xml_foo__c_dot(node: xml.Node) -> yang.gdata.Container:
@@ -1646,7 +1646,7 @@ class foo__cc__death_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:cc', 'death'])
 
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
@@ -1799,7 +1799,7 @@ class foo__cc(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:cc'])
 
 
 mut def from_xml_foo__cc(node: xml.Node) -> yang.gdata.Container:
@@ -1875,7 +1875,7 @@ class foo__conflict__f_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:conflict', 'f:inner'])
 
 
 mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
@@ -1938,7 +1938,7 @@ class foo__conflict__bar_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['bar:conflict', 'bar:inner'])
 
 
 mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
@@ -2042,7 +2042,7 @@ class foo__conflict(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:conflict'])
 
 
 mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
@@ -2133,7 +2133,7 @@ class foo__special_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:special'])
 
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
@@ -2318,7 +2318,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'f:inner', 'li1', 'li2'])
 
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
@@ -2502,7 +2502,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'f:inner', 'li1'])
 
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
@@ -2673,7 +2673,7 @@ class foo__nested__f_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'f:inner'])
 
 
 mut def from_xml_foo__nested__f_inner(node: xml.Node) -> yang.gdata.Container:
@@ -2756,7 +2756,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['bar:nested', 'bar:inner'])
 
 
 mut def from_xml_foo__nested__bar_inner(node: xml.Node) -> yang.gdata.Container:
@@ -2834,7 +2834,7 @@ class foo__nested(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:nested'])
 
 
 mut def from_xml_foo__nested(node: xml.Node) -> yang.gdata.Container:
@@ -2935,7 +2935,7 @@ class foo__li_union_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:li-union'])
 
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
@@ -3124,7 +3124,7 @@ class foo__state__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:state', 'c1'])
 
 
 mut def from_xml_foo__state__c1(node: xml.Node) -> yang.gdata.Container:
@@ -3200,7 +3200,7 @@ class foo__state(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:state'])
 
 
 mut def from_xml_foo__state(node: xml.Node) -> yang.gdata.Container:
@@ -3277,7 +3277,7 @@ class foo__c2(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:c2'])
 
 
 mut def from_xml_foo__c2(node: xml.Node) -> yang.gdata.Container:
@@ -3353,7 +3353,7 @@ class bar__conflict(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['bar:conflict'])
 
 
 mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
@@ -3708,6 +3708,11 @@ schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=True)
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -120,7 +120,7 @@ class foo__tc1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:tc1'])
 
 
 mut def from_xml_foo__tc1(node: xml.Node) -> yang.gdata.Container:
@@ -219,7 +219,7 @@ class foo__li__c1(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:li', 'c1'])
 
 
 mut def from_xml_foo__li__c1(node: xml.Node) -> yang.gdata.Container:
@@ -299,7 +299,7 @@ class foo__li_entry(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:li'])
 
 class foo__li(yang.adata.MNode):
     elements: list[foo__li_entry]
@@ -516,6 +516,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
 schema_namespaces: set[str] = {
     'http://example.com/foo',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', children=[

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -117,6 +117,11 @@ class foo__tc1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__tc1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -211,6 +216,11 @@ class foo__li__c1(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_foo__li__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -285,6 +295,11 @@ class foo__li_entry(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 class foo__li(yang.adata.MNode):
     elements: list[foo__li_entry]
@@ -441,6 +456,11 @@ class root(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -64,6 +64,11 @@ class root(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -149,6 +154,11 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
                 res = leaves + res
         return '\n'.join(res)
 
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
 
 mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
     children = {}
@@ -221,6 +231,11 @@ class yangrpc__foo__input(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_yangrpc__foo__input(node: xml.Node) -> yang.gdata.Container:
@@ -299,6 +314,11 @@ class yangrpc__foo__output(yang.adata.MNode):
             else:
                 res = leaves + res
         return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
 
 
 mut def from_xml_yangrpc__foo__output(node: xml.Node) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -157,7 +157,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
 
 
 mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
@@ -235,7 +235,7 @@ class yangrpc__foo__input(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input'])
 
 
 mut def from_xml_yangrpc__foo__input(node: xml.Node) -> yang.gdata.Container:
@@ -318,7 +318,7 @@ class yangrpc__foo__output(yang.adata.MNode):
     def prsrc_gen3(self, self_name='ad'):
         # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
         s = yang.compile(src_yang())
-        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'output'])
 
 
 mut def from_xml_yangrpc__foo__output(node: xml.Node) -> yang.gdata.Container:
@@ -396,6 +396,11 @@ class rpc_root(yang.adata.RpcRoot):
 schema_namespaces: set[str] = {
     'http://example.com/yangrpc',
 }
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
 def src_schema():
     res = {}
     res["yangrpc"] = Module('yangrpc', yang_version=1.1, namespace='http://example.com/yangrpc', prefix='yrpc', children=[

--- a/test/test_data_classes/test/golden/test_data_classes/adata_foo_pc2
+++ b/test/test_data_classes/test/golden/test_data_classes/adata_foo_pc2
@@ -26,6 +26,7 @@ Container({
   'state': Container({
     'c1': Container()
   }, ns='http://example.com/foo', module='foo'),
+  'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo'),
   'c2': Container(ns='http://example.com/foo', module='foo'),
   'bar:conflict': Container(ns='http://example.com/bar', module='bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
@@ -23,6 +23,7 @@ Container({
   'state': Container({
     'c1': Container()
   }, ns='http://example.com/foo', module='foo'),
+  'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo'),
   'c2': Container(ns='http://example.com/foo', module='foo'),
   'bar:conflict': Container(ns='http://example.com/bar', module='bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
@@ -21,6 +21,7 @@ Container({
   'state': Container({
     'c1': Container()
   }, ns='http://example.com/foo', module='foo'),
+  'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo'),
   'c2': Container(ns='http://example.com/foo', module='foo'),
   'bar:conflict': Container(ns='http://example.com/bar', module='bar')
 })

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -264,6 +264,11 @@ ys_foo = r"""module foo {
             uses g1;
         }
     }
+    leaf-list ll-empty {
+        // Leave this empty, we check that empty leaf-list is not printed
+        type string;
+    }
+
 }"""
 
 ys_bar = r"""module bar {


### PR DESCRIPTION
The new function in *yang.gen3* is `pradata(yang.schema.DRoot, yang.gdata.Node) -> str`. It produces output equivalent to the existing generated `<Adata>.prsrc() -> str` functions. The implementation is more or less a copy of the existing generated code from `prdaclass()`, but without deferring reading data to run time.

For testing and comparing results in orchestron, I added the `prsrc_gen3` wrappers in the generated adata modules. These are like the `from_xml_gen3` and `from_json_gen3` wrappers that compile the schema on demand, on every call, so not suitable for "production".

Closes #184 