### PR TITLE
Merge rpc_root, rpc_handler into rpc_root actor

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1121,87 +1121,58 @@ class DNodeInner(DNode):
                     res.append(child_class_src)
 
             # TODO: unique safe name for RPC function!
-            # Generate rpc_handler actor
-            res.append("actor rpc_handler(tp: yang.gdata.TreeProvider):")
+            # Generate rpc_root actor
+            res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output
 
-                if input_node is not None:
-                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
+                # Build method signature based on input/output presence:
+                # - no input: in inp parameter in the wrapper signature
+                # - no output: no output adata parameter in the callback signature
+                if input_node is not None and output_node is not None:
+                    # RPC with both input and output
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                elif input_node is not None and output_node is None:
+                    # RPC with only input (no output)
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                elif input_node is None and output_node is not None:
+                    # RPC with only output (no input)
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, gen3: bool=False):")
                 else:
-                    input_param = "inp: ?None"
+                    # RPC with neither input nor output
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, gen3: bool=False):")
 
+                # Generate callback wrapper for parsing RPC output XML -> gdata -> adata
                 if output_node is not None:
-                    output_type = get_path_name(output_node)
-                else:
-                    output_type = None
-
-                res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False):")
-                res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
-                res.append("            if res is not None:")
-                if output_type is not None:
+                    res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
+                    res.append("            if res is not None:")
                     res.append("                if gen3:")
                     res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                else:")
-                    res.append("                    gdata_res = from_xml_{output_type}(res)")
-                    res.append("                adata_res = {output_type}.from_gdata(gdata_res)")
+                    res.append("                    gdata_res = from_xml_{get_path_name(output_node)}(res)")
+                    res.append("                adata_res = {get_path_name(output_node)}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
-                else:
+                    res.append("            else:")
                     res.append("                cb(None, err)")
-                res.append("            else:")
-                res.append("                cb(None, err)")
-                res.append("")
+                    res.append("")
+
+                # Generate RPC XML, add input
                 if input_node is not None:
                     res.append("        if inp is not None:")
                     res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
                     res.append("        else:")
                     res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
-                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 else:
                     res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
-                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
-                res.append("")
-            res.append("")
 
-            # Generate rpc_root class
-            # TODO: this wrapper class is not needed! We need an actor
-            # (currently rpc_handler) because we pass callback references, but
-            # we could instantiate it directly instead
-            res.append("class rpc_root(yang.adata.RpcRoot):")
-            res.append("    _handler: rpc_handler")
-            res.append("")
-            res.append("    def __init__(self, tp: yang.gdata.TreeProvider):")
-            res.append("        yang.adata.RpcRoot.__init__(self, tp)")
-            res.append("        self._handler = rpc_handler(tp)")
-            res.append("")
-            for rpc in self.rpcs:
-                input_node = rpc.input
-                output_node = rpc.output
-
-                if input_node is not None:
-                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
-                else:
-                    input_param = ""
-
+                # Call tp.rpc_xml with appropriate callback
                 if output_node is not None:
-                    output_type = get_path_name(output_node)
+                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 else:
-                    output_type = ""
-
-                if input_node is not None and output_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
-                elif input_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), inp, gen3)")
-                elif output_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, None, gen3)")
-                else:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), None, gen3)")
+                    res.append("        tp.rpc_xml(lambda _, err: cb(err), xml.decode(xmlstr))")
                 res.append("")
+            res.append("")
             res.append("")
 
         if top:

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -16,8 +16,3 @@ class MNode(object):
     # TODO: remove mut effect once the compiler is fixed to not leak mut effect out of functions
     mut def prsrc(self, self_name='ad', top=False, list_element=False) -> str:
         raise NotImplementedError("prsrc not implemented for {self._name}")
-
-
-class RpcRoot(object):
-    def __init__(self, tp: yang.gdata.TreeProvider):
-        self._tp = tp

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1117,87 +1117,58 @@ class DNodeInner(DNode):
                     res.append(child_class_src)
 
             # TODO: unique safe name for RPC function!
-            # Generate rpc_handler actor
-            res.append("actor rpc_handler(tp: yang.gdata.TreeProvider):")
+            # Generate rpc_root actor
+            res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output
 
-                if input_node is not None:
-                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
+                # Build method signature based on input/output presence:
+                # - no input: in inp parameter in the wrapper signature
+                # - no output: no output adata parameter in the callback signature
+                if input_node is not None and output_node is not None:
+                    # RPC with both input and output
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                elif input_node is not None and output_node is None:
+                    # RPC with only input (no output)
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                elif input_node is None and output_node is not None:
+                    # RPC with only output (no input)
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, gen3: bool=False):")
                 else:
-                    input_param = "inp: ?None"
+                    # RPC with neither input nor output
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, gen3: bool=False):")
 
+                # Generate callback wrapper for parsing RPC output XML -> gdata -> adata
                 if output_node is not None:
-                    output_type = get_path_name(output_node)
-                else:
-                    output_type = None
-
-                res.append("    def {_safe_name(rpc.name)}(cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False):")
-                res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
-                res.append("            if res is not None:")
-                if output_type is not None:
+                    res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
+                    res.append("            if res is not None:")
                     res.append("                if gen3:")
                     res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                else:")
-                    res.append("                    gdata_res = from_xml_{output_type}(res)")
-                    res.append("                adata_res = {output_type}.from_gdata(gdata_res)")
+                    res.append("                    gdata_res = from_xml_{get_path_name(output_node)}(res)")
+                    res.append("                adata_res = {get_path_name(output_node)}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
-                else:
+                    res.append("            else:")
                     res.append("                cb(None, err)")
-                res.append("            else:")
-                res.append("                cb(None, err)")
-                res.append("")
+                    res.append("")
+
+                # Generate RPC XML, add input
                 if input_node is not None:
                     res.append("        if inp is not None:")
                     res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}">{{inp.to_gdata().to_xmlstr()}}</{rpc.name}>'""")
                     res.append("        else:")
                     res.append("""            xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
-                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 else:
                     res.append("""        xmlstr = '<{rpc.name} xmlns="{rpc.namespace}" />'""")
-                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
-                res.append("")
-            res.append("")
 
-            # Generate rpc_root class
-            # TODO: this wrapper class is not needed! We need an actor
-            # (currently rpc_handler) because we pass callback references, but
-            # we could instantiate it directly instead
-            res.append("class rpc_root(yang.adata.RpcRoot):")
-            res.append("    _handler: rpc_handler")
-            res.append("")
-            res.append("    def __init__(self, tp: yang.gdata.TreeProvider):")
-            res.append("        yang.adata.RpcRoot.__init__(self, tp)")
-            res.append("        self._handler = rpc_handler(tp)")
-            res.append("")
-            for rpc in self.rpcs:
-                input_node = rpc.input
-                output_node = rpc.output
-
-                if input_node is not None:
-                    input_param = "inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}"
-                else:
-                    input_param = ""
-
+                # Call tp.rpc_xml with appropriate callback
                 if output_node is not None:
-                    output_type = get_path_name(output_node)
+                    res.append("        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))")
                 else:
-                    output_type = ""
-
-                if input_node is not None and output_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, inp, gen3)")
-                elif input_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, {input_param}, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), inp, gen3)")
-                elif output_node is not None:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?{output_type}, ?Exception) -> None, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(cb, None, gen3)")
-                else:
-                    res.append("    proc def {_safe_name(rpc.name)}(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:")
-                    res.append("        self._handler.{_safe_name(rpc.name)}(lambda _, err: cb(err), None, gen3)")
+                    res.append("        tp.rpc_xml(lambda _, err: cb(err), xml.decode(xmlstr))")
                 res.append("")
+            res.append("")
             res.append("")
 
         if top:

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -377,7 +377,7 @@ mut def from_json_foo__r1__output(jd: dict[str, ?value]) -> yang.gdata.Container
     yang.gdata.maybe_add(children, 'l4', from_json_foo__r1__output__l4, child_l4)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
-actor rpc_handler(tp: yang.gdata.TreeProvider):
+actor rpc_root(tp: yang.gdata.TreeProvider):
     def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -396,16 +396,6 @@ actor rpc_handler(tp: yang.gdata.TreeProvider):
             xmlstr = '<r1 xmlns="http://example.com/foo" />'
         tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
 
-
-class rpc_root(yang.adata.RpcRoot):
-    _handler: rpc_handler
-
-    def __init__(self, tp: yang.gdata.TreeProvider):
-        yang.adata.RpcRoot.__init__(self, tp)
-        self._handler = rpc_handler(tp)
-
-    proc def r1(self, cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input, gen3: bool=False) -> None:
-        self._handler.r1(cb, inp, gen3)
 
 
 schema_namespaces: set[str] = {

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -326,7 +326,7 @@ mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Cont
     yang.gdata.maybe_add(children, 'outoo', from_json_yangrpc__foo__output__outoo, child_outoo)
     return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
 
-actor rpc_handler(tp: yang.gdata.TreeProvider):
+actor rpc_root(tp: yang.gdata.TreeProvider):
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -345,29 +345,10 @@ actor rpc_handler(tp: yang.gdata.TreeProvider):
             xmlstr = '<foo xmlns="http://example.com/yangrpc" />'
         tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
 
-    def silent(cb: action(?None, ?Exception) -> None, inp: ?None, gen3: bool=False):
-        def cb_wrap(res: ?xml.Node, err: ?Exception):
-            if res is not None:
-                cb(None, err)
-            else:
-                cb(None, err)
-
+    def silent(cb: action(?Exception) -> None, gen3: bool=False):
         xmlstr = '<silent xmlns="http://example.com/yangrpc" />'
-        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+        tp.rpc_xml(lambda _, err: cb(err), xml.decode(xmlstr))
 
-
-class rpc_root(yang.adata.RpcRoot):
-    _handler: rpc_handler
-
-    def __init__(self, tp: yang.gdata.TreeProvider):
-        yang.adata.RpcRoot.__init__(self, tp)
-        self._handler = rpc_handler(tp)
-
-    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False) -> None:
-        self._handler.foo(cb, inp, gen3)
-
-    proc def silent(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:
-        self._handler.silent(lambda _, err: cb(err), None, gen3)
 
 
 schema_namespaces: set[str] = {

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -349,7 +349,7 @@ mut def from_json_yangrpc__foo__output(jd: dict[str, ?value]) -> yang.gdata.Cont
     yang.gdata.maybe_add(children, 'outoo', from_json_yangrpc__foo__output__outoo, child_outoo)
     return yang.gdata.Container(children, ns='http://example.com/yangrpc', module='yangrpc')
 
-actor rpc_handler(tp: yang.gdata.TreeProvider):
+actor rpc_root(tp: yang.gdata.TreeProvider):
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -368,29 +368,10 @@ actor rpc_handler(tp: yang.gdata.TreeProvider):
             xmlstr = '<foo xmlns="http://example.com/yangrpc" />'
         tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
 
-    def silent(cb: action(?None, ?Exception) -> None, inp: ?None, gen3: bool=False):
-        def cb_wrap(res: ?xml.Node, err: ?Exception):
-            if res is not None:
-                cb(None, err)
-            else:
-                cb(None, err)
-
+    def silent(cb: action(?Exception) -> None, gen3: bool=False):
         xmlstr = '<silent xmlns="http://example.com/yangrpc" />'
-        tp.rpc_xml(cb_wrap, xml.decode(xmlstr))
+        tp.rpc_xml(lambda _, err: cb(err), xml.decode(xmlstr))
 
-
-class rpc_root(yang.adata.RpcRoot):
-    _handler: rpc_handler
-
-    def __init__(self, tp: yang.gdata.TreeProvider):
-        yang.adata.RpcRoot.__init__(self, tp)
-        self._handler = rpc_handler(tp)
-
-    proc def foo(self, cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input, gen3: bool=False) -> None:
-        self._handler.foo(cb, inp, gen3)
-
-    proc def silent(self, cb: action(?Exception) -> None, gen3: bool=False) -> None:
-        self._handler.silent(lambda _, err: cb(err), None, gen3)
 
 
 schema_namespaces: set[str] = {


### PR DESCRIPTION
Remove extra layer of indirection that is actually not necessary. In the transform actors, we're creating an instance of rpc_root specific to a device type.