### PR TITLE
Escape XML special characters in gdata.to_xmlstr()

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -204,7 +204,9 @@ def yang_str(v) -> str:
     s = str(v)
     if isinstance(v, bool):
         s = s.lower()
-    return s
+    # Escape XML special characters for text values
+    return s.replace("&", "&amp;").replace("<", "&lt;")
+
 
 def json_val(yang_type: str, v: value) -> ?value:
     if isinstance(v, bytes):


### PR DESCRIPTION
Note: this type of escaping is already implementeed in the stdlib xml module. If we do end up refactoring gdata.to_xmlstr() to output xml.Node then this is no longer needed (#202). But this is a very minimal change that fixes a real problem (Junos configuration group config with a wildcard).