### PR TITLE
Make gdata.diff old arg optional

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1155,7 +1155,11 @@ def merge(a: Node, b: Node) -> Node:
         raise ValueError("Unsupported node type in merge: {str(type(a))}")
 
 
-def diff(old: Node, new: Node) -> ?Node:
+def diff(old: ?Node, new: Node) -> ?Node:
+
+    if old is None:
+        return new
+
     if type(old) != type(new):
         raise ValueError("diff called with nodes of different types: {str(type(old))} vs {str(type(new))}")
 


### PR DESCRIPTION
Changed diff() signature from (old: Node, new: Node) to (old: ?Node, new: Node).  When old is None, the diff simply returns the new value, representing creation of a new node.

Fixes #237 