### PR TITLE
Normalize base identities once

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1721,7 +1721,7 @@ class DRoot(DNodeInner):
                 if base_key in identity_map:
                     resolved_bases.append(identity_map[base_key].identity)
                 else:
-                    raise ValueError("Could not find {id.identity.prefix}:{id.identity.name} in any module")
+                    raise ValueError("Could not resolve base '{base_key}' for identity '{id.identity.prefix}:{id.identity.name}'")
             id.identity.base = resolved_bases
 
         # Detect cycles in the identity hierarchy (DFS)

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -456,8 +456,11 @@ snode_methods = {
         # so we make it easier to later look up bases in DIdentity.
         fq_base = []
         for base in self.base:
-            base_identity = self.get_identity(base, context)
-            fq_base.append("{base_identity.pfx}:{base_identity.name}")
+            if ":" not in base:
+                base_identity = self.get_identity(base, context)
+                fq_base.append("{base_identity.pfx}:{base_identity.name}")
+            else:
+                fq_base.append(base)
 
         new = Identity(self.name,
                        base=fq_base,
@@ -880,8 +883,11 @@ snode_methods = {
             # so we make it easier to later look up bases in DIdentity.
             fq_base = []
             for base in self.base:
-                base_identity = self.get_identity(base, context)
-                fq_base.append("{base_identity.pfx}:{base_identity.name}")
+                if ":" not in base:
+                    base_identity = self.get_identity(base, context)
+                    fq_base.append("{base_identity.pfx}:{base_identity.name}")
+                else:
+                    fq_base.append(base)
 
             new = Type(self.name,
                     base=fq_base,

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2471,6 +2471,6 @@ def _test_fail_identity_missing_imported_base():
     try:
         root = yang.compile([ys_base, ys_derived])
     except ValueError as exc:
-        testing.assertEqual(exc.error_message, "derived - Compile - Failed: Unable to find identity 'network-type' in module 'base'")
+        testing.assertEqual(exc.error_message, "Could not resolve base 'base:network-type' for identity 'derived:ethernet'")
     else:
         testing.error("Expected ValueError for undefined imported base identity")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1717,7 +1717,7 @@ class DRoot(DNodeInner):
                 if base_key in identity_map:
                     resolved_bases.append(identity_map[base_key].identity)
                 else:
-                    raise ValueError("Could not find {id.identity.prefix}:{id.identity.name} in any module")
+                    raise ValueError("Could not resolve base '{base_key}' for identity '{id.identity.prefix}:{id.identity.name}'")
             id.identity.base = resolved_bases
 
         # Detect cycles in the identity hierarchy (DFS)
@@ -4751,8 +4751,11 @@ class Identity(SchemaNodeOuter):
         # so we make it easier to later look up bases in DIdentity.
         fq_base = []
         for base in self.base:
-            base_identity = self.get_identity(base, context)
-            fq_base.append("{base_identity.pfx}:{base_identity.name}")
+            if ":" not in base:
+                base_identity = self.get_identity(base, context)
+                fq_base.append("{base_identity.pfx}:{base_identity.name}")
+            else:
+                fq_base.append(base)
 
         new = Identity(self.name,
                        base=fq_base,
@@ -7230,8 +7233,11 @@ class Type(SchemaNodeOuter):
             # so we make it easier to later look up bases in DIdentity.
             fq_base = []
             for base in self.base:
-                base_identity = self.get_identity(base, context)
-                fq_base.append("{base_identity.pfx}:{base_identity.name}")
+                if ":" not in base:
+                    base_identity = self.get_identity(base, context)
+                    fq_base.append("{base_identity.pfx}:{base_identity.name}")
+                else:
+                    fq_base.append(base)
 
             new = Type(self.name,
                     base=fq_base,


### PR DESCRIPTION
Only prepend prefix (+ lookup current module) for unqualified base identities.  We should not attempt to fully resolve all base identities at the time of type compilation - we do not yet have the global identity registry.

Part of #233