### PR TITLE
Remap namespace qualifiers for submodule expansion

### DIFF
--- a/gen/schema-footer.act
+++ b/gen/schema-footer.act
@@ -1,5 +1,32 @@
 
 
+def _remap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
+    """Remap prefix in augment/deviation paths from old to new prefix
+
+    Example: "/old:foo/old:bar/baz" -> "/new:foo/new:bar/baz"
+    """
+    if old_prefix == new_prefix:
+        return path
+
+    # Split path into segments
+    segments = path.split("/")
+    result = []
+
+    for segment in segments:
+        sp = segment.split(":", 1)
+        if len(sp) > 1:
+            prefix = sp[0]
+            name = sp[1]
+            if prefix == old_prefix:
+                result.append(new_prefix + ":" + name)
+            else:
+                result.append(segment)
+        else:
+            result.append(segment)
+
+    return "/".join(result)
+
+
 def stmt_to_smodule(stmt):
     m = stmt_to_snode(stmt)
     if isinstance(m, Module):

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2394,6 +2394,15 @@ class SchemaNode(object):
 
         return stmt
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        raise NotImplementedError("SchemaNode.update_namespace_qualifiers")
+
+
 class SchemaNodeInner(SchemaNode):
     children: list[SchemaNode]
 

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1298,6 +1298,109 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                     res.append("        new.expand_augments(context)")
             res.append("        return new")
             res.append("")
+        # ==============================================================
+
+        # -- update_namespace_qualifiers
+        if "update_namespace_qualifiers" not in manual_methods:
+            res.append("    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:")
+            res.append('        """Update namespace qualifiers and remap prefix references')
+            res.append('')
+            res.append('        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.')
+            res.append('        If old_pfx differs from new_pfx, remaps all prefix-qualified references.')
+            res.append('        """')
+            res.append("        self.ns = new_ns")
+            res.append("        self.pfx = new_pfx")
+            res.append("        self.mod = new_mod")
+            res.append("")
+
+            if have_children:
+                res.append("        # Recursively update children")
+                res.append("        for child in self.children:")
+                res.append("            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                res.append("")
+
+            res.append("        # Exit early if no prefix remapping is needed")
+            res.append("        if old_pfx == new_pfx:")
+            res.append("            return")
+            res.append("")
+            res.append("        # Remap prefix references")
+
+            for substmt in stmt.substmts.values():
+                attr = _attr_name(substmt.name)
+
+                # XPath expressions that need remapping
+                if substmt.name == "when":
+                    res.append(f"        self_{attr} = self.{attr}")
+                    res.append(f"        if self_{attr} is not None:")
+                    res.append(f"            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+                elif substmt.name == "path":
+                    res.append(f"        self_{attr} = self.{attr}")
+                    res.append(f"        if self_{attr} is not None:")
+                    res.append(f"            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+
+                # Must statements need special handling
+                elif substmt.name == "must":
+                    res.append(f"        for must in self.{attr}:")
+                    res.append(f"            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)")
+
+                # if-feature expressions
+                elif substmt.name == "if-feature":
+                    res.append(f"        self.{attr} = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.{attr}]")
+
+                # Unique statements (for list)
+                elif substmt.name == "unique":
+                    res.append(f"        self.{attr} = [_remap_path_prefix(u, old_pfx, new_pfx) for u in self.{attr}]")
+
+                # Default values that might contain prefixed identities
+                elif substmt.name == "default":
+                    if substmt.cardinality == "0..1":
+                        res.append(f"        self_{attr} = self.{attr}")
+                        res.append(f"        if self_{attr} is not None:")
+                        res.append(f"            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+                    elif substmt.cardinality == "0..n":
+                        res.append(f"        self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
+
+                # Base identities
+                elif substmt.name == "base":
+                    res.append(f"        self.{attr} = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.{attr}]")
+
+                # Type statements in leaf, leaf-list, deviate (unions are handled separately)
+                elif substmt.name == "type":
+                    if substmt.cardinality == "1":
+                        res.append(f"        self.{attr}.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+
+                # Deviation target paths
+                elif substmt.name == "deviation":
+                    res.append(f"        self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
+
+            # Special handling for specific statement types
+            if stmt_name == "uses":
+                # Uses name can be prefixed
+                res.append(f"        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
+                # Handle refine and augment within uses
+                res.append(f"        for refine in self.refine:")
+                res.append(f"            refine.target_node = _remap_path_prefix(refine.target_node, old_pfx, new_pfx)")
+                res.append(f"            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                res.append(f"        for aug in self.augment:")
+                res.append(f"            aug.target_node = _remap_path_prefix(aug.target_node, old_pfx, new_pfx)")
+                res.append(f"            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+
+            elif stmt_name == "augment":
+                # Augment target path
+                res.append(f"        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)")
+
+            elif stmt_name == "refine":
+                # Refine target path
+                res.append(f"        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)")
+
+            elif stmt_name == "type":
+                # Type name can be prefixed for user-defined types
+                res.append(f"        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
+                # Handle nested types for union
+                res.append(f"        for nested_type in self.type_:")
+                res.append(f"            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+
+            res.append("")
 
         res.append("    def __str__(self):")
         strret = ""

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1657,6 +1657,114 @@ def _test_compile_submodules1():
     testing.assertEqual(l2.config, True)
     return root.prdaclass()
 
+def _test_compile_submodule_different_prefix():
+    """Test that submodules can use different prefixes for their parent module"""
+    ys_main = r"""module main-module {
+    yang-version "1.1";
+    namespace "http://example.com/main";
+    prefix "main";
+
+    include sub-module;
+
+    grouping main-group {
+        container group-container {
+            leaf group-leaf {
+                type string;
+            }
+        }
+    }
+
+    container main-container {
+        leaf main-leaf {
+            type string;
+        }
+        uses sub-group;  // Use grouping from submodule
+    }
+}"""
+
+    ys_sub = r"""submodule sub-module {
+    yang-version "1.1";
+    belongs-to main-module {
+        prefix "m";  // Different prefix than parent module uses
+    }
+
+    grouping sub-group {
+        container sub-group-container {
+            leaf sub-group-leaf {
+                type string;
+                default "from-submodule";
+            }
+        }
+    }
+
+    augment "/m:main-container" {
+        leaf sub-leaf {
+            type string;
+            when "../m:main-leaf = 'trigger'";
+            must "string-length(.) > 5" {
+                description "Sub-leaf must be longer than 5 characters";
+            }
+        }
+
+        list sub-list {
+            key "name";
+            unique "m:main-leaf sub-value";
+
+            leaf name {
+                type string;
+            }
+
+            leaf sub-value {
+                type string;
+            }
+
+            leaf ref-to-main {
+                type leafref {
+                    path "/m:main-container/m:main-leaf";
+                }
+            }
+        }
+
+        uses m:main-group {
+            when "m:main-leaf = 'use-group'";
+            refine "group-container/group-leaf" {
+                must "string-length(.) > 3";
+                default "refined-default";
+            }
+            augment "group-container" {
+                when "../m:main-leaf";
+                leaf augmented-in-group {
+                    type string;
+                }
+            }
+        }
+    }
+
+    deviation "/m:main-container/m:main-leaf" {
+        deviate add {
+            default "default-value";
+        }
+    }
+}"""
+
+    # Compile the module with its submodule
+    root = yang.compile([ys_main, ys_sub])
+
+    # Verify the augmented structure exists
+    main_container = root.get("main-container")
+    testing.assertNotNone(main_container, "main-container should exist")
+
+    # Verify augmented leaf exists
+    sub_leaf = main_container.get("sub-leaf")
+    testing.assertNotNone(sub_leaf, "sub-leaf should exist after augment")
+
+    # Verify the sub-list exists
+    sub_list = main_container.get("sub-list")
+    testing.assertNotNone(sub_list, "sub-list should exist after augment")
+
+    # Generate and return the Acton data classes to verify it works end-to-end
+    return root.prdaclass()
+
 def _test_compile_submodules2():
     ys_foo = r"""module foo {
     yang-version "1.1";

--- a/src/yang.act
+++ b/src/yang.act
@@ -8,6 +8,7 @@ def eq_optional[T(Eq)](a: ?T, b: ?T) -> bool:
 def optional_str[T](v: ?T, default: str = "None") -> str:
     return str(v) if v is not None else default
 
+
 class NameRevMap[T](object):
     items: dict[str, (?str, T)]
 
@@ -88,9 +89,12 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
             except KeyError:
                 raise ValueError("{m.name} - submodule {include.module} not found.")
             else:
+                # Track all prefix remappings needed (including parent module prefix)
+                prefix_remaps: dict[str, str] = {}
+
+                # If submodule uses different prefix for parent module, track that remapping
                 if submod.belongs_to.prefix != m.prefix:
-                    # TODO: Remap submodule children to parent prefix, or shift to global namespace?
-                    raise NotImplementedError("Submodule alias to parent module prefix")
+                    prefix_remaps[submod.belongs_to.prefix] = m.prefix
 
                 for sub_import in submod.import_:
                     try:
@@ -111,29 +115,79 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
                         m.import_.append(new_import)
                     else:
                         if sub_import.prefix != import_prefix:
-                            # TODO: Handle import of same module under different prefixes by combined module/submodules
-                            #       E.g. remap submodule children to parent prefix, or shift to global namespace?
-                            raise NotImplementedError("Module/submodule with multiple import prefix to same module")
+                            # Track that we need to remap this prefix in the submodule's content
+                            prefix_remaps[sub_import.prefix] = import_prefix
                         # else: # Duplicate import. We're fine!
 
                 for c in submod.children:
-                    # TODO: Align submodule-local import prefixes to parent module imports
-                    # Attach subtree to parent module, inherit identifier namespace from parent module
+                    # Set parent attribute for direct children only
                     c.parent = m
-                    c.ns = m.get_namespace()
-                    c.pfx = m.get_prefix()
-                    c.mod = m.get_module_name()
+
+                    # Always update namespace qualifiers to parent module's values
+                    c.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+
+                    # Apply all prefix remappings (parent module and imports)
+                    for old_pfx, new_pfx in prefix_remaps.items():
+                        c.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+
                     m.children.append(c)
+
+                # Update augment nodes
+                for aug in submod.augment:
+                    # Set parent attribute
+                    aug.parent = m
+
+                    # Update the augment node's namespace qualifiers
+                    aug.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+
+                    # Apply all prefix remappings to augment paths and content
+                    for old_pfx, new_pfx in prefix_remaps.items():
+                        aug.target_node = yang.schema._remap_path_prefix(aug.target_node, old_pfx, new_pfx)
+                        aug.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
 
                 m.augment.extend(submod.augment)
                 # discard contact
                 # discard description
-                m.deviation.extend(submod.deviation)
+
+                # Remap deviation paths if needed
+                for dev in submod.deviation:
+                    remapped_dev = dev
+                    for old_pfx, new_pfx in prefix_remaps.items():
+                        remapped_dev = yang.schema._remap_path_prefix(remapped_dev, old_pfx, new_pfx)
+                    m.deviation.append(remapped_dev)
+
+                # Update extension nodes
+                for ext in submod.extension_:
+                    # Set parent attribute
+                    ext.parent = m
+
+                    # Update namespace qualifiers
+                    ext.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+
+                    # Apply all prefix remappings
+                    for old_pfx, new_pfx in prefix_remaps.items():
+                        ext.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+
                 m.extension_.extend(submod.extension_)
+
                 # discard organization
                 # discard reference
                 # discard revision
+
+                # Update feature nodes
+                for feat in submod.feature:
+                    # Set parent attribute
+                    feat.parent = m
+
+                    # Update namespace qualifiers
+                    feat.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+
+                    # Apply all prefix remappings
+                    for old_pfx, new_pfx in prefix_remaps.items():
+                        feat.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+
                 m.feature.extend(submod.feature)
+
                 m.exts.extend(submod.exts)
 
         m.include = []

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2390,6 +2390,15 @@ class SchemaNode(object):
 
         return stmt
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        raise NotImplementedError("SchemaNode.update_namespace_qualifiers")
+
+
 class SchemaNodeInner(SchemaNode):
     children: list[SchemaNode]
 
@@ -3412,6 +3421,27 @@ class Action(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+
     def __str__(self):
         return "Action {self.name}"
 
@@ -3549,6 +3579,28 @@ class Anydata(SchemaNodeOuter):
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
 
     def __str__(self):
         return "Anydata {self.name}"
@@ -3688,6 +3740,28 @@ class Anyxml(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
+
     def __str__(self):
         return "Anyxml {self.name}"
 
@@ -3790,6 +3864,31 @@ class Augment(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
+        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)
+
     def __str__(self):
         return "Augment {self.target_node}"
 
@@ -3850,6 +3949,22 @@ class BelongsTo(SchemaNodeOuter):
                         ns=new_ns if new_ns is not None else self.ns,
                         pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "BelongsTo {self.module}"
@@ -3939,6 +4054,23 @@ class Bit(SchemaNodeOuter):
                   ns=new_ns if new_ns is not None else self.ns,
                   pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
         return "Bit {self.name}"
@@ -4041,6 +4173,30 @@ class Case(SchemaNodeInner):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
 
     def __str__(self):
         return "Case {self.name}"
@@ -4165,6 +4321,33 @@ class Choice(SchemaNodeInner):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self_default = self.default
+        if self_default is not None:
+            self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
 
     def __str__(self):
         return "Choice {self.name}"
@@ -4327,6 +4510,32 @@ class Container(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
+
     def __str__(self):
         return "Container {self.name}"
 
@@ -4416,6 +4625,23 @@ class Enum(SchemaNodeOuter):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+
     def __str__(self):
         return "Enum {self.name}"
 
@@ -4497,6 +4723,22 @@ class Extension(SchemaNodeOuter):
                         ns=new_ns if new_ns is not None else self.ns,
                         pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Extension {self.name}"
@@ -4582,6 +4824,23 @@ class Feature(SchemaNodeOuter):
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
         return "Feature {self.name}"
@@ -4673,6 +4932,26 @@ class Grouping(SchemaNodeInner):
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Grouping {self.name}"
@@ -4773,6 +5052,24 @@ class Identity(SchemaNodeOuter):
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.base = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.base]
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+
     def __str__(self):
         return "Identity {self.name}"
 
@@ -4855,6 +5152,22 @@ class Import(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+
     def __str__(self):
         return "Import {self.module}"
 
@@ -4932,6 +5245,22 @@ class Include(SchemaNodeOuter):
                       ns=new_ns if new_ns is not None else self.ns,
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Include {self.module}"
@@ -5033,6 +5362,28 @@ class Input(SchemaNodeInner):
                     pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
 
     def __str__(self):
         return "Input"
@@ -5211,6 +5562,32 @@ class Leaf(SchemaNodeOuter):
             when=self.when,
             exts=self.exts
         )
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self_default = self.default
+        if self_default is not None:
+            self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
 
     def __str__(self):
         return "Leaf {self.name}"
@@ -5409,6 +5786,30 @@ class LeafList(SchemaNodeOuter):
             exts=self.exts
         )
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.default = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.default]
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
+
     def __str__(self):
         return "LeafList {self.name}"
 
@@ -5490,6 +5891,22 @@ class Length(SchemaNodeOuter):
                      ns=new_ns if new_ns is not None else self.ns,
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Length {self.value}"
@@ -5685,6 +6102,33 @@ class List(SchemaNodeInner):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self.unique = [_remap_path_prefix(u, old_pfx, new_pfx) for u in self.unique]
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
 
     def __str__(self):
         return "List {self.name}"
@@ -5941,6 +6385,27 @@ class Module(SchemaNodeInner):
         new.expand_augments(context)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.deviation = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.deviation]
+
     def __str__(self):
         return "Module {self.name}"
 
@@ -6032,6 +6497,22 @@ class Must(SchemaNodeOuter):
                    ns=new_ns if new_ns is not None else self.ns,
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Must {self.condition}"
@@ -6169,6 +6650,29 @@ class Notification(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+
     def __str__(self):
         return "Notification {self.name}"
 
@@ -6273,6 +6777,28 @@ class Output(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+
     def __str__(self):
         return "Output"
 
@@ -6359,6 +6885,22 @@ class Pattern(SchemaNodeOuter):
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+
     def __str__(self):
         return "Pattern {self.value}"
 
@@ -6440,6 +6982,22 @@ class Range(SchemaNodeOuter):
                     ns=new_ns if new_ns is not None else self.ns,
                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Range {self.value}"
@@ -6582,6 +7140,27 @@ class Refine(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.default = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.default]
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        for must in self.must:
+            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
+        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)
+
     def __str__(self):
         return "Refine {self.target_node}"
 
@@ -6655,6 +7234,22 @@ class Revision(SchemaNodeOuter):
                        ns=new_ns if new_ns is not None else self.ns,
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
 
     def __str__(self):
         return "Revision {self.date}"
@@ -6847,6 +7442,27 @@ class Rpc(SchemaNodeInner):
 
     def is_config(self) -> bool:
         return False
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
         return "Rpc {self.name}"
@@ -7064,6 +7680,27 @@ class Submodule(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         new.expand_augments(context)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Recursively update children
+        for child in self.children:
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.deviation = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.deviation]
 
     def __str__(self):
         return "Submodule {self.name}"
@@ -7294,6 +7931,29 @@ class Type(SchemaNodeOuter):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.base = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.base]
+        self_path = self.path
+        if self_path is not None:
+            self.path = _remap_path_prefix(self_path, old_pfx, new_pfx)
+        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)
+        for nested_type in self.type_:
+            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+
     def __str__(self):
         return "Type {self.name}"
 
@@ -7404,6 +8064,26 @@ class Typedef(SchemaNodeOuter):
                       units=new_units,
                       exts=self.exts)
         return new
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self_default = self.default
+        if self_default is not None:
+            self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
+        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
 
     def __str__(self):
         return "Typedef {self.name}"
@@ -7531,6 +8211,33 @@ class Uses(SchemaNodeOuter):
         for refine in self.refine:
             target = get_target(target_base, refine.target_node)
             target.apply_refine(refine)
+
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
+        """Update namespace qualifiers and remap prefix references
+
+        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
+        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+        """
+        self.ns = new_ns
+        self.pfx = new_pfx
+        self.mod = new_mod
+
+        # Exit early if no prefix remapping is needed
+        if old_pfx == new_pfx:
+            return
+
+        # Remap prefix references
+        self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
+        self_when = self.when
+        if self_when is not None:
+            self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
+        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)
+        for refine in self.refine:
+            refine.target_node = _remap_path_prefix(refine.target_node, old_pfx, new_pfx)
+            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+        for aug in self.augment:
+            aug.target_node = _remap_path_prefix(aug.target_node, old_pfx, new_pfx)
+            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
 
     def __str__(self):
         return "Uses {self.name}"
@@ -8762,6 +9469,33 @@ def stmt_to_snode(stmt: Statement, parent: ?SchemaNode=None) -> SchemaNode:
                 raise ValueError("Invalid statement under uses: {name}")
             return n
     raise ValueError("Unknown statement: {stmt.kw}")
+
+
+def _remap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
+    """Remap prefix in augment/deviation paths from old to new prefix
+
+    Example: "/old:foo/old:bar/baz" -> "/new:foo/new:bar/baz"
+    """
+    if old_prefix == new_prefix:
+        return path
+
+    # Split path into segments
+    segments = path.split("/")
+    result = []
+
+    for segment in segments:
+        sp = segment.split(":", 1)
+        if len(sp) > 1:
+            prefix = sp[0]
+            name = sp[1]
+            if prefix == old_prefix:
+                result.append(new_prefix + ":" + name)
+            else:
+                result.append(segment)
+        else:
+            result.append(segment)
+
+    return "/".join(result)
 
 
 def stmt_to_smodule(stmt):

--- a/test/golden/test_yang/compile_submodule_different_prefix
+++ b/test/golden/test_yang/compile_submodule_different_prefix
@@ -1,0 +1,606 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+mut def from_json_main_module__main_container__main_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__main_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_main_module__main_container__sub_group_container__sub_group_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__sub_group_container__sub_group_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class main_module__main_container__sub_group_container(yang.adata.MNode):
+    sub_group_leaf: str
+
+    mut def __init__(self, sub_group_leaf: ?str=None):
+        self._ns = 'http://example.com/main'
+        self.sub_group_leaf = sub_group_leaf if sub_group_leaf is not None else "from-submodule"
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _sub_group_leaf = self.sub_group_leaf
+        if _sub_group_leaf is not None:
+            children['sub-group-leaf'] = yang.gdata.Leaf('string', _sub_group_leaf)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> main_module__main_container__sub_group_container:
+        if n is not None:
+            return main_module__main_container__sub_group_container(sub_group_leaf=n.get_opt_str('sub-group-leaf'))
+        return main_module__main_container__sub_group_container()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /main-container/sub-group-container')
+            res.append('{self_name} = main_module__main_container__sub_group_container()')
+        leaves = []
+        _sub_group_leaf = self.sub_group_leaf
+        if _sub_group_leaf is not None:
+            leaves.append('{self_name}.sub_group_leaf = {repr(_sub_group_leaf)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /main-container/sub-group-container'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container', 'sub-group-container'])
+
+
+mut def from_xml_main_module__main_container__sub_group_container(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sub_group_leaf = yang.gdata.from_xml_opt_str(node, 'sub-group-leaf')
+    yang.gdata.maybe_add(children, 'sub-group-leaf', from_xml_main_module__main_container__sub_group_container__sub_group_leaf, child_sub_group_leaf)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_main_module__main_container__sub_group_container(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'sub-group-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_main_module__main_container__sub_group_container(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_main_module__main_container__sub_group_container(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_sub_group_leaf = yang.gdata.take_json_opt_str(jd, 'sub-group-leaf')
+    yang.gdata.maybe_add(children, 'sub-group-leaf', from_json_main_module__main_container__sub_group_container__sub_group_leaf, child_sub_group_leaf)
+    return yang.gdata.Container(children)
+
+mut def from_json_main_module__main_container__sub_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__sub_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_main_module__main_container__sub_list__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__sub_list__name(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_main_module__main_container__sub_list__sub_value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__sub_list__sub_value(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_main_module__main_container__sub_list__ref_to_main(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+mut def from_xml_main_module__main_container__sub_list__ref_to_main(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('leafref', val)
+
+class main_module__main_container__sub_list_entry(yang.adata.MNode):
+    name: str
+    sub_value: ?str
+    ref_to_main: ?str
+
+    mut def __init__(self, name: str, sub_value: ?str, ref_to_main: ?str):
+        self._ns = 'http://example.com/main'
+        self.name = name
+        self.sub_value = sub_value
+        self.ref_to_main = ref_to_main
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _name = self.name
+        if _name is not None:
+            children['name'] = yang.gdata.Leaf('string', _name)
+        _sub_value = self.sub_value
+        if _sub_value is not None:
+            children['sub-value'] = yang.gdata.Leaf('string', _sub_value)
+        _ref_to_main = self.ref_to_main
+        if _ref_to_main is not None:
+            children['ref-to-main'] = yang.gdata.Leaf('leafref', _ref_to_main)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> main_module__main_container__sub_list_entry:
+        return main_module__main_container__sub_list_entry(name=n.get_str('name'), sub_value=n.get_opt_str('sub-value'), ref_to_main=n.get_opt_str('ref-to-main'))
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /main-container/sub-list')
+            res.append('{self_name} = main_module__main_container__sub_list({repr(self.name)})')
+        leaves = []
+        _sub_value = self.sub_value
+        if _sub_value is not None:
+            leaves.append('{self_name}.sub_value = {repr(_sub_value)}')
+        _ref_to_main = self.ref_to_main
+        if _ref_to_main is not None:
+            leaves.append('{self_name}.ref_to_main = {repr(_ref_to_main)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /main-container/sub-list'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container', 'sub-list'])
+
+class main_module__main_container__sub_list(yang.adata.MNode):
+    elements: list[main_module__main_container__sub_list_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'http://example.com/main'
+        self._name = 'sub-list'
+        self.elements = elements
+
+    mut def create(self, name):
+        for e in self.elements:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if match:
+                return e
+
+        res = main_module__main_container__sub_list_entry(name)
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self.elements:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.Container):
+                elements.append(e_gdata)
+        return yang.gdata.List(['name'], elements)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[main_module__main_container__sub_list_entry]:
+        if n is not None:
+            return [main_module__main_container__sub_list_entry.from_gdata(e) for e in n.elements]
+        return []
+
+
+mut def from_xml_main_module__main_container__sub_list_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.from_xml_str(node, 'name')
+    yang.gdata.maybe_add(children, 'name', from_xml_main_module__main_container__sub_list__name, child_name)
+    child_sub_value = yang.gdata.from_xml_opt_str(node, 'sub-value')
+    yang.gdata.maybe_add(children, 'sub-value', from_xml_main_module__main_container__sub_list__sub_value, child_sub_value)
+    child_ref_to_main = yang.gdata.from_xml_opt_str(node, 'ref-to-main')
+    yang.gdata.maybe_add(children, 'ref-to-main', from_xml_main_module__main_container__sub_list__ref_to_main, child_ref_to_main)
+    return yang.gdata.Container(children)
+
+mut def from_xml_main_module__main_container__sub_list(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = [from_xml_main_module__main_container__sub_list_element(e) for e in nodes]
+    return yang.gdata.List(keys=['name'], elements=elements)
+
+mut def from_json_path_main_module__main_container__sub_list_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        val = from_json_main_module__main_container__sub_list_element(jd_dict)
+        if op == "merge":
+            return val
+        elif op == "remove":
+            return yang.gdata.Absent(val.key_children(['name']))
+        raise ValueError("Invalid operation")
+    elif len(path) > 1:
+        keys = path[0].split(",")
+        point = path[1]
+        rest_path = path[2:]
+        children: dict[str, yang.gdata.Node] = {}
+        children['name'] = from_json_main_module__main_container__sub_list__name(keys[0])
+        if point == 'sub-value':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'ref-to-main':
+            raise ValueError("Invalid json path to non-inner node")
+        return yang.gdata.Container(children)
+    raise ValueError("unreachable - no keys to list element")
+
+mut def from_json_path_main_module__main_container__sub_list(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        # Check that all keys are present in payload.
+        # If present, they must equal the keys in the path
+        # If not present, fill in from path
+        for key in ['name']:
+            if key not in jd_dict:
+                jd_dict[key] = keys.pop(0)
+            else:
+                if str(jd_dict[key]) != keys.pop(0):
+                    raise ValueError("Key value mismatch between path and payload")
+        element = from_json_main_module__main_container__sub_list_element(jd_dict)
+        elements = []
+        if op == "merge":
+            elements.append(element)
+        elif op == "remove":
+            elements.append(yang.gdata.Absent(element.key_children(['name'])))
+        return yang.gdata.List(['name'], elements)
+    elif len(path) > 1:
+        return yang.gdata.List(['name'], [from_json_path_main_module__main_container__sub_list_element(jd, path, op)])
+    raise ValueError("Unable to resolve path, no keys provided")
+
+mut def from_json_main_module__main_container__sub_list_element(jd: dict[str, ?value]) -> yang.gdata.Node:
+    children = {}
+    child_name = yang.gdata.take_json_str(jd, 'name')
+    yang.gdata.maybe_add(children, 'name', from_json_main_module__main_container__sub_list__name, child_name)
+    child_sub_value = yang.gdata.take_json_opt_str(jd, 'sub-value')
+    yang.gdata.maybe_add(children, 'sub-value', from_json_main_module__main_container__sub_list__sub_value, child_sub_value)
+    child_ref_to_main = yang.gdata.take_json_opt_str(jd, 'ref-to-main')
+    yang.gdata.maybe_add(children, 'ref-to-main', from_json_main_module__main_container__sub_list__ref_to_main, child_ref_to_main)
+    return yang.gdata.Container(children)
+
+mut def from_json_main_module__main_container__sub_list(jd: list[dict[str, ?value]]) -> yang.gdata.List:
+    elements = [from_json_main_module__main_container__sub_list_element(e) for e in jd if isinstance(e, dict)]
+    return yang.gdata.List(keys=['name'], elements=elements)
+
+mut def from_json_main_module__main_container__group_container__group_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__group_container__group_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_main_module__main_container__group_container__augmented_in_group(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_main_module__main_container__group_container__augmented_in_group(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class main_module__main_container__group_container(yang.adata.MNode):
+    group_leaf: str
+    augmented_in_group: ?str
+
+    mut def __init__(self, group_leaf: ?str=None, augmented_in_group: ?str):
+        self._ns = 'http://example.com/main'
+        self.group_leaf = group_leaf if group_leaf is not None else "refined-default"
+        self.augmented_in_group = augmented_in_group
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _group_leaf = self.group_leaf
+        if _group_leaf is not None:
+            children['group-leaf'] = yang.gdata.Leaf('string', _group_leaf)
+        _augmented_in_group = self.augmented_in_group
+        if _augmented_in_group is not None:
+            children['augmented-in-group'] = yang.gdata.Leaf('string', _augmented_in_group)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> main_module__main_container__group_container:
+        if n is not None:
+            return main_module__main_container__group_container(group_leaf=n.get_opt_str('group-leaf'), augmented_in_group=n.get_opt_str('augmented-in-group'))
+        return main_module__main_container__group_container()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /main-container/group-container')
+            res.append('{self_name} = main_module__main_container__group_container()')
+        leaves = []
+        _group_leaf = self.group_leaf
+        if _group_leaf is not None:
+            leaves.append('{self_name}.group_leaf = {repr(_group_leaf)}')
+        _augmented_in_group = self.augmented_in_group
+        if _augmented_in_group is not None:
+            leaves.append('{self_name}.augmented_in_group = {repr(_augmented_in_group)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /main-container/group-container'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container', 'group-container'])
+
+
+mut def from_xml_main_module__main_container__group_container(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_group_leaf = yang.gdata.from_xml_opt_str(node, 'group-leaf')
+    yang.gdata.maybe_add(children, 'group-leaf', from_xml_main_module__main_container__group_container__group_leaf, child_group_leaf)
+    child_augmented_in_group = yang.gdata.from_xml_opt_str(node, 'augmented-in-group')
+    yang.gdata.maybe_add(children, 'augmented-in-group', from_xml_main_module__main_container__group_container__augmented_in_group, child_augmented_in_group)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_main_module__main_container__group_container(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'group-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'augmented-in-group':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_main_module__main_container__group_container(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_main_module__main_container__group_container(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_group_leaf = yang.gdata.take_json_opt_str(jd, 'group-leaf')
+    yang.gdata.maybe_add(children, 'group-leaf', from_json_main_module__main_container__group_container__group_leaf, child_group_leaf)
+    child_augmented_in_group = yang.gdata.take_json_opt_str(jd, 'augmented-in-group')
+    yang.gdata.maybe_add(children, 'augmented-in-group', from_json_main_module__main_container__group_container__augmented_in_group, child_augmented_in_group)
+    return yang.gdata.Container(children)
+
+class main_module__main_container(yang.adata.MNode):
+    main_leaf: ?str
+    sub_group_container: main_module__main_container__sub_group_container
+    sub_leaf: ?str
+    sub_list: main_module__main_container__sub_list
+    group_container: main_module__main_container__group_container
+
+    mut def __init__(self, main_leaf: ?str, sub_group_container: ?main_module__main_container__sub_group_container=None, sub_leaf: ?str, sub_list: list[main_module__main_container__sub_list_entry]=[], group_container: ?main_module__main_container__group_container=None):
+        self._ns = 'http://example.com/main'
+        self.main_leaf = main_leaf
+        self.sub_group_container = sub_group_container if sub_group_container is not None else main_module__main_container__sub_group_container()
+        self.sub_leaf = sub_leaf
+        self.sub_list = main_module__main_container__sub_list(elements=sub_list)
+        self.group_container = group_container if group_container is not None else main_module__main_container__group_container()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _main_leaf = self.main_leaf
+        if _main_leaf is not None:
+            children['main-leaf'] = yang.gdata.Leaf('string', _main_leaf)
+        _sub_group_container = self.sub_group_container
+        if _sub_group_container is not None:
+            children['sub-group-container'] = _sub_group_container.to_gdata()
+        _sub_leaf = self.sub_leaf
+        if _sub_leaf is not None:
+            children['sub-leaf'] = yang.gdata.Leaf('string', _sub_leaf)
+        _sub_list = self.sub_list
+        if _sub_list is not None:
+            children['sub-list'] = _sub_list.to_gdata()
+        _group_container = self.group_container
+        if _group_container is not None:
+            children['group-container'] = _group_container.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/main', module='main-module')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> main_module__main_container:
+        if n is not None:
+            return main_module__main_container(main_leaf=n.get_opt_str('main-leaf'), sub_group_container=main_module__main_container__sub_group_container.from_gdata(n.get_opt_cnt('sub-group-container')), sub_leaf=n.get_opt_str('sub-leaf'), sub_list=main_module__main_container__sub_list.from_gdata(n.get_opt_list('sub-list')), group_container=main_module__main_container__group_container.from_gdata(n.get_opt_cnt('group-container')))
+        return main_module__main_container()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /main-container')
+            res.append('{self_name} = main_module__main_container()')
+        leaves = []
+        _main_leaf = self.main_leaf
+        if _main_leaf is not None:
+            leaves.append('{self_name}.main_leaf = {repr(_main_leaf)}')
+        _sub_group_container = self.sub_group_container
+        if _sub_group_container is not None:
+            res.extend(_sub_group_container.prsrc('{self_name}.sub_group_container', False).splitlines())
+        _sub_leaf = self.sub_leaf
+        if _sub_leaf is not None:
+            leaves.append('{self_name}.sub_leaf = {repr(_sub_leaf)}')
+        _sub_list = self.sub_list
+        for _element in _sub_list.elements:
+            res.append('')
+            res.append("# List /main-container/sub-list element: {_element.to_gdata().key_str(['name'])}")
+            list_elem = 'sub_list_element = {self_name}.sub_list.create({repr(_element.name)})'
+            res.append(list_elem)
+            res.extend(_element.prsrc('sub_list_element', False, list_element=True).splitlines())
+        _group_container = self.group_container
+        if _group_container is not None:
+            res.extend(_group_container.prsrc('{self_name}.group_container', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /main-container'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container'])
+
+
+mut def from_xml_main_module__main_container(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_main_leaf = yang.gdata.from_xml_opt_str(node, 'main-leaf')
+    yang.gdata.maybe_add(children, 'main-leaf', from_xml_main_module__main_container__main_leaf, child_main_leaf)
+    child_sub_group_container = yang.gdata.from_xml_opt_cnt(node, 'sub-group-container')
+    yang.gdata.maybe_add(children, 'sub-group-container', from_xml_main_module__main_container__sub_group_container, child_sub_group_container)
+    child_sub_leaf = yang.gdata.from_xml_opt_str(node, 'sub-leaf')
+    yang.gdata.maybe_add(children, 'sub-leaf', from_xml_main_module__main_container__sub_leaf, child_sub_leaf)
+    child_sub_list = yang.gdata.from_xml_opt_list(node, 'sub-list')
+    yang.gdata.maybe_add(children, 'sub-list', from_xml_main_module__main_container__sub_list, child_sub_list)
+    child_group_container = yang.gdata.from_xml_opt_cnt(node, 'group-container')
+    yang.gdata.maybe_add(children, 'group-container', from_xml_main_module__main_container__group_container, child_group_container)
+    return yang.gdata.Container(children, ns='http://example.com/main', module='main-module')
+
+mut def from_json_path_main_module__main_container(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'main-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'sub-group-container':
+            child = {'sub-group-container': from_json_path_main_module__main_container__sub_group_container(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/main', module='main-module')
+        if point == 'sub-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'sub-list':
+            child = {'sub-list': from_json_path_main_module__main_container__sub_list(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/main', module='main-module')
+        if point == 'group-container':
+            child = {'group-container': from_json_path_main_module__main_container__group_container(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/main', module='main-module')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_main_module__main_container(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_main_module__main_container(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_main_leaf = yang.gdata.take_json_opt_str(jd, 'main-leaf')
+    yang.gdata.maybe_add(children, 'main-leaf', from_json_main_module__main_container__main_leaf, child_main_leaf)
+    child_sub_group_container = yang.gdata.take_json_opt_cnt(jd, 'sub-group-container')
+    yang.gdata.maybe_add(children, 'sub-group-container', from_json_main_module__main_container__sub_group_container, child_sub_group_container)
+    child_sub_leaf = yang.gdata.take_json_opt_str(jd, 'sub-leaf')
+    yang.gdata.maybe_add(children, 'sub-leaf', from_json_main_module__main_container__sub_leaf, child_sub_leaf)
+    child_sub_list = yang.gdata.take_json_opt_list(jd, 'sub-list')
+    yang.gdata.maybe_add(children, 'sub-list', from_json_main_module__main_container__sub_list, child_sub_list)
+    child_group_container = yang.gdata.take_json_opt_cnt(jd, 'group-container')
+    yang.gdata.maybe_add(children, 'group-container', from_json_main_module__main_container__group_container, child_group_container)
+    return yang.gdata.Container(children, ns='http://example.com/main', module='main-module')
+
+class root(yang.adata.MNode):
+    main_container: main_module__main_container
+
+    mut def __init__(self, main_container: ?main_module__main_container=None):
+        self._ns = ''
+        self.main_container = main_container if main_container is not None else main_module__main_container()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _main_container = self.main_container
+        if _main_container is not None:
+            children['main-container'] = _main_container.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root(main_container=main_module__main_container.from_gdata(n.get_opt_cnt('main-container')))
+        return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        _main_container = self.main_container
+        if _main_container is not None:
+            res.extend(_main_container.prsrc('{self_name}.main_container', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_main_container = yang.gdata.from_xml_opt_cnt(node, 'main-container', 'http://example.com/main')
+    yang.gdata.maybe_add(children, 'main-container', from_xml_main_module__main_container, child_main_container)
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'main-module:main-container':
+            child = {'main-container': from_json_path_main_module__main_container(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_main_container = yang.gdata.take_json_opt_cnt(jd, 'main-container', 'main-module')
+    yang.gdata.maybe_add(children, 'main-container', from_json_main_module__main_container, child_main_container)
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/main',
+}
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)


### PR DESCRIPTION
When merging submodules into parent modules, all statements must appear as if
defined in the parent module. Submodules may use different prefixes than their
parent module - both for referring to the parent module itself and for imports.
This method updates namespace qualifiers (ns, pfx, mod) to the parent module's
values and remaps all prefixed references when prefixes differ: names of
groupings, identities, custom types, path expressions, ...

We generate SchemaNode.update_namespace_qualifiers() for each YANG
statement class based on RFC 7950's substatement definitions. This seems
less error-prone than doing isinstance(node, Foo) checks for each schema
node type and then remapping its attributes.

Closes #1