### PR TITLE
Suppress adata output in ayangc compile by default

### DIFF
--- a/src/ayangc.act
+++ b/src/ayangc.act
@@ -63,6 +63,7 @@ proc def cmd_compile(env, file_cap, args):
     infiles = args.get_strlist("infile")
     loose = args.get_bool("loose")
     exclude_patterns = args.get_strlist("exclude")
+    output = args.get_str("output")
 
     if len(infiles) == 0:
         print("Error: no input files or directories specified", err=True)
@@ -123,7 +124,12 @@ proc def cmd_compile(env, file_cap, args):
         root = yang.compile(yang_sources)
         t1 = sw.elapsed()
         print("Compiled {len(yang_sources)} YANG modules in {t1.to_float()}s", err=True)
-        print(root.prdaclass(loose=loose))
+        if output == "adata":
+            sw.reset()
+            adata = root.prdaclass(loose=loose)
+            t2 = sw.elapsed()
+            print(adata)
+            print("Generated adata in {t2.to_float()}s", err=True)
     except Exception as exc:
         print("Error during compilation: {exc}", err=True)
         env.exit(1)
@@ -161,6 +167,7 @@ actor main(env):
     compile_cmd.add_option("infile", "strlist", "+", [], "input YANG file(s) or directory(s)")
     compile_cmd.add_bool("loose", "generate loose validation mode classes", short="l")
     compile_cmd.add_option("exclude", "strlist", "*", [], "glob pattern(s) to exclude files", short="e")
+    compile_cmd.add_option("output", "str", "output format (adata, default none)", "", short="o")
 
     try:
         args = p.parse(env.argv)


### PR DESCRIPTION
The primary use case for "ayangc compile" is YANG validation (can we compile the set of YANG modules), so spending extra seconds printing adata is usually a waste.