### PR TITLE
Fix submodule import prefix conflicts

### DIFF
--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1859,6 +1859,112 @@ def _test_compile_submodule_different_prefix():
     # Generate and return the Acton data classes to verify it works end-to-end
     return root.prdaclass()
 
+def _test_compile_submodule_conflicting_import_prefix():
+    """Test that submodule imports with conflicting prefixes are properly remapped"""
+    # Module 'other' that will be imported by the parent module
+    ys_other = r"""module other {
+        yang-version "1.1";
+        namespace "http://example.com/other";
+        prefix "other";
+
+        typedef other-type {
+            type string {
+                length "1..100";
+            }
+        }
+    }"""
+
+    # Module 'another' that will be imported by the submodule with conflicting prefix
+    ys_another = r"""module another {
+        yang-version "1.1";
+        namespace "http://example.com/another";
+        prefix "another";
+
+        typedef another-type {
+            type string {
+                pattern "[a-z]+";
+            }
+        }
+
+        grouping another-group {
+            leaf another-leaf {
+                type string;
+            }
+        }
+    }"""
+
+    # Parent module imports 'other' with prefix 'ext'
+    ys_parent = r"""module parent {
+        yang-version "1.1";
+        namespace "http://example.com/parent";
+        prefix "parent";
+
+        import other {
+            prefix "ext";
+        }
+
+        include sub-parent;
+
+        container parent-container {
+            leaf parent-leaf {
+                type ext:other-type;
+            }
+        }
+    }"""
+
+    # Submodule imports 'another' with same prefix 'ext' (conflict!)
+    ys_sub = r"""submodule sub-parent {
+        yang-version "1.1";
+        belongs-to parent {
+            prefix "p";
+        }
+
+        import another {
+            prefix "ext";  // Same prefix as parent uses for different module!
+        }
+
+        container sub-container {
+            leaf sub-leaf {
+                type ext:another-type;  // Should reference 'another' module after remapping
+            }
+            uses ext:another-group;  // Should also work after prefix remapping
+        }
+
+        augment "/p:parent-container" {
+            leaf augmented-leaf {
+                type ext:another-type;  // References 'another' via remapped prefix
+            }
+        }
+    }"""
+
+    # Compile all modules together
+    root = yang.compile([ys_other, ys_another, ys_parent, ys_sub])
+
+    # Verify the parent container exists and has correct type
+    parent_container = root.get("parent-container")
+    testing.assertNotNone(parent_container, "parent-container should exist")
+
+    parent_leaf = parent_container.get("parent-leaf")
+    testing.assertNotNone(parent_leaf, "parent-leaf should exist")
+
+    # Verify the submodule's container exists
+    sub_container = root.get("sub-container")
+    testing.assertNotNone(sub_container, "sub-container should exist")
+
+    sub_leaf = sub_container.get("sub-leaf")
+    testing.assertNotNone(sub_leaf, "sub-leaf should exist")
+
+    # Verify the augmented leaf exists
+    augmented_leaf = parent_container.get("augmented-leaf")
+    testing.assertNotNone(augmented_leaf, "augmented-leaf should exist after augment")
+
+    # Verify uses from the remapped import works
+    another_leaf = sub_container.get("another-leaf")
+    testing.assertNotNone(another_leaf, "another-leaf from uses should exist")
+
+    # Generate and return the Acton data classes to verify it compiles
+    return root.prdaclass()
+
 def _test_compile_submodules2():
     ys_foo = r"""module foo {
     yang-version "1.1";

--- a/src/yang.act
+++ b/src/yang.act
@@ -89,10 +89,13 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
             except KeyError:
                 raise ValueError("{m.name} - submodule {include.module} not found.")
             else:
-                # Track all prefix remappings needed (including parent module prefix)
+                # Track all prefix remappings needed when merging submodule into parent:
+                # 1. Submodule uses different prefix for parent module (belongs-to)
+                # 2. Same module imported with different prefix in parent vs submodule
+                # 3. Different modules imported with same prefix in parent vs submodule
                 prefix_remaps: dict[str, str] = {}
 
-                # If submodule uses different prefix for parent module, track that remapping
+                # Case 1: Submodule uses different prefix for parent module
                 if submod.belongs_to.prefix != m.prefix:
                     prefix_remaps[submod.belongs_to.prefix] = m.prefix
 
@@ -100,12 +103,21 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
                     try:
                         import_prefix = combined_import_prefixes.get(sub_import.module, sub_import.revision_date)
                     except KeyError:
-                        # New import
-                        combined_import_prefixes.add(sub_import.module, sub_import.revision_date, sub_import.prefix)
+                        # New import - not yet in parent
+                        prefix_to_use = sub_import.prefix
+
+                        # Case 3: Check if this prefix is already used for a different module
+                        for mod_name, (rev, pfx) in combined_import_prefixes:
+                            if pfx == sub_import.prefix and mod_name != sub_import.module:
+                                prefix_to_use = "{sub_import.prefix}-{submod.name}"
+                                prefix_remaps[sub_import.prefix] = prefix_to_use
+                                break
+
+                        combined_import_prefixes.add(sub_import.module, sub_import.revision_date, prefix_to_use)
 
                         new_import = yang.schema.Import(sub_import.module,
                                                         description=sub_import.description,
-                                                        prefix=sub_import.prefix,
+                                                        prefix=prefix_to_use,
                                                         reference=sub_import.reference,
                                                         revision_date=sub_import.revision_date,
                                                         exts=sub_import.exts,
@@ -114,10 +126,11 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
 
                         m.import_.append(new_import)
                     else:
+                        # Case 2: Same module already imported by parent (or another submodule)
                         if sub_import.prefix != import_prefix:
-                            # Track that we need to remap this prefix in the submodule's content
+                            # Remap to use parent's prefix for this module
                             prefix_remaps[sub_import.prefix] = import_prefix
-                        # else: # Duplicate import. We're fine!
+                        # else: # Same module, same prefix. We're fine!
 
                 for c in submod.children:
                     # Set parent attribute for direct children only

--- a/test/golden/test_yang/compile_submodule_conflicting_import_prefix
+++ b/test/golden/test_yang/compile_submodule_conflicting_import_prefix
@@ -1,0 +1,314 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+mut def from_json_parent__parent_container__parent_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_parent__parent_container__parent_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_parent__parent_container__augmented_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_parent__parent_container__augmented_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class parent__parent_container(yang.adata.MNode):
+    parent_leaf: ?str
+    augmented_leaf: ?str
+
+    mut def __init__(self, parent_leaf: ?str, augmented_leaf: ?str):
+        self._ns = 'http://example.com/parent'
+        self.parent_leaf = parent_leaf
+        self.augmented_leaf = augmented_leaf
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _parent_leaf = self.parent_leaf
+        if _parent_leaf is not None:
+            children['parent-leaf'] = yang.gdata.Leaf('string', _parent_leaf)
+        _augmented_leaf = self.augmented_leaf
+        if _augmented_leaf is not None:
+            children['augmented-leaf'] = yang.gdata.Leaf('string', _augmented_leaf)
+        return yang.gdata.Container(children, ns='http://example.com/parent', module='parent')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> parent__parent_container:
+        if n is not None:
+            return parent__parent_container(parent_leaf=n.get_opt_str('parent-leaf'), augmented_leaf=n.get_opt_str('augmented-leaf'))
+        return parent__parent_container()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /parent-container')
+            res.append('{self_name} = parent__parent_container()')
+        leaves = []
+        _parent_leaf = self.parent_leaf
+        if _parent_leaf is not None:
+            leaves.append('{self_name}.parent_leaf = {repr(_parent_leaf)}')
+        _augmented_leaf = self.augmented_leaf
+        if _augmented_leaf is not None:
+            leaves.append('{self_name}.augmented_leaf = {repr(_augmented_leaf)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /parent-container'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['parent:parent-container'])
+
+
+mut def from_xml_parent__parent_container(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_parent_leaf = yang.gdata.from_xml_opt_str(node, 'parent-leaf')
+    yang.gdata.maybe_add(children, 'parent-leaf', from_xml_parent__parent_container__parent_leaf, child_parent_leaf)
+    child_augmented_leaf = yang.gdata.from_xml_opt_str(node, 'augmented-leaf')
+    yang.gdata.maybe_add(children, 'augmented-leaf', from_xml_parent__parent_container__augmented_leaf, child_augmented_leaf)
+    return yang.gdata.Container(children, ns='http://example.com/parent', module='parent')
+
+mut def from_json_path_parent__parent_container(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'parent-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'augmented-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_parent__parent_container(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_parent__parent_container(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_parent_leaf = yang.gdata.take_json_opt_str(jd, 'parent-leaf')
+    yang.gdata.maybe_add(children, 'parent-leaf', from_json_parent__parent_container__parent_leaf, child_parent_leaf)
+    child_augmented_leaf = yang.gdata.take_json_opt_str(jd, 'augmented-leaf')
+    yang.gdata.maybe_add(children, 'augmented-leaf', from_json_parent__parent_container__augmented_leaf, child_augmented_leaf)
+    return yang.gdata.Container(children, ns='http://example.com/parent', module='parent')
+
+mut def from_json_parent__sub_container__sub_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_parent__sub_container__sub_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_parent__sub_container__another_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_parent__sub_container__another_leaf(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+class parent__sub_container(yang.adata.MNode):
+    sub_leaf: ?str
+    another_leaf: ?str
+
+    mut def __init__(self, sub_leaf: ?str, another_leaf: ?str):
+        self._ns = 'http://example.com/parent'
+        self.sub_leaf = sub_leaf
+        self.another_leaf = another_leaf
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _sub_leaf = self.sub_leaf
+        if _sub_leaf is not None:
+            children['sub-leaf'] = yang.gdata.Leaf('string', _sub_leaf)
+        _another_leaf = self.another_leaf
+        if _another_leaf is not None:
+            children['another-leaf'] = yang.gdata.Leaf('string', _another_leaf)
+        return yang.gdata.Container(children, ns='http://example.com/parent', module='parent')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> parent__sub_container:
+        if n is not None:
+            return parent__sub_container(sub_leaf=n.get_opt_str('sub-leaf'), another_leaf=n.get_opt_str('another-leaf'))
+        return parent__sub_container()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /sub-container')
+            res.append('{self_name} = parent__sub_container()')
+        leaves = []
+        _sub_leaf = self.sub_leaf
+        if _sub_leaf is not None:
+            leaves.append('{self_name}.sub_leaf = {repr(_sub_leaf)}')
+        _another_leaf = self.another_leaf
+        if _another_leaf is not None:
+            leaves.append('{self_name}.another_leaf = {repr(_another_leaf)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /sub-container'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['parent:sub-container'])
+
+
+mut def from_xml_parent__sub_container(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_sub_leaf = yang.gdata.from_xml_opt_str(node, 'sub-leaf')
+    yang.gdata.maybe_add(children, 'sub-leaf', from_xml_parent__sub_container__sub_leaf, child_sub_leaf)
+    child_another_leaf = yang.gdata.from_xml_opt_str(node, 'another-leaf')
+    yang.gdata.maybe_add(children, 'another-leaf', from_xml_parent__sub_container__another_leaf, child_another_leaf)
+    return yang.gdata.Container(children, ns='http://example.com/parent', module='parent')
+
+mut def from_json_path_parent__sub_container(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'sub-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'another-leaf':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_parent__sub_container(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_parent__sub_container(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_sub_leaf = yang.gdata.take_json_opt_str(jd, 'sub-leaf')
+    yang.gdata.maybe_add(children, 'sub-leaf', from_json_parent__sub_container__sub_leaf, child_sub_leaf)
+    child_another_leaf = yang.gdata.take_json_opt_str(jd, 'another-leaf')
+    yang.gdata.maybe_add(children, 'another-leaf', from_json_parent__sub_container__another_leaf, child_another_leaf)
+    return yang.gdata.Container(children, ns='http://example.com/parent', module='parent')
+
+class root(yang.adata.MNode):
+    parent_container: parent__parent_container
+    sub_container: parent__sub_container
+
+    mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None):
+        self._ns = ''
+        self.parent_container = parent_container if parent_container is not None else parent__parent_container()
+        self.sub_container = sub_container if sub_container is not None else parent__sub_container()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _parent_container = self.parent_container
+        if _parent_container is not None:
+            children['parent-container'] = _parent_container.to_gdata()
+        _sub_container = self.sub_container
+        if _sub_container is not None:
+            children['sub-container'] = _sub_container.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root(parent_container=parent__parent_container.from_gdata(n.get_opt_cnt('parent-container')), sub_container=parent__sub_container.from_gdata(n.get_opt_cnt('sub-container')))
+        return root()
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        _parent_container = self.parent_container
+        if _parent_container is not None:
+            res.extend(_parent_container.prsrc('{self_name}.parent_container', False).splitlines())
+        _sub_container = self.sub_container
+        if _sub_container is not None:
+            res.extend(_sub_container.prsrc('{self_name}.sub_container', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_parent_container = yang.gdata.from_xml_opt_cnt(node, 'parent-container', 'http://example.com/parent')
+    yang.gdata.maybe_add(children, 'parent-container', from_xml_parent__parent_container, child_parent_container)
+    child_sub_container = yang.gdata.from_xml_opt_cnt(node, 'sub-container', 'http://example.com/parent')
+    yang.gdata.maybe_add(children, 'sub-container', from_xml_parent__sub_container, child_sub_container)
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'parent:parent-container':
+            child = {'parent-container': from_json_path_parent__parent_container(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        if point == 'parent:sub-container':
+            child = {'sub-container': from_json_path_parent__sub_container(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_parent_container = yang.gdata.take_json_opt_cnt(jd, 'parent-container', 'parent')
+    yang.gdata.maybe_add(children, 'parent-container', from_json_parent__parent_container, child_parent_container)
+    child_sub_container = yang.gdata.take_json_opt_cnt(jd, 'sub-container', 'parent')
+    yang.gdata.maybe_add(children, 'sub-container', from_json_parent__sub_container, child_sub_container)
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/parent',
+}
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)


### PR DESCRIPTION
When a submodule imports a module using the same prefix that the parent module uses for a different import, generate a unique prefix to avoid conflicts. The new prefix follows the pattern: {original_prefix}-{submodule_name}

This ensures all imports can coexist when combined in the parent module, after all submodules are expanded into the parent module.

Closes #253 