### PR TITLE
Generate adata.copy() method

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -658,6 +658,24 @@ class DNodeInner(DNode):
                 res.append("        raise ValueError('Missing required subtree {pname(self)}')")
         res.append("")
 
+        # .copy() method
+        res.append("    def copy(self):")
+        res.append('        """Create a deep copy of this adata object"""')
+        if isinstance(self, DList):
+            res.append("        return {pname(self)}_entry.from_gdata(self.to_gdata())")
+        else:
+            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
+            # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
+            # But since we're copying an instance, the output of .copy() is non-optional.
+            if opt_cnt:
+                res.append("        ad = {pname(self)}.from_gdata(self.to_gdata())")
+                res.append("        if ad is not None:")
+                res.append("            return ad")
+                res.append("        raise Exception('Unreachable in {pname(self)}.copy()')")
+            else:
+                res.append("        return {pname(self)}.from_gdata(self.to_gdata())")
+        res.append("")
+
         def find_non_optional_subtree(container: DNodeInner, path: list[str], local_prefix="_") -> (list[str], list[str]):
             r"""Discover the non-optional descendants of a container
 
@@ -929,6 +947,18 @@ class DNodeInner(DNode):
             # why? Above code that iterates over n.elements works fine... Error is:
             # ERROR: Error when compiling y_cfs module: Type error
             # mut must be a subclass of pure
+            res.append("")
+
+            # .copy() method for list wrapper
+            res.append("    def copy(self):")
+            res.append('        """Create a deep copy of this list object"""')
+            res.append("        # Copy each element in the list")
+            res.append("        copied_elements = []")
+            res.append("        for e in self.elements:")
+            res.append("            ce = e.copy()")
+            res.append("            if ce is not None:")
+            res.append("                copied_elements.append(ce)")
+            res.append("        return {pname(self)}(elements=copied_elements)")
             res.append("")
         res.append("")
 

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -14,3 +14,7 @@ class MNode(object):
     # TODO: remove mut effect once the compiler is fixed to not leak mut effect out of functions
     mut def prsrc(self, self_name='ad', top=False, list_element=False) -> str:
         raise NotImplementedError("prsrc not implemented for {type(self)}")
+
+    mut def copy(self) -> Self:
+        """Create a deep copy of this adata object"""
+        raise NotImplementedError()

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -654,6 +654,24 @@ class DNodeInner(DNode):
                 res.append("        raise ValueError('Missing required subtree {pname(self)}')")
         res.append("")
 
+        # .copy() method
+        res.append("    def copy(self):")
+        res.append('        """Create a deep copy of this adata object"""')
+        if isinstance(self, DList):
+            res.append("        return {pname(self)}_entry.from_gdata(self.to_gdata())")
+        else:
+            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
+            # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
+            # But since we're copying an instance, the output of .copy() is non-optional.
+            if opt_cnt:
+                res.append("        ad = {pname(self)}.from_gdata(self.to_gdata())")
+                res.append("        if ad is not None:")
+                res.append("            return ad")
+                res.append("        raise Exception('Unreachable in {pname(self)}.copy()')")
+            else:
+                res.append("        return {pname(self)}.from_gdata(self.to_gdata())")
+        res.append("")
+
         def find_non_optional_subtree(container: DNodeInner, path: list[str], local_prefix="_") -> (list[str], list[str]):
             r"""Discover the non-optional descendants of a container
 
@@ -925,6 +943,18 @@ class DNodeInner(DNode):
             # why? Above code that iterates over n.elements works fine... Error is:
             # ERROR: Error when compiling y_cfs module: Type error
             # mut must be a subclass of pure
+            res.append("")
+
+            # .copy() method for list wrapper
+            res.append("    def copy(self):")
+            res.append('        """Create a deep copy of this list object"""')
+            res.append("        # Copy each element in the list")
+            res.append("        copied_elements = []")
+            res.append("        for e in self.elements:")
+            res.append("            ce = e.copy()")
+            res.append("            if ce is not None:")
+            res.append("                copied_elements.append(ce)")
+            res.append("        return {pname(self)}(elements=copied_elements)")
             res.append("")
         res.append("")
 

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -49,6 +49,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -127,6 +131,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -28,6 +28,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1()
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -88,6 +92,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -180,6 +188,10 @@ class foo__r1__input__c3(yang.adata.MNode):
             return foo__r1__input__c3(l3=n.get_opt_str('l3'))
         return foo__r1__input__c3()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__r1__input__c3.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -249,6 +261,10 @@ class foo__r1__input(yang.adata.MNode):
         if n is not None:
             return foo__r1__input(c3=foo__r1__input__c3.from_gdata(n.get_opt_cnt('c3')))
         return foo__r1__input()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__r1__input.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -326,6 +342,10 @@ class foo__r1__output(yang.adata.MNode):
         if n is not None:
             return foo__r1__output(l4=n.get_opt_str('l4'))
         return foo__r1__output()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__r1__output.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -49,6 +49,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -127,6 +131,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -55,6 +55,10 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=n.get_opt_str('l2'), l3=n.get_opt_str('l3'))
         return foo__c1__c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -139,6 +143,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_cnt('c2')))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -218,6 +226,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -55,6 +55,10 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=n.get_opt_str('l2'), l3=n.get_opt_str('l3'))
         return foo__c1__c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -139,6 +143,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), c2=foo__c1__c2.from_gdata(n.get_opt_cnt('c2')))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -218,6 +226,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -38,6 +38,10 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l1=n.get_opt_str('l1'))
         return foo__c1__c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -107,6 +111,10 @@ class foo__c1(yang.adata.MNode):
         if n is not None:
             return foo__c1(c2=foo__c1__c2.from_gdata(n.get_opt_cnt('c2')))
         return foo__c1()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -178,6 +186,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -49,6 +49,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -127,6 +131,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -47,6 +47,10 @@ class foo__c1__things_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__things_entry:
         return foo__c1__things_entry(name=n.get_str('name'), id=n.get_opt_str('id'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__things_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -101,6 +105,16 @@ class foo__c1__things(yang.adata.MNode):
         if n is not None:
             return [foo__c1__things_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c1__things(elements=copied_elements)
 
 
 mut def from_xml_foo__c1__things_element(node: xml.Node) -> yang.gdata.Node:
@@ -194,6 +208,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(things=foo__c1__things.from_gdata(n.get_opt_list('things')))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -268,6 +286,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -38,6 +38,10 @@ class acme_foo_bar__c1(yang.adata.MNode):
             return acme_foo_bar__c1(l1=n.get_opt_str('l1'))
         return acme_foo_bar__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return acme_foo_bar__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -107,6 +111,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=acme_foo_bar__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -36,6 +36,10 @@ class bar__c1__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> bar__c1__li1_entry:
         return bar__c1__li1_entry(l1=n.get_str('l1'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__c1__li1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -87,6 +91,16 @@ class bar__c1__li1(yang.adata.MNode):
         if n is not None:
             return [bar__c1__li1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return bar__c1__li1(elements=copied_elements)
 
 
 mut def from_xml_bar__c1__li1_element(node: xml.Node) -> yang.gdata.Node:
@@ -174,6 +188,10 @@ class bar__c1(yang.adata.MNode):
             return bar__c1(li1=bar__c1__li1.from_gdata(n.get_opt_list('li1')))
         return bar__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -248,6 +266,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=bar__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -38,6 +38,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_strs('l1'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -107,6 +111,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_submodule_conflicting_import_prefix
+++ b/test/golden/test_yang/compile_submodule_conflicting_import_prefix
@@ -49,6 +49,10 @@ class parent__parent_container(yang.adata.MNode):
             return parent__parent_container(parent_leaf=n.get_opt_str('parent-leaf'), augmented_leaf=n.get_opt_str('augmented-leaf'))
         return parent__parent_container()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return parent__parent_container.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -145,6 +149,10 @@ class parent__sub_container(yang.adata.MNode):
             return parent__sub_container(sub_leaf=n.get_opt_str('sub-leaf'), another_leaf=n.get_opt_str('another-leaf'))
         return parent__sub_container()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return parent__sub_container.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -228,6 +236,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(parent_container=parent__parent_container.from_gdata(n.get_opt_cnt('parent-container')), sub_container=parent__sub_container.from_gdata(n.get_opt_cnt('sub-container')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_submodule_different_prefix
+++ b/test/golden/test_yang/compile_submodule_different_prefix
@@ -44,6 +44,10 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
             return main_module__main_container__sub_group_container(sub_group_leaf=n.get_opt_str('sub-group-leaf'))
         return main_module__main_container__sub_group_container()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return main_module__main_container__sub_group_container.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -146,6 +150,10 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> main_module__main_container__sub_list_entry:
         return main_module__main_container__sub_list_entry(name=n.get_str('name'), sub_value=n.get_opt_str('sub-value'), ref_to_main=n.get_opt_str('ref-to-main'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -203,6 +211,16 @@ class main_module__main_container__sub_list(yang.adata.MNode):
         if n is not None:
             return [main_module__main_container__sub_list_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return main_module__main_container__sub_list(elements=copied_elements)
 
 
 mut def from_xml_main_module__main_container__sub_list_element(node: xml.Node) -> yang.gdata.Node:
@@ -319,6 +337,10 @@ class main_module__main_container__group_container(yang.adata.MNode):
             return main_module__main_container__group_container(group_leaf=n.get_opt_str('group-leaf'), augmented_in_group=n.get_opt_str('augmented-in-group'))
         return main_module__main_container__group_container()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return main_module__main_container__group_container.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -417,6 +439,10 @@ class main_module__main_container(yang.adata.MNode):
         if n is not None:
             return main_module__main_container(main_leaf=n.get_opt_str('main-leaf'), sub_group_container=main_module__main_container__sub_group_container.from_gdata(n.get_opt_cnt('sub-group-container')), sub_leaf=n.get_opt_str('sub-leaf'), sub_list=main_module__main_container__sub_list.from_gdata(n.get_opt_list('sub-list')), group_container=main_module__main_container__group_container.from_gdata(n.get_opt_cnt('group-container')))
         return main_module__main_container()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return main_module__main_container.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -530,6 +556,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(main_container=main_module__main_container.from_gdata(n.get_opt_cnt('main-container')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_submodule_same_module_different_prefix
+++ b/test/golden/test_yang/compile_submodule_same_module_different_prefix
@@ -49,6 +49,10 @@ class parent__parent_container(yang.adata.MNode):
             return parent__parent_container(parent_leaf=n.get_opt_str('parent-leaf'), augmented_leaf=n.get_opt_str('augmented-leaf'))
         return parent__parent_container()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return parent__parent_container.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -145,6 +149,10 @@ class parent__sub_container(yang.adata.MNode):
             return parent__sub_container(sub_leaf=n.get_opt_str('sub-leaf'), shared_leaf=n.get_opt_str('shared-leaf'))
         return parent__sub_container()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return parent__sub_container.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -228,6 +236,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(parent_container=parent__parent_container.from_gdata(n.get_opt_cnt('parent-container')), sub_container=parent__sub_container.from_gdata(n.get_opt_cnt('sub-container')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -38,6 +38,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -114,6 +118,10 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l2=n.get_opt_str('l2'))
         return foo__c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -188,6 +196,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -36,6 +36,10 @@ class foo__c1__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li1_entry:
         return foo__c1__li1_entry(l1=n.get_str('l1'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__li1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -87,6 +91,16 @@ class foo__c1__li1(yang.adata.MNode):
         if n is not None:
             return [foo__c1__li1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c1__li1(elements=copied_elements)
 
 
 mut def from_xml_foo__c1__li1_element(node: xml.Node) -> yang.gdata.Node:
@@ -174,6 +188,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(li1=foo__c1__li1.from_gdata(n.get_opt_list('li1')))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -248,6 +266,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -49,6 +49,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -127,6 +131,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/identityref
+++ b/test/golden/test_yang/identityref
@@ -69,6 +69,10 @@ class base__config(yang.adata.MNode):
             return base__config(active_protocol=n.get_opt_Identityref('active-protocol'))
         return base__config()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__config.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -138,6 +142,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(config=base__config.from_gdata(n.get_opt_cnt('config')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -36,6 +36,10 @@ class foo__c__li__bar(yang.adata.MNode):
             return foo__c__li__bar(man=n.get_str('man'))
         raise ValueError('Missing required subtree foo__c__li__bar')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c__li__bar.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -111,6 +115,10 @@ class foo__c__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c__li_entry:
         return foo__c__li_entry(name=n.get_str('name'), foo=n.get_opt_str('foo'), bar=foo__c__li__bar.from_gdata(n.get_cnt('bar')))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c__li_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -169,6 +177,16 @@ class foo__c__li(yang.adata.MNode):
         if n is not None:
             return [foo__c__li_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c__li(elements=copied_elements)
 
 
 mut def from_xml_foo__c__li_element(node: xml.Node) -> yang.gdata.Node:

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -33,6 +33,10 @@ class base__c1__base_l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
         return base__c1__base_l1_entry(base_k1=n.get_str('base:k1'), foo_k1=n.get_str('foo:k1'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1__base_l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -84,6 +88,16 @@ class base__c1__base_l1(yang.adata.MNode):
         if n is not None:
             return [base__c1__base_l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return base__c1__base_l1(elements=copied_elements)
 
 
 mut def from_xml_base__c1__base_l1_element(node: xml.Node) -> yang.gdata.Node:
@@ -180,6 +194,10 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__foo_l1_entry:
         return base__c1__foo_l1_entry(k2=n.get_str('k2'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1__foo_l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -231,6 +249,16 @@ class base__c1__foo_l1(yang.adata.MNode):
         if n is not None:
             return [base__c1__foo_l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return base__c1__foo_l1(elements=copied_elements)
 
 
 mut def from_xml_base__c1__foo_l1_element(node: xml.Node) -> yang.gdata.Node:
@@ -323,6 +351,10 @@ class base__c1(yang.adata.MNode):
             return base__c1(base_l1=base__c1__base_l1.from_gdata(n.get_opt_list('base:l1')), foo_l1=base__c1__foo_l1.from_gdata(n.get_opt_list('foo:l1')))
         return base__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -411,6 +443,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=base__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -24,6 +24,10 @@ class base__c1__base_c2(yang.adata.MNode):
             return base__c1__base_c2(foo=n.get_opt_str('foo'))
         return base__c1__base_c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1__base_c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -100,6 +104,10 @@ class base__c1__foo_c2(yang.adata.MNode):
             return base__c1__foo_c2(foo=n.get_opt_str('foo'))
         return base__c1__foo_c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1__foo_c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -174,6 +182,10 @@ class base__c1(yang.adata.MNode):
         if n is not None:
             return base__c1(base_c2=base__c1__base_c2.from_gdata(n.get_opt_cnt('base:c2')), foo_c2=base__c1__foo_c2.from_gdata(n.get_opt_cnt('foo:c2')))
         return base__c1()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -255,6 +267,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=base__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -35,6 +35,10 @@ class base__c1(yang.adata.MNode):
             return base__c1(bar_foo=n.get_opt_str('bar:foo'), foo_foo=n.get_opt_str('foo:foo'))
         return base__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -38,6 +38,10 @@ class foo__ieee_802_3(yang.adata.MNode):
             return foo__ieee_802_3(ieee_802_3=n.get_opt_str('ieee-802.3'))
         return foo__ieee_802_3()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__ieee_802_3.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -107,6 +111,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(ieee_802_3=foo__ieee_802_3.from_gdata(n.get_opt_cnt('ieee-802.3')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_identityref_list_key
+++ b/test/golden/test_yang/prdaclass_identityref_list_key
@@ -72,6 +72,10 @@ class foo__c1__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
         return foo__c1__l1_entry(k1=n.get_str('k1'), k2=n.get_Identityref('k2'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -126,6 +130,16 @@ class foo__c1__l1(yang.adata.MNode):
         if n is not None:
             return [foo__c1__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c1__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__c1__l1_element(node: xml.Node) -> yang.gdata.Node:
@@ -218,6 +232,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=foo__c1__l1.from_gdata(n.get_opt_list('l1')))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -292,6 +310,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -68,6 +68,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(as_=n.get_opt_str('as'), for_=n.get_opt_str('for'), import_=n.get_opt_str('import'), in_=n.get_opt_str('in'), with_=n.get_opt_str('with'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -22,6 +22,10 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -73,6 +77,16 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -33,6 +33,10 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), id=n.get_opt_str('id'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -87,6 +91,16 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -24,6 +24,10 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=n.get_opt_str('l1'))
         raise ValueError('Missing required subtree foo__foo__bar')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__foo__bar.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -93,6 +97,10 @@ class foo__foo(yang.adata.MNode):
         if n is not None:
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt('bar')))
         raise ValueError('Missing required subtree foo__foo')
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__foo.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -24,6 +24,13 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=n.get_opt_str('l1'))
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__foo__bar.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__foo__bar.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -98,6 +105,13 @@ class foo__foo(yang.adata.MNode):
         if n is not None:
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt('bar')))
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__foo.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__foo.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -36,6 +36,10 @@ class foo__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
         return foo__li1_entry(l1=n.get_str('l1'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__li1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -87,6 +91,16 @@ class foo__li1(yang.adata.MNode):
         if n is not None:
             return [foo__li1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__li1(elements=copied_elements)
 
 
 mut def from_xml_foo__li1_element(node: xml.Node) -> yang.gdata.Node:
@@ -184,6 +198,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(li1=foo__li1.from_gdata(n.get_opt_list('li1')), ll1=n.get_opt_strs('ll1'))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -36,6 +36,10 @@ class foo__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
         return foo__li1_entry(l1=n.get_str('l1'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__li1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -87,6 +91,16 @@ class foo__li1(yang.adata.MNode):
         if n is not None:
             return [foo__li1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__li1(elements=copied_elements)
 
 
 mut def from_xml_foo__li1_element(node: xml.Node) -> yang.gdata.Node:
@@ -184,6 +198,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(li1=foo__li1.from_gdata(n.get_list('li1')), ll1=n.get_strs('ll1'))
         raise ValueError('Missing required subtree root')
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -50,6 +50,10 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=n.get_opt_str('hi'))
         raise ValueError('Missing required subtree foo__l1__bar')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__l1__bar.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -128,6 +132,10 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), id=n.get_opt_str('id'), bar=foo__l1__bar.from_gdata(n.get_opt_cnt('bar')))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -185,6 +193,16 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:
@@ -283,6 +301,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(l1=foo__l1.from_gdata(n.get_opt_list('l1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -28,6 +28,10 @@ class root(yang.adata.MNode):
             return root()
         return root()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -115,6 +119,10 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
             return yangrpc__foo__input__woo(woo_b=n.get_opt_int('woo_b'))
         return yangrpc__foo__input__woo()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -189,6 +197,10 @@ class yangrpc__foo__input(yang.adata.MNode):
         if n is not None:
             return yangrpc__foo__input(a=n.get_opt_str('a'), woo=yangrpc__foo__input__woo.from_gdata(n.get_opt_cnt('woo')))
         return yangrpc__foo__input()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return yangrpc__foo__input.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -275,6 +287,10 @@ class yangrpc__foo__output(yang.adata.MNode):
         if n is not None:
             return yangrpc__foo__output(outoo=n.get_opt_str('outoo'))
         return yangrpc__foo__output()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return yangrpc__foo__output.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -33,6 +33,10 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), id=n.get_str('id'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -84,6 +88,16 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -30,6 +30,13 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=n.get_str('hi'))
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__l1__bar.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__l1__bar.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -105,6 +112,10 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str('name'), bar=foo__l1__bar.from_gdata(n.get_opt_cnt('bar')))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -162,6 +173,16 @@ class foo__l1(yang.adata.MNode):
         if n is not None:
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__l1_element(node: xml.Node) -> yang.gdata.Node:

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -60,6 +60,13 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(foo_l1=n.get_str('foo:l1'), bar_l1=n.get_str('bar:l1'), l2=n.get_str('l2'))
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__foo__bar.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__foo__bar.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -144,6 +151,13 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt('bar')))
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__foo.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__foo.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -222,6 +236,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(foo=foo__foo.from_gdata(n.get_opt_cnt('foo')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -38,6 +38,10 @@ class bar__c1(yang.adata.MNode):
             return bar__c1(l1=n.get_opt_str('l1'))
         return bar__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -114,6 +118,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -188,6 +196,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(bar_c1=bar__c1.from_gdata(n.get_opt_cnt('bar:c1')), foo_c1=foo__c1.from_gdata(n.get_opt_cnt('foo:c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -38,6 +38,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str('l1'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -114,6 +118,10 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_str('l1'))
         return foo__pc1__foo()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc1__foo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -183,6 +191,13 @@ class foo__pc1(yang.adata.MNode):
         if n is not None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc1.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc1.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -264,6 +279,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -58,6 +58,10 @@ class foo__c1__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
         return foo__c1__l1_entry(k1=n.get_str('k1'), k2=n.get_value('k2'), l1=n.get_str('l1'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__l1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -119,6 +123,16 @@ class foo__c1__l1(yang.adata.MNode):
         if n is not None:
             return [foo__c1__l1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c1__l1(elements=copied_elements)
 
 
 mut def from_xml_foo__c1__l1_element(node: xml.Node) -> yang.gdata.Node:
@@ -217,6 +231,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=foo__c1__l1.from_gdata(n.get_opt_list('l1')))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -291,6 +309,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -71,6 +71,10 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_int('l1'), l2=n.get_opt_int('l2'), l3=n.get_opt_int('l3'), l4=n.get_opt_int('l4'))
         return root()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -38,6 +38,10 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_str('l1'))
         return root()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -38,6 +38,10 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_value('l1'))
         return root()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -1281,3 +1281,15 @@ def _test_gen3_from_xml_full():
     s = yang.compile(yang_foo.src_yang())
     gd = yang.gen3.from_xml(s, xml.decode(xml_text_full))
     return gd.prsrc()
+
+def _test_copy_full_xml_tree():
+    """Test copying a full XML tree and comparing gdata outputs"""
+    gd = yang_foo.from_xml(xml.decode(xml_text_full))
+    original = yang_foo_root.from_gdata(gd)
+
+    copied = original.copy()
+    original_gdata = original.to_gdata()
+    copied_gdata = copied.to_gdata()
+
+    gdiff = yang.gdata.diff(original_gdata, copied_gdata)
+    testing.assertNone(gdiff)

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -236,6 +236,10 @@ class basics__c(yang.adata.MNode):
             return basics__c(l_str_def=n.get_opt_str('l_str_def'), l_str_def_quoted=n.get_opt_str('l_str_def_quoted'), l_uint64_def=n.get_opt_int('l_uint64_def'), l_union_def_str=n.get_opt_value('l_union_def_str'), l_union_def_int=n.get_opt_value('l_union_def_int'), l_union_def_float=n.get_opt_value('l_union_def_float'), l_union_def_bool=n.get_opt_value('l_union_def_bool'), l_union_def_enumeration=n.get_opt_value('l_union_def_enumeration'), l_binary_def=n.get_opt_bytes('l_binary_def'), l_identityref_def=n.get_opt_Identityref('l_identityref_def'))
         return basics__c()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return basics__c.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -386,6 +390,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c=basics__c.from_gdata(n.get_opt_cnt('c')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -350,6 +350,10 @@ class foo__c1__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
         return foo__c1__li_entry(name=n.get_str('name'), val=n.get_opt_str('val'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__li_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -404,6 +408,16 @@ class foo__c1__li(yang.adata.MNode):
         if n is not None:
             return [foo__c1__li_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c1__li(elements=copied_elements)
 
 
 mut def from_xml_foo__c1__li_element(node: xml.Node) -> yang.gdata.Node:
@@ -624,6 +638,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l_identityref=n.get_opt_Identityref('l_identityref'), ll_identityref=n.get_opt_Identityrefs('ll_identityref'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -795,6 +813,10 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_bytess('l1'))
         return foo__pc1__foo()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc1__foo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -864,6 +886,13 @@ class foo__pc1(yang.adata.MNode):
         if n is not None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc1.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc1.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -942,6 +971,10 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=n.get_str('l_mandatory'))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc2__foo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1008,6 +1041,13 @@ class foo__pc2(yang.adata.MNode):
         if n is not None:
             return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt('foo')))
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc2.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc2.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1122,6 +1162,10 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
             return foo__pc3__level1__level2__level3(l3=n.get_str('l3'), l3_optional=n.get_opt_str('l3-optional'))
         raise ValueError('Missing required subtree foo__pc3__level1__level2__level3')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1207,6 +1251,10 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         if n is not None:
             return foo__pc3__level1__level2(l2=n.get_str('l2'), l2_optional=n.get_opt_str('l2-optional'), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt('level3')))
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1305,6 +1353,10 @@ class foo__pc3__level1(yang.adata.MNode):
             return foo__pc3__level1(l1=n.get_str('l1'), l1_optional=n.get_opt_str('l1-optional'), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt('level2')))
         raise ValueError('Missing required subtree foo__pc3__level1')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc3__level1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1393,6 +1445,13 @@ class foo__pc3(yang.adata.MNode):
             return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt('level1')))
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc3.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc3.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1462,6 +1521,13 @@ class foo__empty_presence(yang.adata.MNode):
         if n is not None:
             return foo__empty_presence()
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__empty_presence.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__empty_presence.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1540,6 +1606,10 @@ class foo__c_dot(yang.adata.MNode):
         if n is not None:
             return foo__c_dot(l_dot1=n.get_opt_str('l.dot1'), l_dot2=n.get_opt_str('l.dot2'))
         return foo__c_dot()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c_dot.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1630,6 +1700,10 @@ class foo__cc__death_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
         return foo__cc__death_entry(name=n.get_str('name'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__cc__death_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1681,6 +1755,16 @@ class foo__cc__death(yang.adata.MNode):
         if n is not None:
             return [foo__cc__death_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__cc__death(elements=copied_elements)
 
 
 mut def from_xml_foo__cc__death_element(node: xml.Node) -> yang.gdata.Node:
@@ -1773,6 +1857,10 @@ class foo__cc(yang.adata.MNode):
             return foo__cc(cake=n.get_opt_str('cake'), death=foo__cc__death.from_gdata(n.get_opt_list('death')))
         return foo__cc()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__cc.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1859,6 +1947,13 @@ class foo__conflict__f_inner(yang.adata.MNode):
             return foo__conflict__f_inner()
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__conflict__f_inner.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__conflict__f_inner.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1921,6 +2016,13 @@ class foo__conflict__bar_inner(yang.adata.MNode):
         if n is not None:
             return foo__conflict__bar_inner()
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__conflict__bar_inner.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__conflict__bar_inner.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -2007,6 +2109,10 @@ class foo__conflict(yang.adata.MNode):
         if n is not None:
             return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__conflict()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -2117,6 +2223,10 @@ class foo__special_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
         return foo__special_entry(yes=n.get_bool('yes'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__special_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2168,6 +2278,16 @@ class foo__special(yang.adata.MNode):
         if n is not None:
             return [foo__special_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__special(elements=copied_elements)
 
 
 mut def from_xml_foo__special_element(node: xml.Node) -> yang.gdata.Node:
@@ -2299,6 +2419,10 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
         return foo__nested__f_inner__li1__li2_entry(key1=n.get_str('key1'), key2=n.get_str('key2'), baz=n.get_opt_str('baz'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2356,6 +2480,16 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         if n is not None:
             return [foo__nested__f_inner__li1__li2_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__nested__f_inner__li1__li2(elements=copied_elements)
 
 
 mut def from_xml_foo__nested__f_inner__li1__li2_element(node: xml.Node) -> yang.gdata.Node:
@@ -2473,6 +2607,10 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
         return foo__nested__f_inner__li1_entry(name=n.get_str('name'), f_bar=n.get_opt_str('f:bar'), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list('li2')), bar_bar=n.get_opt_str('bar:bar'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2537,6 +2675,16 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         if n is not None:
             return [foo__nested__f_inner__li1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__nested__f_inner__li1(elements=copied_elements)
 
 
 mut def from_xml_foo__nested__f_inner__li1_element(node: xml.Node) -> yang.gdata.Node:
@@ -2647,6 +2795,10 @@ class foo__nested__f_inner(yang.adata.MNode):
             return foo__nested__f_inner(foo=n.get_opt_str('foo'), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list('li1')))
         return foo__nested__f_inner()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__f_inner.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2737,6 +2889,10 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=n.get_opt_str('foo'))
         return foo__nested__bar_inner()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__bar_inner.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2811,6 +2967,10 @@ class foo__nested(yang.adata.MNode):
         if n is not None:
             return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__nested()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -2919,6 +3079,10 @@ class foo__li_union_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
         return foo__li_union_entry(k1=n.get_str('k1'), k2=n.get_value('k2'), k3=n.get_bytes('k3'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__li_union_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2988,6 +3152,16 @@ class foo__li_union(yang.adata.MNode):
         if n is not None:
             return [foo__li_union_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__li_union(elements=copied_elements)
 
 
 mut def from_xml_foo__li_union_element(node: xml.Node) -> yang.gdata.Node:
@@ -3102,6 +3276,10 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__state__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__state__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -3180,6 +3358,10 @@ class foo__state(yang.adata.MNode):
         if n is not None:
             return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt('c1')))
         return foo__state()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__state.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -3264,6 +3446,10 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l1=n.get_opt_str('l1'))
         return foo__c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -3339,6 +3525,10 @@ class bar__conflict(yang.adata.MNode):
         if n is not None:
             return bar__conflict(foo=n.get_opt_str('foo'))
         return bar__conflict()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -3499,6 +3689,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -350,6 +350,10 @@ class foo__c1__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
         return foo__c1__li_entry(name=n.get_str('name'), val=n.get_opt_str('val'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__li_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -404,6 +408,16 @@ class foo__c1__li(yang.adata.MNode):
         if n is not None:
             return [foo__c1__li_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__c1__li(elements=copied_elements)
 
 
 mut def from_xml_foo__c1__li_element(node: xml.Node) -> yang.gdata.Node:
@@ -624,6 +638,10 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l_identityref=n.get_opt_Identityref('l_identityref'), ll_identityref=n.get_opt_Identityrefs('ll_identityref'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -795,6 +813,10 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_bytess('l1'))
         return foo__pc1__foo()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc1__foo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -864,6 +886,13 @@ class foo__pc1(yang.adata.MNode):
         if n is not None:
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc1.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc1.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -942,6 +971,10 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=n.get_opt_str('l_mandatory'))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc2__foo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1011,6 +1044,13 @@ class foo__pc2(yang.adata.MNode):
         if n is not None:
             return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt('foo')))
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc2.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc2.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1124,6 +1164,10 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
             return foo__pc3__level1__level2__level3(l3=n.get_opt_str('l3'), l3_optional=n.get_opt_str('l3-optional'))
         raise ValueError('Missing required subtree foo__pc3__level1__level2__level3')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1212,6 +1256,10 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         if n is not None:
             return foo__pc3__level1__level2(l2=n.get_opt_str('l2'), l2_optional=n.get_opt_str('l2-optional'), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt('level3')))
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1312,6 +1360,10 @@ class foo__pc3__level1(yang.adata.MNode):
             return foo__pc3__level1(l1=n.get_opt_str('l1'), l1_optional=n.get_opt_str('l1-optional'), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt('level2')))
         raise ValueError('Missing required subtree foo__pc3__level1')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__pc3__level1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1401,6 +1453,13 @@ class foo__pc3(yang.adata.MNode):
             return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt('level1')))
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__pc3.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__pc3.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1467,6 +1526,13 @@ class foo__empty_presence(yang.adata.MNode):
         if n is not None:
             return foo__empty_presence()
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__empty_presence.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__empty_presence.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1545,6 +1611,10 @@ class foo__c_dot(yang.adata.MNode):
         if n is not None:
             return foo__c_dot(l_dot1=n.get_opt_str('l.dot1'), l_dot2=n.get_opt_str('l.dot2'))
         return foo__c_dot()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c_dot.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -1635,6 +1705,10 @@ class foo__cc__death_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
         return foo__cc__death_entry(name=n.get_str('name'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__cc__death_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1686,6 +1760,16 @@ class foo__cc__death(yang.adata.MNode):
         if n is not None:
             return [foo__cc__death_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__cc__death(elements=copied_elements)
 
 
 mut def from_xml_foo__cc__death_element(node: xml.Node) -> yang.gdata.Node:
@@ -1778,6 +1862,10 @@ class foo__cc(yang.adata.MNode):
             return foo__cc(cake=n.get_opt_str('cake'), death=foo__cc__death.from_gdata(n.get_opt_list('death')))
         return foo__cc()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__cc.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1864,6 +1952,13 @@ class foo__conflict__f_inner(yang.adata.MNode):
             return foo__conflict__f_inner()
         return None
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__conflict__f_inner.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__conflict__f_inner.copy()')
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -1926,6 +2021,13 @@ class foo__conflict__bar_inner(yang.adata.MNode):
         if n is not None:
             return foo__conflict__bar_inner()
         return None
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        ad = foo__conflict__bar_inner.from_gdata(self.to_gdata())
+        if ad is not None:
+            return ad
+        raise Exception('Unreachable in foo__conflict__bar_inner.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -2012,6 +2114,10 @@ class foo__conflict(yang.adata.MNode):
         if n is not None:
             return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__conflict()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -2122,6 +2228,10 @@ class foo__special_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
         return foo__special_entry(yes=n.get_bool('yes'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__special_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2173,6 +2283,16 @@ class foo__special(yang.adata.MNode):
         if n is not None:
             return [foo__special_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__special(elements=copied_elements)
 
 
 mut def from_xml_foo__special_element(node: xml.Node) -> yang.gdata.Node:
@@ -2304,6 +2424,10 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
         return foo__nested__f_inner__li1__li2_entry(key1=n.get_str('key1'), key2=n.get_str('key2'), baz=n.get_opt_str('baz'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2361,6 +2485,16 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         if n is not None:
             return [foo__nested__f_inner__li1__li2_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__nested__f_inner__li1__li2(elements=copied_elements)
 
 
 mut def from_xml_foo__nested__f_inner__li1__li2_element(node: xml.Node) -> yang.gdata.Node:
@@ -2478,6 +2612,10 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
         return foo__nested__f_inner__li1_entry(name=n.get_str('name'), f_bar=n.get_opt_str('f:bar'), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list('li2')), bar_bar=n.get_opt_str('bar:bar'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2542,6 +2680,16 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         if n is not None:
             return [foo__nested__f_inner__li1_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__nested__f_inner__li1(elements=copied_elements)
 
 
 mut def from_xml_foo__nested__f_inner__li1_element(node: xml.Node) -> yang.gdata.Node:
@@ -2652,6 +2800,10 @@ class foo__nested__f_inner(yang.adata.MNode):
             return foo__nested__f_inner(foo=n.get_opt_str('foo'), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list('li1')))
         return foo__nested__f_inner()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__f_inner.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2742,6 +2894,10 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=n.get_opt_str('foo'))
         return foo__nested__bar_inner()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested__bar_inner.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2816,6 +2972,10 @@ class foo__nested(yang.adata.MNode):
         if n is not None:
             return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
         return foo__nested()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__nested.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -2924,6 +3084,10 @@ class foo__li_union_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
         return foo__li_union_entry(k1=n.get_str('k1'), k2=n.get_value('k2'), k3=n.get_bytes('k3'))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__li_union_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -2993,6 +3157,16 @@ class foo__li_union(yang.adata.MNode):
         if n is not None:
             return [foo__li_union_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__li_union(elements=copied_elements)
 
 
 mut def from_xml_foo__li_union_element(node: xml.Node) -> yang.gdata.Node:
@@ -3107,6 +3281,10 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=n.get_opt_str('l1'), l2=n.get_opt_str('l2'))
         return foo__state__c1()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__state__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -3185,6 +3363,10 @@ class foo__state(yang.adata.MNode):
         if n is not None:
             return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt('c1')))
         return foo__state()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__state.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -3269,6 +3451,10 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l1=n.get_opt_str('l1'))
         return foo__c2()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c2.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -3344,6 +3530,10 @@ class bar__conflict(yang.adata.MNode):
         if n is not None:
             return bar__conflict(foo=n.get_opt_str('foo'))
         return bar__conflict()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -3504,6 +3694,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -101,6 +101,10 @@ class foo__tc1(yang.adata.MNode):
             return foo__tc1(l1=n.get_str('l1'), l2=n.get_opt_str('l2'))
         raise ValueError('Missing required subtree foo__tc1')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__tc1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -200,6 +204,10 @@ class foo__li__c1(yang.adata.MNode):
             return foo__li__c1(l1=n.get_str('l1'), l2=n.get_opt_str('l2'))
         raise ValueError('Missing required subtree foo__li__c1')
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__li__c1.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -279,6 +287,10 @@ class foo__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_entry:
         return foo__li_entry(name=n.get_str('name'), c1=foo__li__c1.from_gdata(n.get_cnt('c1')))
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__li_entry.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -334,6 +346,16 @@ class foo__li(yang.adata.MNode):
         if n is not None:
             return [foo__li_entry.from_gdata(e) for e in n.elements]
         return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self.elements:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__li(elements=copied_elements)
 
 
 mut def from_xml_foo__li_element(node: xml.Node) -> yang.gdata.Node:
@@ -431,6 +453,10 @@ class root(yang.adata.MNode):
         if n is not None:
             return root(tc1=foo__tc1.from_gdata(n.get_cnt('tc1')), li=foo__li.from_gdata(n.get_opt_list('li')))
         raise ValueError('Missing required subtree root')
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -51,6 +51,10 @@ class root(yang.adata.MNode):
             return root()
         return root()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -138,6 +142,10 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
             return yangrpc__foo__input__woo(woo_b=n.get_opt_int('woo_b'))
         return yangrpc__foo__input__woo()
 
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
+
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
@@ -212,6 +220,10 @@ class yangrpc__foo__input(yang.adata.MNode):
         if n is not None:
             return yangrpc__foo__input(a=n.get_opt_str('a'), woo=yangrpc__foo__input__woo.from_gdata(n.get_opt_cnt('woo')))
         return yangrpc__foo__input()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return yangrpc__foo__input.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
@@ -298,6 +310,10 @@ class yangrpc__foo__output(yang.adata.MNode):
         if n is not None:
             return yangrpc__foo__output(outoo=n.get_opt_str('outoo'))
         return yangrpc__foo__output()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return yangrpc__foo__output.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []


### PR DESCRIPTION
Implements deep copy functionality for adata objects. We must generate the method for each adata type because how do we get the type to call the static .from_gdata() method on?! @plajjan PTAL

Closes #121 