### PR TITLE
Remap local module import prefix references

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2424,13 +2424,15 @@ class SchemaNode(object):
 
         return stmt
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         raise NotImplementedError("SchemaNode.update_namespace_qualifiers")
+
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+        raise NotImplementedError("SchemaNode.remap_prefix_references")
 
 
 class SchemaNodeInner(SchemaNode):

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1302,11 +1302,8 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
 
         # -- update_namespace_qualifiers
         if "update_namespace_qualifiers" not in manual_methods:
-            res.append("    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:")
-            res.append('        """Update namespace qualifiers and remap prefix references')
-            res.append('')
-            res.append('        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.')
-            res.append('        If old_pfx differs from new_pfx, remaps all prefix-qualified references.')
+            res.append("    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:")
+            res.append('        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.')
             res.append('        """')
             res.append("        self.ns = new_ns")
             res.append("        self.pfx = new_pfx")
@@ -1316,14 +1313,40 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             if have_children:
                 res.append("        # Recursively update children")
                 res.append("        for child in self.children:")
-                res.append("            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                res.append("            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
                 res.append("")
 
-            res.append("        # Exit early if no prefix remapping is needed")
-            res.append("        if old_pfx == new_pfx:")
-            res.append("            return")
+            if any(filter(lambda substmt: substmt.name == "type" and substmt.cardinality == "1", stmt.substmts.values())):
+                # Type statements in leaf, leaf-list, deviate (unions are handled separately)
+                res.append(f"        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+
+            # Special handling for specific statement types
+            if stmt_name == "uses":
+                # Handle refine and augment within uses
+                res.append(f"        for refine in self.refine:")
+                res.append(f"            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+                res.append(f"        for aug in self.augment:")
+                res.append(f"            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+
+            elif stmt_name == "type":
+                # Handle nested types for union
+                res.append(f"        for nested_type in self.type_:")
+                res.append(f"            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+
             res.append("")
-            res.append("        # Remap prefix references")
+        # ==============================================================
+
+        # -- remap_prefix_references
+        if "remap_prefix_references" not in manual_methods:
+            res.append("    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:")
+            res.append('        """Remaps prefix references (in paths, defaults, ...) to true module prefix.')
+            res.append('        """')
+            res.append("")
+
+            if have_children:
+                res.append("        for child in self.children:")
+                res.append("            child.remap_prefix_references(old_pfx, new_pfx)")
+                res.append("")
 
             for substmt in stmt.substmts.values():
                 attr = _attr_name(substmt.name)
@@ -1369,7 +1392,7 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                 # Type statements in leaf, leaf-list, deviate (unions are handled separately)
                 elif substmt.name == "type":
                     if substmt.cardinality == "1":
-                        res.append(f"        self.{attr}.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                        res.append(f"        self.{attr}.remap_prefix_references(old_pfx, new_pfx)")
 
                 # Deviation target paths
                 elif substmt.name == "deviation":
@@ -1382,10 +1405,10 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                 # Handle refine and augment within uses
                 res.append(f"        for refine in self.refine:")
                 res.append(f"            refine.target_node = _remap_path_prefix(refine.target_node, old_pfx, new_pfx)")
-                res.append(f"            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                res.append(f"            refine.remap_prefix_references(old_pfx, new_pfx)")
                 res.append(f"        for aug in self.augment:")
                 res.append(f"            aug.target_node = _remap_path_prefix(aug.target_node, old_pfx, new_pfx)")
-                res.append(f"            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                res.append(f"            aug.remap_prefix_references(old_pfx, new_pfx)")
 
             elif stmt_name == "augment":
                 # Augment target path
@@ -1400,7 +1423,7 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                 res.append(f"        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
                 # Handle nested types for union
                 res.append(f"        for nested_type in self.type_:")
-                res.append(f"            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)")
+                res.append(f"            nested_type.remap_prefix_references(old_pfx, new_pfx)")
 
             res.append("")
 

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1352,13 +1352,15 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
                     res.append(f"        self.{attr} = [_remap_path_prefix(u, old_pfx, new_pfx) for u in self.{attr}]")
 
                 # Default values that might contain prefixed identities
-                elif substmt.name == "default":
+                elif substmt.name == "default" and stmt.name in {"leaf", "leaf-list", "typedef"}:
                     if substmt.cardinality == "0..1":
-                        res.append(f"        self_{attr} = self.{attr}")
-                        res.append(f"        if self_{attr} is not None:")
-                        res.append(f"            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+                        res.append(f"        if self.type_.name == 'identityref':")
+                        res.append(f"            self_{attr} = self.{attr}")
+                        res.append(f"            if self_{attr} is not None:")
+                        res.append(f"                self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
                     elif substmt.cardinality == "0..n":
-                        res.append(f"        self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
+                        res.append(f"        if self.type_.name == 'identityref':")
+                        res.append(f"            self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
 
                 # Base identities
                 elif substmt.name == "base":

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1354,20 +1354,20 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
 
             if any(filter(lambda substmt: substmt.name == "type" and substmt.cardinality == "1", stmt.substmts.values())):
                 # Type statements in leaf, leaf-list, deviate (unions are handled separately)
-                res.append(f"        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+                res.append("        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
 
             # Special handling for specific statement types
             if stmt_name == "uses":
                 # Handle refine and augment within uses
-                res.append(f"        for refine in self.refine:")
-                res.append(f"            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
-                res.append(f"        for aug in self.augment:")
-                res.append(f"            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+                res.append("        for refine in self.refine:")
+                res.append("            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+                res.append("        for aug in self.augment:")
+                res.append("            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
 
             elif stmt_name == "type":
                 # Handle nested types for union
-                res.append(f"        for nested_type in self.type_:")
-                res.append(f"            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
+                res.append("        for nested_type in self.type_:")
+                res.append("            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod)")
 
             res.append("")
         # ==============================================================
@@ -1389,77 +1389,77 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
 
                 # XPath expressions that need remapping
                 if substmt.name == "when":
-                    res.append(f"        self_{attr} = self.{attr}")
-                    res.append(f"        if self_{attr} is not None:")
-                    res.append(f"            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+                    res.append("        self_{attr} = self.{attr}")
+                    res.append("        if self_{attr} is not None:")
+                    res.append("            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
                 elif substmt.name == "path":
-                    res.append(f"        self_{attr} = self.{attr}")
-                    res.append(f"        if self_{attr} is not None:")
-                    res.append(f"            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+                    res.append("        self_{attr} = self.{attr}")
+                    res.append("        if self_{attr} is not None:")
+                    res.append("            self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
 
                 # Must statements need special handling
                 elif substmt.name == "must":
-                    res.append(f"        for must in self.{attr}:")
-                    res.append(f"            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)")
+                    res.append("        for must in self.{attr}:")
+                    res.append("            must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)")
 
                 # if-feature expressions
                 elif substmt.name == "if-feature":
-                    res.append(f"        self.{attr} = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.{attr}]")
+                    res.append("        self.{attr} = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.{attr}]")
 
                 # Unique statements (for list)
                 elif substmt.name == "unique":
-                    res.append(f"        self.{attr} = [_remap_path_prefix(u, old_pfx, new_pfx) for u in self.{attr}]")
+                    res.append("        self.{attr} = [_remap_path_prefix(u, old_pfx, new_pfx) for u in self.{attr}]")
 
                 # Default values that might contain prefixed identities
                 elif substmt.name == "default" and stmt.name in {"leaf", "leaf-list", "typedef"}:
                     if substmt.cardinality == "0..1":
-                        res.append(f"        if self.type_.name == 'identityref':")
-                        res.append(f"            self_{attr} = self.{attr}")
-                        res.append(f"            if self_{attr} is not None:")
-                        res.append(f"                self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
+                        res.append("        if self.type_.name == 'identityref':")
+                        res.append("            self_{attr} = self.{attr}")
+                        res.append("            if self_{attr} is not None:")
+                        res.append("                self.{attr} = _remap_path_prefix(self_{attr}, old_pfx, new_pfx)")
                     elif substmt.cardinality == "0..n":
-                        res.append(f"        if self.type_.name == 'identityref':")
-                        res.append(f"            self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
+                        res.append("        if self.type_.name == 'identityref':")
+                        res.append("            self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
 
                 # Base identities
                 elif substmt.name == "base":
-                    res.append(f"        self.{attr} = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.{attr}]")
+                    res.append("        self.{attr} = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.{attr}]")
 
                 # Type statements in leaf, leaf-list, deviate (unions are handled separately)
                 elif substmt.name == "type":
                     if substmt.cardinality == "1":
-                        res.append(f"        self.{attr}.remap_prefix_references(old_pfx, new_pfx)")
+                        res.append("        self.{attr}.remap_prefix_references(old_pfx, new_pfx)")
 
                 # Deviation target paths
                 elif substmt.name == "deviation":
-                    res.append(f"        self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
+                    res.append("        self.{attr} = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.{attr}]")
 
             # Special handling for specific statement types
             if stmt_name == "uses":
                 # Uses name can be prefixed
-                res.append(f"        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
+                res.append("        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
                 # Handle refine and augment within uses
-                res.append(f"        for refine in self.refine:")
-                res.append(f"            refine.target_node = _remap_path_prefix(refine.target_node, old_pfx, new_pfx)")
-                res.append(f"            refine.remap_prefix_references(old_pfx, new_pfx)")
-                res.append(f"        for aug in self.augment:")
-                res.append(f"            aug.target_node = _remap_path_prefix(aug.target_node, old_pfx, new_pfx)")
-                res.append(f"            aug.remap_prefix_references(old_pfx, new_pfx)")
+                res.append("        for refine in self.refine:")
+                res.append("            refine.target_node = _remap_path_prefix(refine.target_node, old_pfx, new_pfx)")
+                res.append("            refine.remap_prefix_references(old_pfx, new_pfx)")
+                res.append("        for aug in self.augment:")
+                res.append("            aug.target_node = _remap_path_prefix(aug.target_node, old_pfx, new_pfx)")
+                res.append("            aug.remap_prefix_references(old_pfx, new_pfx)")
 
             elif stmt_name == "augment":
                 # Augment target path
-                res.append(f"        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)")
+                res.append("        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)")
 
             elif stmt_name == "refine":
                 # Refine target path
-                res.append(f"        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)")
+                res.append("        self.target_node = _remap_path_prefix(self.target_node, old_pfx, new_pfx)")
 
             elif stmt_name == "type":
                 # Type name can be prefixed for user-defined types
-                res.append(f"        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
+                res.append("        self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)")
                 # Handle nested types for union
-                res.append(f"        for nested_type in self.type_:")
-                res.append(f"            nested_type.remap_prefix_references(old_pfx, new_pfx)")
+                res.append("        for nested_type in self.type_:")
+                res.append("            nested_type.remap_prefix_references(old_pfx, new_pfx)")
 
             res.append("")
 

--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -539,6 +539,42 @@ snode_methods = {
         "is_config": """    def is_config(self) -> bool:
         return False
 
+""",
+        "compile": r"""    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
+        new = Module(self.name,
+                     yang_version=self.yang_version,
+                     namespace=self.namespace,
+                     prefix=self.prefix,
+                     import_=self.import_,
+                     include=self.include,
+                     organization=self.organization,
+                     contact=self.contact,
+                     description=self.description,
+                     reference=self.reference,
+                     revision=self.revision,
+                     augment=self.augment,
+                     deviation=self.deviation,
+                     extension_=self.extension_,
+                     feature=self.feature,
+                     exts=self.exts)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
+        new.expand_augments(context)
+
+        # Normalize import prefixes at compile time
+        # When a module imports another module with a different prefix than its actual prefix,
+        # we need to normalize all references to use the actual prefix
+        for import_ in self.import_:
+            try:
+                imported_module = context.get_module(import_.module, import_.revision_date)
+            except ValueError as e:
+                # TODO: import a non-existant module? error!
+                print(e.error_message, err=True)
+            else:
+                if import_.prefix != imported_module.prefix:
+                    new.remap_prefix_references(import_.prefix, imported_module.prefix)
+
+        return new
+
 """
     },
     "notification": {

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2750,6 +2750,49 @@ def _test_is_derived_from():
     testing.assertTrue(yang.identity.is_derived_from(three, [base]), "three should be transitively derived from base through one")
     testing.assertTrue(yang.identity.is_derived_from(three, [one]), "three should be directly derived from one")
 
+def _test_identity_base_resolution_import_prefix():
+    """Test that identity base references using import prefixes are correctly resolved"""
+    # Base module with identity using its own prefix
+    ys_base = r"""module base-module {
+        yang-version "1.1";
+        namespace "http://example.com/base";
+        prefix "base-pfx";
+
+        identity PROTOCOL {
+            description "Base protocol identity";
+        }
+
+        identity TCP {
+            base PROTOCOL;
+            description "TCP protocol";
+        }
+    }"""
+
+    # Another module that imports base with different prefix
+    ys_derived = r"""module derived-module {
+        yang-version "1.1";
+        namespace "http://example.com/derived";
+        prefix "derived";
+
+        import base-module {
+            prefix "bm";  // Different prefix than base-module's actual prefix!
+        }
+
+        identity HTTP {
+            base "bm:TCP";  // Uses import prefix "bm", not actual prefix "base-pfx"
+            description "HTTP protocol over TCP";
+        }
+
+        identity HTTPS {
+            base HTTP;  // Local reference without prefix
+            description "Secure HTTP";
+        }
+    }"""
+
+    root = yang.compile([ys_base, ys_derived])
+    src = root.prdaclass()
+    return src
+
 def _test_fail_identity_missing_imported_base():
     """Test that compilation fails when identity references a missing base from imported module"""
     ys_base = r"""module base {

--- a/src/transform_list_order.act
+++ b/src/transform_list_order.act
@@ -76,10 +76,6 @@ test_yang = r"""module test_yang {
   namespace "http://example.com/test_yang";
   prefix "test_yang";
   description "test yang module";
-  import ietf-inet-types {
-    prefix "inet";
-    revision-date 2013-07-15;
-  }
   container c1 {
     description "container 1";
     list l1 {

--- a/src/yang.act
+++ b/src/yang.act
@@ -137,11 +137,11 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
                     c.parent = m
 
                     # Always update namespace qualifiers to parent module's values
-                    c.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+                    c.update_namespace_qualifiers(m.namespace, m.prefix, m.name)
 
                     # Apply all prefix remappings (parent module and imports)
                     for old_pfx, new_pfx in prefix_remaps.items():
-                        c.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+                        c.remap_prefix_references(old_pfx, new_pfx)
 
                     m.children.append(c)
 
@@ -151,12 +151,12 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
                     aug.parent = m
 
                     # Update the augment node's namespace qualifiers
-                    aug.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+                    aug.update_namespace_qualifiers(m.namespace, m.prefix, m.name)
 
                     # Apply all prefix remappings to augment paths and content
                     for old_pfx, new_pfx in prefix_remaps.items():
                         aug.target_node = yang.schema._remap_path_prefix(aug.target_node, old_pfx, new_pfx)
-                        aug.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+                        aug.remap_prefix_references(old_pfx, new_pfx)
 
                 m.augment.extend(submod.augment)
                 # discard contact
@@ -175,11 +175,11 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
                     ext.parent = m
 
                     # Update namespace qualifiers
-                    ext.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+                    ext.update_namespace_qualifiers(m.namespace, m.prefix, m.name)
 
                     # Apply all prefix remappings
                     for old_pfx, new_pfx in prefix_remaps.items():
-                        ext.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+                        ext.remap_prefix_references(old_pfx, new_pfx)
 
                 m.extension_.extend(submod.extension_)
 
@@ -193,11 +193,11 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
                     feat.parent = m
 
                     # Update namespace qualifiers
-                    feat.update_namespace_qualifiers(m.namespace, m.prefix, m.name, m.prefix)
+                    feat.update_namespace_qualifiers(m.namespace, m.prefix, m.name)
 
                     # Apply all prefix remappings
                     for old_pfx, new_pfx in prefix_remaps.items():
-                        feat.update_namespace_qualifiers(m.namespace, new_pfx, m.name, old_pfx)
+                        feat.remap_prefix_references(old_pfx, new_pfx)
 
                 m.feature.extend(submod.feature)
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -4371,9 +4371,6 @@ class Choice(SchemaNodeInner):
             return
 
         # Remap prefix references
-        self_default = self.default
-        if self_default is not None:
-            self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         self_when = self.when
         if self_when is not None:
@@ -5608,9 +5605,10 @@ class Leaf(SchemaNodeOuter):
             return
 
         # Remap prefix references
-        self_default = self.default
-        if self_default is not None:
-            self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
+        if self.type_.name == 'identityref':
+            self_default = self.default
+            if self_default is not None:
+                self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -5831,7 +5829,8 @@ class LeafList(SchemaNodeOuter):
             return
 
         # Remap prefix references
-        self.default = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.default]
+        if self.type_.name == 'identityref':
+            self.default = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.default]
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -7185,7 +7184,6 @@ class Refine(SchemaNodeOuter):
             return
 
         # Remap prefix references
-        self.default = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.default]
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -8110,9 +8108,10 @@ class Typedef(SchemaNodeOuter):
             return
 
         # Remap prefix references
-        self_default = self.default
-        if self_default is not None:
-            self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
+        if self.type_.name == 'identityref':
+            self_default = self.default
+            if self_default is not None:
+                self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
         self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
 
     def __str__(self):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -6377,6 +6377,20 @@ class Module(SchemaNodeInner):
                      exts=self.exts)
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         new.expand_augments(context)
+
+        # Normalize import prefixes at compile time
+        # When a module imports another module with a different prefix than its actual prefix,
+        # we need to normalize all references to use the actual prefix
+        for import_ in self.import_:
+            try:
+                imported_module = context.get_module(import_.module, import_.revision_date)
+            except ValueError as e:
+                # TODO: import a non-existant module? error!
+                print(e.error_message, err=True)
+            else:
+                if import_.prefix != imported_module.prefix:
+                    new.remap_prefix_references(import_.prefix, imported_module.prefix)
+
         return new
 
     def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2420,13 +2420,15 @@ class SchemaNode(object):
 
         return stmt
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         raise NotImplementedError("SchemaNode.update_namespace_qualifiers")
+
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+        raise NotImplementedError("SchemaNode.remap_prefix_references")
 
 
 class SchemaNodeInner(SchemaNode):
@@ -3451,11 +3453,8 @@ class Action(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -3463,13 +3462,16 @@ class Action(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
@@ -3610,21 +3612,18 @@ class Anydata(SchemaNodeOuter):
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -3770,21 +3769,18 @@ class Anyxml(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -3894,11 +3890,8 @@ class Augment(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -3906,13 +3899,16 @@ class Augment(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         self_when = self.when
         if self_when is not None:
@@ -3980,21 +3976,18 @@ class BelongsTo(SchemaNodeOuter):
                         pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "BelongsTo {self.module}"
@@ -4085,21 +4078,18 @@ class Bit(SchemaNodeOuter):
                   pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
@@ -4204,11 +4194,8 @@ class Case(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -4216,13 +4203,16 @@ class Case(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         self_when = self.when
         if self_when is not None:
@@ -4352,11 +4342,8 @@ class Choice(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -4364,13 +4351,16 @@ class Choice(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         self_when = self.when
         if self_when is not None:
@@ -4537,11 +4527,8 @@ class Container(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -4549,13 +4536,16 @@ class Container(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -4652,21 +4642,18 @@ class Enum(SchemaNodeOuter):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
@@ -4751,21 +4738,18 @@ class Extension(SchemaNodeOuter):
                         pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Extension {self.name}"
@@ -4852,21 +4836,18 @@ class Feature(SchemaNodeOuter):
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
@@ -4960,11 +4941,8 @@ class Grouping(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -4972,13 +4950,16 @@ class Grouping(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
 
     def __str__(self):
         return "Grouping {self.name}"
@@ -5079,21 +5060,18 @@ class Identity(SchemaNodeOuter):
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.base = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.base]
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
@@ -5179,21 +5157,18 @@ class Import(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Import {self.module}"
@@ -5273,21 +5248,18 @@ class Include(SchemaNodeOuter):
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Include {self.module}"
@@ -5390,11 +5362,8 @@ class Input(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -5402,13 +5371,16 @@ class Input(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
 
@@ -5590,21 +5562,19 @@ class Leaf(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
+        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         if self.type_.name == 'identityref':
             self_default = self.default
             if self_default is not None:
@@ -5612,7 +5582,7 @@ class Leaf(SchemaNodeOuter):
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
-        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+        self.type_.remap_prefix_references(old_pfx, new_pfx)
         self_when = self.when
         if self_when is not None:
             self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
@@ -5814,27 +5784,25 @@ class LeafList(SchemaNodeOuter):
             exts=self.exts
         )
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
+        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         if self.type_.name == 'identityref':
             self.default = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.default]
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
-        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+        self.type_.remap_prefix_references(old_pfx, new_pfx)
         self_when = self.when
         if self_when is not None:
             self.when = _remap_path_prefix(self_when, old_pfx, new_pfx)
@@ -5921,21 +5889,18 @@ class Length(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Length {self.value}"
@@ -6132,11 +6097,8 @@ class List(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -6144,13 +6106,16 @@ class List(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -6414,11 +6379,8 @@ class Module(SchemaNodeInner):
         new.expand_augments(context)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -6426,13 +6388,16 @@ class Module(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.deviation = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.deviation]
 
     def __str__(self):
@@ -6527,21 +6492,18 @@ class Must(SchemaNodeOuter):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Must {self.condition}"
@@ -6679,11 +6641,8 @@ class Notification(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -6691,13 +6650,16 @@ class Notification(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -6806,11 +6768,8 @@ class Output(SchemaNodeInner):
         self.expand_children(context, new, new_mod, new_ns, new_pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -6818,13 +6777,16 @@ class Output(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
 
@@ -6914,21 +6876,18 @@ class Pattern(SchemaNodeOuter):
                       pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Pattern {self.value}"
@@ -7012,21 +6971,18 @@ class Range(SchemaNodeOuter):
                     pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Range {self.value}"
@@ -7169,21 +7125,18 @@ class Refine(SchemaNodeOuter):
                      pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         for must in self.must:
             must.condition = _remap_path_prefix(must.condition, old_pfx, new_pfx)
@@ -7263,21 +7216,18 @@ class Revision(SchemaNodeOuter):
                        pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
 
     def __str__(self):
         return "Revision {self.date}"
@@ -7471,11 +7421,8 @@ class Rpc(SchemaNodeInner):
     def is_config(self) -> bool:
         return False
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -7483,13 +7430,16 @@ class Rpc(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
 
     def __str__(self):
@@ -7709,11 +7659,8 @@ class Submodule(SchemaNodeInner):
         new.expand_augments(context)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
@@ -7721,13 +7668,16 @@ class Submodule(SchemaNodeInner):
 
         # Recursively update children
         for child in self.children:
-            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            child.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
+        for child in self.children:
+            child.remap_prefix_references(old_pfx, new_pfx)
+
         self.deviation = [_remap_path_prefix(d, old_pfx, new_pfx) for d in self.deviation]
 
     def __str__(self):
@@ -7959,28 +7909,27 @@ class Type(SchemaNodeOuter):
                    pfx=new_pfx if new_pfx is not None else self.pfx)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
+        for nested_type in self.type_:
+            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.base = [_remap_path_prefix(b, old_pfx, new_pfx) for b in self.base]
         self_path = self.path
         if self_path is not None:
             self.path = _remap_path_prefix(self_path, old_pfx, new_pfx)
         self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)
         for nested_type in self.type_:
-            nested_type.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            nested_type.remap_prefix_references(old_pfx, new_pfx)
 
     def __str__(self):
         return "Type {self.name}"
@@ -8093,26 +8042,24 @@ class Typedef(SchemaNodeOuter):
                       exts=self.exts)
         return new
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
+        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         if self.type_.name == 'identityref':
             self_default = self.default
             if self_default is not None:
                 self.default = _remap_path_prefix(self_default, old_pfx, new_pfx)
-        self.type_.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+        self.type_.remap_prefix_references(old_pfx, new_pfx)
 
     def __str__(self):
         return "Typedef {self.name}"
@@ -8241,21 +8188,22 @@ class Uses(SchemaNodeOuter):
             target = get_target(target_base, refine.target_node)
             target.apply_refine(refine)
 
-    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str, old_pfx: str) -> None:
-        """Update namespace qualifiers and remap prefix references
-
-        Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
-        If old_pfx differs from new_pfx, remaps all prefix-qualified references.
+    def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
+        """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
         """
         self.ns = new_ns
         self.pfx = new_pfx
         self.mod = new_mod
 
-        # Exit early if no prefix remapping is needed
-        if old_pfx == new_pfx:
-            return
+        for refine in self.refine:
+            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
+        for aug in self.augment:
+            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod)
 
-        # Remap prefix references
+    def remap_prefix_references(self, old_pfx: str, new_pfx: str) -> None:
+        """Remaps prefix references (in paths, defaults, ...) to true module prefix.
+        """
+
         self.if_feature = [_remap_path_prefix(f, old_pfx, new_pfx) for f in self.if_feature]
         self_when = self.when
         if self_when is not None:
@@ -8263,10 +8211,10 @@ class Uses(SchemaNodeOuter):
         self.name = _remap_path_prefix(self.name, old_pfx, new_pfx)
         for refine in self.refine:
             refine.target_node = _remap_path_prefix(refine.target_node, old_pfx, new_pfx)
-            refine.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            refine.remap_prefix_references(old_pfx, new_pfx)
         for aug in self.augment:
             aug.target_node = _remap_path_prefix(aug.target_node, old_pfx, new_pfx)
-            aug.update_namespace_qualifiers(new_ns, new_pfx, new_mod, old_pfx)
+            aug.remap_prefix_references(old_pfx, new_pfx)
 
     def __str__(self):
         return "Uses {self.name}"

--- a/test/golden/test_yang/identity_base_resolution_import_prefix
+++ b/test/golden/test_yang/identity_base_resolution_import_prefix
@@ -1,0 +1,114 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_base_base_module_PROTOCOL = DIdentity(module='base-module', namespace='http://example.com/base', prefix='base-pfx', name='PROTOCOL', base=[])
+_base_base_module_TCP = DIdentity(module='base-module', namespace='http://example.com/base', prefix='base-pfx', name='TCP', base=[_base_base_module_PROTOCOL])
+_base_derived_module_HTTP = DIdentity(module='derived-module', namespace='http://example.com/derived', prefix='derived', name='HTTP', base=[_base_base_module_TCP])
+_identities = [
+    _base_base_module_PROTOCOL,
+    _base_base_module_TCP,
+    _base_derived_module_HTTP,
+    DIdentity(module='derived-module', namespace='http://example.com/derived', prefix='derived', name='HTTPS', base=[_base_derived_module_HTTP]),
+]
+
+
+# Identityref constants
+base_module_PROTOCOL = Identityref('PROTOCOL', ns='http://example.com/base', mod='base-module', pfx='base-pfx')
+base_module_TCP = Identityref('TCP', ns='http://example.com/base', mod='base-module', pfx='base-pfx')
+derived_module_HTTP = Identityref('HTTP', ns='http://example.com/derived', mod='derived-module', pfx='derived')
+derived_module_HTTPS = Identityref('HTTPS', ns='http://example.com/derived', mod='derived-module', pfx='derived')
+
+
+class root(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = ''
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root()
+        return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+schema_namespaces: set[str] = {
+}
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -168,6 +168,10 @@ xml_text_full = """<data>
 <c2 xmlns="http://example.com/foo">
   <l1>foo-qux</l1>
 </c2>
+<test-idref xmlns="http://example.com/bar">
+  <idref xmlns:bar="http://example.com/bar">bar:bary</idref>
+  <idref xmlns:foo="http://example.com/foo">foo:fooy</idref>
+</test-idref>
 <conflict xmlns="http://example.com/bar">
   <foo>foo-bar</foo>
 </conflict>

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -253,16 +253,23 @@ def src_yang():
     namespace "http://example.com/bar";
     prefix "bar";
     import foo {
-        prefix "f";
+        prefix "foo-local";
     }
     identity bary {
-        base f:basey;
+        base foo-local:basey;
     }
-    augment /f:c1 {
-        // create a conflict with /f:c1/l1
-        uses f:g1;
+    container test-idref {
+        leaf-list idref {
+            type identityref {
+                base foo-local:basey;
+            }
+        }
     }
-    augment /f:c.dot {
+    augment /foo-local:c1 {
+        // create a conflict with /foo-local:c1/l1
+        uses foo-local:g1;
+    }
+    augment /foo-local:c.dot {
         leaf l.dot2 {
             type string;
         }
@@ -272,7 +279,7 @@ def src_yang():
             type string;
         }
     }
-    augment /f:conflict {
+    augment /foo-local:conflict {
         leaf foo {
             type string;
         }
@@ -280,15 +287,15 @@ def src_yang():
             presence "inner presence from bar";
         }
     }
-    augment /f:nested {
-        // conflict with /f:nested/inner
+    augment /foo-local:nested {
+        // conflict with /foo-local:nested/inner
         container inner {
             leaf foo {
                 type string;
             }
         }
     }
-    augment /f:nested/inner/li1 {
+    augment /foo-local:nested/inner/li1 {
         leaf bar {
             type string;
         }
@@ -3500,6 +3507,108 @@ mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_json_foo__c2__l1, child_l1)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
+mut def from_json_bar__test_idref__idref(val: list[PartialIdentityref]) -> yang.gdata.LeafList:
+    new_val = []
+    for v in val:
+        nv, error = complete_and_validate_identityref(v, _identities, ['f:basey'], 'bar')
+        if nv is not None:
+            new_val.append(nv)
+        else:
+            raise ValueError('Invalid value for identityref leaf-list idref: {error}')
+    return yang.gdata.LeafList('identityref', new_val)
+
+mut def from_xml_bar__test_idref__idref(val: list[PartialIdentityref]) -> yang.gdata.LeafList:
+    new_val = []
+    for v in val:
+        nv, error = complete_and_validate_identityref(v, _identities, ['f:basey'], 'bar')
+        if nv is not None:
+            new_val.append(nv)
+        else:
+            raise ValueError('Invalid value for identityref leaf-list idref: {error}')
+    return yang.gdata.LeafList('identityref', new_val)
+
+class bar__test_idref(yang.adata.MNode):
+    idref: list[Identityref]
+
+    mut def __init__(self, idref: ?list[Identityref]=None):
+        self._ns = 'http://example.com/bar'
+        self.idref = idref if idref is not None else []
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _idref = self.idref
+        if _idref is not None:
+            _identityref_idref = []
+            for v in _idref:
+                nv, error = complete_and_validate_identityref(v, _identities, ['f:basey'], 'bar')
+                if nv is not None:
+                    _identityref_idref.append(nv)
+                else:
+                    raise ValueError('Invalid value for identityref leaf-list idref: {error}')
+            _idref = _identityref_idref
+            children['idref'] = yang.gdata.LeafList('identityref', _idref)
+        return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__test_idref:
+        if n is not None:
+            return bar__test_idref(idref=n.get_opt_Identityrefs('idref'))
+        return bar__test_idref()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__test_idref.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /test-idref')
+            res.append('{self_name} = bar__test_idref()')
+        leaves = []
+        _idref = self.idref
+        if len(_idref) != 0:
+            leaves.append('{self_name}.idref = {repr(_idref)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /test-idref'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:test-idref'])
+
+
+mut def from_xml_bar__test_idref(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_idref = yang.gdata.from_xml_opt_Identityrefs(node, 'idref')
+    yang.gdata.maybe_add(children, 'idref', from_xml_bar__test_idref__idref, child_idref)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
+mut def from_json_path_bar__test_idref(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'idref':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_bar__test_idref(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_bar__test_idref(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_idref = yang.gdata.take_json_opt_Identityrefs(jd, 'idref')
+    yang.gdata.maybe_add(children, 'idref', from_json_bar__test_idref__idref, child_idref)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -3595,9 +3704,10 @@ class root(yang.adata.MNode):
     state: foo__state
     ll_empty: list[str]
     c2: foo__c2
+    test_idref: bar__test_idref
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -3613,6 +3723,7 @@ class root(yang.adata.MNode):
         self.state = state if state is not None else foo__state()
         self.ll_empty = ll_empty if ll_empty is not None else []
         self.c2 = c2 if c2 is not None else foo__c2()
+        self.test_idref = test_idref if test_idref is not None else bar__test_idref()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
 
     mut def create_pc1(self):
@@ -3679,6 +3790,9 @@ class root(yang.adata.MNode):
         _c2 = self.c2
         if _c2 is not None:
             children['c2'] = _c2.to_gdata()
+        _test_idref = self.test_idref
+        if _test_idref is not None:
+            children['test-idref'] = _test_idref.to_gdata()
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
             children['bar:conflict'] = _bar_conflict.to_gdata()
@@ -3687,7 +3801,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt('test-idref')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def copy(self):
@@ -3766,6 +3880,9 @@ class root(yang.adata.MNode):
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
+        _test_idref = self.test_idref
+        if _test_idref is not None:
+            res.extend(_test_idref.prsrc('{self_name}.test_idref', False).splitlines())
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
             res.extend(_bar_conflict.prsrc('{self_name}.bar_conflict', False).splitlines())
@@ -3812,6 +3929,8 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll-empty', from_xml_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
+    child_test_idref = yang.gdata.from_xml_opt_cnt(node, 'test-idref', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'test-idref', from_xml_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
@@ -3867,6 +3986,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         if point == 'foo:c2':
             child = {'c2': from_json_path_foo__c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
+        if point == 'bar:test-idref':
+            child = {'test-idref': from_json_path_bar__test_idref(jd, rest_path, op) }
+            return yang.gdata.Container(child)
         if point == 'bar:conflict':
             child = {'bar:conflict': from_json_path_bar__conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
@@ -3909,6 +4031,8 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll-empty', from_json_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.take_json_opt_cnt(jd, 'c2', 'foo')
     yang.gdata.maybe_add(children, 'c2', from_json_foo__c2, child_c2)
+    child_test_idref = yang.gdata.take_json_opt_cnt(jd, 'test-idref', 'bar')
+    yang.gdata.maybe_add(children, 'test-idref', from_json_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'bar')
     yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
@@ -4044,28 +4168,31 @@ def src_schema():
     ])
 ])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='f')
+        Import('foo', prefix='foo-local')
     ], augment=[
-        Augment('/f:c1', children=[
-            Uses('f:g1')
+        Augment('/foo-local:c1', children=[
+            Uses('foo-local:g1')
         ]),
-        Augment('/f:c.dot', children=[
+        Augment('/foo-local:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/f:conflict', children=[
+        Augment('/foo-local:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ]),
-        Augment('/f:nested', children=[
+        Augment('/foo-local:nested', children=[
             Container('inner', children=[
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/f:nested/inner/li1', children=[
+        Augment('/foo-local:nested/inner/li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[
-    Identity('bary', base=['f:basey']),
+    Identity('bary', base=['foo-local:basey']),
+    Container('test-idref', children=[
+        LeafList('idref', type_=Type('identityref', base=['foo-local:basey']))
+    ]),
     Container('conflict', children=[
         Leaf('foo', type_=Type('string'))
     ])
@@ -4192,28 +4319,31 @@ def src_schema_compiled():
     ])
 ])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='f')
+        Import('foo', prefix='foo-local')
     ], augment=[
-        Augment('/f:c1', children=[
-            Uses('f:g1')
+        Augment('/foo-local:c1', children=[
+            Uses('foo-local:g1')
         ]),
-        Augment('/f:c.dot', children=[
+        Augment('/foo-local:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/f:conflict', children=[
+        Augment('/foo-local:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ]),
-        Augment('/f:nested', children=[
+        Augment('/foo-local:nested', children=[
             Container('inner', children=[
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/f:nested/inner/li1', children=[
+        Augment('/foo-local:nested/inner/li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[
     Identity('bary', base=['f:basey']),
+    Container('test-idref', children=[
+        LeafList('idref', type_=Type('identityref', base=['f:basey']))
+    ]),
     Container('conflict', children=[
         Leaf('foo', type_=Type('string'))
     ])

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -253,16 +253,23 @@ def src_yang():
     namespace "http://example.com/bar";
     prefix "bar";
     import foo {
-        prefix "f";
+        prefix "foo-local";
     }
     identity bary {
-        base f:basey;
+        base foo-local:basey;
     }
-    augment /f:c1 {
-        // create a conflict with /f:c1/l1
-        uses f:g1;
+    container test-idref {
+        leaf-list idref {
+            type identityref {
+                base foo-local:basey;
+            }
+        }
     }
-    augment /f:c.dot {
+    augment /foo-local:c1 {
+        // create a conflict with /foo-local:c1/l1
+        uses foo-local:g1;
+    }
+    augment /foo-local:c.dot {
         leaf l.dot2 {
             type string;
         }
@@ -272,7 +279,7 @@ def src_yang():
             type string;
         }
     }
-    augment /f:conflict {
+    augment /foo-local:conflict {
         leaf foo {
             type string;
         }
@@ -280,15 +287,15 @@ def src_yang():
             presence "inner presence from bar";
         }
     }
-    augment /f:nested {
-        // conflict with /f:nested/inner
+    augment /foo-local:nested {
+        // conflict with /foo-local:nested/inner
         container inner {
             leaf foo {
                 type string;
             }
         }
     }
-    augment /f:nested/inner/li1 {
+    augment /foo-local:nested/inner/li1 {
         leaf bar {
             type string;
         }
@@ -3505,6 +3512,108 @@ mut def from_json_foo__c2(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_json_foo__c2__l1, child_l1)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
+mut def from_json_bar__test_idref__idref(val: list[PartialIdentityref]) -> yang.gdata.LeafList:
+    new_val = []
+    for v in val:
+        nv, error = complete_and_validate_identityref(v, _identities, ['f:basey'], 'bar')
+        if nv is not None:
+            new_val.append(nv)
+        else:
+            raise ValueError('Invalid value for identityref leaf-list idref: {error}')
+    return yang.gdata.LeafList('identityref', new_val)
+
+mut def from_xml_bar__test_idref__idref(val: list[PartialIdentityref]) -> yang.gdata.LeafList:
+    new_val = []
+    for v in val:
+        nv, error = complete_and_validate_identityref(v, _identities, ['f:basey'], 'bar')
+        if nv is not None:
+            new_val.append(nv)
+        else:
+            raise ValueError('Invalid value for identityref leaf-list idref: {error}')
+    return yang.gdata.LeafList('identityref', new_val)
+
+class bar__test_idref(yang.adata.MNode):
+    idref: list[Identityref]
+
+    mut def __init__(self, idref: ?list[Identityref]=None):
+        self._ns = 'http://example.com/bar'
+        self.idref = idref if idref is not None else []
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _idref = self.idref
+        if _idref is not None:
+            _identityref_idref = []
+            for v in _idref:
+                nv, error = complete_and_validate_identityref(v, _identities, ['f:basey'], 'bar')
+                if nv is not None:
+                    _identityref_idref.append(nv)
+                else:
+                    raise ValueError('Invalid value for identityref leaf-list idref: {error}')
+            _idref = _identityref_idref
+            children['idref'] = yang.gdata.LeafList('identityref', _idref)
+        return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__test_idref:
+        if n is not None:
+            return bar__test_idref(idref=n.get_opt_Identityrefs('idref'))
+        return bar__test_idref()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return bar__test_idref.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /test-idref')
+            res.append('{self_name} = bar__test_idref()')
+        leaves = []
+        _idref = self.idref
+        if len(_idref) != 0:
+            leaves.append('{self_name}.idref = {repr(_idref)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /test-idref'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['bar:test-idref'])
+
+
+mut def from_xml_bar__test_idref(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_idref = yang.gdata.from_xml_opt_Identityrefs(node, 'idref')
+    yang.gdata.maybe_add(children, 'idref', from_xml_bar__test_idref__idref, child_idref)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
+mut def from_json_path_bar__test_idref(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'idref':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_bar__test_idref(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_bar__test_idref(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_idref = yang.gdata.take_json_opt_Identityrefs(jd, 'idref')
+    yang.gdata.maybe_add(children, 'idref', from_json_bar__test_idref__idref, child_idref)
+    return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
+
 mut def from_json_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -3600,9 +3709,10 @@ class root(yang.adata.MNode):
     state: foo__state
     ll_empty: list[str]
     c2: foo__c2
+    test_idref: bar__test_idref
     bar_conflict: bar__conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -3618,6 +3728,7 @@ class root(yang.adata.MNode):
         self.state = state if state is not None else foo__state()
         self.ll_empty = ll_empty if ll_empty is not None else []
         self.c2 = c2 if c2 is not None else foo__c2()
+        self.test_idref = test_idref if test_idref is not None else bar__test_idref()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
 
     mut def create_pc1(self):
@@ -3684,6 +3795,9 @@ class root(yang.adata.MNode):
         _c2 = self.c2
         if _c2 is not None:
             children['c2'] = _c2.to_gdata()
+        _test_idref = self.test_idref
+        if _test_idref is not None:
+            children['test-idref'] = _test_idref.to_gdata()
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
             children['bar:conflict'] = _bar_conflict.to_gdata()
@@ -3692,7 +3806,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt('test-idref')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def copy(self):
@@ -3767,6 +3881,9 @@ class root(yang.adata.MNode):
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())
+        _test_idref = self.test_idref
+        if _test_idref is not None:
+            res.extend(_test_idref.prsrc('{self_name}.test_idref', False).splitlines())
         _bar_conflict = self.bar_conflict
         if _bar_conflict is not None:
             res.extend(_bar_conflict.prsrc('{self_name}.bar_conflict', False).splitlines())
@@ -3813,6 +3930,8 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll-empty', from_xml_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.from_xml_opt_cnt(node, 'c2', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
+    child_test_idref = yang.gdata.from_xml_opt_cnt(node, 'test-idref', 'http://example.com/bar')
+    yang.gdata.maybe_add(children, 'test-idref', from_xml_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
@@ -3868,6 +3987,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         if point == 'foo:c2':
             child = {'c2': from_json_path_foo__c2(jd, rest_path, op) }
             return yang.gdata.Container(child)
+        if point == 'bar:test-idref':
+            child = {'test-idref': from_json_path_bar__test_idref(jd, rest_path, op) }
+            return yang.gdata.Container(child)
         if point == 'bar:conflict':
             child = {'bar:conflict': from_json_path_bar__conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
@@ -3910,6 +4032,8 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll-empty', from_json_foo__ll_empty, child_ll_empty)
     child_c2 = yang.gdata.take_json_opt_cnt(jd, 'c2', 'foo')
     yang.gdata.maybe_add(children, 'c2', from_json_foo__c2, child_c2)
+    child_test_idref = yang.gdata.take_json_opt_cnt(jd, 'test-idref', 'bar')
+    yang.gdata.maybe_add(children, 'test-idref', from_json_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'bar')
     yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
@@ -4045,28 +4169,31 @@ def src_schema():
     ])
 ])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='f')
+        Import('foo', prefix='foo-local')
     ], augment=[
-        Augment('/f:c1', children=[
-            Uses('f:g1')
+        Augment('/foo-local:c1', children=[
+            Uses('foo-local:g1')
         ]),
-        Augment('/f:c.dot', children=[
+        Augment('/foo-local:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/f:conflict', children=[
+        Augment('/foo-local:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ]),
-        Augment('/f:nested', children=[
+        Augment('/foo-local:nested', children=[
             Container('inner', children=[
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/f:nested/inner/li1', children=[
+        Augment('/foo-local:nested/inner/li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[
-    Identity('bary', base=['f:basey']),
+    Identity('bary', base=['foo-local:basey']),
+    Container('test-idref', children=[
+        LeafList('idref', type_=Type('identityref', base=['foo-local:basey']))
+    ]),
     Container('conflict', children=[
         Leaf('foo', type_=Type('string'))
     ])
@@ -4193,28 +4320,31 @@ def src_schema_compiled():
     ])
 ])
     res["bar"] = Module('bar', yang_version=1.1, namespace='http://example.com/bar', prefix='bar', import_=[
-        Import('foo', prefix='f')
+        Import('foo', prefix='foo-local')
     ], augment=[
-        Augment('/f:c1', children=[
-            Uses('f:g1')
+        Augment('/foo-local:c1', children=[
+            Uses('foo-local:g1')
         ]),
-        Augment('/f:c.dot', children=[
+        Augment('/foo-local:c.dot', children=[
             Leaf('l.dot2', type_=Type('string'))
         ]),
-        Augment('/f:conflict', children=[
+        Augment('/foo-local:conflict', children=[
             Leaf('foo', type_=Type('string')),
             Container('inner', presence='inner presence from bar')
         ]),
-        Augment('/f:nested', children=[
+        Augment('/foo-local:nested', children=[
             Container('inner', children=[
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/f:nested/inner/li1', children=[
+        Augment('/foo-local:nested/inner/li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[
     Identity('bary', base=['f:basey']),
+    Container('test-idref', children=[
+        LeafList('idref', type_=Type('identityref', base=['f:basey']))
+    ]),
     Container('conflict', children=[
         Leaf('foo', type_=Type('string'))
     ])

--- a/test/test_data_classes/test/golden/test_data_classes/adata_foo_pc2
+++ b/test/test_data_classes/test/golden/test_data_classes/adata_foo_pc2
@@ -28,5 +28,8 @@ Container({
   }, ns='http://example.com/foo', module='foo'),
   'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo'),
   'c2': Container(ns='http://example.com/foo', module='foo'),
+  'test-idref': Container({
+    'idref': LeafList('identityref', [])
+  }, ns='http://example.com/bar', module='bar'),
   'bar:conflict': Container(ns='http://example.com/bar', module='bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_c1_l1
@@ -25,5 +25,8 @@ Container({
   }, ns='http://example.com/foo', module='foo'),
   'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo'),
   'c2': Container(ns='http://example.com/foo', module='foo'),
+  'test-idref': Container({
+    'idref': LeafList('identityref', [])
+  }, ns='http://example.com/bar', module='bar'),
   'bar:conflict': Container(ns='http://example.com/bar', module='bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_gdata_empty
@@ -23,5 +23,8 @@ Container({
   }, ns='http://example.com/foo', module='foo'),
   'll-empty': LeafList('string', [], ns='http://example.com/foo', module='foo'),
   'c2': Container(ns='http://example.com/foo', module='foo'),
+  'test-idref': Container({
+    'idref': LeafList('identityref', [])
+  }, ns='http://example.com/bar', module='bar'),
   'bar:conflict': Container(ns='http://example.com/bar', module='bar')
 })

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -81,6 +81,9 @@ Container({
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')
   }, ns='http://example.com/foo', module='foo'),
+  'test-idref': Container({
+    'idref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar'), Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')])
+  }, ns='http://example.com/bar', module='bar'),
   'bar:conflict': Container({
     'foo': Leaf('string', 'foo-bar')
   }, ns='http://example.com/bar', module='bar')

--- a/test/test_data_classes/test/golden/test_data_classes/gen3_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/gen3_from_xml_full
@@ -81,6 +81,9 @@ Container({
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')
   }, ns='http://example.com/foo', module='foo'),
+  'test-idref': Container({
+    'idref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar'), Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')])
+  }, ns='http://example.com/bar', module='bar'),
   'bar:conflict': Container({
     'foo': Leaf('string', 'foo-bar')
   }, ns='http://example.com/bar', module='bar')

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -276,16 +276,23 @@ ys_bar = r"""module bar {
     namespace "http://example.com/bar";
     prefix "bar";
     import foo {
-        prefix "f";
+        prefix "foo-local";
     }
     identity bary {
-        base f:basey;
+        base foo-local:basey;
     }
-    augment /f:c1 {
-        // create a conflict with /f:c1/l1
-        uses f:g1;
+    container test-idref {
+        leaf-list idref {
+            type identityref {
+                base foo-local:basey;
+            }
+        }
     }
-    augment /f:c.dot {
+    augment /foo-local:c1 {
+        // create a conflict with /foo-local:c1/l1
+        uses foo-local:g1;
+    }
+    augment /foo-local:c.dot {
         leaf l.dot2 {
             type string;
         }
@@ -295,7 +302,7 @@ ys_bar = r"""module bar {
             type string;
         }
     }
-    augment /f:conflict {
+    augment /foo-local:conflict {
         leaf foo {
             type string;
         }
@@ -303,15 +310,15 @@ ys_bar = r"""module bar {
             presence "inner presence from bar";
         }
     }
-    augment /f:nested {
-        // conflict with /f:nested/inner
+    augment /foo-local:nested {
+        // conflict with /foo-local:nested/inner
         container inner {
             leaf foo {
                 type string;
             }
         }
     }
-    augment /f:nested/inner/li1 {
+    augment /foo-local:nested/inner/li1 {
         leaf bar {
             type string;
         }

--- a/test/test_data_source_roundtrip/src/xml_full_adata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata.act
@@ -80,6 +80,9 @@ def adata():
     # Container: /c2
     ad.c2.l1 = 'foo-qux'
     
+    # Container: /test-idref
+    ad.test_idref.idref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar'), Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')]
+    
     # Container: /conflict
     ad.bar_conflict.foo = 'foo-bar'
     return ad

--- a/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
@@ -82,6 +82,9 @@ def adata():
     # Container: /c2
     ad.c2.l1 = 'foo-qux'
     
+    # Container: /test-idref
+    ad.test_idref.idref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar'), Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')]
+    
     # Container: /conflict
     ad.bar_conflict.foo = 'foo-bar'
     return ad

--- a/test/test_data_source_roundtrip/src/xml_full_gdata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_gdata.act
@@ -84,6 +84,9 @@ xml_full = Container({
   'c2': Container({
     'l1': Leaf('string', 'foo-qux')
   }, ns='http://example.com/foo', module='foo'),
+  'test-idref': Container({
+    'idref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar'), Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')])
+  }, ns='http://example.com/bar', module='bar'),
   'bar:conflict': Container({
     'foo': Leaf('string', 'foo-bar')
   }, ns='http://example.com/bar', module='bar')


### PR DESCRIPTION
When a module imports another module, but with a locally different prefix from the one defined in the imported module, we must remap the references. I initially stared at this problem in the context of identityref base, but then realized the same rules apply to path references and XPath, basically anywhere the locally defined prefix may appear.

In the `Module.compile()` method we now inspect the imports, and if the prefixes are different, remap in all children recursively.