### PR TITLE
Fix uses-refine path resolution for cross-module augments

### DIFF
--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -1003,7 +1003,13 @@ snode_methods = {
                 if prefix is not None:
                     # TODO: or is prefix OK when it is the local prefix?
                     raise ValueError("Relative path in refine under uses cannot have prefixes")
-                current_node = current_node.get(name)
+                # Must use the Uses statement namespace (self.get_namespace()),
+                # not default match with target (current_node).
+                # In cross-module augments (Module A augments Module B), the
+                # groupings expanded children have Module A namespace while the
+                # target has Module B. Without an explicit namespace,
+                # current_node.get() would search Module B namespace and fail.
+                current_node = current_node.get(name, ns=self.get_namespace())
             return current_node
 
         for refine in self.refine:

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2825,3 +2825,61 @@ def _test_fail_identity_missing_imported_base():
         testing.assertEqual(exc.error_message, "Could not resolve base 'base:network-type' for identity 'derived:ethernet'")
     else:
         testing.error("Expected ValueError for undefined imported base identity")
+
+
+def _test_augment_with_uses_refine():
+    """Test cross-module augment with uses and refine
+
+    This test verifies that refine statements correctly find nodes when:
+    1. Module 'augmenter' augments a node in module 'base'
+    2. The augment uses a grouping with refine statements
+    3. The expanded nodes have 'augmenter' namespace but are added to 'base' tree
+    """
+    ys_base = r"""module base {
+  yang-version 1.1;
+  namespace "http://example.com/base";
+  prefix base;
+
+  container system-capabilities {
+    description "System capabilities";
+
+    list per-node-capabilities {
+      description "Per-node capabilities";
+    }
+  }
+}"""
+
+    ys_augmenter = r"""module augmenter {
+  yang-version 1.1;
+  namespace "http://example.com/augmenter";
+  prefix aug;
+
+  import base {
+    prefix base;
+  }
+
+  grouping subscription-capabilities {
+    container subscription-capabilities {
+      leaf max-nodes {
+        type uint32;
+      }
+      leaf-list supported-excluded-change-type {
+        type string;
+      }
+    }
+  }
+
+  augment "/base:system-capabilities" {
+    uses subscription-capabilities {
+      refine "subscription-capabilities/supported-excluded-change-type" {
+        default "leaf-list default doesn't work right now";
+      }
+      refine "subscription-capabilities/max-nodes" {
+        default 42;
+      }
+    }
+  }
+}"""
+
+    root = yang.compile([ys_base, ys_augmenter])
+    return root.prdaclass()

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -8202,7 +8202,13 @@ class Uses(SchemaNodeOuter):
                 if prefix is not None:
                     # TODO: or is prefix OK when it is the local prefix?
                     raise ValueError("Relative path in refine under uses cannot have prefixes")
-                current_node = current_node.get(name)
+                # Must use the Uses statement namespace (self.get_namespace()),
+                # not default match with target (current_node).
+                # In cross-module augments (Module A augments Module B), the
+                # groupings expanded children have Module A namespace while the
+                # target has Module B. Without an explicit namespace,
+                # current_node.get() would search Module B namespace and fail.
+                current_node = current_node.get(name, ns=self.get_namespace())
             return current_node
 
         for refine in self.refine:

--- a/test/golden/test_yang/augment_with_uses_refine
+++ b/test/golden/test_yang/augment_with_uses_refine
@@ -1,0 +1,447 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
+
+    mut def __init__(self):
+        self._ns = 'http://example.com/base'
+        pass
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> base__system_capabilities__per_node_capabilities_entry:
+        return base__system_capabilities__per_node_capabilities_entry()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__system_capabilities__per_node_capabilities_entry.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /system-capabilities/per-node-capabilities')
+            res.append('{self_name} = base__system_capabilities__per_node_capabilities()')
+        leaves = []
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /system-capabilities/per-node-capabilities'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:system-capabilities', 'per-node-capabilities'])
+
+class base__system_capabilities__per_node_capabilities(yang.adata.MNode):
+    elements: list[base__system_capabilities__per_node_capabilities_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'http://example.com/base'
+        self._name = 'per-node-capabilities'
+        self.elements = elements
+
+    mut def create(self):
+        for e in self:
+            match = True
+            if match:
+                return e
+
+        res = base__system_capabilities__per_node_capabilities_entry()
+        self.elements.append(res)
+        return res
+
+    mut def to_gdata(self):
+        elements = []
+        for e in self:
+            e_gdata = e.to_gdata()
+            if isinstance(e_gdata, yang.gdata.Container):
+                elements.append(e_gdata)
+        return yang.gdata.List([], elements)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[base__system_capabilities__per_node_capabilities_entry]:
+        if n is not None:
+            return [base__system_capabilities__per_node_capabilities_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return base__system_capabilities__per_node_capabilities(elements=copied_elements)
+
+extension base__system_capabilities__per_node_capabilities(Iterable[base__system_capabilities__per_node_capabilities_entry]):
+    def __iter__(self) -> Iterator[base__system_capabilities__per_node_capabilities_entry]:
+        return self.elements.__iter__()
+
+mut def from_xml_base__system_capabilities__per_node_capabilities_element(node: xml.Node) -> yang.gdata.Node:
+    children = {}
+    return yang.gdata.Container(children)
+
+mut def from_xml_base__system_capabilities__per_node_capabilities(nodes: list[xml.Node]) -> yang.gdata.List:
+    elements = [from_xml_base__system_capabilities__per_node_capabilities_element(e) for e in nodes]
+    return yang.gdata.List(keys=[], elements=elements)
+
+mut def from_json_path_base__system_capabilities__per_node_capabilities_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        val = from_json_base__system_capabilities__per_node_capabilities_element(jd_dict)
+        if op == "merge":
+            return val
+        elif op == "remove":
+            return yang.gdata.Absent(val.key_children([]))
+        raise ValueError("Invalid operation")
+    elif len(path) > 1:
+        keys = path[0].split(",")
+        point = path[1]
+        rest_path = path[2:]
+        children: dict[str, yang.gdata.Node] = {}
+        return yang.gdata.Container(children)
+    raise ValueError("unreachable - no keys to list element")
+
+mut def from_json_path_base__system_capabilities__per_node_capabilities(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.List:
+    if len(path) == 1:
+        point = path[0]
+        keys = point.split(",")
+        jd_dict = yang.gdata.unwrap_dict(jd)
+        # Check that all keys are present in payload.
+        # If present, they must equal the keys in the path
+        # If not present, fill in from path
+        for key in []:
+            if key not in jd_dict:
+                jd_dict[key] = keys.pop(0)
+            else:
+                if str(jd_dict[key]) != keys.pop(0):
+                    raise ValueError("Key value mismatch between path and payload")
+        element = from_json_base__system_capabilities__per_node_capabilities_element(jd_dict)
+        elements = []
+        if op == "merge":
+            elements.append(element)
+        elif op == "remove":
+            elements.append(yang.gdata.Absent(element.key_children([])))
+        return yang.gdata.List([], elements)
+    elif len(path) > 1:
+        return yang.gdata.List([], [from_json_path_base__system_capabilities__per_node_capabilities_element(jd, path, op)])
+    raise ValueError("Unable to resolve path, no keys provided")
+
+mut def from_json_base__system_capabilities__per_node_capabilities_element(jd: dict[str, ?value]) -> yang.gdata.Node:
+    children = {}
+    return yang.gdata.Container(children)
+
+mut def from_json_base__system_capabilities__per_node_capabilities(jd: list[dict[str, ?value]]) -> yang.gdata.List:
+    elements = [from_json_base__system_capabilities__per_node_capabilities_element(e) for e in jd if isinstance(e, dict)]
+    return yang.gdata.List(keys=[], elements=elements)
+
+mut def from_json_base__system_capabilities__subscription_capabilities__max_nodes(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_xml_base__system_capabilities__subscription_capabilities__max_nodes(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint32', val)
+
+mut def from_json_base__system_capabilities__subscription_capabilities__supported_excluded_change_type(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+mut def from_xml_base__system_capabilities__subscription_capabilities__supported_excluded_change_type(val: list[value]) -> yang.gdata.LeafList:
+    return yang.gdata.LeafList('string', val)
+
+class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
+    max_nodes: int
+    supported_excluded_change_type: list[str]
+
+    mut def __init__(self, max_nodes: ?int=None, supported_excluded_change_type: ?list[str]=None):
+        self._ns = 'http://example.com/augmenter'
+        self.max_nodes = max_nodes if max_nodes is not None else 42
+        self.supported_excluded_change_type = supported_excluded_change_type if supported_excluded_change_type is not None else []
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _max_nodes = self.max_nodes
+        if _max_nodes is not None:
+            children['max-nodes'] = yang.gdata.Leaf('uint32', _max_nodes)
+        _supported_excluded_change_type = self.supported_excluded_change_type
+        if _supported_excluded_change_type is not None:
+            children['supported-excluded-change-type'] = yang.gdata.LeafList('string', _supported_excluded_change_type)
+        return yang.gdata.Container(children, ns='http://example.com/augmenter', module='augmenter')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__system_capabilities__subscription_capabilities:
+        if n is not None:
+            return base__system_capabilities__subscription_capabilities(max_nodes=n.get_opt_int('max-nodes'), supported_excluded_change_type=n.get_opt_strs('supported-excluded-change-type'))
+        return base__system_capabilities__subscription_capabilities()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__system_capabilities__subscription_capabilities.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /system-capabilities/subscription-capabilities')
+            res.append('{self_name} = base__system_capabilities__subscription_capabilities()')
+        leaves = []
+        _max_nodes = self.max_nodes
+        if _max_nodes is not None:
+            leaves.append('{self_name}.max_nodes = {repr(_max_nodes)}')
+        _supported_excluded_change_type = self.supported_excluded_change_type
+        if len(_supported_excluded_change_type) != 0:
+            leaves.append('{self_name}.supported_excluded_change_type = {repr(_supported_excluded_change_type)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /system-capabilities/subscription-capabilities'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['augmenter:system-capabilities', 'subscription-capabilities'])
+
+
+mut def from_xml_base__system_capabilities__subscription_capabilities(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_max_nodes = yang.gdata.from_xml_opt_int(node, 'max-nodes')
+    yang.gdata.maybe_add(children, 'max-nodes', from_xml_base__system_capabilities__subscription_capabilities__max_nodes, child_max_nodes)
+    child_supported_excluded_change_type = yang.gdata.from_xml_opt_strs(node, 'supported-excluded-change-type')
+    yang.gdata.maybe_add(children, 'supported-excluded-change-type', from_xml_base__system_capabilities__subscription_capabilities__supported_excluded_change_type, child_supported_excluded_change_type)
+    return yang.gdata.Container(children, ns='http://example.com/augmenter', module='augmenter')
+
+mut def from_json_path_base__system_capabilities__subscription_capabilities(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'max-nodes':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'supported-excluded-change-type':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__system_capabilities__subscription_capabilities(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__system_capabilities__subscription_capabilities(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_max_nodes = yang.gdata.take_json_opt_int(jd, 'max-nodes')
+    yang.gdata.maybe_add(children, 'max-nodes', from_json_base__system_capabilities__subscription_capabilities__max_nodes, child_max_nodes)
+    child_supported_excluded_change_type = yang.gdata.take_json_opt_strs(jd, 'supported-excluded-change-type')
+    yang.gdata.maybe_add(children, 'supported-excluded-change-type', from_json_base__system_capabilities__subscription_capabilities__supported_excluded_change_type, child_supported_excluded_change_type)
+    return yang.gdata.Container(children, ns='http://example.com/augmenter', module='augmenter')
+
+class base__system_capabilities(yang.adata.MNode):
+    per_node_capabilities: base__system_capabilities__per_node_capabilities
+    subscription_capabilities: base__system_capabilities__subscription_capabilities
+
+    mut def __init__(self, per_node_capabilities: list[base__system_capabilities__per_node_capabilities_entry]=[], subscription_capabilities: ?base__system_capabilities__subscription_capabilities=None):
+        self._ns = 'http://example.com/base'
+        self.per_node_capabilities = base__system_capabilities__per_node_capabilities(elements=per_node_capabilities)
+        self.subscription_capabilities = subscription_capabilities if subscription_capabilities is not None else base__system_capabilities__subscription_capabilities()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _per_node_capabilities = self.per_node_capabilities
+        if _per_node_capabilities is not None:
+            children['per-node-capabilities'] = _per_node_capabilities.to_gdata()
+        _subscription_capabilities = self.subscription_capabilities
+        if _subscription_capabilities is not None:
+            children['subscription-capabilities'] = _subscription_capabilities.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__system_capabilities:
+        if n is not None:
+            return base__system_capabilities(per_node_capabilities=base__system_capabilities__per_node_capabilities.from_gdata(n.get_opt_list('per-node-capabilities')), subscription_capabilities=base__system_capabilities__subscription_capabilities.from_gdata(n.get_opt_cnt('subscription-capabilities')))
+        return base__system_capabilities()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__system_capabilities.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /system-capabilities')
+            res.append('{self_name} = base__system_capabilities()')
+        leaves = []
+        _per_node_capabilities = self.per_node_capabilities
+        for _element in _per_node_capabilities:
+            res.append('')
+            res.append("# List /system-capabilities/per-node-capabilities element: {_element.to_gdata().key_str([])}")
+            list_elem = 'per_node_capabilities_element = {self_name}.per_node_capabilities.create()'
+            res.append(list_elem)
+            res.extend(_element.prsrc('per_node_capabilities_element', False, list_element=True).splitlines())
+        _subscription_capabilities = self.subscription_capabilities
+        if _subscription_capabilities is not None:
+            res.extend(_subscription_capabilities.prsrc('{self_name}.subscription_capabilities', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /system-capabilities'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:system-capabilities'])
+
+
+mut def from_xml_base__system_capabilities(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_per_node_capabilities = yang.gdata.from_xml_opt_list(node, 'per-node-capabilities')
+    yang.gdata.maybe_add(children, 'per-node-capabilities', from_xml_base__system_capabilities__per_node_capabilities, child_per_node_capabilities)
+    child_subscription_capabilities = yang.gdata.from_xml_opt_cnt(node, 'subscription-capabilities', 'http://example.com/augmenter')
+    yang.gdata.maybe_add(children, 'subscription-capabilities', from_xml_base__system_capabilities__subscription_capabilities, child_subscription_capabilities)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+mut def from_json_path_base__system_capabilities(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'per-node-capabilities':
+            child = {'per-node-capabilities': from_json_path_base__system_capabilities__per_node_capabilities(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/base', module='base')
+        if point == 'augmenter:subscription-capabilities':
+            child = {'subscription-capabilities': from_json_path_base__system_capabilities__subscription_capabilities(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/base', module='base')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__system_capabilities(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__system_capabilities(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_per_node_capabilities = yang.gdata.take_json_opt_list(jd, 'per-node-capabilities')
+    yang.gdata.maybe_add(children, 'per-node-capabilities', from_json_base__system_capabilities__per_node_capabilities, child_per_node_capabilities)
+    child_subscription_capabilities = yang.gdata.take_json_opt_cnt(jd, 'subscription-capabilities', 'augmenter')
+    yang.gdata.maybe_add(children, 'subscription-capabilities', from_json_base__system_capabilities__subscription_capabilities, child_subscription_capabilities)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+class root(yang.adata.MNode):
+    system_capabilities: base__system_capabilities
+
+    mut def __init__(self, system_capabilities: ?base__system_capabilities=None):
+        self._ns = ''
+        self.system_capabilities = system_capabilities if system_capabilities is not None else base__system_capabilities()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _system_capabilities = self.system_capabilities
+        if _system_capabilities is not None:
+            children['system-capabilities'] = _system_capabilities.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root(system_capabilities=base__system_capabilities.from_gdata(n.get_opt_cnt('system-capabilities')))
+        return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        _system_capabilities = self.system_capabilities
+        if _system_capabilities is not None:
+            res.extend(_system_capabilities.prsrc('{self_name}.system_capabilities', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_system_capabilities = yang.gdata.from_xml_opt_cnt(node, 'system-capabilities', 'http://example.com/base')
+    yang.gdata.maybe_add(children, 'system-capabilities', from_xml_base__system_capabilities, child_system_capabilities)
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:system-capabilities':
+            child = {'system-capabilities': from_json_path_base__system_capabilities(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_system_capabilities = yang.gdata.take_json_opt_cnt(jd, 'system-capabilities', 'base')
+    yang.gdata.maybe_add(children, 'system-capabilities', from_json_base__system_capabilities, child_system_capabilities)
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/augmenter',
+    'http://example.com/base',
+}
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)


### PR DESCRIPTION
The issue occurs when Module A augments a node in Module B, and the augment contains a uses statement with refines. The grouping's expanded children have Module A namespace but the target node has Module B namespace. Without explicit namespace, SchemaNode.get() searches Module B namespace and fails.