### PR TITLE
Fix cross-module augment path resolution

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2227,10 +2227,10 @@ class SchemaNode(object):
 
                     if prefix is not None:
                         target_ns = self.get_module_by_prefix(prefix, context).get_namespace()
-                        # Use namespace when resolving
-                        current_node = current_node.get(name, ns=target_ns)
                     else:
-                        current_node = current_node.get(name)
+                        # Use the augmenting module's namespace for unprefixed segments
+                        target_ns =  self.get_namespace()
+                    current_node = current_node.get(name, ns=target_ns)
 
             else: # augment under uses
                 if not in_uses:
@@ -2241,7 +2241,8 @@ class SchemaNode(object):
                     if prefix is not None:
                         # TODO: or is prefix OK when it is the local prefix?
                         raise ValueError("Relative path in augment under uses cannot have prefixes")
-                    current_node = current_node.get(name)
+                    # Use the augmenting module's namespace for unprefixed segments
+                    current_node = current_node.get(name, ns=self.get_namespace())
 
             return current_node
 

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1156,6 +1156,64 @@ def _test_compile_augment_implicit_input_output():
     root = yang.compile([ys])
     return root.prdaclass()
 
+def _test_compile_augment_augmented_node():
+    """Test augmenting with grouping, then augmenting nodes added by that grouping
+    """
+    ys_base = r"""module base {
+  yang-version 1.1;
+  namespace "http://example.com/base";
+  prefix base;
+
+  container native {
+  }
+}"""
+
+    ys_voice = r"""module voice {
+  yang-version 1.1;
+  namespace "http://example.com/voice";
+  prefix voice;
+
+  import base {
+    prefix base;
+  }
+
+  grouping voice-config-grouping {
+    container voice {
+      container service {
+        container voip {
+          leaf enabled {
+            type boolean;
+            default false;
+          }
+        }
+      }
+    }
+  }
+
+  // First augment: add voice container using grouping
+  augment "/base:native" {
+    uses voice-config-grouping;
+  }
+
+  // Second augment: augment the voice/service/voip container
+  // that was just added by the first augment+grouping
+  augment "/base:native/voice/service/voip" {
+    container sip {
+      leaf bind {
+        type string;
+      }
+      leaf port {
+        type uint16;
+        default 5060;
+      }
+    }
+  }
+}"""
+
+    root = yang.compile([ys_base, ys_voice])
+    src = root.prdaclass()
+    return src
+
 def _test_compile_refine():
     """Refining a grouping"""
     ys = r"""module foo {
@@ -2145,8 +2203,8 @@ def _test_prdaclass_strict_p_container_with_mandatory_leaf():
   import foo {
     prefix "foo";
   }
-  augment "/foo:foo/bar" {
-    // conflicts with /foo:foo/bar/l1
+  augment "/foo:foo/foo:bar" {
+    // conflicts with /foo:foo/foo:bar/foo:l1
     leaf l1 {
       type string;
       mandatory true;
@@ -2383,7 +2441,7 @@ def _test_prdaclass_augment_inner_list_conflict():
             }
         }
     }
-    augment "/b:c1/l1" {
+    augment "/b:c1/b:l1" {
         leaf k1 {
             type string;
             mandatory true;

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2223,10 +2223,10 @@ class SchemaNode(object):
 
                     if prefix is not None:
                         target_ns = self.get_module_by_prefix(prefix, context).get_namespace()
-                        # Use namespace when resolving
-                        current_node = current_node.get(name, ns=target_ns)
                     else:
-                        current_node = current_node.get(name)
+                        # Use the augmenting module's namespace for unprefixed segments
+                        target_ns =  self.get_namespace()
+                    current_node = current_node.get(name, ns=target_ns)
 
             else: # augment under uses
                 if not in_uses:
@@ -2237,7 +2237,8 @@ class SchemaNode(object):
                     if prefix is not None:
                         # TODO: or is prefix OK when it is the local prefix?
                         raise ValueError("Relative path in augment under uses cannot have prefixes")
-                    current_node = current_node.get(name)
+                    # Use the augmenting module's namespace for unprefixed segments
+                    current_node = current_node.get(name, ns=self.get_namespace())
 
             return current_node
 

--- a/test/golden/test_yang/compile_augment_augmented_node
+++ b/test/golden/test_yang/compile_augment_augmented_node
@@ -1,0 +1,532 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+mut def from_json_base__native__voice__service__voip__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_xml_base__native__voice__service__voip__enabled(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('boolean', val)
+
+mut def from_json_base__native__voice__service__voip__sip__bind(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_xml_base__native__voice__service__voip__sip__bind(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('string', val)
+
+mut def from_json_base__native__voice__service__voip__sip__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+mut def from_xml_base__native__voice__service__voip__sip__port(val: value) -> yang.gdata.Leaf:
+    return yang.gdata.Leaf('uint16', val)
+
+class base__native__voice__service__voip__sip(yang.adata.MNode):
+    bind: ?str
+    port: int
+
+    mut def __init__(self, bind: ?str, port: ?int=None):
+        self._ns = 'http://example.com/voice'
+        self.bind = bind
+        self.port = port if port is not None else 5060
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _bind = self.bind
+        if _bind is not None:
+            children['bind'] = yang.gdata.Leaf('string', _bind)
+        _port = self.port
+        if _port is not None:
+            children['port'] = yang.gdata.Leaf('uint16', _port)
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__native__voice__service__voip__sip:
+        if n is not None:
+            return base__native__voice__service__voip__sip(bind=n.get_opt_str('bind'), port=n.get_opt_int('port'))
+        return base__native__voice__service__voip__sip()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__native__voice__service__voip__sip.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /native/voice/service/voip/sip')
+            res.append('{self_name} = base__native__voice__service__voip__sip()')
+        leaves = []
+        _bind = self.bind
+        if _bind is not None:
+            leaves.append('{self_name}.bind = {repr(_bind)}')
+        _port = self.port
+        if _port is not None:
+            leaves.append('{self_name}.port = {repr(_port)}')
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /native/voice/service/voip/sip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['voice:native', 'voice', 'service', 'voip', 'sip'])
+
+
+mut def from_xml_base__native__voice__service__voip__sip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_bind = yang.gdata.from_xml_opt_str(node, 'bind')
+    yang.gdata.maybe_add(children, 'bind', from_xml_base__native__voice__service__voip__sip__bind, child_bind)
+    child_port = yang.gdata.from_xml_opt_int(node, 'port')
+    yang.gdata.maybe_add(children, 'port', from_xml_base__native__voice__service__voip__sip__port, child_port)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_base__native__voice__service__voip__sip(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'bind':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'port':
+            raise ValueError("Invalid json path to non-inner node")
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__native__voice__service__voip__sip(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__native__voice__service__voip__sip(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_bind = yang.gdata.take_json_opt_str(jd, 'bind')
+    yang.gdata.maybe_add(children, 'bind', from_json_base__native__voice__service__voip__sip__bind, child_bind)
+    child_port = yang.gdata.take_json_opt_int(jd, 'port')
+    yang.gdata.maybe_add(children, 'port', from_json_base__native__voice__service__voip__sip__port, child_port)
+    return yang.gdata.Container(children)
+
+class base__native__voice__service__voip(yang.adata.MNode):
+    enabled: bool
+    sip: base__native__voice__service__voip__sip
+
+    mut def __init__(self, enabled: ?bool=None, sip: ?base__native__voice__service__voip__sip=None):
+        self._ns = 'http://example.com/voice'
+        self.enabled = enabled if enabled is not None else False
+        self.sip = sip if sip is not None else base__native__voice__service__voip__sip()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _enabled = self.enabled
+        if _enabled is not None:
+            children['enabled'] = yang.gdata.Leaf('boolean', _enabled)
+        _sip = self.sip
+        if _sip is not None:
+            children['sip'] = _sip.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__native__voice__service__voip:
+        if n is not None:
+            return base__native__voice__service__voip(enabled=n.get_opt_bool('enabled'), sip=base__native__voice__service__voip__sip.from_gdata(n.get_opt_cnt('sip')))
+        return base__native__voice__service__voip()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__native__voice__service__voip.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /native/voice/service/voip')
+            res.append('{self_name} = base__native__voice__service__voip()')
+        leaves = []
+        _enabled = self.enabled
+        if _enabled is not None:
+            leaves.append('{self_name}.enabled = {repr(_enabled)}')
+        _sip = self.sip
+        if _sip is not None:
+            res.extend(_sip.prsrc('{self_name}.sip', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /native/voice/service/voip'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['voice:native', 'voice', 'service', 'voip'])
+
+
+mut def from_xml_base__native__voice__service__voip(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.from_xml_opt_bool(node, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_xml_base__native__voice__service__voip__enabled, child_enabled)
+    child_sip = yang.gdata.from_xml_opt_cnt(node, 'sip')
+    yang.gdata.maybe_add(children, 'sip', from_xml_base__native__voice__service__voip__sip, child_sip)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_base__native__voice__service__voip(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'enabled':
+            raise ValueError("Invalid json path to non-inner node")
+        if point == 'sip':
+            child = {'sip': from_json_path_base__native__voice__service__voip__sip(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__native__voice__service__voip(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__native__voice__service__voip(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_enabled = yang.gdata.take_json_opt_bool(jd, 'enabled')
+    yang.gdata.maybe_add(children, 'enabled', from_json_base__native__voice__service__voip__enabled, child_enabled)
+    child_sip = yang.gdata.take_json_opt_cnt(jd, 'sip')
+    yang.gdata.maybe_add(children, 'sip', from_json_base__native__voice__service__voip__sip, child_sip)
+    return yang.gdata.Container(children)
+
+class base__native__voice__service(yang.adata.MNode):
+    voip: base__native__voice__service__voip
+
+    mut def __init__(self, voip: ?base__native__voice__service__voip=None):
+        self._ns = 'http://example.com/voice'
+        self.voip = voip if voip is not None else base__native__voice__service__voip()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _voip = self.voip
+        if _voip is not None:
+            children['voip'] = _voip.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__native__voice__service:
+        if n is not None:
+            return base__native__voice__service(voip=base__native__voice__service__voip.from_gdata(n.get_opt_cnt('voip')))
+        return base__native__voice__service()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__native__voice__service.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /native/voice/service')
+            res.append('{self_name} = base__native__voice__service()')
+        leaves = []
+        _voip = self.voip
+        if _voip is not None:
+            res.extend(_voip.prsrc('{self_name}.voip', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /native/voice/service'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['voice:native', 'voice', 'service'])
+
+
+mut def from_xml_base__native__voice__service(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_voip = yang.gdata.from_xml_opt_cnt(node, 'voip')
+    yang.gdata.maybe_add(children, 'voip', from_xml_base__native__voice__service__voip, child_voip)
+    return yang.gdata.Container(children)
+
+mut def from_json_path_base__native__voice__service(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'voip':
+            child = {'voip': from_json_path_base__native__voice__service__voip(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__native__voice__service(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__native__voice__service(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_voip = yang.gdata.take_json_opt_cnt(jd, 'voip')
+    yang.gdata.maybe_add(children, 'voip', from_json_base__native__voice__service__voip, child_voip)
+    return yang.gdata.Container(children)
+
+class base__native__voice(yang.adata.MNode):
+    service: base__native__voice__service
+
+    mut def __init__(self, service: ?base__native__voice__service=None):
+        self._ns = 'http://example.com/voice'
+        self.service = service if service is not None else base__native__voice__service()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _service = self.service
+        if _service is not None:
+            children['service'] = _service.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/voice', module='voice')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__native__voice:
+        if n is not None:
+            return base__native__voice(service=base__native__voice__service.from_gdata(n.get_opt_cnt('service')))
+        return base__native__voice()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__native__voice.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /native/voice')
+            res.append('{self_name} = base__native__voice()')
+        leaves = []
+        _service = self.service
+        if _service is not None:
+            res.extend(_service.prsrc('{self_name}.service', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /native/voice'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['voice:native', 'voice'])
+
+
+mut def from_xml_base__native__voice(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_service = yang.gdata.from_xml_opt_cnt(node, 'service')
+    yang.gdata.maybe_add(children, 'service', from_xml_base__native__voice__service, child_service)
+    return yang.gdata.Container(children, ns='http://example.com/voice', module='voice')
+
+mut def from_json_path_base__native__voice(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'service':
+            child = {'service': from_json_path_base__native__voice__service(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/voice', module='voice')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__native__voice(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__native__voice(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_service = yang.gdata.take_json_opt_cnt(jd, 'service')
+    yang.gdata.maybe_add(children, 'service', from_json_base__native__voice__service, child_service)
+    return yang.gdata.Container(children, ns='http://example.com/voice', module='voice')
+
+class base__native(yang.adata.MNode):
+    voice: base__native__voice
+
+    mut def __init__(self, voice: ?base__native__voice=None):
+        self._ns = 'http://example.com/base'
+        self.voice = voice if voice is not None else base__native__voice()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _voice = self.voice
+        if _voice is not None:
+            children['voice'] = _voice.to_gdata()
+        return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> base__native:
+        if n is not None:
+            return base__native(voice=base__native__voice.from_gdata(n.get_opt_cnt('voice')))
+        return base__native()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return base__native.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /native')
+            res.append('{self_name} = base__native()')
+        leaves = []
+        _voice = self.voice
+        if _voice is not None:
+            res.extend(_voice.prsrc('{self_name}.voice', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /native'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['base:native'])
+
+
+mut def from_xml_base__native(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_voice = yang.gdata.from_xml_opt_cnt(node, 'voice', 'http://example.com/voice')
+    yang.gdata.maybe_add(children, 'voice', from_xml_base__native__voice, child_voice)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+mut def from_json_path_base__native(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'voice:voice':
+            child = {'voice': from_json_path_base__native__voice(jd, rest_path, op) }
+            return yang.gdata.Container(child, ns='http://example.com/base', module='base')
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json_base__native(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json_base__native(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_voice = yang.gdata.take_json_opt_cnt(jd, 'voice', 'voice')
+    yang.gdata.maybe_add(children, 'voice', from_json_base__native__voice, child_voice)
+    return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+class root(yang.adata.MNode):
+    native: base__native
+
+    mut def __init__(self, native: ?base__native=None):
+        self._ns = ''
+        self.native = native if native is not None else base__native()
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        children = {}
+        _native = self.native
+        if _native is not None:
+            children['native'] = _native.to_gdata()
+        return yang.gdata.Container(children)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root(native=base__native.from_gdata(n.get_opt_cnt('native')))
+        return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+    def prsrc(self, self_name='ad', top=True, list_element=False):
+        res = []
+        if top:
+            res.append('# Top node: /root')
+            res.append('{self_name} = root()')
+        leaves = []
+        _native = self.native
+        if _native is not None:
+            res.extend(_native.prsrc('{self_name}.native', False).splitlines())
+        if leaves:
+            if not list_element:
+               res = ['', '# Container: /root'] + leaves + res
+            else:
+                res = leaves + res
+        return '\n'.join(res)
+
+    def prsrc_gen3(self, self_name='ad'):
+        # WARNING: this wrapper for the gen3.pradata schema-driven parser compiles the schema on every call!
+        s = yang.compile(src_yang())
+        return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False)
+
+
+mut def from_xml(node: xml.Node) -> yang.gdata.Container:
+    children = {}
+    child_native = yang.gdata.from_xml_opt_cnt(node, 'native', 'http://example.com/base')
+    yang.gdata.maybe_add(children, 'native', from_xml_base__native, child_native)
+    return yang.gdata.Container(children)
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_xml(s, node, loose=False, root_path=root_path)
+
+mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    # path handling
+    if len(path) > 0:
+        point = path[0]
+        rest_path = path[1:]
+        if point == 'base:native':
+            child = {'native': from_json_path_base__native(jd, rest_path, op) }
+            return yang.gdata.Container(child)
+        raise ValueError("Invalid path")
+    elif len(path) == 0:
+        if op == "merge":
+            return from_json(yang.gdata.unwrap_dict(jd))
+        elif op == "remove":
+            return yang.gdata.Absent()
+        raise ValueError("Invalid operation")
+    raise ValueError("Unable to resolve path")
+
+mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
+    children = {}
+    child_native = yang.gdata.take_json_opt_cnt(jd, 'native', 'base')
+    yang.gdata.maybe_add(children, 'native', from_json_base__native, child_native)
+    return yang.gdata.Container(children)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/base',
+    'http://example.com/voice',
+}
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -295,7 +295,7 @@ def src_yang():
             }
         }
     }
-    augment /foo-local:nested/inner/li1 {
+    augment /foo-local:nested/foo-local:inner/foo-local:li1 {
         leaf bar {
             type string;
         }
@@ -4203,7 +4203,7 @@ def src_schema():
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/foo-local:nested/inner/li1', children=[
+        Augment('/foo-local:nested/foo-local:inner/foo-local:li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[
@@ -4354,7 +4354,7 @@ def src_schema_compiled():
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/foo-local:nested/inner/li1', children=[
+        Augment('/foo-local:nested/foo-local:inner/foo-local:li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -295,7 +295,7 @@ def src_yang():
             }
         }
     }
-    augment /foo-local:nested/inner/li1 {
+    augment /foo-local:nested/foo-local:inner/foo-local:li1 {
         leaf bar {
             type string;
         }
@@ -4204,7 +4204,7 @@ def src_schema():
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/foo-local:nested/inner/li1', children=[
+        Augment('/foo-local:nested/foo-local:inner/foo-local:li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[
@@ -4355,7 +4355,7 @@ def src_schema_compiled():
                 Leaf('foo', type_=Type('string'))
             ])
         ]),
-        Augment('/foo-local:nested/inner/li1', children=[
+        Augment('/foo-local:nested/foo-local:inner/foo-local:li1', children=[
             Leaf('bar', type_=Type('string'))
         ])
     ], children=[

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -318,7 +318,7 @@ ys_bar = r"""module bar {
             }
         }
     }
-    augment /foo-local:nested/inner/li1 {
+    augment /foo-local:nested/foo-local:inner/foo-local:li1 {
         leaf bar {
             type string;
         }


### PR DESCRIPTION
When an augment path contains unprefixed segments, they must be resolved in the augmenting module's namespace, not the target node's namespace (RFC 7950 Section 6.5 Schema Node Identiifer).

This "worked" before we modified SchemaNode.get(child_name, child_ns) to implicitly search for a child in the current node namespace, if no explicit namespace for the child was provided.