### PR TITLE
Transform to create explicit Case nodes under Choice

### DIFF
--- a/src/ayangc.act
+++ b/src/ayangc.act
@@ -2,11 +2,13 @@ import argparse
 import file
 import fs
 import time
+import testing
 
 import yang
 import yang.parser
 import yang.schema
 import transform_unions
+import transform_explicit_cases
 
 
 proc def cmd_transform(env, file_cap, args):
@@ -42,6 +44,9 @@ proc def cmd_transform(env, file_cap, args):
                 if transform == "unions":
                     print("Applying transform '{transform}' to {infile}", err=True)
                     transform_unions.rewrite_unions(n)
+                elif transform == "explicit-cases":
+                    print("Applying transform '{transform}' to {infile}", err=True)
+                    transform_explicit_cases.create_explicit_cases(n)
                 else:
                     print("Unknown transform: {transform}", err=True)
                     env.exit(1)
@@ -160,7 +165,7 @@ actor main(env):
     # Transform subcommand
     transform_cmd = p.add_cmd("transform", "apply transforms to a YANG module", _cmd_transform)
     transform_cmd.add_arg("infile", "input YANG file", required=True)
-    transform_cmd.add_arg("transform", "transform(s) to apply (e.g., unions)", required=True, nargs="+")
+    transform_cmd.add_arg("transform", "transform(s) to apply (e.g., unions, explicit-cases)", required=True, nargs="+")
 
     # Compile subcommand
     compile_cmd = p.add_cmd("compile", "compile YANG modules together", _cmd_compile)
@@ -233,4 +238,39 @@ test_yang = r"""module test_ayangc {
 def _test_ayangc_transform_unions():
     n = yang.schema_from_src(test_yang)
     transform_unions.rewrite_unions(n)
+    return n.to_statement().pryang()
+
+def _test_ayangc_transform_explicit_cases():
+    """Test the explicit-cases transform"""
+    test_yang_choice = r"""module test_choice {
+  yang-version "1.1";
+  namespace "http://example.com/test_choice";
+  prefix "test";
+
+  container config {
+    choice protocol {
+      // Direct leaf - should be wrapped
+      leaf http {
+        type empty;
+      }
+
+      // Direct container - should be wrapped
+      container https {
+        leaf port {
+          type uint16;
+        }
+      }
+
+      // Explicit case - should remain
+      case ssh {
+        leaf ssh-port {
+          type uint16;
+        }
+      }
+    }
+  }
+}
+"""
+    n = yang.schema_from_src(test_yang_choice)
+    transform_explicit_cases.create_explicit_cases(n)
     return n.to_statement().pryang()

--- a/src/test_transform_explicit_cases.act
+++ b/src/test_transform_explicit_cases.act
@@ -1,0 +1,77 @@
+from transform_explicit_cases import create_explicit_cases
+import testing
+import yang
+
+def _test_transform_explicit_cases():
+    test_yang = r"""module test_explicit_cases {
+  yang-version "1.1";
+  namespace "http://example.com/test_explicit_cases";
+  prefix "test";
+
+  container main {
+    choice protocol {
+      // Direct leaf - should be wrapped in implicit case
+      leaf http {
+        type empty;
+        description "HTTP protocol";
+      }
+
+      // Direct container - should be wrapped in implicit case
+      container https {
+        description "HTTPS configuration";
+        leaf port {
+          type uint16;
+          default 443;
+        }
+      }
+
+      // Explicit case - should remain as is
+      case ssh {
+        leaf ssh-port {
+          type uint16;
+          default 22;
+        }
+        leaf ssh-user {
+          type string;
+        }
+      }
+
+      // Direct list - should be wrapped in implicit case
+      list servers {
+        key "name";
+        leaf name {
+          type string;
+        }
+        leaf address {
+          type string;
+        }
+      }
+
+      // Direct leaf-list - should be wrapped
+      leaf-list ports {
+        type uint16;
+      }
+
+      // Nested choice as direct child - should be wrapped
+      choice authentication {
+        leaf none {
+          type empty;
+        }
+        case basic {
+          leaf username {
+            type string;
+          }
+          leaf password {
+            type string;
+          }
+        }
+        anydata config-data;
+        anyxml legacy-data;
+      }
+    }
+  }
+}
+"""
+    n = yang.schema_from_src(test_yang)
+    create_explicit_cases(n)
+    return n.to_statement().pryang()

--- a/src/transform_explicit_cases.act
+++ b/src/transform_explicit_cases.act
@@ -1,0 +1,51 @@
+import yang.schema
+
+
+mut def create_explicit_cases(node: yang.schema.SchemaNode) -> None:
+    """Create explicit Case nodes for all direct data node children of Choice nodes.
+
+    In YANG, a choice statement can have either explicit case statements or
+    direct data definition statements (shorthand case). This transform ensures
+    all choice children are wrapped in explicit Case nodes.
+
+    According to RFC 7950, short-case can be:
+    - container
+    - leaf
+    - leaf-list
+    - list
+    - anydata
+    - anyxml
+
+    This modifies the schema in place, wrapping any direct data nodes under
+    Choice nodes with implicit Case nodes. The implicit Case name will be
+    the same as the wrapped node's name.
+    """
+
+    if isinstance(node, yang.schema.Choice):
+        new_children = []
+        for child in node.children:
+            if not isinstance(child, yang.schema.Case):
+                name = child._get_arg()
+                if name is not None:
+                    implicit_case = yang.schema.Case(
+                        name=name,
+                        children=[child],  # The data node becomes child of the case
+                        parent=node,
+                        mod=child.mod,
+                        ns=child.ns,
+                        pfx=child.pfx
+                    )
+                    # Update the child's parent to be the new Case node
+                    child.parent = implicit_case
+                    new_children.append(implicit_case)
+                else:
+                    raise ValueError("Child {child} name is empty")
+            else:
+                new_children.append(child)
+
+        node.children = new_children
+
+    if isinstance(node, yang.schema.SchemaNodeInner):
+        for child in node.children:
+            create_explicit_cases(child)
+

--- a/src/yang.act
+++ b/src/yang.act
@@ -1,6 +1,7 @@
 
 import yang.parser
 import yang.schema
+import transform_explicit_cases
 
 def eq_optional[T(Eq)](a: ?T, b: ?T) -> bool:
     return a is not None and b is not None and a == b or a is None and b is None
@@ -70,6 +71,8 @@ def compile_modules(yang_sources: list[str]) -> list[yang.schema.Module]:
 
     for yang_source in yang_sources:
         yang_module = yang.schema.stmt_to_snode(yang.parser.parse(yang_source))
+        # Normalize schema: wrap standalone data nodes in "choice" with explicit "case"
+        transform_explicit_cases.create_explicit_cases(yang_module)
         if isinstance(yang_module, yang.schema.Module):
             modrev = yang_module.get_modrev()
             modules.add(modrev.modname, modrev.rev, yang_module)

--- a/test/golden/ayangc/ayangc_transform_explicit_cases
+++ b/test/golden/ayangc/ayangc_transform_explicit_cases
@@ -1,0 +1,26 @@
+module test_choice {
+  yang-version "1.1";
+  namespace "http://example.com/test_choice";
+  prefix "test";
+  container config {
+    choice protocol {
+      case http {
+        leaf http {
+          type empty;
+        }
+      }
+      case https {
+        container https {
+          leaf port {
+            type uint16;
+          }
+        }
+      }
+      case ssh {
+        leaf ssh-port {
+          type uint16;
+        }
+      }
+    }
+  }
+}

--- a/test/golden/test_transform_explicit_cases/transform_explicit_cases
+++ b/test/golden/test_transform_explicit_cases/transform_explicit_cases
@@ -1,0 +1,72 @@
+module test_explicit_cases {
+  yang-version "1.1";
+  namespace "http://example.com/test_explicit_cases";
+  prefix "test";
+  container main {
+    choice protocol {
+      case http {
+        leaf http {
+          type empty;
+          description "HTTP protocol";
+        }
+      }
+      case https {
+        container https {
+          description "HTTPS configuration";
+          leaf port {
+            type uint16;
+            default "443";
+          }
+        }
+      }
+      case ssh {
+        leaf ssh-port {
+          type uint16;
+          default "22";
+        }
+        leaf ssh-user {
+          type string;
+        }
+      }
+      case servers {
+        list servers {
+          key name;
+          leaf name {
+            type string;
+          }
+          leaf address {
+            type string;
+          }
+        }
+      }
+      case ports {
+        leaf-list ports {
+          type uint16;
+        }
+      }
+      case authentication {
+        choice authentication {
+          case none {
+            leaf none {
+              type empty;
+            }
+          }
+          case basic {
+            leaf username {
+              type string;
+            }
+            leaf password {
+              type string;
+            }
+          }
+          case config-data {
+            anydata config-data;
+          }
+          case legacy-data {
+            anyxml legacy-data;
+          }
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
Choice statements can contain either explicit case statements or standalone data nodes (shorthand syntax). This transform converts all shorthand cases to explicit cases by wrapping standalone data nodes under Choice in Case nodes with matching names.

This is important for augment statements targeting a case node. Paths must always include the explicit case name. We include the transform unconditionally in the YANG compiler pipeline with the aim of always normalizing the schema.