### PR TITLE
Support NETCONF operations

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -177,6 +177,9 @@ def _ind(n):
     return "  " * n
 
 remove_op = [("xmlns:xc", '"urn:ietf:params:xml:ns:netconf:base:1.0"'), ("xc:operation", '"remove"')]
+create_op = [("xmlns:xc", '"urn:ietf:params:xml:ns:netconf:base:1.0"'), ("xc:operation", '"create"')]
+delete_op = [("xmlns:xc", '"urn:ietf:params:xml:ns:netconf:base:1.0"'), ("xc:operation", '"delete"')]
+replace_op = [("xmlns:xc", '"urn:ietf:params:xml:ns:netconf:base:1.0"'), ("xc:operation", '"replace"')]
 
 def either(a: ?str, b: ?str):
     if a is not None:
@@ -294,6 +297,19 @@ class Node(value):
                     ",\n".join(child_strs),
                     "{_ind(indent)}}}{args_str})"
                 ])
+        elif isinstance(self, Delete):
+            sname = "Delete"
+            if len(self.children) == 0:
+                return "{sname}({", ".join(base_args)})"
+            else:
+                child_strs = ["{_ind(indent+1)}'{nm}': {child.prsrc(deterministic, indent+1, nm)}"
+                             for nm,child in self.children.items()]
+                args_str = ", {", ".join(base_args)}" if len(base_args) > 0 else ""
+                return "\n".join([
+                    sname + r"({",
+                    ",\n".join(child_strs),
+                    "{_ind(indent)}}}{args_str})"
+                ])
         elif isinstance(self, List):
             keys_arg = [str(self.keys)]
             order_args = ["user_order=True"] if self.user_order else []
@@ -314,6 +330,34 @@ class Node(value):
             sname = "Container"
             presence_args = ["presence=True"] if self.presence else []
             args = presence_args + base_args
+            if len(self.children) == 0:
+                return "{sname}({", ".join(args)})"
+            else:
+                child_strs = ["{_ind(indent+1)}'{nm}': {child.prsrc(deterministic, indent+1, nm)}"
+                             for nm,child in self.children.items()]
+                args_str = ", {", ".join(args)}" if len(args) > 0 else ""
+                return "\n".join([
+                    sname + r"({",
+                    ",\n".join(child_strs),
+                    "{_ind(indent)}}}{args_str})"
+                ])
+        elif isinstance(self, Create):
+            sname = "Create"
+            args = base_args
+            if len(self.children) == 0:
+                return "{sname}({", ".join(args)})"
+            else:
+                child_strs = ["{_ind(indent+1)}'{nm}': {child.prsrc(deterministic, indent+1, nm)}"
+                             for nm,child in self.children.items()]
+                args_str = ", {", ".join(args)}" if len(args) > 0 else ""
+                return "\n".join([
+                    sname + r"({",
+                    ",\n".join(child_strs),
+                    "{_ind(indent)}}}{args_str})"
+                ])
+        elif isinstance(self, Replace):
+            sname = "Replace"
+            args = base_args
             if len(self.children) == 0:
                 return "{sname}({", ".join(args)})"
             else:
@@ -386,7 +430,36 @@ class Node(value):
                 return "\n"
             return ""
 
-        if isinstance(self, Container):
+        if isinstance(self, Create):
+            # Render as element with create op
+            child_indent = indent if name == "top" else indent + 1
+            child_xml = ""
+            for nm, child in self.children.items():
+                child_xml += child.to_xmlstr(nm, pretty, child_indent)
+            if name == "top":
+                return child_xml
+            if child_xml == "":
+                return _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=create_op, end=True) + _nl()
+            xml = _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=create_op) + _nl()
+            xml += child_xml
+            xml += _indent() + fmt_tag(name, close=True) + _nl()
+            return xml
+        elif isinstance(self, Replace):
+            child_indent = indent if name == "top" else indent + 1
+            child_xml = ""
+            for nm, child in self.children.items():
+                child_xml += child.to_xmlstr(nm, pretty, child_indent)
+            if name == "top":
+                return child_xml
+            if child_xml == "":
+                return _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=replace_op, end=True) + _nl()
+            xml = _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=replace_op) + _nl()
+            xml += child_xml
+            xml += _indent() + fmt_tag(name, close=True) + _nl()
+            return xml
+        elif isinstance(self, Delete):
+            return _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=delete_op, end=True) + _nl()
+        elif isinstance(self, Container):
             child_indent = indent if name == "top" else indent + 1
             child_cns = None if name == "top" else either(self.ns, cns)
             child_xml = ""
@@ -409,14 +482,26 @@ class Node(value):
         elif isinstance(self, List):
             xml = ""
             for elem in self.elements if self.user_order else sorted_elements(self.elements, self.keys):
-                remove = isinstance(elem, Absent)
-                xml += _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=remove_op if remove else []) + _nl()
+                # Determine NETCONF operation for list element based on node type
+                attrs = []
+                skip_nonkeys = False
+                if isinstance(elem, Absent):
+                    attrs = remove_op
+                    skip_nonkeys = True
+                elif isinstance(elem, Delete):
+                    attrs = delete_op
+                    skip_nonkeys = True
+                elif isinstance(elem, Create):
+                    attrs = create_op
+                elif isinstance(elem, Replace):
+                    attrs = replace_op
+                xml += _indent() + fmt_tag(name, nsq(either(self.ns, cns)), attrs=attrs) + _nl()
                 # Print key leafs first
                 for key_name, key_leaf in elem.key_children(self.keys).items():
                     v = yang_str(key_leaf.val)
                     xml += _indent(1) + fmt_tag(key_name, nsq(v=key_leaf.val)) + v + fmt_tag(key_name, close=True) + _nl()
                 for nm,child in elem.children.items():
-                    if nm in self.keys or remove:
+                    if nm in self.keys or skip_nonkeys:
                         continue
                     xml += child.to_xmlstr(nm, pretty, indent+1)
                 xml += _indent() + fmt_tag(name, close=True) + _nl()
@@ -455,7 +540,7 @@ class Node(value):
         raise ValueError("Cannot find leaf child in {self} with name: {name}")
 
     def get_opt_leaf(self, name) -> ?Leaf:
-        if isinstance(self, Container) or isinstance(self, Absent):
+        if isinstance(self, Container) or isinstance(self, Absent) or isinstance(self, Create) or isinstance(self, Replace) or isinstance(self, Delete):
             for nm,child in self.children.items():
                 if isinstance(child, Leaf) and nm == name:
                     return child
@@ -833,10 +918,10 @@ class Delete(Node):
 
     Unlike Absent / remove, Delete of a non-existent node is a failure.
     """
-    def __init__(self, ns: ?str=None, module: ?str=None):
+    def __init__(self, children: dict[str, Node]={}, ns: ?str=None, module: ?str=None):
         self.ns = ns
         self.module = module
-        self.children = {}
+        self.children = children
         self.txid = None
 
 class Create(Node):

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -15,6 +15,9 @@ from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 
 
+NETCONF_OPS = {"create", "delete", "remove", "replace", "merge"}
+NETCONF_NS = "urn:ietf:params:xml:ns:netconf:base:1.0"
+
 # Map of gdata getter method names to actual methods
 GDATA_TAKERS = {
     # Container getters
@@ -222,6 +225,41 @@ def format_schema_path(path: list[PathElement]) -> str:
             path_str = path_str + "[" + predicates + "]"
     return path_str
 
+
+def get_netconf_operation(node: xml.Node) -> str:
+    """Extract NETCONF operation from an XML node
+    """
+    def ns_uri(prefix: ?str) -> ?str:
+        for p, uri in node.nsdefs:
+            # default namespace is stored with prefix == None
+            if (prefix is None and p is None) or (prefix is not None and p is not None and prefix == p):
+                return uri
+        return None
+
+    for attr_key, attr_val in node.attributes:
+        if attr_key == "operation":
+            # Unprefixed operation; must be in default NETCONF namespace
+            if attr_val in NETCONF_OPS and ns_uri(None) == NETCONF_NS:
+                return attr_val
+        elif attr_key.endswith(":operation"):
+            # Prefixed operation; resolve prefix and validate NETCONF namespace
+            prefix = attr_key.split(":", 1)[0]
+            if attr_val in NETCONF_OPS and ns_uri(prefix) == NETCONF_NS:
+                return attr_val
+
+    return "merge"
+
+
+def _test_get_nc_op_def():
+    xml_in = xml.decode('<cfg xmlns="urn:ietf:params:xml:ns:netconf:base:1.0" operation="delete"/>')
+    op = get_netconf_operation(xml_in)
+    testing.assertEqual(op, "delete")
+
+
+def _test_get_nc_op_pref():
+    xml_in = xml.decode('<cfg xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="replace"/>')
+    op = get_netconf_operation(xml_in)
+    testing.assertEqual(op, "replace")
 
 
 def try_parse_value(text_value: str, schema_type: yang.schema.Type, path: list[PathElement]) -> (t: str, val: value):
@@ -732,8 +770,23 @@ def _from_data[A(YangData)](s: yang.schema.DNodeInner, global_identity: list[yan
                 val = data.take_container(child, child.name, ns, spath)
             if val is not None:
                 if isinstance(val, xml.Node):
-                    maybe = _from_data(child, global_identity, val, loose, set_ns=s.namespace != child.namespace, path=path, root_path=root_path, spath=spath + [PathElement(child)])
-                    children[uname(child)] = maybe
+                    # NETCONF operation on container
+                    cop = get_netconf_operation(val)
+                    cns = child.namespace if set_ns and child.namespace != "" else None
+                    cmod = child.module if set_ns and child.module != "" else None
+                    if cop == "remove":
+                        children[uname(child)] = yang.gdata.Absent(ns=cns, module=cmod)
+                    elif cop == "delete":
+                        children[uname(child)] = yang.gdata.Delete(ns=cns, module=cmod)
+                    elif cop == "create":
+                        inner = _from_data(child, global_identity, val, loose, set_ns=False, path=path, root_path=root_path, spath=spath + [PathElement(child)])
+                        children[uname(child)] = yang.gdata.Create(inner.children, ns=cns, module=cmod)
+                    elif cop == "replace":
+                        inner = _from_data(child, global_identity, val, loose, set_ns=False, path=path, root_path=root_path, spath=spath + [PathElement(child)])
+                        children[uname(child)] = yang.gdata.Replace(inner.children, ns=cns, module=cmod)
+                    else:
+                        maybe = _from_data(child, global_identity, val, loose, set_ns=s.namespace != child.namespace, path=path, root_path=root_path, spath=spath + [PathElement(child)])
+                        children[uname(child)] = maybe
                 elif isinstance(val, dict):
                     maybe = _from_data(child, global_identity, val, loose, set_ns=s.namespace != child.namespace, path=path, root_path=root_path, spath=spath + [PathElement(child)])
                     children[uname(child)] = maybe
@@ -762,8 +815,29 @@ def _from_data[A(YangData)](s: yang.schema.DNodeInner, global_identity: list[yan
                                 kt = key_node.text
                                 if kt is not None:
                                     key_values[key_name] = kt
-                        element_gdata = _from_data(child, global_identity, element_data, loose, set_ns=False, path=path, root_path=root_path, spath=spath + [PathElement(child, key_values)])
-                        list_elements.append(element_gdata)
+                        # Check NETCONF operation on the element
+                        eop = get_netconf_operation(element_data)
+                        if eop in ["remove", "delete"]:
+                                # Build element to extract proper key leaves, then create Absent/Delete with keys
+                                eg = _from_data(child, global_identity, element_data, loose, set_ns=False, path=path, root_path=root_path, spath=spath + [PathElement(child, key_values)])
+                                key_children = {}
+                                for key in child.key:
+                                    kc = eg.children.get(key)
+                                    if kc is not None:
+                                        key_children[key] = kc
+                                if eop == "remove":
+                                    list_elements.append(yang.gdata.Absent(key_children))
+                                else:
+                                    list_elements.append(yang.gdata.Delete(key_children))
+                        elif eop in ["create", "replace"]:
+                            eg = _from_data(child, global_identity, element_data, loose, set_ns=False, path=path, root_path=root_path, spath=spath + [PathElement(child, key_values)])
+                            if eop == "create":
+                                list_elements.append(yang.gdata.Create(eg.children))
+                            else:
+                                list_elements.append(yang.gdata.Replace(eg.children))
+                        else:
+                            element_gdata = _from_data(child, global_identity, element_data, loose, set_ns=False, path=path, root_path=root_path, spath=spath + [PathElement(child, key_values)])
+                            list_elements.append(element_gdata)
                     elif isinstance(element_data, dict):
                         # Extract key values from JSON element
                         key_values: dict[str, value] = {}
@@ -811,6 +885,23 @@ def _from_data[A(YangData)](s: yang.schema.DNodeInner, global_identity: list[yan
         elif isinstance(child, yang.schema.DLeaf):
             typed = None
             if isinstance(data, xml.Node) or isinstance(data, dict):
+                # If XML, inspect NETCONF operation first
+                if isinstance(data, xml.Node):
+                    leaf_node = yang.gdata.get_xml_opt_child(data, child.name, ns)
+                    if leaf_node is not None:
+                        lop = get_netconf_operation(leaf_node)
+                        if lop == "remove":
+                            # Represent removal of the leaf
+                            children[uname(child)] = yang.gdata.Absent()
+                            # Skip normal value parsing
+                            typed = None
+                            # Continue to next child
+                            continue
+                        elif lop == "delete":
+                            children[uname(child)] = yang.gdata.Delete()
+                            typed = None
+                            continue
+                        # create/replace for leaf are treated as normal set; a scalar set replaces any prior value
                 typed = data.take_leaf(child, child.name, ns, spath)
             if typed is not None:
                 # identityref validation
@@ -1212,7 +1303,7 @@ def _test_error_path_json_list_range():
       key "k1";
       leaf k1 { type string; }
       leaf v1 {
-        type uint8 { range "1..10"; }
+        type uint8 { range 1..10; }
       }
     }
   }
@@ -1597,6 +1688,293 @@ def _test_json_path_nested_lists():
         }, ns='urn:example:y1', module='y1')
     })
     testing.assertEqual(gd2.prsrc(), expected2.prsrc())
+
+def _test_netconf_remove_container():
+    """NETCONF remove on a container produces Absent"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    presence "p";
+    leaf l1 { type string; }
+  }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="remove"/>
+</data>"""
+
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_remove_list_element():
+    """NETCONF remove on a list element produces Absent with key children"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    list l2 {
+      key "k1";
+      leaf k1 { type string; }
+      leaf v1 { type string; }
+    }
+  }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l2 xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="remove">
+    <k1>Key 1</k1>
+  </l2>
+</c1>
+</data>"""
+
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_remove_leaf():
+    """NETCONF remove on a leaf produces Absent"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    leaf l1 { type string; }
+  }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l1 xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="remove"/>
+</c1>
+</data>"""
+
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_replace_leaf_sets_value():
+    """NETCONF replace on a leaf is treated as a normal set"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    leaf l1 { type string; }
+  }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l1 xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="replace">VAL</l1>
+</c1>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_remove_mixed():
+    """Mixed normal and remove elements in the same list"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  list l {
+    key "k";
+    leaf k { type string; }
+    leaf v { type string; }
+  }
+}"""
+
+    xml_in = r"""<data>
+<l xmlns="urn:example:y">
+  <k>A</k>
+  <v>keep</v>
+</l>
+<l xmlns="urn:example:y" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="remove">
+  <k>B</k>
+</l>
+</data>
+"""
+
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_create_list_element():
+    """NETCONF create on a list element renders operation and content"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    list l2 {
+      key "k1";
+      leaf k1 { type string; }
+      leaf v1 { type string; }
+    }
+  }
+}"""
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l2 xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="create">
+    <k1>X</k1>
+    <v1>Y</v1>
+  </l2>
+</c1>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_replace_list_element():
+    """NETCONF replace on a list element renders operation and content"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    list l2 {
+      key "k1";
+      leaf k1 { type string; }
+      leaf v1 { type string; }
+    }
+  }
+}"""
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l2 xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="replace">
+    <k1>Z</k1>
+    <v1>W</v1>
+  </l2>
+</c1>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_delete_list_element():
+    """NETCONF delete on a list element renders operation with keys only"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    list l2 {
+      key "k1";
+      leaf k1 { type string; }
+      leaf v1 { type string; }
+    }
+  }
+}"""
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l2 xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="delete">
+    <k1>DEL</k1>
+  </l2>
+</c1>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_union_int_json():
+    """Union(int8 range 1..10 | string): textual int within range resolves as int"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  leaf u {
+    type union {
+      type int8 { range 1..10; }
+      type string;
+    }
+  }
+}"""
+    s = yang.compile([y])
+    jd = {"y:u": "7"}
+    gd = from_json(s, jd)
+    return gd.prsrc()
+
+def _test_union_str_json():
+    """Union(int8 range 1..10 | string): textual int out of range resolves as string"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  leaf u {
+    type union {
+      type int8 { range 1..10; }
+      type string;
+    }
+  }
+}"""
+    s = yang.compile([y])
+    jd = {"y:u": "100"}
+    gd = from_json(s, jd)
+    return gd.prsrc()
+
+def _test_union_str_xml():
+    """Union(int8 range 1..10 | string): XML numeric text out of range resolves as string"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  leaf u {
+    type union {
+      type int8 { range 1..10; }
+      type string;
+    }
+  }
+}"""
+    xml_in = r"""<data>
+<u xmlns="urn:example:y">100</u>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_create_container():
+    """NETCONF create on a container produces Create wrapper and serializes op"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 { leaf l1 { type string; } }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="create">
+  <l1>v</l1>
+</c1>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_replace_container():
+    """NETCONF replace on a container produces Replace wrapper and serializes op"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 { leaf l1 { type string; } }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="replace">
+  <l1>nv</l1>
+</c1>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
+
+def _test_netconf_delete_container():
+    """NETCONF delete on a container produces Delete wrapper and serializes op"""
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 { leaf l1 { type string; } }
+}"""
+
+    xml_in = r"""<data>
+<c1 xmlns="urn:example:y" xmlns:nc="urn:ietf:params:xml:ns:netconf:base:1.0" nc:operation="delete"/>
+</data>"""
+    s = yang.compile([y])
+    gd = from_xml(s, xml.decode(xml_in))
+    return gd.prsrc()
 
     # Test remove operation on nested list element
     gd3 = from_json_path(s, {}, ["y1:c1", "outer", "key1", "inner", "key2"], "remove")

--- a/src/yang/test_data.act
+++ b/src/yang/test_data.act
@@ -1,0 +1,84 @@
+import testing
+import xml
+
+import yang
+import yang.gen3
+import yang.gdata
+
+
+def _unwrap_node(n: ?yang.gdata.Node) -> yang.gdata.Node:
+    if n is not None:
+        return n
+    raise ValueError("Expected non-empty node")
+
+
+def _test_remove_list_roundtrip():
+    """Remove (Absent) on list element: A → diff → ops-XML → ops-gdata → patch(A) == B.
+
+    - Parse XML A and B into gdata using the same schema
+    - Compute diff(A,B) which produces an Absent element for the removed key
+    - Serialize diff to NETCONF op-XML and parse it back to gdata; ensure equality
+    - Apply parsed ops to A; ensure patched equals B
+    - Serialize patched to XML and parse back; ensure it equals B as well
+    """
+
+    y = r"""module y {
+  namespace "urn:example:y";
+  prefix y;
+  container c1 {
+    list l2 {
+      key "k1";
+      leaf k1 { type string; }
+      leaf v1 { type string; }
+    }
+  }
+}"""
+
+    # XML A: two list elements (A, B)
+    xml_a = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l2>
+    <k1>A</k1>
+    <v1>keep</v1>
+  </l2>
+  <l2>
+    <k1>B</k1>
+    <v1>gone</v1>
+  </l2>
+  </c1>
+</data>"""
+
+    # XML B: only element A remains (B is removed)
+    xml_b = r"""<data>
+<c1 xmlns="urn:example:y">
+  <l2>
+    <k1>A</k1>
+    <v1>keep</v1>
+  </l2>
+</c1>
+</data>"""
+
+    s = yang.compile([y])
+
+    gd_a = yang.gen3.from_xml(s, xml.decode(xml_a))
+    gd_b = yang.gen3.from_xml(s, xml.decode(xml_b))
+
+    # Compute diff: expect Absent list element for key B
+    d = _unwrap_node(yang.gdata.diff(gd_a, gd_b))
+
+    # Serialize diff to XML (NETCONF ops), then parse back
+    xml_ops = d.to_xmlstr(name="data")
+    gd_ops = yang.gen3.from_xml(s, xml.decode(xml_ops))
+
+    # Check idempotent roundtrip of operations, gdata -> XML -> gdata
+    testing.assertEqual(d.prsrc(deterministic=True), gd_ops.prsrc(deterministic=True))
+
+    # Verify that applying the parsed ops to A yields B
+    patched = yang.gdata.patch(gd_a, gd_ops)
+    pnode = _unwrap_node(patched)
+    testing.assertEqual(pnode.prsrc(deterministic=True), gd_b.prsrc(deterministic=True))
+
+    # Also check that XML serialization of the patched state parses back to B
+    xml_patched = pnode.to_xmlstr(name="data")
+    gd_from_xml_patched = yang.gen3.from_xml(s, xml.decode(xml_patched))
+    testing.assertEqual(gd_from_xml_patched.prsrc(deterministic=True), gd_b.prsrc(deterministic=True))

--- a/test/golden/yang.gen3/netconf_create_container
+++ b/test/golden/yang.gen3/netconf_create_container
@@ -1,0 +1,5 @@
+Container({
+  'c1': Create({
+    'l1': Leaf('string', 'v')
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_create_list_element
+++ b/test/golden/yang.gen3/netconf_create_list_element
@@ -1,0 +1,10 @@
+Container({
+  'c1': Container({
+    'l2': List(['k1'], elements=[
+      Create({
+        'k1': Leaf('string', 'X'),
+        'v1': Leaf('string', 'Y')
+      })
+    ])
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_delete_container
+++ b/test/golden/yang.gen3/netconf_delete_container
@@ -1,0 +1,3 @@
+Container({
+  'c1': Delete(ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_delete_list_element
+++ b/test/golden/yang.gen3/netconf_delete_list_element
@@ -1,0 +1,9 @@
+Container({
+  'c1': Container({
+    'l2': List(['k1'], elements=[
+      Delete({
+        'k1': Leaf('string', 'DEL')
+      })
+    ])
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_remove_container
+++ b/test/golden/yang.gen3/netconf_remove_container
@@ -1,0 +1,3 @@
+Container({
+  'c1': Absent(ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_remove_leaf
+++ b/test/golden/yang.gen3/netconf_remove_leaf
@@ -1,0 +1,5 @@
+Container({
+  'c1': Container({
+    'l1': Absent()
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_remove_list_element
+++ b/test/golden/yang.gen3/netconf_remove_list_element
@@ -1,0 +1,9 @@
+Container({
+  'c1': Container({
+    'l2': List(['k1'], elements=[
+      Absent({
+        'k1': Leaf('string', 'Key 1')
+      })
+    ])
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_remove_mixed
+++ b/test/golden/yang.gen3/netconf_remove_mixed
@@ -1,0 +1,11 @@
+Container({
+  'l': List(['k'], ns='urn:example:y', module='y', elements=[
+    Container({
+      'k': Leaf('string', 'A'),
+      'v': Leaf('string', 'keep')
+    }),
+    Absent({
+      'k': Leaf('string', 'B')
+    })
+  ])
+})

--- a/test/golden/yang.gen3/netconf_replace_container
+++ b/test/golden/yang.gen3/netconf_replace_container
@@ -1,0 +1,5 @@
+Container({
+  'c1': Replace({
+    'l1': Leaf('string', 'nv')
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_replace_leaf_sets_value
+++ b/test/golden/yang.gen3/netconf_replace_leaf_sets_value
@@ -1,0 +1,5 @@
+Container({
+  'c1': Container({
+    'l1': Leaf('string', 'VAL')
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/netconf_replace_list_element
+++ b/test/golden/yang.gen3/netconf_replace_list_element
@@ -1,0 +1,10 @@
+Container({
+  'c1': Container({
+    'l2': List(['k1'], elements=[
+      Replace({
+        'k1': Leaf('string', 'Z'),
+        'v1': Leaf('string', 'W')
+      })
+    ])
+  }, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/union_int_json
+++ b/test/golden/yang.gen3/union_int_json
@@ -1,0 +1,3 @@
+Container({
+  'u': Leaf('union', 7, ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/union_str_json
+++ b/test/golden/yang.gen3/union_str_json
@@ -1,0 +1,3 @@
+Container({
+  'u': Leaf('union', '100', ns='urn:example:y', module='y')
+})

--- a/test/golden/yang.gen3/union_str_xml
+++ b/test/golden/yang.gen3/union_str_xml
@@ -1,0 +1,3 @@
+Container({
+  'u': Leaf('union', '100', ns='urn:example:y', module='y')
+})


### PR DESCRIPTION
NETCONF supports operations on all data nodes to remove, replace, merge or create. We now parse those and represent using Absent and the other similar operation nodes in gdata. prsrc() has been extended to be able to print them all.

Also add a new test_data module which focuses on a bit more complex validation of data. It's a single test for now but it goes through multiple steps with round-trips etc to verify things work correctly.