### PR TITLE
Early return to avoid too many strings

### DIFF
--- a/gen/schema-footer.act
+++ b/gen/schema-footer.act
@@ -7,6 +7,9 @@ def _remap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
     """
     if old_prefix == new_prefix:
         return path
+    # elif path.find("{old_prefix}:") == -1:    # This creates a new B_str though ...
+    elif path.find(old_prefix) == -1:
+        return path
 
     # Split path into segments
     segments = path.split("/")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -9490,6 +9490,9 @@ def _remap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
     """
     if old_prefix == new_prefix:
         return path
+    # elif path.find("{old_prefix}:") == -1:    # This creates a new B_str though ...
+    elif path.find(old_prefix) == -1:
+        return path
 
     # Split path into segments
     segments = path.split("/")


### PR DESCRIPTION
The yang.schema._remap_path_prefix function examines every path that appears in the schema (augment, must, when, leafref, ...). We return early if the path doesn't include the old prefix, in order to avoid path.split("/") allocating too many strings that we discard in most cases.

base:
```
 Tests - module test_yang_compile:
  cisco_xrd_24_1_1:                     OK:    1 runs in 163486.594ms
  cisco_xe_17_15_03a:                   OK:    1 runs in 67338.220ms
  juniper_crpd_24_4R1_9:                OK:    1 runs in 28475.934ms
  nokia_sr_linux_25_3_2:                OK:    1 runs in 21170.118ms
  notconf:                              OK:    1 runs in 640.536ms
  notconf_cisco_xr_2411:                OK:    1 runs in 168278.676ms
  notconf_juniper_crpd_24_4R1_9_local:  OK:    1 runs in 29617.329ms

All 7 tests passed (288.882s)
```

opt:
```
Tests - module test_yang_compile:
  cisco_xrd_24_1_1:                     OK:    1 runs in 139716.841ms
  cisco_xe_17_15_03a:                   OK:    1 runs in 63816.415ms
  juniper_crpd_24_4R1_9:                OK:    1 runs in 28767.374ms
  nokia_sr_linux_25_3_2:                OK:    1 runs in 12922.418ms
  notconf:                              OK:    1 runs in 615.627ms
  notconf_cisco_xr_2411:                OK:    1 runs in 143184.199ms
  notconf_juniper_crpd_24_4R1_9_local:  OK:    1 runs in 30203.817ms

All 7 tests passed (252.306s)
```