### PR TITLE
Use str.contains() instead of str.find()

### DIFF
--- a/gen/schema-footer.act
+++ b/gen/schema-footer.act
@@ -7,8 +7,7 @@ def _remap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
     """
     if old_prefix == new_prefix:
         return path
-    # elif path.find("{old_prefix}:") == -1:    # This creates a new B_str though ...
-    elif path.find(old_prefix) == -1:
+    elif old_prefix not in path:
         return path
 
     # Split path into segments

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1833,7 +1833,7 @@ class DRpc(DNodeInner):
 # -------------------------------------------------------------------------------
 
 def split_prefix_name(name: str) -> (?str, str):
-    if name.find(":") != -1:
+    if ":" in name:
         parts = name.split(":", 1)
         return (parts[0], parts[1])
     return None, name

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1829,7 +1829,7 @@ class DRpc(DNodeInner):
 # -------------------------------------------------------------------------------
 
 def split_prefix_name(name: str) -> (?str, str):
-    if name.find(":") != -1:
+    if ":" in name:
         parts = name.split(":", 1)
         return (parts[0], parts[1])
     return None, name
@@ -9490,8 +9490,7 @@ def _remap_path_prefix(path: str, old_prefix: str, new_prefix: str) -> str:
     """
     if old_prefix == new_prefix:
         return path
-    # elif path.find("{old_prefix}:") == -1:    # This creates a new B_str though ...
-    elif path.find(old_prefix) == -1:
+    elif old_prefix not in path:
         return path
 
     # Split path into segments


### PR DESCRIPTION
str.contains() returns a bool, which is internally a statically allocated singleton. In contrast to str.find() that (as of right now) returns a newly allocated instance of an int if the position is >255 or <0 (not found), this has no GC penalty.