### PR TITLE
Optimize gdata.Node.to_dict for list elements

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -403,11 +403,7 @@ class Node(value):
                     elems = []
                     for elem in child.elements if child.user_order else sorted_elements(child.elements, child.keys):
                         if isinstance(elem, Container):
-                            elem_dict = {}
-                            for key_name, key_leaf in elem.key_children(child.keys).items():
-                                elem_dict[fmt_json_name(key_name)] = json_val(key_leaf.t, key_leaf.val)
-                            elem_dict.update(elem.to_dict(pretty).items())
-                            elems.append(elem_dict)
+                            elems.append(elem.to_dict(pretty))
                         else:
                             raise ValueError("Unexpected list ({nm}) element type: {type(elem)}")
                     child_dict[fmt_json_name(nm, child.module)] = elems


### PR DESCRIPTION
Unlike XML, there is no ordering requirement for the child nodes of a list entry in JSON - all child nodes are placed in an unordered collection.