### PR TITLE
Skip absent nodes in gdata.Node.to_dict()

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -407,6 +407,8 @@ class Node(value):
                         else:
                             raise ValueError("Unexpected list ({nm}) element type: {type(elem)}")
                     child_dict[fmt_json_name(nm, child.module)] = elems
+                elif isinstance(child, Absent):
+                    continue
                 else:
                     raise ValueError("Unsupported child ({nm}) node type in to_dict: {type(child)}")
             return child_dict


### PR DESCRIPTION
We have no way of representing a delete operation in dict -> JSON.