### PR TITLE
Produce valid XML in gdata.Node.to_xmlstr()

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -408,7 +408,7 @@ class Node(value):
             return child_dict
         raise ValueError("Unsupported node type in to_dict: {type(self)}")
 
-    def to_xmlstr(self, name="", pretty=True, indent=0) -> str:
+    def to_xmlstr(self, name="", pretty=True, indent=1) -> str:
         def _indent(extra=0):
             if pretty:
                 return "  " * (indent+extra)
@@ -419,6 +419,9 @@ class Node(value):
                 return "\n"
             return ""
 
+        def _top(c):
+            return "<data>" + _nl() + c + "</data>"
+
         if isinstance(self, Create):
             # Render as element with create op
             child_indent = indent if name == "" else indent + 1
@@ -426,7 +429,7 @@ class Node(value):
             for nm, child in self.children.items():
                 child_xml += child.to_xmlstr(nm, pretty, child_indent)
             if name == "":
-                return child_xml
+                return _top(child_xml)
             if child_xml == "":
                 return _indent() + fmt_tag(name, nsq(self.ns), attrs=create_op, end=True) + _nl()
             xml = _indent() + fmt_tag(name, nsq(self.ns), attrs=create_op) + _nl()
@@ -439,7 +442,7 @@ class Node(value):
             for nm, child in self.children.items():
                 child_xml += child.to_xmlstr(nm, pretty, child_indent)
             if name == "":
-                return child_xml
+                return _top(child_xml)
             if child_xml == "":
                 return _indent() + fmt_tag(name, nsq(self.ns), attrs=replace_op, end=True) + _nl()
             xml = _indent() + fmt_tag(name, nsq(self.ns), attrs=replace_op) + _nl()
@@ -447,14 +450,17 @@ class Node(value):
             xml += _indent() + fmt_tag(name, close=True) + _nl()
             return xml
         elif isinstance(self, Delete):
-            return _indent() + fmt_tag(name, nsq(self.ns), attrs=delete_op, end=True) + _nl()
+            xml = _indent() + fmt_tag(name, nsq(self.ns), attrs=delete_op, end=True) + _nl()
+            if name == "":
+                return _top(xml)
+            return xml
         elif isinstance(self, Container):
             child_indent = indent if name == "" else indent + 1
             child_xml = ""
             for nm, child in self.children.items():
                 child_xml += child.to_xmlstr(nm, pretty, child_indent)
             if name == "":
-                return child_xml
+                return _top(child_xml)
 
             if child_xml == "":
                 if self.presence:
@@ -493,6 +499,8 @@ class Node(value):
                         continue
                     xml += child.to_xmlstr(nm, pretty, indent+1)
                 xml += _indent() + fmt_tag(name, close=True) + _nl()
+            if name == "":
+                return _top(xml)
             return xml
         elif isinstance(self, Leaf):
             xml = _indent()

--- a/test/golden/yang.gdata/to_xmlstr
+++ b/test/golden/yang.gdata/to_xmlstr
@@ -1,21 +1,23 @@
-<foo xmlns="http://example.com/acme">
-  <a>1</a>
-  <l1>
-    <name>k1</name>
-    <name_two>k1a</name_two>
-    <n1>1</n1>
-    <n2>2</n2>
-  </l1>
-  <l1>
-    <name>k4</name>
-    <name_two>k4a</name_two>
-    <n4>4</n4>
-  </l1>
-  <b>false</b>
-  <lb>SGVsbG8gQWN0b24g8J+roQ==</lb>
-  <llb>SGVsbG8gQWN0b24g8J+roQ==</llb>
-  <c>18446744073709551615</c>
-</foo>
-<foo xmlns="http://example.com/beep">
-  <a>1</a>
-</foo>
+<data>
+  <foo xmlns="http://example.com/acme">
+    <a>1</a>
+    <l1>
+      <name>k1</name>
+      <name_two>k1a</name_two>
+      <n1>1</n1>
+      <n2>2</n2>
+    </l1>
+    <l1>
+      <name>k4</name>
+      <name_two>k4a</name_two>
+      <n4>4</n4>
+    </l1>
+    <b>false</b>
+    <lb>SGVsbG8gQWN0b24g8J+roQ==</lb>
+    <llb>SGVsbG8gQWN0b24g8J+roQ==</llb>
+    <c>18446744073709551615</c>
+  </foo>
+  <foo xmlns="http://example.com/beep">
+    <a>1</a>
+  </foo>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_empty_leaf
+++ b/test/golden/yang.gdata/to_xmlstr_empty_leaf
@@ -1,2 +1,4 @@
-<e1/>
-<e2 xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="remove"/>
+<data>
+  <e1/>
+  <e2 xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="remove"/>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_identityref
+++ b/test/golden/yang.gdata/to_xmlstr_identityref
@@ -1,3 +1,5 @@
-<identity-local xmlns:acme="http://example.com/acme">acme:foo</identity-local>
-<identity-other xmlns:bar="http://example.com/bar">bar:bar</identity-other>
-<augmented-identity-other xmlns="http://example.com/augmentor" xmlns:bar="http://example.com/bar">bar:bar</augmented-identity-other>
+<data>
+  <identity-local xmlns:acme="http://example.com/acme">acme:foo</identity-local>
+  <identity-other xmlns:bar="http://example.com/bar">bar:bar</identity-other>
+  <augmented-identity-other xmlns="http://example.com/augmentor" xmlns:bar="http://example.com/bar">bar:bar</augmented-identity-other>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_leaf_ns
+++ b/test/golden/yang.gdata/to_xmlstr_leaf_ns
@@ -1,4 +1,6 @@
-<foo xmlns="http://example.com/acme">
-  <a xmlns="http://example.com/foo">1</a>
-  <b>2</b>
-</foo>
+<data>
+  <foo xmlns="http://example.com/acme">
+    <a xmlns="http://example.com/foo">1</a>
+    <b>2</b>
+  </foo>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_mixed
+++ b/test/golden/yang.gdata/to_xmlstr_mixed
@@ -1,16 +1,18 @@
-<device xmlns="http://orchestron.org/yang/orchestron-device.yang">
-  <name>dev1</name>
-  <config>
-    <hostname xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg">
-      <system-network-name>dev1</system-network-name>
-    </hostname>
-  </config>
-</device>
-<device xmlns="http://orchestron.org/yang/orchestron-device.yang">
-  <name>dev2</name>
-  <config>
-    <hostname xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg">
-      <system-network-name>dev2</system-network-name>
-    </hostname>
-  </config>
-</device>
+<data>
+  <device xmlns="http://orchestron.org/yang/orchestron-device.yang">
+    <name>dev1</name>
+    <config>
+      <hostname xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg">
+        <system-network-name>dev1</system-network-name>
+      </hostname>
+    </config>
+  </device>
+  <device xmlns="http://orchestron.org/yang/orchestron-device.yang">
+    <name>dev2</name>
+    <config>
+      <hostname xmlns="http://cisco.com/ns/yang/Cisco-IOS-XR-um-hostname-cfg">
+        <system-network-name>dev2</system-network-name>
+      </hostname>
+    </config>
+  </device>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_module
+++ b/test/golden/yang.gdata/to_xmlstr_module
@@ -1,6 +1,8 @@
-<foo xmlns="http://example.com/acme">
-  <a>1</a>
-  <b>a</b>
-  <b>b</b>
-  <b>c</b>
-</foo>
+<data>
+  <foo xmlns="http://example.com/acme">
+    <a>1</a>
+    <b>a</b>
+    <b>b</b>
+    <b>c</b>
+  </foo>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_presence
+++ b/test/golden/yang.gdata/to_xmlstr_presence
@@ -1,3 +1,5 @@
-<foo xmlns="http://example.com/acme">
-  <a>1</a>
-</foo>
+<data>
+  <foo xmlns="http://example.com/acme">
+    <a>1</a>
+  </foo>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_presence_childless
+++ b/test/golden/yang.gdata/to_xmlstr_presence_childless
@@ -1,1 +1,3 @@
-<foo xmlns="http://example.com/acme"/>
+<data>
+  <foo xmlns="http://example.com/acme"/>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_root
+++ b/test/golden/yang.gdata/to_xmlstr_root
@@ -1,6 +1,8 @@
-<foo xmlns="http://example.com/acme">
-  <a>1</a>
-  <b>a</b>
-  <b>b</b>
-  <b>c</b>
-</foo>
+<data>
+  <foo xmlns="http://example.com/acme">
+    <a>1</a>
+    <b>a</b>
+    <b>b</b>
+    <b>c</b>
+  </foo>
+</data>

--- a/test/golden/yang.gdata/to_xmlstr_root_merge
+++ b/test/golden/yang.gdata/to_xmlstr_root_merge
@@ -1,9 +1,11 @@
-<foo xmlns="http://example.com/acme">
-  <a>1</a>
-  <b>a</b>
-  <b>b</b>
-  <b>c</b>
-</foo>
-<bar xmlns="http://example.com/bar">
-  <b>42</b>
-</bar>
+<data>
+  <foo xmlns="http://example.com/acme">
+    <a>1</a>
+    <b>a</b>
+    <b>b</b>
+    <b>c</b>
+  </foo>
+  <bar xmlns="http://example.com/bar">
+    <b>42</b>
+  </bar>
+</data>

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -78,91 +78,91 @@ def _test_mandatory2():
 # }
 
 xml_text_full = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l1>foo-foo</l1>
-  <l3>18446744073709551615</l3>
-  <l_empty/>
-  <li>
-    <name>tuta</name>
-    <val>baba</val>
-  </li>
-  <ll_uint64>4</ll_uint64>
-  <ll_uint64>42</ll_uint64>
-  <ll_str>kava</ll_str>
-  <ll_str>čaj</ll_str>
-  <l_identityref xmlns:foo="http://example.com/foo">foo:fooy</l_identityref>
-  <ll_identityref xmlns:bar="http://example.com/bar">bar:bary</ll_identityref>
-  <l4>foo-qux</l4>
-  <l1 xmlns="http://example.com/bar">foo-bar</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
-<pc1 xmlns="http://example.com/foo">
-  <foo>
-    <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
-  </foo>
-</pc1>
-<pc2 xmlns="http://example.com/foo">
-  <foo>
-    <l_mandatory>baz</l_mandatory>
-  </foo>
-</pc2>
-<pc3 xmlns="http://example.com/foo">
-  <level1>
-    <l1>l1-foo</l1>
-    <l1-optional>l1-optional</l1-optional>
-    <level2>
-      <l2>l2-bar</l2>
-      <l2-optional>l2-optional</l2-optional>
-      <level3>
-        <l3>l3-baz</l3>
-        <l3-optional>l3-optional</l3-optional>
-      </level3>
-    </level2>
-  </level1>
-</pc3>
-<c.dot xmlns="http://example.com/foo">
-  <l.dot1>who put that here?!</l.dot1>
-</c.dot>
-<cc xmlns="http://example.com/foo">
-  <cake>cake</cake>
-</cc>
-<conflict xmlns="http://example.com/foo">
-  <foo>foo-foo</foo>
-  <inner/>
-  <foo xmlns="http://example.com/bar">foo-augmented-from-bar</foo>
-  <inner xmlns="http://example.com/bar"/>
-</conflict>
-<special xmlns="http://example.com/foo">
-  <yes>false</yes>
-</special>
-<special xmlns="http://example.com/foo">
-  <yes>true</yes>
-</special>
-<li-union xmlns="http://example.com/foo">
-  <k1>first</k1>
-  <k2>4</k2>
-  <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
-</li-union>
-<li-union xmlns="http://example.com/foo">
-  <k1>second</k1>
-  <k2>unlimited</k2>
-  <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
-</li-union>
-<li-union xmlns="http://example.com/foo">
-  <k1>third</k1>
-  <k2>aGk=</k2>
-  <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
-</li-union>
-<c2 xmlns="http://example.com/foo">
-  <l1>foo-qux</l1>
-</c2>
-<test-idref xmlns="http://example.com/bar">
-  <idref xmlns:bar="http://example.com/bar">bar:bary</idref>
-  <idref xmlns:foo="http://example.com/foo">foo:fooy</idref>
-</test-idref>
-<conflict xmlns="http://example.com/bar">
-  <foo>foo-bar</foo>
-</conflict>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo-foo</l1>
+    <l3>18446744073709551615</l3>
+    <l_empty/>
+    <li>
+      <name>tuta</name>
+      <val>baba</val>
+    </li>
+    <ll_uint64>4</ll_uint64>
+    <ll_uint64>42</ll_uint64>
+    <ll_str>kava</ll_str>
+    <ll_str>čaj</ll_str>
+    <l_identityref xmlns:foo="http://example.com/foo">foo:fooy</l_identityref>
+    <ll_identityref xmlns:bar="http://example.com/bar">bar:bary</ll_identityref>
+    <l4>foo-qux</l4>
+    <l1 xmlns="http://example.com/bar">foo-bar</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
+  <pc1 xmlns="http://example.com/foo">
+    <foo>
+      <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
+    </foo>
+  </pc1>
+  <pc2 xmlns="http://example.com/foo">
+    <foo>
+      <l_mandatory>baz</l_mandatory>
+    </foo>
+  </pc2>
+  <pc3 xmlns="http://example.com/foo">
+    <level1>
+      <l1>l1-foo</l1>
+      <l1-optional>l1-optional</l1-optional>
+      <level2>
+        <l2>l2-bar</l2>
+        <l2-optional>l2-optional</l2-optional>
+        <level3>
+          <l3>l3-baz</l3>
+          <l3-optional>l3-optional</l3-optional>
+        </level3>
+      </level2>
+    </level1>
+  </pc3>
+  <c.dot xmlns="http://example.com/foo">
+    <l.dot1>who put that here?!</l.dot1>
+  </c.dot>
+  <cc xmlns="http://example.com/foo">
+    <cake>cake</cake>
+  </cc>
+  <conflict xmlns="http://example.com/foo">
+    <foo>foo-foo</foo>
+    <inner/>
+    <foo xmlns="http://example.com/bar">foo-augmented-from-bar</foo>
+    <inner xmlns="http://example.com/bar"/>
+  </conflict>
+  <special xmlns="http://example.com/foo">
+    <yes>false</yes>
+  </special>
+  <special xmlns="http://example.com/foo">
+    <yes>true</yes>
+  </special>
+  <li-union xmlns="http://example.com/foo">
+    <k1>first</k1>
+    <k2>4</k2>
+    <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
+  </li-union>
+  <li-union xmlns="http://example.com/foo">
+    <k1>second</k1>
+    <k2>unlimited</k2>
+    <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
+  </li-union>
+  <li-union xmlns="http://example.com/foo">
+    <k1>third</k1>
+    <k2>aGk=</k2>
+    <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
+  </li-union>
+  <c2 xmlns="http://example.com/foo">
+    <l1>foo-qux</l1>
+  </c2>
+  <test-idref xmlns="http://example.com/bar">
+    <idref xmlns:bar="http://example.com/bar">bar:bary</idref>
+    <idref xmlns:foo="http://example.com/foo">foo:fooy</idref>
+  </test-idref>
+  <conflict xmlns="http://example.com/bar">
+    <foo>foo-bar</foo>
+  </conflict>
 </data>"""
 
 def _test_foo_from_xml_full():
@@ -199,7 +199,7 @@ def _test_foo_from_xml_full():
 
     # Prove roundtrip XML -> gdata -> XML is idempotent
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
     # Return golden gdata
     return gd2.prsrc()
@@ -265,22 +265,22 @@ def adata():
 def _test_foo_from_xml1():
     """"""
     xml_text = """<data>
-<pc1 xmlns="http://example.com/foo">
-  <foo>
-    <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
-  </foo>
-</pc1>
+  <pc1 xmlns="http://example.com/foo">
+    <foo>
+      <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
+    </foo>
+  </pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_foo_from_xml_pc1():
     """"""
     xml_text = """<data>
-<pc1 xmlns="http://example.com/foo"></pc1>
+  <pc1 xmlns="http://example.com/foo"></pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
@@ -295,13 +295,13 @@ def _test_foo_from_xml_pc1():
     if pc1 is None:
         testing.error("pc1 not found in adata")
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_foo_from_xml_pc2():
     """"""
     xml_text = """<data>
-<pc2 xmlns="http://example.com/foo"></pc2>
+  <pc2 xmlns="http://example.com/foo"></pc2>
 </data>"""
     xml_in = xml.decode(xml_text)
     try:
@@ -313,9 +313,9 @@ def _test_foo_from_xml_pc2():
 def _test_foo_from_xml2():
     """"""
     xml_text = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-</c1>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+  </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
@@ -329,20 +329,20 @@ def _test_foo_from_xml2():
     if pc1 is not None:
         testing.error("pc1 found in adata")
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_foo_from_xml_leaf_ns():
     xml_text = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 
@@ -356,7 +356,7 @@ def _test_foo_from_xml_named_ns():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 
@@ -370,7 +370,7 @@ def _test_foo_from_xml_dots():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 
@@ -427,9 +427,9 @@ def _test_foo_from_xml_li_union():
 def _test_foo_from_xml_empty_leaf():
     """"""
     xml_text = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l_empty/>
-</c1>
+  <c1 xmlns="http://example.com/foo">
+    <l_empty/>
+  </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
@@ -439,7 +439,8 @@ def _test_foo_from_xml_empty_leaf():
     if l_empty is not None:
         testing.assertTrue(l_empty)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
+    print(xml_out.encode())
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_list_create_idempotency():
@@ -586,7 +587,7 @@ def _test_empty_presence():
     ad = yang_foo_root.from_gdata(gd2)
     testing.assertNotNone(ad.empty_presence)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     # testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 

--- a/test/test_data_classes/src/test_data_classes_gen2.act
+++ b/test/test_data_classes/src/test_data_classes_gen2.act
@@ -89,91 +89,91 @@ def _test_mandatory2():
 # }
 
 xml_text_full = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l1>foo-foo</l1>
-  <l3>18446744073709551615</l3>
-  <l_empty/>
-  <li>
-    <name>tuta</name>
-    <val>baba</val>
-  </li>
-  <ll_uint64>4</ll_uint64>
-  <ll_uint64>42</ll_uint64>
-  <ll_str>kava</ll_str>
-  <ll_str>čaj</ll_str>
-  <l_identityref xmlns:foo="http://example.com/foo">foo:fooy</l_identityref>
-  <ll_identityref xmlns:bar="http://example.com/bar">bar:bary</ll_identityref>
-  <l4>foo-qux</l4>
-  <l1 xmlns="http://example.com/bar">foo-bar</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
-<pc1 xmlns="http://example.com/foo">
-  <foo>
-    <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
-  </foo>
-</pc1>
-<pc2 xmlns="http://example.com/foo">
-  <foo>
-    <l_mandatory>baz</l_mandatory>
-  </foo>
-</pc2>
-<pc3 xmlns="http://example.com/foo">
-  <level1>
-    <l1>l1-foo</l1>
-    <l1-optional>l1-optional</l1-optional>
-    <level2>
-      <l2>l2-bar</l2>
-      <l2-optional>l2-optional</l2-optional>
-      <level3>
-        <l3>l3-baz</l3>
-        <l3-optional>l3-optional</l3-optional>
-      </level3>
-    </level2>
-  </level1>
-</pc3>
-<c.dot xmlns="http://example.com/foo">
-  <l.dot1>who put that here?!</l.dot1>
-</c.dot>
-<cc xmlns="http://example.com/foo">
-  <cake>cake</cake>
-</cc>
-<conflict xmlns="http://example.com/foo">
-  <foo>foo-foo</foo>
-  <inner/>
-  <foo xmlns="http://example.com/bar">foo-augmented-from-bar</foo>
-  <inner xmlns="http://example.com/bar"/>
-</conflict>
-<special xmlns="http://example.com/foo">
-  <yes>false</yes>
-</special>
-<special xmlns="http://example.com/foo">
-  <yes>true</yes>
-</special>
-<li-union xmlns="http://example.com/foo">
-  <k1>first</k1>
-  <k2>4</k2>
-  <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
-</li-union>
-<li-union xmlns="http://example.com/foo">
-  <k1>second</k1>
-  <k2>unlimited</k2>
-  <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
-</li-union>
-<li-union xmlns="http://example.com/foo">
-  <k1>third</k1>
-  <k2>aGk=</k2>
-  <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
-</li-union>
-<c2 xmlns="http://example.com/foo">
-  <l1>foo-qux</l1>
-</c2>
-<test-idref xmlns="http://example.com/bar">
-  <idref xmlns:bar="http://example.com/bar">bar:bary</idref>
-  <idref xmlns:foo="http://example.com/foo">foo:fooy</idref>
-</test-idref>
-<conflict xmlns="http://example.com/bar">
-  <foo>foo-bar</foo>
-</conflict>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo-foo</l1>
+    <l3>18446744073709551615</l3>
+    <l_empty/>
+    <li>
+      <name>tuta</name>
+      <val>baba</val>
+    </li>
+    <ll_uint64>4</ll_uint64>
+    <ll_uint64>42</ll_uint64>
+    <ll_str>kava</ll_str>
+    <ll_str>čaj</ll_str>
+    <l_identityref xmlns:foo="http://example.com/foo">foo:fooy</l_identityref>
+    <ll_identityref xmlns:bar="http://example.com/bar">bar:bary</ll_identityref>
+    <l4>foo-qux</l4>
+    <l1 xmlns="http://example.com/bar">foo-bar</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
+  <pc1 xmlns="http://example.com/foo">
+    <foo>
+      <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
+    </foo>
+  </pc1>
+  <pc2 xmlns="http://example.com/foo">
+    <foo>
+      <l_mandatory>baz</l_mandatory>
+    </foo>
+  </pc2>
+  <pc3 xmlns="http://example.com/foo">
+    <level1>
+      <l1>l1-foo</l1>
+      <l1-optional>l1-optional</l1-optional>
+      <level2>
+        <l2>l2-bar</l2>
+        <l2-optional>l2-optional</l2-optional>
+        <level3>
+          <l3>l3-baz</l3>
+          <l3-optional>l3-optional</l3-optional>
+        </level3>
+      </level2>
+    </level1>
+  </pc3>
+  <c.dot xmlns="http://example.com/foo">
+    <l.dot1>who put that here?!</l.dot1>
+  </c.dot>
+  <cc xmlns="http://example.com/foo">
+    <cake>cake</cake>
+  </cc>
+  <conflict xmlns="http://example.com/foo">
+    <foo>foo-foo</foo>
+    <inner/>
+    <foo xmlns="http://example.com/bar">foo-augmented-from-bar</foo>
+    <inner xmlns="http://example.com/bar"/>
+  </conflict>
+  <special xmlns="http://example.com/foo">
+    <yes>false</yes>
+  </special>
+  <special xmlns="http://example.com/foo">
+    <yes>true</yes>
+  </special>
+  <li-union xmlns="http://example.com/foo">
+    <k1>first</k1>
+    <k2>4</k2>
+    <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
+  </li-union>
+  <li-union xmlns="http://example.com/foo">
+    <k1>second</k1>
+    <k2>unlimited</k2>
+    <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
+  </li-union>
+  <li-union xmlns="http://example.com/foo">
+    <k1>third</k1>
+    <k2>aGk=</k2>
+    <k3>SGVsbG8gQWN0b24g8J+roQ==</k3>
+  </li-union>
+  <c2 xmlns="http://example.com/foo">
+    <l1>foo-qux</l1>
+  </c2>
+  <test-idref xmlns="http://example.com/bar">
+    <idref xmlns:bar="http://example.com/bar">bar:bary</idref>
+    <idref xmlns:foo="http://example.com/foo">foo:fooy</idref>
+  </test-idref>
+  <conflict xmlns="http://example.com/bar">
+    <foo>foo-bar</foo>
+  </conflict>
 </data>"""
 
 def _test_foo_from_xml_full():
@@ -210,7 +210,7 @@ def _test_foo_from_xml_full():
 
     # Prove roundtrip XML -> gdata -> XML is idempotent
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
     # Return golden gdata
     return gd2.prsrc()
@@ -272,22 +272,22 @@ def adata():
 def _test_foo_from_xml1():
     """"""
     xml_text = """<data>
-<pc1 xmlns="http://example.com/foo">
-  <foo>
-    <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
-  </foo>
-</pc1>
+  <pc1 xmlns="http://example.com/foo">
+    <foo>
+      <l1>SGVsbG8gQWN0b24g8J+roQ==</l1>
+    </foo>
+  </pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_foo_from_xml_pc1():
     """"""
     xml_text = """<data>
-<pc1 xmlns="http://example.com/foo"></pc1>
+  <pc1 xmlns="http://example.com/foo"></pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
@@ -302,7 +302,7 @@ def _test_foo_from_xml_pc1():
     if pc1 is None:
         testing.error("pc1 not found in adata")
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_foo_from_xml_pc2():
@@ -326,9 +326,9 @@ def _test_foo_from_xml_pc2():
 def _test_foo_from_xml2():
     """"""
     xml_text = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-</c1>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+  </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
@@ -342,7 +342,7 @@ def _test_foo_from_xml2():
     if pc1 is not None:
         testing.error("pc1 found in adata")
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_foo_from_xml_leaf_ns():
@@ -355,7 +355,7 @@ def _test_foo_from_xml_leaf_ns():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 
@@ -369,7 +369,7 @@ def _test_foo_from_xml_named_ns():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 
@@ -383,7 +383,7 @@ def _test_foo_from_xml_dots():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 
@@ -434,9 +434,9 @@ def _test_foo_from_xml_li_union():
 def _test_foo_from_xml_empty_leaf():
     """"""
     xml_text = """<data>
-<c1 xmlns="http://example.com/foo">
-  <l_empty/>
-</c1>
+  <c1 xmlns="http://example.com/foo">
+    <l_empty/>
+  </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
@@ -446,7 +446,7 @@ def _test_foo_from_xml_empty_leaf():
     if l_empty is not None:
         testing.assertTrue(l_empty)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     testing.assertEqual(xml_in.encode(), xml_out.encode())
 
 def _test_list_create_idempotency():
@@ -593,7 +593,7 @@ def _test_empty_presence():
     ad = yang_foo_root.from_gdata(gd2)
     testing.assertNotNone(ad.empty_presence)
     xml_out_text = gd2.to_xmlstr()
-    xml_out = xml.decode("<data>\n{xml_out_text}</data>")
+    xml_out = xml.decode(xml_out_text)
     # testing.assertEqual(xml_in.encode(), xml_out.encode())
     return xml_out_text
 

--- a/test/test_data_classes/test/golden/test_data_classes/empty_false
+++ b/test/test_data_classes/test/golden/test_data_classes/empty_false
@@ -1,3 +1,5 @@
-<c1 xmlns="http://example.com/foo">
-  <l_empty xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="remove"/>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l_empty xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="remove"/>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/empty_presence
+++ b/test/test_data_classes/test/golden/test_data_classes/empty_presence
@@ -1,1 +1,3 @@
-<empty-presence xmlns="http://example.com/foo"/>
+<data>
+  <empty-presence xmlns="http://example.com/foo"/>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/empty_true
+++ b/test/test_data_classes/test/golden/test_data_classes/empty_true
@@ -1,3 +1,5 @@
-<c1 xmlns="http://example.com/foo">
-  <l_empty/>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l_empty/>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_dots
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_dots
@@ -1,4 +1,6 @@
-<c.dot xmlns="http://example.com/foo">
-  <l.dot1>foo</l.dot1>
-  <l.dot2 xmlns="http://example.com/bar">bar</l.dot2>
-</c.dot>
+<data>
+  <c.dot xmlns="http://example.com/foo">
+    <l.dot1>foo</l.dot1>
+    <l.dot2 xmlns="http://example.com/bar">bar</l.dot2>
+  </c.dot>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_leaf_ns
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_leaf_ns
@@ -1,4 +1,6 @@
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_named_ns
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_named_ns
@@ -1,4 +1,6 @@
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/from_json
+++ b/test/test_data_classes/test/golden/test_data_classes/from_json
@@ -1,3 +1,5 @@
-<tc1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-</tc1>
+<data>
+  <tc1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+  </tc1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes/list_create_idempotency
+++ b/test/test_data_classes/test/golden/test_data_classes/list_create_idempotency
@@ -1,6 +1,8 @@
-<c1 xmlns="http://example.com/foo">
-  <li>
-    <name>a</name>
-    <val>2</val>
-  </li>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <li>
+      <name>a</name>
+      <val>2</val>
+    </li>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/empty_false
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/empty_false
@@ -1,3 +1,5 @@
-<c1 xmlns="http://example.com/foo">
-  <l_empty xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="remove"/>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l_empty xmlns:xc="urn:ietf:params:xml:ns:netconf:base:1.0" xc:operation="remove"/>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/empty_presence
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/empty_presence
@@ -1,1 +1,3 @@
-<empty-presence xmlns="http://example.com/foo"/>
+<data>
+  <empty-presence xmlns="http://example.com/foo"/>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/empty_true
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/empty_true
@@ -1,3 +1,5 @@
-<c1 xmlns="http://example.com/foo">
-  <l_empty/>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l_empty/>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_dots
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_dots
@@ -1,4 +1,6 @@
-<c.dot xmlns="http://example.com/foo">
-  <l.dot1>foo</l.dot1>
-  <l.dot2 xmlns="http://example.com/bar">bar</l.dot2>
-</c.dot>
+<data>
+  <c.dot xmlns="http://example.com/foo">
+    <l.dot1>foo</l.dot1>
+    <l.dot2 xmlns="http://example.com/bar">bar</l.dot2>
+  </c.dot>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_leaf_ns
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_leaf_ns
@@ -1,4 +1,6 @@
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_named_ns
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_named_ns
@@ -1,4 +1,6 @@
-<c1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-  <l2 xmlns="http://example.com/bar">bar</l2>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+    <l2 xmlns="http://example.com/bar">bar</l2>
+  </c1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/from_json
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/from_json
@@ -1,3 +1,5 @@
-<tc1 xmlns="http://example.com/foo">
-  <l1>foo</l1>
-</tc1>
+<data>
+  <tc1 xmlns="http://example.com/foo">
+    <l1>foo</l1>
+  </tc1>
+</data>

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/list_create_idempotency
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/list_create_idempotency
@@ -1,6 +1,8 @@
-<c1 xmlns="http://example.com/foo">
-  <li>
-    <name>a</name>
-    <val>2</val>
-  </li>
-</c1>
+<data>
+  <c1 xmlns="http://example.com/foo">
+    <li>
+      <name>a</name>
+      <val>2</val>
+    </li>
+  </c1>
+</data>

--- a/test/test_data_source_roundtrip/src/test_data_source_roundtrip.act
+++ b/test/test_data_source_roundtrip/src/test_data_source_roundtrip.act
@@ -14,8 +14,7 @@ import xml_full_adata_loose
 
 def _test_xml_full():
     xml_out_full = xml_full_gdata.xml_full.to_xmlstr()
-    xml_out_full_wrapped = "<data>\n{xml_out_full}</data>"
-    testing.assertEqual(test_data_classes.xml_text_full, xml_out_full_wrapped)
+    testing.assertEqual(test_data_classes.xml_text_full, xml_out_full)
 
 def _test_gdata_full():
     xml_in = xml.decode(test_data_classes.xml_text_full)
@@ -25,14 +24,12 @@ def _test_gdata_full():
 def _test_adata_full():
     ad = xml_full_adata.adata()
     xml_out_adata = ad.to_gdata().to_xmlstr()
-    xml_out_adata_wrapped = "<data>\n{xml_out_adata}</data>"
-    testing.assertEqual(test_data_classes.xml_text_full, xml_out_adata_wrapped)
+    testing.assertEqual(test_data_classes.xml_text_full, xml_out_adata)
 
 def _test_adata_full_loose():
     ad = xml_full_adata_loose.adata()
     xml_out_adata = ad.to_gdata().to_xmlstr()
-    xml_out_adata_wrapped = "<data>\n{xml_out_adata}</data>"
-    testing.assertEqual(test_data_classes.xml_text_full, xml_out_adata_wrapped)
+    testing.assertEqual(test_data_classes.xml_text_full, xml_out_adata)
 
 actor _test_adata_loose_diff(t: testing.EnvT):
     """Golden test for tracking diff between .prsrc() output for "strict" and "loose" adata.


### PR DESCRIPTION
A valid XML document only has a single top-level node. We now always include a synthetic `<data>` wrapper node on the root level. With that we no longer have to do the same wrapping whenever we use  `xml.decode()` to decode the output. And it also aligns the output with the planned replacement function `to_xml() -> xml.Node`.