### PR TITLE
Include error path in gdata merge, diff, patch

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1930,7 +1930,7 @@ def take_json_opt_strs(jd: dict[str, ?value], name: str, module: ?str=None) -> ?
             elem = child[0]
             if isinstance(elem, str):
                 return child
-            raise ValueError("{name}is a list of wrong type, should be str, not {str(type(elem))}")
+            raise ValueError("{name}is a list of wrong type, should be str, not {type(elem)}")
         raise ValueError(name + "is not a list of strings")
     return None
 
@@ -1969,7 +1969,7 @@ def take_json_opt_ints(jd: dict[str, ?value], name: str, module: ?str=None) -> ?
                 if isinstance(c, int):
                     int_vals.append(c)
                 else:
-                    raise ValueError("{name}is a list of wrong type, should be int, not {str(type(elem))}")
+                    raise ValueError("{name}is a list of wrong type, should be int, not {type(elem)}")
             return int_vals
         raise ValueError(name + "is not a list of ints")
     return None
@@ -2006,7 +2006,7 @@ def take_json_opt_int64s(jd: dict[str, ?value], name: str, module: ?str=None) ->
                 if isinstance(c, str):
                     int_vals.append(int(c))
                 else:
-                    raise ValueError("{name}is a list of wrong type, should be str, not {str(type(elem))}")
+                    raise ValueError("{name}is a list of wrong type, should be str, not {type(elem)}")
             return int_vals
         raise ValueError(name + "is not a list of 64-bit numbers")
     return None
@@ -2079,7 +2079,7 @@ def take_json_opt_bytess(jd: dict[str, ?value], name: str, module: ?str=None) ->
                 if isinstance(c, str):
                     decoded.append(base64.decode(c.encode()))
                 else:
-                    raise ValueError("{name}is a list of wrong type, should be base64 encoded strings, not {str(type(c))}")
+                    raise ValueError("{name}is a list of wrong type, should be base64 encoded strings, not {type(c)}")
             return decoded
         raise ValueError(name + "is not a list of bytes")
     return None
@@ -2101,7 +2101,7 @@ def take_json_opt_floats(jd: dict[str, ?value], name: str, module: ?str=None) ->
                 if isinstance(c, float):
                     float_vals.append(c)
                 else:
-                    raise ValueError("{name}is a list of wrong type, should be float, not {str(type(c))}")
+                    raise ValueError("{name}is a list of wrong type, should be float, not {type(c)}")
             return float_vals
         raise ValueError(name + "is not a list of floats")
     return None
@@ -2123,7 +2123,7 @@ def take_json_opt_bools(jd: dict[str, ?value], name: str, module: ?str=None) -> 
                 if isinstance(c, bool):
                     bool_vals.append(c)
                 else:
-                    raise ValueError("{name}is a list of wrong type, should be bool, not {str(type(c))}")
+                    raise ValueError("{name}is a list of wrong type, should be bool, not {type(c)}")
             return bool_vals
         raise ValueError(name + "is not a list of bools")
     return None
@@ -2179,7 +2179,7 @@ def take_json_opt_Identityrefs(jd: dict[str, ?value], name: str, module: ?str=No
                 if isinstance(c, str):
                     result.append(Identityref.from_json(c))
                 else:
-                    raise ValueError("{name} is a list of wrong type, should be str for identityref, not {str(type(c))}")
+                    raise ValueError("{name} is a list of wrong type, should be str for identityref, not {type(c)}")
             return result
         raise ValueError(name + " is not a list of identityrefs")
     return None


### PR DESCRIPTION
Exceptions now include a path to the error node(s) in the message. Closes #292 