### PR TITLE
Include "range" in reserved keywords

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2866,7 +2866,7 @@ def _attr_name(name: str):
         i += 1
         if i == len(name):
             break
-    if res in {"extension", "import", "type"}:
+    if res in {"extension", "import", "range", "type"}:
         res = res + "_"
 
     return res

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2862,7 +2862,7 @@ def _attr_name(name: str):
         i += 1
         if i == len(name):
             break
-    if res in {"extension", "import", "type"}:
+    if res in {"extension", "import", "range", "type"}:
         res = res + "_"
 
     return res

--- a/test/golden/test_yang/prsrc_leaf_type_uint
+++ b/test/golden/test_yang/prsrc_leaf_type_uint
@@ -1,1 +1,1 @@
-Leaf('foo', type_=Type('uint32', range=Range('1..10')))
+Leaf('foo', type_=Type('uint32', range_=Range('1..10')))


### PR DESCRIPTION
In rfcgen.act we already use the "range_" name for the Type class attribute, now we do the same when printing with SchemaNode.prsrc().