### PR TITLE
Use repr(arg) to print arguments in .prsrc()

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2005,7 +2005,7 @@ class SchemaNode(object):
         res = []
         self_arg = self._get_arg()
         if self_arg is not None:
-            args = ["'{self_arg}'"]
+            args = [repr(self_arg)]
         else:
             args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -256,12 +256,11 @@ class Node(value):
         base_args = ns_args + module_args
 
         if isinstance(self, Leaf):
-            val = "'{self.val}'" if isinstance(self.val, str) else str(self.val)
-            args = ["'{str(self.t)}'", val] + base_args
+            args = ["'{str(self.t)}'", repr(self.val)] + base_args
             return "Leaf({", ".join(args)})"
         elif isinstance(self, LeafList):
             # Only sort if deterministic=True and not user_order
-            vals_str = str(self.vals if (self.user_order or not deterministic) else vals_list_sorted(self.vals))
+            vals_str = repr(self.vals if (self.user_order or not deterministic) else vals_list_sorted(self.vals))
             order_args = ["user_order=True"] if self.user_order else []
             args = ["'{str(self.t)}'", vals_str] + base_args + order_args
             return "LeafList({", ".join(args)})"

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2001,7 +2001,7 @@ class SchemaNode(object):
         res = []
         self_arg = self._get_arg()
         if self_arg is not None:
-            args = ["'{self_arg}'"]
+            args = [repr(self_arg)]
         else:
             args = []
         attrs_text = _prsrc_attrs(indent, self.get_attrs())


### PR DESCRIPTION
Rely on repr() to escape characters that need escaping, like quotes or braces. Part of #102