### PR TITLE
Print module globals in DRoot.prdaclass

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -364,7 +364,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -455,7 +455,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -464,44 +464,6 @@ class DNodeInner(DNode):
         if self.namespace != "":
             schema_ns.add(self.namespace)
         res = []
-        if top:
-            res.append("import base64")
-            res.append("import json")
-            res.append("import xml")
-            res.append("import yang")
-            res.append("import yang.adata")
-            res.append("import yang.gdata")
-            res.append("import yang.gen3")
-            res.append("from yang.identity import complete_and_validate_identityref")
-            res.append("from yang.identityref import Identityref, PartialIdentityref")
-            res.append("from yang.schema import DIdentity")
-            res.append("")
-            res.append("# == This file is generated ==")
-            res.append("")
-            res.append("")
-            if isinstance(self, DRoot) and len(self.identities) > 0:
-                res.extend(DIdentity.format_identity_list(self.identities))
-                res.append("")
-                res.append("")
-                res.extend(DIdentity.format_identityref_constants(self.identities))
-                res.append("")
-                res.append("")
-            if schema_yang is not None:
-# TODO: serialize list[str] of YANG models with repr(), use raw string to avoid interpolation?!
-# TODO: Why is the src_yang() function not found in from_xml, if it is
-# defined at the bottom of the module?!
-# After these two are addressed, then we can do away with these hacky workarounds
-#
-#"""def src_yang():
-#   return {repr(self.src)}
-#"""
-                res.append("def src_yang():")
-                res.append("    res = []")
-                for s in schema_yang:
-                    res.append('    res.append(r"""{s}""")')
-                res.append("    return res")
-                res.append("")
-                res.append("")
 
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
@@ -549,7 +511,7 @@ class DNodeInner(DNode):
             return ", user_order=True" if n.ordered_by == "user" else ""
 
         for child in self.children:
-            res.append(child._prdaclass_rec(path_with_child(child), schema_yang=schema_yang, loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -1103,13 +1065,6 @@ class DNodeInner(DNode):
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
-        if gen_xml and isinstance(self, DRoot):
-            res.append("def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.from_data(s, node, loose={loose}, root_path=root_path)")
-            res.append("")
-
         # == JSON serde ================================
 
         # from_json(): from JSON -> gdata
@@ -1252,17 +1207,6 @@ class DNodeInner(DNode):
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
-        if gen_json and isinstance(self, DRoot):
-            res.append("def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.from_data(s, jd, loose={loose}, root_path=root_path)")
-            res.append("")
-            res.append("def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.from_json_path(s, jd, path, op, loose={loose})")
-            res.append("")
-
         if isinstance(self, DRoot) and len(self.rpcs) > 0:
             # First generate data classes for RPC input/output
             for rpc in self.rpcs:
@@ -1270,8 +1214,8 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src = child._prdaclass_rec(spath + [rpc, child], schema_yang=schema_yang, loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
-                    res.append(child_class_src)
+                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
+                    res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
@@ -1325,19 +1269,7 @@ class DNodeInner(DNode):
             res.append("")
             res.append("")
 
-        if top:
-            res.append("schema_namespaces: set[str] = {{")
-            for ns in sorted(schema_ns):
-                res.append("    '{ns}',")
-            res.append("}}")
-            res.append("")
-            res.append("def prsrc_gen3(data, self_name='ad'):")
-            res.append("    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.pradata(s, data, self_name, loose={loose})")
-            res.append("")
-
-        return "\n".join(res)
+        return res
 
 class DNodeLeaf(DNode):
     if_feature: list[str]
@@ -1466,8 +1398,8 @@ class DIdentity(DNode):
 
         Returns a list of strings to be added to the result
         """
-        if not identities:
-            return ["_identities = []"]
+        if len(identities) == 0:
+            return ["_identities: list[DIdentity] = []", "", ""]
 
         result = []
 
@@ -1512,6 +1444,8 @@ class DIdentity(DNode):
                 base_refs = [base_var_map[base.key()] for base in identity.base]
                 result.append("    DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base=[{', '.join(base_refs)}]),")
         result.append("]")
+        result.append("")
+        result.append("")
 
         return result
 
@@ -1531,6 +1465,8 @@ class DIdentity(DNode):
             # Create variable name by replacing hyphens with underscores
             var_name = "{identity.module}_{identity.name}".replace("-", "_")
             result.append("{var_name} = Identityref({repr(identity.name)}, ns={repr(identity.namespace)}, mod={repr(identity.module)}, pfx={repr(identity.prefix)})")
+        result.append("")
+        result.append("")
 
         return result
 
@@ -1662,11 +1598,11 @@ class DLeaf(DNodeLeaf):
                     return True
         return False
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> list[str]:
         if self.namespace != "":
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
-            return ""
+            return []
         def pname(n):
             return get_path_name(n)
         # Include namespace qualifier(s) iff our namespace is different than our parent
@@ -1683,7 +1619,7 @@ class DLeaf(DNodeLeaf):
             else:
                 res.append("    return yang.gdata.Leaf('{self.type_.name}', val{gdata_nsq})")
             res.append("")
-        return "\n".join(res)
+        return res
 
 
 class DLeafList(DNodeLeaf):
@@ -1715,11 +1651,11 @@ class DLeafList(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> list[str]:
         if self.namespace != "":
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
-            return ""
+            return []
         def pname(n):
             return get_path_name(n)
         maybe_user_order = ", user_order=True" if self.ordered_by == "user" else ""
@@ -1741,7 +1677,7 @@ class DLeafList(DNodeLeaf):
             else:
                 res.append("    return yang.gdata.LeafList('{self.type_.name}', val{maybe_user_order}{gdata_nsq})")
             res.append("")
-        return "\n".join(res)
+        return res
 
 
 class DNotification(DNodeInner):
@@ -1880,8 +1816,73 @@ class DRoot(DNodeInner):
             child = spath[-1].get(local_name, module=module, allow_unqualified=False)
             return build_spath(spath + [child])
 
+        res = []
+        res.append("import base64")
+        res.append("import json")
+        res.append("import xml")
+        res.append("import yang")
+        res.append("import yang.adata")
+        res.append("import yang.gdata")
+        res.append("import yang.gen3")
+        res.append("from yang.identity import complete_and_validate_identityref")
+        res.append("from yang.identityref import Identityref, PartialIdentityref")
+        res.append("from yang.schema import DIdentity")
+        res.append("")
+        res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
+        res.extend(DIdentity.format_identity_list(self.identities))
+        res.extend(DIdentity.format_identityref_constants(self.identities))
+        if schema_yang is not None:
+# TODO: serialize list[str] of YANG models with repr(), use raw string to avoid interpolation?!
+# TODO: Why is the src_yang() function not found in from_xml, if it is
+# defined at the bottom of the module?!
+# After these two are addressed, then we can do away with these hacky workarounds
+#
+#"""def src_yang():
+#   return {repr(self.src)}
+#"""
+            res.append("def src_yang():")
+            res.append("    res = []")
+            for s in schema_yang:
+                res.append('    res.append(r"""{s}""")')
+            res.append("    return res")
+            res.append("")
+            res.append("")
+
         spath = build_spath([self])
-        return spath[-1]._prdaclass_rec(spath, schema_yang, loose, top=top, set_ns=True, schema_ns=set(), gen_json=gen_json, gen_xml=gen_xml, include_state=include_state)
+        schema_ns = set()
+        res.extend(spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+
+        if gen_xml:
+            res.append("def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:")
+            res.append("    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.from_data(s, node, loose={loose}, root_path=root_path)")
+            res.append("")
+        if gen_json:
+            res.append("def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:")
+            res.append("    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.from_data(s, jd, loose={loose}, root_path=root_path)")
+            res.append("")
+            res.append("def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.from_json_path(s, jd, path, op, loose={loose})")
+            res.append("")
+        res.append("def prsrc_gen3(data, self_name='ad'):")
+        res.append("    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!")
+        res.append("    s = yang.compile(src_yang())")
+        res.append("    return yang.gen3.pradata(s, data, self_name, loose={loose})")
+        res.append("")
+
+        res.append("schema_namespaces: set[str] = {{")
+        for ns in sorted(schema_ns):
+            res.append("    '{ns}',")
+        res.append("}}")
+        res.append("")
+
+        return "\n".join(res)
 
 
 class DRpc(DNodeInner):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -360,7 +360,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -451,7 +451,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -460,44 +460,6 @@ class DNodeInner(DNode):
         if self.namespace != "":
             schema_ns.add(self.namespace)
         res = []
-        if top:
-            res.append("import base64")
-            res.append("import json")
-            res.append("import xml")
-            res.append("import yang")
-            res.append("import yang.adata")
-            res.append("import yang.gdata")
-            res.append("import yang.gen3")
-            res.append("from yang.identity import complete_and_validate_identityref")
-            res.append("from yang.identityref import Identityref, PartialIdentityref")
-            res.append("from yang.schema import DIdentity")
-            res.append("")
-            res.append("# == This file is generated ==")
-            res.append("")
-            res.append("")
-            if isinstance(self, DRoot) and len(self.identities) > 0:
-                res.extend(DIdentity.format_identity_list(self.identities))
-                res.append("")
-                res.append("")
-                res.extend(DIdentity.format_identityref_constants(self.identities))
-                res.append("")
-                res.append("")
-            if schema_yang is not None:
-# TODO: serialize list[str] of YANG models with repr(), use raw string to avoid interpolation?!
-# TODO: Why is the src_yang() function not found in from_xml, if it is
-# defined at the bottom of the module?!
-# After these two are addressed, then we can do away with these hacky workarounds
-#
-#"""def src_yang():
-#   return {repr(self.src)}
-#"""
-                res.append("def src_yang():")
-                res.append("    res = []")
-                for s in schema_yang:
-                    res.append('    res.append(r"""{s}""")')
-                res.append("    return res")
-                res.append("")
-                res.append("")
 
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
@@ -545,7 +507,7 @@ class DNodeInner(DNode):
             return ", user_order=True" if n.ordered_by == "user" else ""
 
         for child in self.children:
-            res.append(child._prdaclass_rec(path_with_child(child), schema_yang=schema_yang, loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -1099,13 +1061,6 @@ class DNodeInner(DNode):
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
-        if gen_xml and isinstance(self, DRoot):
-            res.append("def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.from_data(s, node, loose={loose}, root_path=root_path)")
-            res.append("")
-
         # == JSON serde ================================
 
         # from_json(): from JSON -> gdata
@@ -1248,17 +1203,6 @@ class DNodeInner(DNode):
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
-        if gen_json and isinstance(self, DRoot):
-            res.append("def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.from_data(s, jd, loose={loose}, root_path=root_path)")
-            res.append("")
-            res.append("def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.from_json_path(s, jd, path, op, loose={loose})")
-            res.append("")
-
         if isinstance(self, DRoot) and len(self.rpcs) > 0:
             # First generate data classes for RPC input/output
             for rpc in self.rpcs:
@@ -1266,8 +1210,8 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src = child._prdaclass_rec(spath + [rpc, child], schema_yang=schema_yang, loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
-                    res.append(child_class_src)
+                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
+                    res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
@@ -1321,19 +1265,7 @@ class DNodeInner(DNode):
             res.append("")
             res.append("")
 
-        if top:
-            res.append("schema_namespaces: set[str] = {{")
-            for ns in sorted(schema_ns):
-                res.append("    '{ns}',")
-            res.append("}}")
-            res.append("")
-            res.append("def prsrc_gen3(data, self_name='ad'):")
-            res.append("    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!")
-            res.append("    s = yang.compile(src_yang())")
-            res.append("    return yang.gen3.pradata(s, data, self_name, loose={loose})")
-            res.append("")
-
-        return "\n".join(res)
+        return res
 
 class DNodeLeaf(DNode):
     if_feature: list[str]
@@ -1462,8 +1394,8 @@ class DIdentity(DNode):
 
         Returns a list of strings to be added to the result
         """
-        if not identities:
-            return ["_identities = []"]
+        if len(identities) == 0:
+            return ["_identities: list[DIdentity] = []", "", ""]
 
         result = []
 
@@ -1508,6 +1440,8 @@ class DIdentity(DNode):
                 base_refs = [base_var_map[base.key()] for base in identity.base]
                 result.append("    DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base=[{', '.join(base_refs)}]),")
         result.append("]")
+        result.append("")
+        result.append("")
 
         return result
 
@@ -1527,6 +1461,8 @@ class DIdentity(DNode):
             # Create variable name by replacing hyphens with underscores
             var_name = "{identity.module}_{identity.name}".replace("-", "_")
             result.append("{var_name} = Identityref({repr(identity.name)}, ns={repr(identity.namespace)}, mod={repr(identity.module)}, pfx={repr(identity.prefix)})")
+        result.append("")
+        result.append("")
 
         return result
 
@@ -1658,11 +1594,11 @@ class DLeaf(DNodeLeaf):
                     return True
         return False
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> list[str]:
         if self.namespace != "":
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
-            return ""
+            return []
         def pname(n):
             return get_path_name(n)
         # Include namespace qualifier(s) iff our namespace is different than our parent
@@ -1679,7 +1615,7 @@ class DLeaf(DNodeLeaf):
             else:
                 res.append("    return yang.gdata.Leaf('{self.type_.name}', val{gdata_nsq})")
             res.append("")
-        return "\n".join(res)
+        return res
 
 
 class DLeafList(DNodeLeaf):
@@ -1711,11 +1647,11 @@ class DLeafList(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def _prdaclass_rec(self, spath: list[DNode], schema_yang: ?list[str]=None, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> str:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> list[str]:
         if self.namespace != "":
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
-            return ""
+            return []
         def pname(n):
             return get_path_name(n)
         maybe_user_order = ", user_order=True" if self.ordered_by == "user" else ""
@@ -1737,7 +1673,7 @@ class DLeafList(DNodeLeaf):
             else:
                 res.append("    return yang.gdata.LeafList('{self.type_.name}', val{maybe_user_order}{gdata_nsq})")
             res.append("")
-        return "\n".join(res)
+        return res
 
 
 class DNotification(DNodeInner):
@@ -1876,8 +1812,73 @@ class DRoot(DNodeInner):
             child = spath[-1].get(local_name, module=module, allow_unqualified=False)
             return build_spath(spath + [child])
 
+        res = []
+        res.append("import base64")
+        res.append("import json")
+        res.append("import xml")
+        res.append("import yang")
+        res.append("import yang.adata")
+        res.append("import yang.gdata")
+        res.append("import yang.gen3")
+        res.append("from yang.identity import complete_and_validate_identityref")
+        res.append("from yang.identityref import Identityref, PartialIdentityref")
+        res.append("from yang.schema import DIdentity")
+        res.append("")
+        res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
+        res.extend(DIdentity.format_identity_list(self.identities))
+        res.extend(DIdentity.format_identityref_constants(self.identities))
+        if schema_yang is not None:
+# TODO: serialize list[str] of YANG models with repr(), use raw string to avoid interpolation?!
+# TODO: Why is the src_yang() function not found in from_xml, if it is
+# defined at the bottom of the module?!
+# After these two are addressed, then we can do away with these hacky workarounds
+#
+#"""def src_yang():
+#   return {repr(self.src)}
+#"""
+            res.append("def src_yang():")
+            res.append("    res = []")
+            for s in schema_yang:
+                res.append('    res.append(r"""{s}""")')
+            res.append("    return res")
+            res.append("")
+            res.append("")
+
         spath = build_spath([self])
-        return spath[-1]._prdaclass_rec(spath, schema_yang, loose, top=top, set_ns=True, schema_ns=set(), gen_json=gen_json, gen_xml=gen_xml, include_state=include_state)
+        schema_ns = set()
+        res.extend(spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+
+        if gen_xml:
+            res.append("def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:")
+            res.append("    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.from_data(s, node, loose={loose}, root_path=root_path)")
+            res.append("")
+        if gen_json:
+            res.append("def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:")
+            res.append("    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.from_data(s, jd, loose={loose}, root_path=root_path)")
+            res.append("")
+            res.append("def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:")
+            res.append("    s = yang.compile(src_yang())")
+            res.append("    return yang.gen3.from_json_path(s, jd, path, op, loose={loose})")
+            res.append("")
+        res.append("def prsrc_gen3(data, self_name='ad'):")
+        res.append("    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!")
+        res.append("    s = yang.compile(src_yang())")
+        res.append("    return yang.gen3.pradata(s, data, self_name, loose={loose})")
+        res.append("")
+
+        res.append("schema_namespaces: set[str] = {{")
+        for ns in sorted(schema_ns):
+            res.append("    '{ns}',")
+        res.append("}}")
+        res.append("")
+
+        return "\n".join(res)
 
 
 class DRpc(DNodeInner):

--- a/test/golden/test_yang/augment_with_uses_refine
+++ b/test/golden/test_yang/augment_with_uses_refine
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
 
     mut def __init__(self):
@@ -393,11 +396,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'system-capabilities', from_xml_base__system_capabilities, child_system_capabilities)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -421,6 +419,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'system-capabilities', from_json_base__system_capabilities, child_system_capabilities)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -430,12 +433,12 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/augmenter',
-    'http://example.com/base',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/augmenter',
+    'http://example.com/base',
+}

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -158,11 +161,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -186,6 +184,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -195,11 +198,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_augment_augmented_node
+++ b/test/golden/test_yang/compile_augment_augmented_node
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_base__native__voice__service__voip__enabled(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('boolean', val)
 
@@ -475,11 +478,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'native', from_xml_base__native, child_native)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -503,6 +501,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'native', from_json_base__native, child_native)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -512,12 +515,12 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/base',
-    'http://example.com/voice',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/base',
+    'http://example.com/voice',
+}

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 class foo__c1(yang.adata.MNode):
 
     mut def __init__(self):
@@ -125,11 +128,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -152,15 +150,6 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_c1 = yang.gdata.take_json_opt_cnt(jd, 'c1', 'foo')
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
-
-def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
-
-def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    s = yang.compile(src_yang())
-    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
 mut def from_data_foo__r1__input__c3__l3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -411,11 +400,25 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
 
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -158,11 +161,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -186,6 +184,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -195,12 +198,12 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -250,11 +253,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -278,6 +276,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -287,11 +290,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -250,11 +253,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -278,6 +276,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -287,13 +290,13 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
 schema_namespaces: set[str] = {
     'http://example.com/bar',
     'http://example.com/baz',
     'http://example.com/foo',
 }
-
-def prsrc_gen3(data, self_name='ad'):
-    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.pradata(s, data, self_name, loose=False)

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__c2__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -216,11 +219,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -244,6 +242,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -253,11 +256,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -158,11 +161,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -186,6 +184,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -195,12 +198,12 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__things__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -316,11 +319,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -344,6 +342,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -353,11 +356,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_acme_foo_bar__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -141,11 +144,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_acme_foo_bar__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -169,6 +167,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_acme_foo_bar__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -178,11 +181,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_bar__c1__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -299,11 +302,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_bar__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -327,6 +325,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_bar__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -336,11 +339,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+}

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: list[value]) -> yang.gdata.LeafList:
     return yang.gdata.LeafList('string', val)
 
@@ -141,11 +144,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -169,6 +167,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -178,11 +181,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_submodule_conflicting_import_prefix
+++ b/test/golden/test_yang/compile_submodule_conflicting_import_prefix
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_parent__parent_container__parent_leaf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -262,11 +265,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'sub-container', from_xml_parent__sub_container, child_sub_container)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -295,6 +293,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'sub-container', from_json_parent__sub_container, child_sub_container)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -304,11 +307,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/parent',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/parent',
+}

--- a/test/golden/test_yang/compile_submodule_different_prefix
+++ b/test/golden/test_yang/compile_submodule_different_prefix
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_main_module__main_container__main_leaf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -568,11 +571,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'main-container', from_xml_main_module__main_container, child_main_container)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -596,6 +594,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'main-container', from_json_main_module__main_container, child_main_container)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -605,11 +608,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/main',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/main',
+}

--- a/test/golden/test_yang/compile_submodule_same_module_different_prefix
+++ b/test/golden/test_yang/compile_submodule_same_module_different_prefix
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_parent__parent_container__parent_leaf(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -262,11 +265,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'sub-container', from_xml_parent__sub_container, child_sub_container)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -295,6 +293,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'sub-container', from_json_parent__sub_container, child_sub_container)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -304,11 +307,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/parent',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/parent',
+}

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -228,11 +231,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c2', from_xml_foo__c2, child_c2)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -261,6 +259,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c2', from_json_foo__c2, child_c2)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -270,11 +273,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -299,11 +302,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -327,6 +325,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -336,11 +339,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -158,11 +161,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -186,6 +184,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -195,11 +198,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/identity_base_resolution_import_prefix
+++ b/test/golden/test_yang/identity_base_resolution_import_prefix
@@ -73,11 +73,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -96,6 +91,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -105,10 +105,10 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+}

--- a/test/golden/test_yang/identityref
+++ b/test/golden/test_yang/identityref
@@ -168,11 +168,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'config', from_xml_base__config, child_config)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -196,6 +191,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'config', from_json_base__config, child_config)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -205,11 +205,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/base',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/base',
+}

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c__li__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -259,3 +276,26 @@ mut def from_json_foo__c__li_element(jd: dict[str, ?value]) -> yang.gdata.Node:
 mut def from_json_foo__c__li(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = [from_json_foo__c__li_element(e) for e in jd if isinstance(e, dict)]
     return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_base__c1__base_l1__base_k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -473,11 +490,6 @@ mut def from_xml_root(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_base__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path_root(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -501,6 +513,11 @@ mut def from_json_root(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_base__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -509,3 +526,13 @@ def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata
 def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/base',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_base__c1__base_c2__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -294,11 +311,6 @@ mut def from_xml_root(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_base__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path_root(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -322,6 +334,11 @@ mut def from_json_root(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_base__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -330,3 +347,13 @@ def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata
 def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/base',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_base__c1__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
@@ -91,3 +108,28 @@ mut def from_json_base__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_foo_foo = yang.gdata.take_json_opt_str(jd, 'foo', 'foo')
     yang.gdata.maybe_add(children, 'foo:foo', from_data_base__c1__foo_foo, child_foo_foo)
     return yang.gdata.Container(children, ns='http://example.com/base', module='base')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/base',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__ieee_802_3__ieee_802_3(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -141,11 +144,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'ieee-802.3', from_xml_foo__ieee_802_3, child_ieee_802_3)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -169,6 +167,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'ieee-802.3', from_json_foo__ieee_802_3, child_ieee_802_3)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -178,11 +181,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_identityref_list_key
+++ b/test/golden/test_yang/prdaclass_identityref_list_key
@@ -336,11 +336,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -364,6 +359,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -373,11 +373,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__as(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -142,3 +159,26 @@ mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_with_ = yang.gdata.take_json_opt_str(jd, 'with')
     yang.gdata.maybe_add(children, 'with', from_data_foo__c1__with, child_with_)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -153,3 +170,26 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = [from_json_foo__l1_element(e) for e in jd if isinstance(e, dict)]
     return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -170,3 +187,26 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = [from_json_foo__l1_element(e) for e in jd if isinstance(e, dict)]
     return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__foo__bar__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -149,3 +166,26 @@ mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_bar = yang.gdata.take_json_opt_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__foo__bar, child_bar)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=True, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=True, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=True)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=True)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__foo__bar__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -166,3 +183,26 @@ mut def from_json_foo__foo(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_bar = yang.gdata.take_json_opt_cnt(jd, 'bar')
     yang.gdata.maybe_add(children, 'bar', from_json_foo__foo__bar, child_bar)
     return yang.gdata.Container(children, presence=True, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=True, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=True, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=True)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=True)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -237,11 +240,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll1', from_data_foo__ll1, child_ll1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -269,6 +267,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll1', from_data_foo__ll1, child_ll1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -278,11 +281,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__li1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -237,11 +240,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll1', from_data_foo__ll1, child_ll1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -269,6 +267,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'll1', from_data_foo__ll1, child_ll1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -278,11 +281,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -332,11 +335,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_xml_foo__l1, child_l1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=True, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -360,6 +358,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_json_foo__l1, child_l1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=True, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -369,11 +372,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=True)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=True)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 class root(yang.adata.MNode):
 
     mut def __init__(self):
@@ -55,11 +58,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -77,15 +75,6 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
-
-def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
-
-def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    s = yang.compile(src_yang())
-    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
 mut def from_data_yangrpc__foo__input__a(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -357,11 +346,25 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
 
 
-schema_namespaces: set[str] = {
-    'http://example.com/yangrpc',
-}
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/yangrpc',
+}

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -167,3 +184,26 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = [from_json_foo__l1_element(e) for e in jd if isinstance(e, dict)]
     return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -1,3 +1,20 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.gen3
+from yang.identity import complete_and_validate_identityref
+from yang.identityref import Identityref, PartialIdentityref
+from yang.schema import DIdentity
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1__name(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -255,3 +272,26 @@ mut def from_json_foo__l1_element(jd: dict[str, ?value]) -> yang.gdata.Node:
 mut def from_json_foo__l1(jd: list[dict[str, ?value]]) -> yang.gdata.List:
     elements = [from_json_foo__l1_element(e) for e in jd if isinstance(e, dict)]
     return yang.gdata.List(keys=['name'], elements=elements, ns='http://example.com/foo', module='foo')
+
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
+
+def prsrc_gen3(data, self_name='ad'):
+    # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__foo__bar__foo_l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -269,11 +272,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'foo', from_xml_foo__foo, child_foo)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -297,6 +295,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'foo', from_json_foo__foo, child_foo)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -306,12 +309,12 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_bar__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -228,11 +231,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'foo:c1', from_xml_foo__c1, child_foo_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -261,6 +259,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'foo:c1', from_json_foo__c1, child_foo_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -270,12 +273,12 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -317,11 +320,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'pc1', from_xml_foo__pc1, child_pc1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -350,6 +348,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'pc1', from_json_foo__pc1, child_pc1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -359,11 +362,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__c1__l1__k1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
@@ -336,11 +339,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_xml_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -364,6 +362,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c1', from_json_foo__c1, child_c1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -373,11 +376,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
@@ -106,11 +109,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l4', from_data_foo__l4, child_l4)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -145,6 +143,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l4', from_data_foo__l4, child_l4)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -154,11 +157,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
@@ -67,11 +70,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_data_foo__l1, child_l1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -94,6 +92,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_data_foo__l1, child_l1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -103,11 +106,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -12,6 +12,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 mut def from_data_foo__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
@@ -67,11 +70,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_data_foo__l1, child_l1)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -94,6 +92,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l1', from_data_foo__l1, child_l1)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -103,11 +106,11 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -389,11 +389,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c', from_xml_basics__c, child_c)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -417,6 +412,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'c', from_json_basics__c, child_c)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -426,14 +426,14 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/basics',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/basics',
+}
 def src_schema():
     res = {}
     res["basics"] = Module('basics', yang_version=1.1, namespace='http://example.com/basics', prefix='b', children=[

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -3917,11 +3917,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -4019,6 +4014,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -4028,15 +4028,15 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/foo',
+}
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -3918,11 +3918,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=True, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -4020,6 +4015,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=True, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -4029,15 +4029,15 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=True)
 
-schema_namespaces: set[str] = {
-    'http://example.com/bar',
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=True)
+
+schema_namespaces: set[str] = {
+    'http://example.com/bar',
+    'http://example.com/foo',
+}
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -485,11 +485,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'li', from_xml_foo__li, child_li)
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -518,6 +513,11 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'li', from_json_foo__li, child_li)
     return yang.gdata.Container(children)
 
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
 def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
     # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
@@ -527,14 +527,14 @@ def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='mer
     s = yang.compile(src_yang())
     return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
-schema_namespaces: set[str] = {
-    'http://example.com/foo',
-}
-
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/foo',
+}
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', children=[

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -13,6 +13,9 @@ from yang.schema import DIdentity
 # == This file is generated ==
 
 
+_identities: list[DIdentity] = []
+
+
 def src_yang():
     res = []
     res.append(r"""module yangrpc {
@@ -78,11 +81,6 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
 
-def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
-
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
@@ -100,15 +98,6 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children)
-
-def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
-    s = yang.compile(src_yang())
-    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
-
-def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    s = yang.compile(src_yang())
-    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
 mut def from_data_yangrpc__foo__input__a(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
@@ -380,14 +369,28 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
 
 
-schema_namespaces: set[str] = {
-    'http://example.com/yangrpc',
-}
+def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_xml schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, node, loose=False, root_path=root_path)
+
+def from_json_gen3(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
+    # WARNING: this wrapper for the gen3.from_json schema-driven parser compiles the schema on every call!
+    s = yang.compile(src_yang())
+    return yang.gen3.from_data(s, jd, loose=False, root_path=root_path)
+
+def from_json_path_gen3(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+    s = yang.compile(src_yang())
+    return yang.gen3.from_json_path(s, jd, path, op, loose=False)
 
 def prsrc_gen3(data, self_name='ad'):
     # WARNING: this wrapper for the gen3.prsrc schema-driven parser compiles the schema on every call!
     s = yang.compile(src_yang())
     return yang.gen3.pradata(s, data, self_name, loose=False)
+
+schema_namespaces: set[str] = {
+    'http://example.com/yangrpc',
+}
 def src_schema():
     res = {}
     res["yangrpc"] = Module('yangrpc', yang_version=1.1, namespace='http://example.com/yangrpc', prefix='yrpc', children=[


### PR DESCRIPTION
Only DRoot has full view of some aspects of the compiled schema, like the global identity registry, or YANG sources. Ensures that global constants like "_identities" are always defined in the module.