### PR TITLE
Use a better non-optional leaf check in gen3 parser

### DIFF
--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -862,6 +862,9 @@ def _from_data_recursive[A(YangData)](s: yang.schema.DNodeInner, global_identity
                     leaflist_type = "union" if child.type_.name == "union" else (leaflist_val[0].t)
                     if len(unwrapped_values) > 0:
                         children[uname(child)] = yang.gdata.LeafList(leaflist_type, unwrapped_values, user_order=_user_order(child.ordered_by))
+            elif not yang.schema.is_optional_arg_yang_leaf(child, loose):
+                # Missing leaf-list value
+                raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find xml child with name {child.name}")
 
         elif isinstance(child, yang.schema.DLeaf):
             typed = None
@@ -916,11 +919,9 @@ def _from_data_recursive[A(YangData)](s: yang.schema.DNodeInner, global_identity
                     else:
                         if av is not None:
                             children[uname(child)] = yang.gdata.Leaf(concrete_type, av, ns=leaf_ns, module=leaf_module)
-            else:
+            elif not yang.schema.is_optional_arg_yang_leaf(child, loose):
                 # Missing leaf value
-                if not loose and child.mandatory:
-                    # Match legacy error format expected by tests
-                    raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find xml child with name {child.name}")
+                raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find xml child with name {child.name}")
         else:
             raise ValueError(f"Unknown schema node type at {format_schema_path(path_with_child())}: {child}")
 


### PR DESCRIPTION
Just inspecting the leaf mandatory property is not sufficient to determine whether a leaf is optional. Also adds a check for leaf-list.