### PR TITLE
Thread parent DList where needed

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -477,7 +477,7 @@ class DNodeInner(DNode):
                 continue # TODO
             elif isinstance(child, DAnyxml):
                 continue # TODO
-            if isinstance(child, DLeaf) and child.is_key():
+            if isinstance(child, DLeaf) and isinstance(self, DList) and child.is_key(self):
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
             else:
@@ -524,7 +524,7 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if isinstance(child, DLeaf):
-                res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, loose)}")
+                res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, self, loose)}")
             elif isinstance(child, DLeafList):
                 res.append("    {usname(child)}: {yang_leaflist_to_acton_type(child)}")
             elif isinstance(child, DContainer):
@@ -562,8 +562,8 @@ class DNodeInner(DNode):
                 child_default = child.default
                 if not loose and child_default is not None:
                     defval = "=None"
-                child_arg = "{usname(child)}: {yang_leaf_to_acton_arg_type(child, loose)}{defval}"
-                if is_optional_arg_yang_leaf(child, loose):
+                child_arg = "{usname(child)}: {yang_leaf_to_acton_arg_type(child, self, loose)}{defval}"
+                if is_optional_arg_yang_leaf(child, self, loose):
                     opt_args.append(child_arg)
                 else:
                     req_args.append(child_arg)
@@ -693,9 +693,9 @@ class DNodeInner(DNode):
         from_gdata_args_list = []
         for child in self.children:
             if isinstance(child, DNodeLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}')")
+                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, self, 'gdata', loose=loose)}('{uname(child)}')")
             else:
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}'))")
+                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, self, 'gdata', loose=loose)}('{uname(child)}'))")
         from_gdata_args = ", ".join(from_gdata_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
@@ -769,7 +769,7 @@ class DNodeInner(DNode):
                 if isinstance(cchild, DLeaf):
                     # The list of children is already sorted so that key leaves
                     # come first in the correct order.
-                    if not is_optional_arg_yang_leaf(cchild, loose):
+                    if not is_optional_arg_yang_leaf(cchild, container, loose):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
                         # Use repr() in nested f-string to print local variable / attribute verbatim
                         non_optional_args.append("{{repr({local_prefix}{'.'.join(path)}.{cchild_safe_name})}}")
@@ -826,7 +826,7 @@ class DNodeInner(DNode):
         res.append("        leaves = []")
         for child in self.children:
             if isinstance(child, DNodeLeaf):
-                if not top and not is_optional_arg_yang_leaf(child, loose):
+                if not top and not is_optional_arg_yang_leaf(child, self, loose):
                     # Do not print non-optional leafs if not top level, because
                     # they are implicitly set with .create*()
                     continue
@@ -1043,7 +1043,7 @@ class DNodeInner(DNode):
                 maybe_ns = ", '{child.namespace}'" if child.namespace != self.namespace else ""
                 # TODO: no need for local variables when we switch from the
                 # gdata.Container.key attribute to key_str() method
-                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, 'xml', loose=loose)}(node, '{child.name}'{maybe_ns})")
+                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, self, 'xml', loose=loose)}(node, '{child.name}'{maybe_ns})")
                 if isinstance(child, DNodeLeaf):
                     res.append("    yang.gdata.maybe_add(children, '{uname(child)}', from_data_{pname(child)}, child_{usname(child)})")
                 else:
@@ -1185,7 +1185,7 @@ class DNodeInner(DNode):
                 maybe_module = ", '{child.module}'" if child.namespace != self.namespace else ""
                 # TODO: no need for local variables when we switch from the
                 # gdata.Container.key attribute to key_str() method
-                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, 'json', loose=loose)}(jd, '{child.name}'{maybe_module})")
+                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, self, 'json', loose=loose)}(jd, '{child.name}'{maybe_module})")
                 if isinstance(child, DNodeLeaf):
                     res.append("    yang.gdata.maybe_add(children, '{uname(child)}', from_data_{pname(child)}, child_{usname(child)})")
                 else:
@@ -1587,15 +1587,13 @@ class DLeaf(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def is_key(self) -> bool:
-        parent = self.parent
-        if isinstance(parent, DList):
-            # If the leaf is in a different namespace as the list, it:
-            # - cannot possibly be a key,
-            # - may even have the same name as one of the keys!
-            if self.namespace == parent.namespace:
-                if self.name in parent.key:
-                    return True
+    def is_key(self, parent: DList) -> bool:
+        # If the leaf is in a different namespace as the list, it:
+        # - cannot possibly be a key,
+        # - may even have the same name as one of the keys!
+        if self.namespace == parent.namespace:
+            if self.name in parent.key:
+                return True
         return False
 
     def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> list[str]:
@@ -2886,7 +2884,7 @@ def _prsrc_attrs(indent, attrs):
     return ", ".join(res)
 
 
-def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
+def is_optional_yang_leaf(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> bool:
     """Maps YANG leaf optionality to Acton type
     """
     optional = True
@@ -2913,13 +2911,12 @@ def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     if loose:
         optional = True
     # ... although being part of a key always makes it non-optional
-    parent = leaf.parent
     if isinstance(parent, DList):
         if leaf.name in parent.key:
             optional = False
     return optional
 
-def is_optional_arg_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
+def is_optional_arg_yang_leaf(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> bool:
     r"""Maps YANG leaf optionality to Acton type for object constructor arg
 
     This is different from the is_optional_yang_leaf because for YANG leafs with
@@ -2935,7 +2932,7 @@ def is_optional_arg_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     argument, it is optional. This method is used to determine if the argument
     type should be optional.
     """
-    optional = is_optional_yang_leaf(leaf, loose)
+    optional = is_optional_yang_leaf(leaf, parent, loose)
 
     if isinstance(leaf, DLeaf):
         if leaf.default is not None:
@@ -2943,14 +2940,14 @@ def is_optional_arg_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
 
     return optional
 
-def yang_leaf_to_acton_type(leaf: DNodeLeaf, loose: bool=False) -> str:
-    optional = is_optional_yang_leaf(leaf, loose)
+def yang_leaf_to_acton_type(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> str:
+    optional = is_optional_yang_leaf(leaf, parent, loose)
     optional_str = "?" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
 
-def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, loose: bool=False) -> str:
-    optional = is_optional_yang_leaf(leaf, loose)
+def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> str:
+    optional = is_optional_yang_leaf(leaf, parent, loose)
     if isinstance(leaf, DLeaf):
         if leaf.default is not None:
             optional = True
@@ -2958,7 +2955,7 @@ def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, loose: bool=False) -> str:
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
 
-def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
+def taker_name(n: DNode, parent: DNodeInner, input_format: str, loose: bool=False) -> str:
     taker_prefix = ""
     if input_format == "xml":
         taker_prefix = "from_xml_"
@@ -2977,7 +2974,7 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         return taker_prefix + optional_str + "list"
     if isinstance(n, DLeaf):
-        optional = is_optional_arg_yang_leaf(n, loose)
+        optional = is_optional_arg_yang_leaf(n, parent, loose)
         optional_str = "opt_" if optional else ""
         if n.type_.name == "empty":
             return taker_prefix + optional_str + "empty"

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1342,7 +1342,7 @@ def _test_resolve_type_union_of_string():
     l1 = root.get("l1")
 
     if isinstance(l1, yang.schema.DLeaf):
-        acton_type = yang.schema.yang_leaf_to_acton_type(l1)
+        acton_type = yang.schema.yang_leaf_to_acton_type(l1, root)
         testing.assertEqual(acton_type, "?str")
     return root.prdaclass()
 
@@ -1388,25 +1388,25 @@ def _test_resolve_type_union_of_intX():
     l4 = root.get("l4")
 
     if isinstance(l1, yang.schema.DLeaf):
-        acton_type = yang.schema.yang_leaf_to_acton_type(l1)
+        acton_type = yang.schema.yang_leaf_to_acton_type(l1, root)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i32")
         testing.assertEqual(acton_type, "?int")
 
     if isinstance(l2, yang.schema.DLeaf):
-        acton_type = yang.schema.yang_leaf_to_acton_type(l2)
+        acton_type = yang.schema.yang_leaf_to_acton_type(l2, root)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?u32")
         testing.assertEqual(acton_type, "?int")
 
     if isinstance(l3, yang.schema.DLeaf):
-        acton_type = yang.schema.yang_leaf_to_acton_type(l3)
+        acton_type = yang.schema.yang_leaf_to_acton_type(l3, root)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i16")
         testing.assertEqual(acton_type, "?int")
 
     if isinstance(l4, yang.schema.DLeaf):
-        acton_type = yang.schema.yang_leaf_to_acton_type(l4)
+        acton_type = yang.schema.yang_leaf_to_acton_type(l4, root)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i64")
         testing.assertEqual(acton_type, "?int")

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -862,7 +862,7 @@ def _from_data_recursive[A(YangData)](s: yang.schema.DNodeInner, global_identity
                     leaflist_type = "union" if child.type_.name == "union" else (leaflist_val[0].t)
                     if len(unwrapped_values) > 0:
                         children[uname(child)] = yang.gdata.LeafList(leaflist_type, unwrapped_values, user_order=_user_order(child.ordered_by))
-            elif not yang.schema.is_optional_arg_yang_leaf(child, loose):
+            elif not yang.schema.is_optional_arg_yang_leaf(child, s, loose):
                 # Missing leaf-list value
                 raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find xml child with name {child.name}")
 
@@ -919,7 +919,7 @@ def _from_data_recursive[A(YangData)](s: yang.schema.DNodeInner, global_identity
                     else:
                         if av is not None:
                             children[uname(child)] = yang.gdata.Leaf(concrete_type, av, ns=leaf_ns, module=leaf_module)
-            elif not yang.schema.is_optional_arg_yang_leaf(child, loose):
+            elif not yang.schema.is_optional_arg_yang_leaf(child, s, loose):
                 # Missing leaf value
                 raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find xml child with name {child.name}")
         else:
@@ -993,7 +993,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
             if isinstance(cchild, yang.schema.DLeaf):
                 # The list of children is already sorted so that key leaves
                 # come first in the correct order.
-                if not yang.schema.is_optional_arg_yang_leaf(cchild, loose):
+                if not yang.schema.is_optional_arg_yang_leaf(cchild, container, loose):
                     leaf = node.get_leaf(unique_namer.unique_name(cchild.name, cchild.prefix))
                     non_optional_args.append("{repr(leaf.val)}")
             elif isinstance(cchild, yang.schema.DContainer):
@@ -1051,7 +1051,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
         if isinstance(child, yang.schema.DLeaf):
             leaf = node.get_opt_leaf(uname(child))
             if leaf is not None:
-                if not top and not yang.schema.is_optional_arg_yang_leaf(child, loose):
+                if not top and not yang.schema.is_optional_arg_yang_leaf(child, s, loose):
                     # Do not print non-optional leafs if not top level, because
                     # they are implicitly set with .create*()
                     continue

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -473,7 +473,7 @@ class DNodeInner(DNode):
                 continue # TODO
             elif isinstance(child, DAnyxml):
                 continue # TODO
-            if isinstance(child, DLeaf) and child.is_key():
+            if isinstance(self, DList) and isinstance(child, DLeaf) and child.is_key(self):
                 new_children.insert(pos_child_idx, child)
                 pos_child_idx += 1
             else:
@@ -520,7 +520,7 @@ class DNodeInner(DNode):
 
         for child in self.children:
             if isinstance(child, DLeaf):
-                res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, loose)}")
+                res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, self, loose)}")
             elif isinstance(child, DLeafList):
                 res.append("    {usname(child)}: {yang_leaflist_to_acton_type(child)}")
             elif isinstance(child, DContainer):
@@ -558,8 +558,8 @@ class DNodeInner(DNode):
                 child_default = child.default
                 if not loose and child_default is not None:
                     defval = "=None"
-                child_arg = "{usname(child)}: {yang_leaf_to_acton_arg_type(child, loose)}{defval}"
-                if is_optional_arg_yang_leaf(child, loose):
+                child_arg = "{usname(child)}: {yang_leaf_to_acton_arg_type(child, self, loose)}{defval}"
+                if is_optional_arg_yang_leaf(child, self, loose):
                     opt_args.append(child_arg)
                 else:
                     req_args.append(child_arg)
@@ -689,9 +689,9 @@ class DNodeInner(DNode):
         from_gdata_args_list = []
         for child in self.children:
             if isinstance(child, DNodeLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}')")
+                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, self, 'gdata', loose=loose)}('{uname(child)}')")
             else:
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, 'gdata', loose=loose)}('{uname(child)}'))")
+                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, self, 'gdata', loose=loose)}('{uname(child)}'))")
         from_gdata_args = ", ".join(from_gdata_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
@@ -765,7 +765,7 @@ class DNodeInner(DNode):
                 if isinstance(cchild, DLeaf):
                     # The list of children is already sorted so that key leaves
                     # come first in the correct order.
-                    if not is_optional_arg_yang_leaf(cchild, loose):
+                    if not is_optional_arg_yang_leaf(cchild, container, loose):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
                         # Use repr() in nested f-string to print local variable / attribute verbatim
                         non_optional_args.append("{{repr({local_prefix}{'.'.join(path)}.{cchild_safe_name})}}")
@@ -822,7 +822,7 @@ class DNodeInner(DNode):
         res.append("        leaves = []")
         for child in self.children:
             if isinstance(child, DNodeLeaf):
-                if not top and not is_optional_arg_yang_leaf(child, loose):
+                if not top and not is_optional_arg_yang_leaf(child, self, loose):
                     # Do not print non-optional leafs if not top level, because
                     # they are implicitly set with .create*()
                     continue
@@ -1039,7 +1039,7 @@ class DNodeInner(DNode):
                 maybe_ns = ", '{child.namespace}'" if child.namespace != self.namespace else ""
                 # TODO: no need for local variables when we switch from the
                 # gdata.Container.key attribute to key_str() method
-                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, 'xml', loose=loose)}(node, '{child.name}'{maybe_ns})")
+                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, self, 'xml', loose=loose)}(node, '{child.name}'{maybe_ns})")
                 if isinstance(child, DNodeLeaf):
                     res.append("    yang.gdata.maybe_add(children, '{uname(child)}', from_data_{pname(child)}, child_{usname(child)})")
                 else:
@@ -1181,7 +1181,7 @@ class DNodeInner(DNode):
                 maybe_module = ", '{child.module}'" if child.namespace != self.namespace else ""
                 # TODO: no need for local variables when we switch from the
                 # gdata.Container.key attribute to key_str() method
-                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, 'json', loose=loose)}(jd, '{child.name}'{maybe_module})")
+                res.append("    child_{usname(child)} = yang.gdata.{taker_name(child, self, 'json', loose=loose)}(jd, '{child.name}'{maybe_module})")
                 if isinstance(child, DNodeLeaf):
                     res.append("    yang.gdata.maybe_add(children, '{uname(child)}', from_data_{pname(child)}, child_{usname(child)})")
                 else:
@@ -1583,15 +1583,13 @@ class DLeaf(DNodeLeaf):
         self.when = when
         self.exts = exts
 
-    def is_key(self) -> bool:
-        parent = self.parent
-        if isinstance(parent, DList):
-            # If the leaf is in a different namespace as the list, it:
-            # - cannot possibly be a key,
-            # - may even have the same name as one of the keys!
-            if self.namespace == parent.namespace:
-                if self.name in parent.key:
-                    return True
+    def is_key(self, parent: DList) -> bool:
+        # If the leaf is in a different namespace as the list, it:
+        # - cannot possibly be a key,
+        # - may even have the same name as one of the keys!
+        if self.namespace == parent.namespace:
+            if self.name in parent.key:
+                return True
         return False
 
     def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json: bool=True, gen_xml: bool=True, include_state=False) -> list[str]:
@@ -2882,7 +2880,7 @@ def _prsrc_attrs(indent, attrs):
     return ", ".join(res)
 
 
-def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
+def is_optional_yang_leaf(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> bool:
     """Maps YANG leaf optionality to Acton type
     """
     optional = True
@@ -2909,13 +2907,12 @@ def is_optional_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     if loose:
         optional = True
     # ... although being part of a key always makes it non-optional
-    parent = leaf.parent
     if isinstance(parent, DList):
         if leaf.name in parent.key:
             optional = False
     return optional
 
-def is_optional_arg_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
+def is_optional_arg_yang_leaf(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> bool:
     r"""Maps YANG leaf optionality to Acton type for object constructor arg
 
     This is different from the is_optional_yang_leaf because for YANG leafs with
@@ -2931,7 +2928,7 @@ def is_optional_arg_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
     argument, it is optional. This method is used to determine if the argument
     type should be optional.
     """
-    optional = is_optional_yang_leaf(leaf, loose)
+    optional = is_optional_yang_leaf(leaf, parent, loose)
 
     if isinstance(leaf, DLeaf):
         if leaf.default is not None:
@@ -2939,14 +2936,14 @@ def is_optional_arg_yang_leaf(leaf: DNodeLeaf, loose: bool=False) -> bool:
 
     return optional
 
-def yang_leaf_to_acton_type(leaf: DNodeLeaf, loose: bool=False) -> str:
-    optional = is_optional_yang_leaf(leaf, loose)
+def yang_leaf_to_acton_type(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> str:
+    optional = is_optional_yang_leaf(leaf, parent, loose)
     optional_str = "?" if optional else ""
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
 
-def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, loose: bool=False) -> str:
-    optional = is_optional_yang_leaf(leaf, loose)
+def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, parent: DNodeInner, loose: bool=False) -> str:
+    optional = is_optional_yang_leaf(leaf, parent, loose)
     if isinstance(leaf, DLeaf):
         if leaf.default is not None:
             optional = True
@@ -2954,7 +2951,7 @@ def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, loose: bool=False) -> str:
     t = yang_type_to_acton_type(leaf.type_)
     return optional_str + t
 
-def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
+def taker_name(n: DNode, parent: DNodeInner, input_format: str, loose: bool=False) -> str:
     taker_prefix = ""
     if input_format == "xml":
         taker_prefix = "from_xml_"
@@ -2973,7 +2970,7 @@ def taker_name(n: DNode, input_format: str, loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         return taker_prefix + optional_str + "list"
     if isinstance(n, DLeaf):
-        optional = is_optional_arg_yang_leaf(n, loose)
+        optional = is_optional_arg_yang_leaf(n, parent, loose)
         optional_str = "opt_" if optional else ""
         if n.type_.name == "empty":
             return taker_prefix + optional_str + "empty"


### PR DESCRIPTION
The fact that a leaf is part of a key in a list is important when deciding whether a leaf is optional or non-optional. This affects the Acton value type in adata, as well as the parsers. By threading the parent DList node we ensure this information is available where needed and remove the reliance on the DNode.parent attribute.

Part of #199