### PR TITLE
Adapt to Acton builtin-i64 branch

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -771,8 +771,8 @@ class DNodeInner(DNode):
                     # come first in the correct order.
                     if not is_optional_arg_yang_leaf(cchild, list_keys(container), loose):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
-                        # Use repr() in nested f-string to print local variable / attribute verbatim
-                        non_optional_args.append("{{repr({local_prefix}{'.'.join(path)}.{cchild_safe_name})}}")
+                        # Use our bigint-aware repr helper in nested f-string to print local variable / attribute verbatim
+                        non_optional_args.append("{{repr_yang({local_prefix}{'.'.join(path)}.{cchild_safe_name})}}")
                 elif isinstance(cchild, DContainer):
                     if not (cchild.presence or loose or optional_subtree(cchild)):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
@@ -838,7 +838,7 @@ class DNodeInner(DNode):
                     res.append("        if len(_{usname(child)}) != 0:")
                 else:
                     res.append("        if _{usname(child)} is not None:")
-                res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
+                res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr_yang(_{usname(child)})}}')")
             elif isinstance(child, DContainer):
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        if _{usname(child)} is not None:")
@@ -1822,11 +1822,14 @@ class DRoot(DNodeInner):
         res.append("import yang.adata")
         res.append("import yang.gdata")
         res.append("import yang.gen3")
+        res.append("from yang.gdata import repr_yang")
         res.append("from yang.identity import complete_and_validate_identityref")
         res.append("from yang.identityref import Identityref, PartialIdentityref")
         res.append("from yang.schema import DIdentity")
         res.append("")
         res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
         res.append("")
         res.append("")
         res.extend(DIdentity.format_identity_list(self.identities))
@@ -3015,7 +3018,7 @@ def yang_typename_to_acton_type(type_name: str) -> str:
     elif type_name == "instance-identifier":
         return "str"
     elif type_name in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return "int"
+        return "bigint"
     elif type_name == "leafref":
         return "str"
     elif type_name == "string":
@@ -3072,12 +3075,12 @@ def yang_type_to_acton_type(t: ?Type) -> str:
                 max_size = max(list(map(lambda x: int(x[3:]), unique_base_types)))
                 # TODO: once we have integer subtyping, return largest necessary iXX type
                 #return "i{max_size}"
-                return "int"
+                return "bigint"
             elif all(map(lambda x: x in {"uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
                 max_size = max(list(map(lambda x: int(x[4:]), unique_base_types)))
                 # TODO: once we have integer subtyping, return largest necessary uXX type
                 #return "u{max_size}"
-                return "int"
+                return "bigint"
             elif all(map(lambda x: x in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
                 # We have a union of a mix of signed and unsigned integers, so let's find the largest
                 int_sizes = filter(lambda x: x in {"int8", "int16", "int32", "int64"}, unique_base_types)
@@ -3093,10 +3096,10 @@ def yang_type_to_acton_type(t: ?Type) -> str:
                 max_size = max([max_int_size, max_int_mapped_uint_size])
                 if max_size > 64:
                     # Need to use our int (a.k.a. "bigint")
-                    return "int"
+                    return "bigint"
                 # TODO: once we have integer subtyping, return largest necessary iXX type
                 #return "i{max_size}"
-                return "int"
+                return "bigint"
 
             # TODO: use atom when union consists of types that we represent with Acton built-in types
             # TODO: use Acton union
@@ -3115,7 +3118,7 @@ def prsrc_literal(ytype: str, value: str) -> str:
     elif ytype == "identityref":
         return value
     elif ytype in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return value
+        return "bigint(" + value + ")"
     elif ytype == "binary":
         # Binary values are encoded as base64 strings in YANG and NETCONF, but
         # stored as Acton bytes, so we need to decode it first

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1391,25 +1391,25 @@ def _test_resolve_type_union_of_intX():
         acton_type = yang.schema.yang_leaf_to_acton_type(l1, None)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i32")
-        testing.assertEqual(acton_type, "?int")
+        testing.assertEqual(acton_type, "?bigint")
 
     if isinstance(l2, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l2, None)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?u32")
-        testing.assertEqual(acton_type, "?int")
+        testing.assertEqual(acton_type, "?bigint")
 
     if isinstance(l3, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l3, None)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i16")
-        testing.assertEqual(acton_type, "?int")
+        testing.assertEqual(acton_type, "?bigint")
 
     if isinstance(l4, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l4, None)
         # TODO: once we have integer subtyping, expect...
         #testing.assertEqual(acton_type, "?i64")
-        testing.assertEqual(acton_type, "?int")
+        testing.assertEqual(acton_type, "?bigint")
     return root.prdaclass()
 
 def _test_resolve_type_union_of_string_and_int():

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -204,6 +204,9 @@ def yang_str(v) -> str:
     return s
 
 
+_min_i64 = bigint(-9223372036854775807-1)
+_max_i64 = bigint(9223372036854775807)
+_max_u64 = bigint(18446744073709551615)
 def json_val(yang_type: str, v: value) -> ?value:
     if isinstance(v, bytes):
         return base64.encode(v).decode()
@@ -211,6 +214,14 @@ def json_val(yang_type: str, v: value) -> ?value:
         return str(v)
     if isinstance(v, Identityref):
         return "{v.mod}:{v.val}"
+    # JSON encoder doesn't handle bigint, so we convert to a fixed size int, else a string
+    if isinstance(v, bigint):
+        if v >= _min_i64 and v <= _max_i64:
+            return int(v)
+        elif v >= 0 and v <= _max_u64:
+            return u64(v)
+        else:
+            return str(v)
     return v
 
 
@@ -219,6 +230,16 @@ def fmt_json_name(name, module=None):
     if module is not None:
         return "{module}:{name_without_prefix}"
     return name_without_prefix
+
+
+def repr_yang(v) -> str:
+    # All numeric gdata values are bigint, so include an explicit cast because
+    # these printed values are assigned to the "value" type when compiled
+    if isinstance(v, bigint):
+        return "bigint({v})"
+    elif isinstance(v, list):
+        return "[" + ", ".join([repr_yang(e) for e in v]) + "]"
+    return repr(v)
 
 
 class Node(value):
@@ -259,11 +280,11 @@ class Node(value):
         base_args = ns_args + module_args
 
         if isinstance(self, Leaf):
-            args = ["'{str(self.t)}'", repr(self.val)] + base_args
+            args = ["'{str(self.t)}'", repr_yang(self.val)] + base_args
             return "Leaf({", ".join(args)})"
         elif isinstance(self, LeafList):
             # Only sort if deterministic=True and not user_order
-            vals_str = repr(self.vals if (self.user_order or not deterministic) else vals_list_sorted(self.vals))
+            vals_str = repr_yang(self.vals if (self.user_order or not deterministic) else vals_list_sorted(self.vals))
             order_args = ["user_order=True"] if self.user_order else []
             args = ["'{str(self.t)}'", vals_str] + base_args + order_args
             return "LeafList({", ".join(args)})"
@@ -575,34 +596,34 @@ class Node(value):
             if isinstance(childval, float):
                 return childval
 
-    def get_int(self, name) -> int:
+    def get_bigint(self, name) -> bigint:
         child = self.get_leaf(name)
         childval = child.val
-        if isinstance(childval, int):
+        if isinstance(childval, bigint):
             return childval
-        raise ValueError("Leaf {name} is not of type int")
+        raise ValueError("Leaf {name} is not of type bigint")
 
-    def get_ints(self, name) -> list[int]:
+    def get_bigints(self, name) -> list[bigint]:
         if isinstance(self, Container):
             for nm,child in self.children.items():
                 if isinstance(child, LeafList) and nm == name:
                     cvals = []
                     for v in child.vals:
-                        if isinstance(v, int):
+                        if isinstance(v, bigint):
                             cvals.append(v)
                     return cvals
         raise ValueError("Cannot find leaf-list child with name {name}")
 
-    def get_opt_int(self, name) -> ?int:
+    def get_opt_bigint(self, name) -> ?bigint:
         child = self.get_opt_leaf(name)
         if child is not None:
             childval = child.val
-            if isinstance(childval, int):
+            if isinstance(childval, bigint):
                 return childval
 
-    def get_opt_ints(self, name) -> list[int]:
+    def get_opt_bigints(self, name) -> list[bigint]:
         try:
-            return self.get_ints(name)
+            return self.get_bigints(name)
         except ValueError:
             return []
 
@@ -924,7 +945,7 @@ def sorted_elements(elements, key_names):
 
 def vals_equal(a: value, b: value) -> bool:
     # Compare known leaf value types
-    if isinstance(a, int) and isinstance(b, int):
+    if isinstance(a, bigint) and isinstance(b, bigint):
         return a == b
     if isinstance(a, bool) and isinstance(b, bool):
         return a == b
@@ -950,7 +971,7 @@ def vals_equal(a: value, b: value) -> bool:
         return a == b
     if isinstance(a, i32) and isinstance(b, i32):
         return a == b
-    if isinstance(a, i64) and isinstance(b, i64):
+    if isinstance(a, int) and isinstance(b, int):
         return a == b
     if isinstance(a, Identityref) and isinstance(b, Identityref):
         return a == b
@@ -972,7 +993,7 @@ def vals_list_equal(a: list[value], b: list[value]) -> bool:
 
 def vals_less_than(a: value, b: value) -> bool:
     # Compare known leaf value types
-    if isinstance(a, int) and isinstance(b, int):
+    if isinstance(a, bigint) and isinstance(b, bigint):
         return a < b
     if isinstance(a, bool) and isinstance(b, bool):
         return not a  # False (0) before True (1)
@@ -998,7 +1019,7 @@ def vals_less_than(a: value, b: value) -> bool:
         return a < b
     if isinstance(a, i32) and isinstance(b, i32):
         return a < b
-    if isinstance(a, i64) and isinstance(b, i64):
+    if isinstance(a, int) and isinstance(b, int):
         return a < b
     if isinstance(a, Identityref) and isinstance(b, Identityref):
         return a < b
@@ -1679,16 +1700,16 @@ def from_xml_opt_float(n: xml.Node, name: str, ns: ?str) -> ?float:
     except ValueError:
         return None
 
-def from_xml_opt_int(n: xml.Node, name: str, ns: ?str) -> ?int:
+def from_xml_opt_bigint(n: xml.Node, name: str, ns: ?str) -> ?bigint:
     try:
         text = get_xml_child(n, name, ns).text
         if text is not None:
-            return int(text)
+            return bigint(text)
     except ValueError:
         return None
 
-def from_xml_int(n: xml.Node, name: str, ns: ?str) -> int:
-    r = from_xml_opt_int(n, name, ns)
+def from_xml_bigint(n: xml.Node, name: str, ns: ?str) -> bigint:
+    r = from_xml_opt_bigint(n, name, ns)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name {name}")
@@ -1814,18 +1835,18 @@ def from_xml_opt_values(n: xml.Node, name: str, ns: ?str) -> ?list[value]:
         return None
     return res
 
-def from_xml_ints(n: xml.Node, name: str, ns: ?str) -> list[int]:
-    r = from_xml_opt_ints(n, name, ns)
+def from_xml_bigints(n: xml.Node, name: str, ns: ?str) -> list[bigint]:
+    r = from_xml_opt_bigints(n, name, ns)
     if r is not None:
         return r
     raise ValueError("Cannot find xml child with name {name}")
 
-def from_xml_opt_ints(n: xml.Node, name: str, ns: ?str) -> ?list[int]:
+def from_xml_opt_bigints(n: xml.Node, name: str, ns: ?str) -> ?list[bigint]:
     res = []
     for child in get_xml_children(n, name, ns):
         ctext = child.text
         if ctext is not None:
-            res.append(int(ctext))
+            res.append(bigint(ctext))
     if len(res) == 0:
         return None
     return res
@@ -1952,24 +1973,24 @@ def take_json_strs(jd: dict[str, ?value], name: str, module: ?str=None) -> list[
         return val
     raise ValueError("Cannot find json str child with name {name}")
 
-def take_json_opt_int(jd: dict[str, ?value], name: str, module: ?str=None) -> ?int:
+def take_json_opt_bigint(jd: dict[str, ?value], name: str, module: ?str=None) -> ?bigint:
     child = take_json_opt_value(jd, name, module)
     if child is not None:
-        if isinstance(child, int):
+        if isinstance(child, bigint):
             return child
         # TODO: strings are only allowed / mandated for 64-bit numbers!
         elif isinstance(child, str):
-            return int(child)
+            return bigint(child)
         raise ValueError("Expected an int for {name}")
     return None
 
-def take_json_int(jd: dict[str, ?value], name: str, module: ?str=None) -> int:
-    val = take_json_opt_int(jd, name, module)
+def take_json_bigint(jd: dict[str, ?value], name: str, module: ?str=None) -> bigint:
+    val = take_json_opt_bigint(jd, name, module)
     if val is not None:
         return val
     raise ValueError("Cannot find json int child with name {name}")
 
-def take_json_opt_ints(jd: dict[str, ?value], name: str, module: ?str=None) -> ?list[int]:
+def take_json_opt_bigints(jd: dict[str, ?value], name: str, module: ?str=None) -> ?list[bigint]:
     child = take_json_opt_value(jd, name, module)
     if child is not None:
         if isinstance(child, list):
@@ -1978,7 +1999,7 @@ def take_json_opt_ints(jd: dict[str, ?value], name: str, module: ?str=None) -> ?
             elem = child[0]
             int_vals = []
             for c in child:
-                if isinstance(c, int):
+                if isinstance(c, bigint):
                     int_vals.append(c)
                 else:
                     raise ValueError("{name}is a list of wrong type, should be int, not {type(elem)}")
@@ -1986,27 +2007,27 @@ def take_json_opt_ints(jd: dict[str, ?value], name: str, module: ?str=None) -> ?
         raise ValueError(name + "is not a list of ints")
     return None
 
-def take_json_ints(jd: dict[str, ?value], name: str, module: ?str=None) -> list[int]:
-    val = take_json_opt_ints(jd, name, module)
+def take_json_bigints(jd: dict[str, ?value], name: str, module: ?str=None) -> list[bigint]:
+    val = take_json_opt_bigints(jd, name, module)
     if val is not None:
         return val
     raise ValueError("Cannot find json int child with name {name}")
 
-def take_json_opt_int64(jd: dict[str, ?value], name: str, module: ?str=None) -> ?int:
+def take_json_opt_int64(jd: dict[str, ?value], name: str, module: ?str=None) -> ?bigint:
     child = take_json_opt_value(jd, name, module)
     if child is not None:
         if isinstance(child, str):
-            return int(child)
+            return bigint(child)
         raise ValueError("Expected a string for 64-bit number {name}")
     return None
 
-def take_json_int64(jd: dict[str, ?value], name: str, module: ?str=None) -> int:
+def take_json_int64(jd: dict[str, ?value], name: str, module: ?str=None) -> bigint:
     val = take_json_opt_int64(jd, name, module)
     if val is not None:
         return val
     raise ValueError("Cannot find json int64 child with name {name}")
 
-def take_json_opt_int64s(jd: dict[str, ?value], name: str, module: ?str=None) -> ?list[int]:
+def take_json_opt_int64s(jd: dict[str, ?value], name: str, module: ?str=None) -> ?list[bigint]:
     child = take_json_opt_value(jd, name, module)
     if child is not None:
         if isinstance(child, list):
@@ -2016,14 +2037,14 @@ def take_json_opt_int64s(jd: dict[str, ?value], name: str, module: ?str=None) ->
             int_vals = []
             for c in child:
                 if isinstance(c, str):
-                    int_vals.append(int(c))
+                    int_vals.append(bigint(c))
                 else:
                     raise ValueError("{name}is a list of wrong type, should be str, not {type(elem)}")
             return int_vals
         raise ValueError(name + "is not a list of 64-bit numbers")
     return None
 
-def take_json_int64s(jd: dict[str, ?value], name: str, module: ?str=None) -> list[int]:
+def take_json_int64s(jd: dict[str, ?value], name: str, module: ?str=None) -> list[bigint]:
     val = take_json_opt_int64s(jd, name, module)
     if val is not None:
         return val
@@ -2234,37 +2255,37 @@ def _test_format_gdata_path():
     path = [
         _PathElement("config"),
         _PathElement("interfaces"),
-        _PathElement(keys={"name": Leaf("str", "eth0"), "vlan": Leaf("int", 100)}),
+        _PathElement(keys={"name": Leaf("str", "eth0"), "vlan": Leaf("int", bigint(100))}),
         _PathElement("ipv4"),
-        _PathElement(keys={"ip": Leaf("str", "10.0.0.1"), "prefix": Leaf("int", 24)})
+        _PathElement(keys={"ip": Leaf("str", "10.0.0.1"), "prefix": Leaf("int", bigint(24))})
     ]
     testing.assertEqual("/config/interfaces[name='eth0',vlan=100]/ipv4[ip='10.0.0.1',prefix=24]", _format_gdata_path(path))
 
 
 def _test_merge1():
     y1 = Container({
-        "a": Leaf("int", 1),
+        "a": Leaf("int", bigint(1)),
         "l1": List(["name"], [
             Container({
                 "name": Leaf("str", "k1"),
-                "n1": Leaf("int", 1),
-                "n2": Leaf("int", 2)
+                "n1": Leaf("int", bigint(1)),
+                "n2": Leaf("int", bigint(2))
             }),
             Container({
                 "name": Leaf("str", "k4"),
-                "n4": Leaf("int", 4),
+                "n4": Leaf("int", bigint(4)),
             }),
         ])
     }, ns="http://example.com/acme", module="acme")
 
     y2 = Container({
-        "b": Leaf("int", 2),
-        "c": Leaf("int", 3),
+        "b": Leaf("int", bigint(2)),
+        "c": Leaf("int", bigint(3)),
         "l1": List(["name"], [
             Container({
                 "name": Leaf("str", "k2"),
-                "n1": Leaf("int", 1),
-                "n3": Leaf("int", 3)
+                "n1": Leaf("int", bigint(1)),
+                "n3": Leaf("int", bigint(3))
             }),
         ]),
         "d": LeafList("str", ["a", "b", "c"])
@@ -2273,23 +2294,23 @@ def _test_merge1():
     res = merge(y1, y2)
 
     exp = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2),
-        "c": Leaf("int", 3),
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2)),
+        "c": Leaf("int", bigint(3)),
         "l1": List(["name"], [
             Container({
                 "name": Leaf("str", "k1"),
-                "n1": Leaf("int", 1),
-                "n2": Leaf("int", 2)
+                "n1": Leaf("int", bigint(1)),
+                "n2": Leaf("int", bigint(2))
             }),
             Container({
                 "name": Leaf("str", "k2"),
-                "n1": Leaf("int", 1),
-                "n3": Leaf("int", 3)
+                "n1": Leaf("int", bigint(1)),
+                "n3": Leaf("int", bigint(3))
             }),
             Container({
                 "name": Leaf("str", "k4"),
-                "n4": Leaf("int", 4),
+                "n4": Leaf("int", bigint(4)),
             }),
         ]),
         "d": LeafList("str", ["a", "b", "c"])
@@ -2301,23 +2322,23 @@ def _test_merge_list1():
     y1 = List(["name"], [
         Container({
             "name": Leaf("str", "first"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "breaker"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "fourth"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "common"),
-            "n2": Leaf("int", 2)
+            "n2": Leaf("int", bigint(2))
         }),
         Container({
             "name": Leaf("str", "last"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
@@ -2327,15 +2348,15 @@ def _test_merge_list1():
         }),
         Container({
             "name": Leaf("str", "second"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "third"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "common"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "last")
@@ -2345,32 +2366,32 @@ def _test_merge_list1():
     exp = List(["name"], [
         Container({
             "name": Leaf("str", "first"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "breaker"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "fourth"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "common"),
-            "n2": Leaf("int", 2),
-            "n1": Leaf("int", 1)
+            "n2": Leaf("int", bigint(2)),
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "last"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "second"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "third"),
-            "n1": Leaf("int", 1)
+            "n1": Leaf("int", bigint(1))
         }),
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
@@ -2378,10 +2399,10 @@ def _test_merge_list1():
 
 def _test_merge_leaf_conflict():
     y1 = Container({
-        "a": Leaf("int", 1)
+        "a": Leaf("int", bigint(1))
     })
     y2 = Container({
-        "a": Leaf("int", 2)
+        "a": Leaf("int", bigint(2))
     })
 
     try:
@@ -2394,21 +2415,21 @@ def _test_eq_list():
     l1 = List(["name"], [
         Container({
             "name": Leaf("str", "a"),
-            "x": Leaf("int", 1)
+            "x": Leaf("int", bigint(1))
         }),
         Container({
             "name": Leaf("str", "b"),
-            "x": Leaf("int", 2)
+            "x": Leaf("int", bigint(2))
         })
     ])
     l2 = List(["name"], [
         Container({
             "name": Leaf("str", "b"),
-            "x": Leaf("int", 2)
+            "x": Leaf("int", bigint(2))
         }),
         Container({
             "name": Leaf("str", "a"),
-            "x": Leaf("int", 1)
+            "x": Leaf("int", bigint(1))
         })
     ])
     testing.assertEqual(l1, l1)
@@ -2417,18 +2438,18 @@ def _test_eq_list():
 def _test_eq_list_user_order():
     l1 = List(["name"], user_order=True, elements=[
         Container({
-            "x": Leaf("int", 1)
+            "x": Leaf("int", bigint(1))
         }),
         Container({
-            "x": Leaf("int", 2)
+            "x": Leaf("int", bigint(2))
         })
     ])
     l2 = List(["name"], user_order=True, elements=[
         Container({
-            "x": Leaf("int", 2)
+            "x": Leaf("int", bigint(2))
         }),
         Container({
-            "x": Leaf("int", 1)
+            "x": Leaf("int", bigint(1))
         })
     ])
     testing.assertEqual(l1, l1)
@@ -2451,13 +2472,13 @@ def _test_diff_no_change():
     since there are no differences.
     """
     old = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2)
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2)
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
@@ -2468,19 +2489,19 @@ def _test_diff_leaf_change():
     with just that leaf changed.
     """
     old = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2)
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        "a": Leaf("int", 42), # Changed from 1 to 42
-        "b": Leaf("int", 2)
+        "a": Leaf("int", bigint(42)), # Changed from 1 to 42
+        "b": Leaf("int", bigint(2))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
 
     exp = Container({
-        "a": Leaf("int", 42)
+        "a": Leaf("int", bigint(42))
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
@@ -2490,14 +2511,14 @@ def _test_diff_node_removal():
     diff at the place where c was.
     """
     old = Container({
-        "a": Leaf("int", 1),
-        "c": Leaf("int", 3),
-        "d": Leaf("int", 4)
+        "a": Leaf("int", bigint(1)),
+        "c": Leaf("int", bigint(3)),
+        "d": Leaf("int", bigint(4))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        "a": Leaf("int", 1),
-        "d": Leaf("int", 4)
+        "a": Leaf("int", bigint(1)),
+        "d": Leaf("int", bigint(4))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
@@ -2505,7 +2526,7 @@ def _test_diff_node_removal():
     # c is removed
     exp = Container({
         "c": Absent({
-            "c": Leaf("int", 3)
+            "c": Leaf("int", bigint(3))
         })
     }, ns="http://example.com/acme", module="acme")
 
@@ -2517,12 +2538,12 @@ def _test_diff_list_removal():
         "l": List(["name"], [
         Container({
             "name": Leaf("str", "k1"),
-            "n1": Leaf("int", 1),
-            "n2": Leaf("int", 2),
+            "n1": Leaf("int", bigint(1)),
+            "n2": Leaf("int", bigint(2)),
         }),
         Container({
             "name": Leaf("str", "k4"),
-            "n4": Leaf("int", 4),
+            "n4": Leaf("int", bigint(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
     })
@@ -2537,12 +2558,12 @@ def _test_diff_list_removal():
             "l": List(["name"], [
                 Container({
                     "name": Leaf("str", "k1"),
-                    "n1": Leaf("int", 1),
-                    "n2": Leaf("int", 2),
+                    "n1": Leaf("int", bigint(1)),
+                    "n2": Leaf("int", bigint(2)),
                 }),
                 Container({
                     "name": Leaf("str", "k4"),
-                    "n4": Leaf("int", 4),
+                    "n4": Leaf("int", bigint(4)),
                 }),
             ], ns="http://example.com/acme", module="acme")
         }, ns="http://example.com/acme", module="acme")
@@ -2559,19 +2580,19 @@ def _test_diff_elem_removal():
     old = List(["name"], [
         Container({
             "name": Leaf("str", "k1"),
-            "n1": Leaf("int", 1),
-            "n2": Leaf("int", 2),
+            "n1": Leaf("int", bigint(1)),
+            "n2": Leaf("int", bigint(2)),
         }),
         Container({
             "name": Leaf("str", "k4"),
-            "n4": Leaf("int", 4),
+            "n4": Leaf("int", bigint(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
     new = List(["name"], [
         Container({
             "name": Leaf("str", "k4"),
-            "n4": Leaf("int", 4),
+            "n4": Leaf("int", bigint(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
@@ -2590,19 +2611,19 @@ def _test_diff_node_addition():
     """A new node e is added in new. We expect the diff to have that new node.
     """
     old = Container({
-        "a": Leaf("int", 1)
+        "a": Leaf("int", bigint(1))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        "a": Leaf("int", 1),
-        "e": Leaf("int", 5)
+        "a": Leaf("int", bigint(1)),
+        "e": Leaf("int", bigint(5))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
 
     # e is new
     exp = Container({
-        "e": Leaf("int", 5)
+        "e": Leaf("int", bigint(5))
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
@@ -2633,15 +2654,15 @@ def _test_diff_complex_ordering():
     before the new node d in the diff.
     """
     old = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2),
-        "c": Leaf("int", 3)
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2)),
+        "c": Leaf("int", bigint(3))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        "a": Leaf("int", 1),
-        "c": Leaf("int", 3),
-        "d": Leaf("int", 4)
+        "a": Leaf("int", bigint(1)),
+        "c": Leaf("int", bigint(3)),
+        "d": Leaf("int", bigint(4))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
@@ -2649,17 +2670,17 @@ def _test_diff_complex_ordering():
     # "b" is absent before "d" is introduced
     exp = Container({
         "b": Absent({
-            "b": Leaf("int", 2)
+            "b": Leaf("int", bigint(2))
         }),
-        "d": Leaf("int", 4)
+        "d": Leaf("int", bigint(4))
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
 
 def _test_patch_no_change():
     old = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2),
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2)),
     }, ns="http://example.com/acme", module="acme")
 
     # diff is None means no changes
@@ -2670,28 +2691,28 @@ def _test_patch_no_change():
 
 def _test_patch_leaf_change():
     old = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2),
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2)),
     }, ns="http://example.com/acme", module="acme")
 
     # Suppose we want to change leaf 'a' from 1 to 42
     # diff would look like this:
     p = Container({
-        "a": Leaf("int", 42),
+        "a": Leaf("int", bigint(42)),
     }, ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = Container({
-        "a": Leaf("int", 42),
-        "b": Leaf("int", 2),
+        "a": Leaf("int", bigint(42)),
+        "b": Leaf("int", bigint(2)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
 
 def _test_patch_node_removal():
     old = Container({
-        "a": Leaf("int", 1),
-        "c": Leaf("int", 3),
+        "a": Leaf("int", bigint(1)),
+        "c": Leaf("int", bigint(3)),
     }, ns="http://example.com/acme", module="acme")
 
     # Suppose we remove 'c'
@@ -2702,7 +2723,7 @@ def _test_patch_node_removal():
 
     res = patch(old, p)
     exp = Container({
-        "a": Leaf("int", 1),
+        "a": Leaf("int", bigint(1)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2711,12 +2732,12 @@ def _test_patch_elem_removal():
     old = List(["name"], [
         Container({
             "name": Leaf("str", "k1"),
-            "n1": Leaf("int", 1),
-            "n2": Leaf("int", 2)
+            "n1": Leaf("int", bigint(1)),
+            "n2": Leaf("int", bigint(2))
         }),
         Container({
             "name": Leaf("str", "k4"),
-            "n4": Leaf("int", 4),
+            "n4": Leaf("int", bigint(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
@@ -2732,7 +2753,7 @@ def _test_patch_elem_removal():
     exp = List(["name"], [
         Container({
             "name": Leaf("str", "k4"),
-            "n4": Leaf("int", 4),
+            "n4": Leaf("int", bigint(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
@@ -2740,8 +2761,8 @@ def _test_patch_elem_removal():
 
 def _test_patch_elem_removal2():
     old = Container({
-        "n1": Leaf("int", 1),
-        "n2": Leaf("int", 2)
+        "n1": Leaf("int", bigint(1)),
+        "n2": Leaf("int", bigint(2))
     })
 
     p = Absent({
@@ -2754,18 +2775,18 @@ def _test_patch_elem_removal2():
 
 def _test_patch_node_addition():
     old = Container({
-        "a": Leaf("int", 1),
+        "a": Leaf("int", bigint(1)),
     }, ns="http://example.com/acme", module="acme")
 
     # Add a new leaf 'e':
     p = Container({
-        "e": Leaf("int", 5)
+        "e": Leaf("int", bigint(5))
     }, ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = Container({
-        "a": Leaf("int", 1),
-        "e": Leaf("int", 5),
+        "a": Leaf("int", bigint(1)),
+        "e": Leaf("int", bigint(5)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2773,23 +2794,23 @@ def _test_patch_node_addition():
 def _test_patch_complex_ordering():
     # old: a, b, c
     old = Container({
-        "a": Leaf("int", 1),
-        "b": Leaf("int", 2),
-        "c": Leaf("int", 3),
+        "a": Leaf("int", bigint(1)),
+        "b": Leaf("int", bigint(2)),
+        "c": Leaf("int", bigint(3)),
     }, ns="http://example.com/acme", module="acme")
 
     # new: a, c, d
     # diff: remove b, add d
     p = Container({
         "b": Absent(),
-        "d": Leaf("int", 4)
+        "d": Leaf("int", bigint(4))
     }, ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = Container({
-        "a": Leaf("int", 1),
-        "c": Leaf("int", 3),
-        "d": Leaf("int", 4),
+        "a": Leaf("int", bigint(1)),
+        "c": Leaf("int", bigint(3)),
+        "d": Leaf("int", bigint(4)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2875,13 +2896,13 @@ def _test_diff_and_patch_large_tree():
             "acl": Container(children={
                 "rules": List(["id"], elements=[
                     Container({
-                        "id": Leaf("int", 10),
+                        "id": Leaf("int", bigint(10)),
                         "action": Leaf("str", "permit"),
                         "src": Leaf("str", "10.0.0.0/24"),
                         "dst": Leaf("str", "10.0.1.0/24"),
                     }),
                     Container({
-                        "id": Leaf("int", 20),
+                        "id": Leaf("int", bigint(20)),
                         "action": Leaf("str", "deny"),
                         "src": Leaf("str", "any"),
                         "dst": Leaf("str", "any"),
@@ -2927,19 +2948,19 @@ def _test_diff_and_patch_large_tree():
             "acl": Container(children={
                 "rules": List(["id"], elements=[
                     Container({
-                        "id": Leaf("int", 10),
+                        "id": Leaf("int", bigint(10)),
                         "action": Leaf("str", "permit"),
                         "src": Leaf("str", "10.0.0.0/24"),
                         "dst": Leaf("str", "10.0.1.0/24"),
                     }),
                     Container({
-                        "id": Leaf("int", 20),
+                        "id": Leaf("int", bigint(20)),
                         "action": Leaf("str", "drop"),  # changed from deny
                         "src": Leaf("str", "any"),
                         "dst": Leaf("str", "any"),
                     }),
                     Container({
-                        "id": Leaf("int", 30),
+                        "id": Leaf("int", bigint(30)),
                         "action": Leaf("str", "permit"),
                         "src": Leaf("str", "192.0.2.0/24"),
                         "dst": Leaf("str", "198.51.100.0/24"),
@@ -2971,16 +2992,16 @@ def _test_diff_and_patch_large_tree():
 def _test_prsrc():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "l1": List(["name"], [
                 Container({
                     "name": Leaf("str", "k1"),
-                    "n1": Leaf("int", 1),
-                    "n2": Leaf("int", 2)
+                    "n1": Leaf("int", bigint(1)),
+                    "n2": Leaf("int", bigint(2))
                 }),
                 Container({
                     "name": Leaf("str", "k4"),
-                    "n4": Leaf("int", 4),
+                    "n4": Leaf("int", bigint(4)),
                 }),
             ])
         }, ns="http://example.com/acme", module="acme")
@@ -2998,7 +3019,7 @@ def _test_prsrc_absent():
                 }),
                 Container({
                     "name": Leaf("str", "k4"),
-                    "n4": Leaf("int", 4),
+                    "n4": Leaf("int", bigint(4)),
                 }),
             ])
         }, ns="http://example.com/acme", module="acme")
@@ -3009,7 +3030,7 @@ def _test_prsrc_absent():
 def _test_prsrc_root():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "b": LeafList("str", ["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
@@ -3019,8 +3040,8 @@ def _test_prsrc_root():
 def _test_prsrc_leaf_ns():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1, ns="http://example.com/foo", module="foo"),
-            "b": Leaf("int", 2)
+            "a": Leaf("int", bigint(1), ns="http://example.com/foo", module="foo"),
+            "b": Leaf("int", bigint(2))
         }, ns="http://example.com/acme", module="acme")
     })
 
@@ -3038,27 +3059,27 @@ def _test_prsrc_identityref():
 def _test_to_json():
     y1 = Container({
         "acme:foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "l1": List(["name", "name_two"], [
                 Container({
                     "name": Leaf("str", "k1"),
                     "name_two": Leaf("str", "k1a"),
-                    "n1": Leaf("int", 1),
-                    "n2": Leaf("int", 2)
+                    "n1": Leaf("int", bigint(1)),
+                    "n2": Leaf("int", bigint(2))
                 }),
                 Container({
                     "name": Leaf("str", "k4"),
                     "name_two": Leaf("str", "k4a"),
-                    "n4": Leaf("int", 4),
+                    "n4": Leaf("int", bigint(4)),
                 }),
             ]),
             "b": Leaf("bool", False),
             "lb": Leaf("binary", b"Hello Acton \xf0\x9f\xab\xa1"),
             "llb": LeafList("binary", [b"Hello Acton \xf0\x9f\xab\xa1"]),
-            "c": Leaf("uint64", 18446744073709551615),
+            "c": Leaf("uint64", bigint(18446744073709551615)),
         }, ns="http://example.com/acme", module="acme"),
         "beep:foo": Container({
-            "a": Leaf("int", 1)
+            "a": Leaf("int", bigint(1))
         }, ns="http://example.com/beep", module="beep")
     })
 
@@ -3084,27 +3105,27 @@ def _test_to_json_identityref():
 def _test_to_xmlstr():
     y1 = Container({
         "acme:foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "l1": List(["name", "name_two"], [
                 Container({
                     "name": Leaf("str", "k1"),
                     "name_two": Leaf("str", "k1a"),
-                    "n1": Leaf("int", 1),
-                    "n2": Leaf("int", 2)
+                    "n1": Leaf("int", bigint(1)),
+                    "n2": Leaf("int", bigint(2))
                 }),
                 Container({
                     "name": Leaf("str", "k4"),
                     "name_two": Leaf("str", "k4a"),
-                    "n4": Leaf("int", 4),
+                    "n4": Leaf("int", bigint(4)),
                 }),
             ]),
             "b": Leaf("bool", False),
             "lb": Leaf("binary", b"Hello Acton \xf0\x9f\xab\xa1"),
             "llb": LeafList("binary", [b"Hello Acton \xf0\x9f\xab\xa1"]),
-            "c": Leaf("uint64", 18446744073709551615),
+            "c": Leaf("uint64", bigint(18446744073709551615)),
         }, ns="http://example.com/acme", module="acme"),
         "beep:foo": Container({
-            "a": Leaf("int", 1)
+            "a": Leaf("int", bigint(1))
         }, ns="http://example.com/beep", module="beep")
     })
 
@@ -3113,7 +3134,7 @@ def _test_to_xmlstr():
 def _test_to_xmlstr_root():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "b": LeafList("binary", ["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
@@ -3123,7 +3144,7 @@ def _test_to_xmlstr_root():
 def _test_to_xmlstr_module():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "b": LeafList("str", ["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
@@ -3133,8 +3154,8 @@ def _test_to_xmlstr_module():
 def _test_to_xmlstr_leaf_ns():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1, ns="http://example.com/foo", module="foo"),
-            "b": Leaf("int", 2)
+            "a": Leaf("int", bigint(1), ns="http://example.com/foo", module="foo"),
+            "b": Leaf("int", bigint(2))
         }, ns="http://example.com/acme", module="acme")
     })
 
@@ -3167,13 +3188,13 @@ def _test_to_xmlstr_mixed():
 def _test_to_xmlstr_root_merge():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1),
+            "a": Leaf("int", bigint(1)),
             "b": LeafList("str", ["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
     y2 = Container({
         "bar": Container({
-            "b": Leaf("int", 42),
+            "b": Leaf("int", bigint(42)),
         }, ns="http://example.com/bar", module="bar")
     })
     ym = merge(y1, y2)
@@ -3183,7 +3204,7 @@ def _test_to_xmlstr_root_merge():
 def _test_to_xmlstr_presence():
     y1 = Container({
         "foo": Container({
-            "a": Leaf("int", 1)
+            "a": Leaf("int", bigint(1))
         }, presence=True, ns="http://example.com/acme", module="acme")
     })
 
@@ -3219,12 +3240,12 @@ def _test_to_xmlstr_list_removal():
             "l": List(["name"], [
                 Container({
                     "name": Leaf("str", "k1"),
-                    "n1": Leaf("int", 1),
-                    "n2": Leaf("int", 2),
+                    "n1": Leaf("int", bigint(1)),
+                    "n2": Leaf("int", bigint(2)),
                 }),
                 Container({
                     "name": Leaf("str", "k4"),
-                    "n4": Leaf("int", 4),
+                    "n4": Leaf("int", bigint(4)),
                 }),
             ], ns="http://example.com/acme", module="acme")
         }, ns="http://example.com/acme", module="acme")

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -13,6 +13,7 @@ import yang.gdata
 import yang.schema
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
+from yang.gdata import repr_yang
 
 
 NETCONF_OPS = {"create", "delete", "remove", "replace", "merge"}
@@ -74,15 +75,15 @@ def parse_range_constraint(range_str: str) -> list[(min_str: str, max_str: str)]
     return intervals
 
 
-def validate_int_range(value: int, range_str: str, type_name: str) -> bool:
+def validate_int_range(value: bigint, range_str: str, type_name: str) -> bool:
     intervals = parse_range_constraint(range_str)
-    numeric_value_i: int = value
+    numeric_value_i: bigint = value
     for interval in intervals:
         min_str = interval.min_str
         max_str = interval.max_str
 
         # Compute integer bounds
-        min_val_i: int = 0
+        min_val_i: bigint = 0   # bigint because even the start of range may exceed i64_max
         if min_str == "min":
             if type_name == "int8":
                 min_val_i = -128
@@ -91,19 +92,19 @@ def validate_int_range(value: int, range_str: str, type_name: str) -> bool:
             elif type_name == "int32":
                 min_val_i = -2147483648
             elif type_name == "int64":
-                min_val_i = -9223372036854775808
+                min_val_i = bigint(-9223372036854775807-1)
             elif type_name in ["uint8", "uint16", "uint32", "uint64"]:
                 min_val_i = 0
             else:
-                min_val_i = -9223372036854775808
+                min_val_i = bigint(-9223372036854775807-1)
         else:
             try:
-                min_val_i = int(min_str)
+                min_val_i = bigint(min_str)
             except ValueError:
                 # Malformed bound for integer type, skip this interval
                 continue
 
-        max_val_i: int = 0
+        max_val_i: bigint = 0
         if max_str == "max":
             if type_name == "int8":
                 max_val_i = 127
@@ -120,12 +121,12 @@ def validate_int_range(value: int, range_str: str, type_name: str) -> bool:
             elif type_name == "uint32":
                 max_val_i = 4294967295
             elif type_name == "uint64":
-                max_val_i = 18446744073709551615
+                max_val_i = bigint(18446744073709551615)
             else:
                 max_val_i = 9223372036854775807
         else:
             try:
-                max_val_i = int(max_str)
+                max_val_i = bigint(max_str)
             except ValueError:
                 # Malformed bound for integer type, skip this interval
                 continue
@@ -144,7 +145,7 @@ def validate_decimal_range(value: float, range_str: str) -> bool:
         # Defaults align with previous behavior
         min_val_f: float = 0.0
         if min_str == "min":
-            min_val_f = -9223372036854775808.0
+            min_val_f = -9223372036854775807.0-1.0
         else:
             try:
                 min_val_f = float(min_str)
@@ -248,7 +249,7 @@ def try_parse_value(text_value: str, schema_type: yang.schema.Type, path: list[P
         return (t=type_name, val=text_value)
     elif type_name == "int8" or type_name == "int16" or type_name == "int32" or type_name == "int64":
         try:
-            int_val = int(text_value)
+            int_val = bigint(text_value)
             range_obj = schema_type.range_
             if range_obj is not None:
                 if not validate_int_range(int_val, range_obj.value, type_name):
@@ -258,7 +259,7 @@ def try_parse_value(text_value: str, schema_type: yang.schema.Type, path: list[P
             raise YangValidationError(path, schema_type, text_value)
     elif type_name == "uint8" or type_name == "uint16" or type_name == "uint32" or type_name == "uint64":
         try:
-            int_val = int(text_value)
+            int_val = bigint(text_value)
             if int_val < 0:
                 raise YangValidationError(path, schema_type, text_value)
             range_obj = schema_type.range_
@@ -429,11 +430,12 @@ extension dict[A(Hashable), B] (YangData):
                             if isinstance(leaf_value, bool) and member_name == "boolean":
                                 concrete_type = "boolean"
                                 break
-                            elif isinstance(leaf_value, int) and not isinstance(leaf_value, bool):
+                            elif isinstance(leaf_value, int) or isinstance(leaf_value, bigint):
+                                bigint_leaf_value = bigint(leaf_value)
                                 if member_name in ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]:
                                     range_obj = member_type.range_
                                     if range_obj is not None:
-                                        if validate_int_range(leaf_value, range_obj.value, member_name):
+                                        if validate_int_range(bigint_leaf_value, range_obj.value, member_name):
                                             concrete_type = member_name
                                             break
                                     else:
@@ -444,12 +446,15 @@ extension dict[A(Hashable), B] (YangData):
                                 break
                     range_obj = schema.type_.range_
                     if range_obj is not None:
-                        if isinstance(leaf_value, int) and not isinstance(leaf_value, bool):
-                            if not validate_int_range(leaf_value, range_obj.value, concrete_type):
+                        if isinstance(leaf_value, int) or isinstance(leaf_value, bigint):
+                            bigint_leaf_value = bigint(leaf_value)
+                            if not validate_int_range(bigint_leaf_value, range_obj.value, concrete_type):
                                 raise YangValidationError(new_path, schema.type_, str(leaf_value))
                         elif isinstance(leaf_value, float):
                             if not validate_decimal_range(leaf_value, range_obj.value):
                                 raise YangValidationError(new_path, schema.type_, str(leaf_value))
+                    if isinstance(leaf_value, int):
+                        return (t=concrete_type, val=bigint(leaf_value))
                     return (t=concrete_type, val=leaf_value)
             else:
                 return None
@@ -492,7 +497,7 @@ extension dict[A(Hashable), B] (YangData):
                                 if isinstance(item, bool) and member_name == "boolean":
                                     concrete_type = "boolean"
                                     break
-                                elif isinstance(item, int) and not isinstance(item, bool):
+                                elif isinstance(item, bigint) and not isinstance(item, bool):
                                     if member_name in ["int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"]:
                                         range_obj = member_type.range_
                                         if range_obj is not None:
@@ -507,7 +512,7 @@ extension dict[A(Hashable), B] (YangData):
                                     break
                         range_obj = schema.type_.range_
                         if range_obj is not None:
-                            if isinstance(item, int) and not isinstance(item, bool):
+                            if isinstance(item, bigint) and not isinstance(item, bool):
                                 if not validate_int_range(item, range_obj.value, concrete_type):
                                     raise YangValidationError(new_path, schema.type_, str(item))
                             elif isinstance(item, float):
@@ -995,7 +1000,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                 # come first in the correct order.
                 if not yang.schema.is_optional_arg_yang_leaf(cchild, yang.schema.list_keys(container), loose):
                     leaf = node.get_leaf(unique_namer.unique_name(cchild.name, cchild.prefix))
-                    non_optional_args.append("{repr(leaf.val)}")
+                    non_optional_args.append("{repr_yang(leaf.val)}")
             elif isinstance(cchild, yang.schema.DContainer):
                 if not (cchild.presence or loose or yang.schema.optional_subtree(cchild)):
                     cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
@@ -1056,12 +1061,12 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     # they are implicitly set with .create*()
                     continue
                 # DLeaf values are copied verbatim
-                leaves.append("{self_name}.{usname(child)} = {repr(leaf.val)}")
+                leaves.append("{self_name}.{usname(child)} = {repr_yang(leaf.val)}")
         elif isinstance(child, yang.schema.DLeafList):
             leaflist = node.get_opt_leaflist(uname(child))
             if leaflist is not None:
                 # DLeafList values are copied verbatim
-                leaves.append("{self_name}.{usname(child)} = {repr(leaflist.vals)}")
+                leaves.append("{self_name}.{usname(child)} = {repr_yang(leaflist.vals)}")
         elif isinstance(child, yang.schema.DContainer):
             container = node.get_opt_cnt(uname(child))
             if container is not None:
@@ -1712,7 +1717,7 @@ def _test_json_path_nested_lists():
                             'deep': yang.gdata.List(['deep-key'], elements=[
                                 yang.gdata.Container({
                                     'deep-key': yang.gdata.Leaf('string', 'key3'),
-                                    'data': yang.gdata.Leaf('int32', 42)
+                                    'data': yang.gdata.Leaf('int32', bigint(42))
                                 })
                             ])
                         })
@@ -2119,7 +2124,7 @@ def _test_pradata():
     gdata_tree = yang.gdata.Container({
         "top-level-leaf": yang.gdata.Leaf("string", "root value"),
         "c1": yang.gdata.Container({
-            "optional-leaf": yang.gdata.Leaf("int32", 42),
+            "optional-leaf": yang.gdata.Leaf("int32", bigint(42)),
             "c2": yang.gdata.Container({
                 "l1": yang.gdata.Leaf("string", "inner value"),
                 "mandatory-leaf": yang.gdata.Leaf("string", "required value")
@@ -2127,13 +2132,13 @@ def _test_pradata():
             "li1": yang.gdata.List(["name", "extra-key"], [
                 yang.gdata.Container({
                     "name": yang.gdata.Leaf("string", "item1"),
-                    "extra-key": yang.gdata.Leaf("int32", 1),
-                    "value": yang.gdata.Leaf("int32", 100)
+                    "extra-key": yang.gdata.Leaf("int32", bigint(1)),
+                    "value": yang.gdata.Leaf("int32", bigint(100))
                 }),
                 yang.gdata.Container({
                     "name": yang.gdata.Leaf("string", "item2"),
-                    "extra-key": yang.gdata.Leaf("int32", 2),
-                    "value": yang.gdata.Leaf("int32", 200),
+                    "extra-key": yang.gdata.Leaf("int32", bigint(2)),
+                    "value": yang.gdata.Leaf("int32", bigint(200)),
                     "c3": yang.gdata.Container({
                         "nested-leaf": yang.gdata.Leaf("string", "birb")
                     })
@@ -2172,7 +2177,7 @@ def _test_pradata_root_path():
             "middle": yang.gdata.Container({
                 "value1": yang.gdata.Leaf("string", "test value"),
                 "inner": yang.gdata.Container({
-                    "value2": yang.gdata.Leaf("int32", 42)
+                    "value2": yang.gdata.Leaf("int32", bigint(42))
                 })
             })
         })
@@ -2219,7 +2224,7 @@ def _test_json_path_container_list_container():
                     'name': yang.gdata.Leaf('string', 'item1'),
                     'bottom': yang.gdata.Container({
                         'data': yang.gdata.Leaf('string', 'test'),
-                        'value': yang.gdata.Leaf('int32', 42)
+                        'value': yang.gdata.Leaf('int32', bigint(42))
                     })
                 })
             ])

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -767,8 +767,8 @@ class DNodeInner(DNode):
                     # come first in the correct order.
                     if not is_optional_arg_yang_leaf(cchild, list_keys(container), loose):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
-                        # Use repr() in nested f-string to print local variable / attribute verbatim
-                        non_optional_args.append("{{repr({local_prefix}{'.'.join(path)}.{cchild_safe_name})}}")
+                        # Use our bigint-aware repr helper in nested f-string to print local variable / attribute verbatim
+                        non_optional_args.append("{{repr_yang({local_prefix}{'.'.join(path)}.{cchild_safe_name})}}")
                 elif isinstance(cchild, DContainer):
                     if not (cchild.presence or loose or optional_subtree(cchild)):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
@@ -834,7 +834,7 @@ class DNodeInner(DNode):
                     res.append("        if len(_{usname(child)}) != 0:")
                 else:
                     res.append("        if _{usname(child)} is not None:")
-                res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr(_{usname(child)})}}')")
+                res.append("            leaves.append('{{self_name}}.{usname(child)} = {{repr_yang(_{usname(child)})}}')")
             elif isinstance(child, DContainer):
                 res.append("        _{usname(child)} = self.{usname(child)}")
                 res.append("        if _{usname(child)} is not None:")
@@ -1818,11 +1818,14 @@ class DRoot(DNodeInner):
         res.append("import yang.adata")
         res.append("import yang.gdata")
         res.append("import yang.gen3")
+        res.append("from yang.gdata import repr_yang")
         res.append("from yang.identity import complete_and_validate_identityref")
         res.append("from yang.identityref import Identityref, PartialIdentityref")
         res.append("from yang.schema import DIdentity")
         res.append("")
         res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
         res.append("")
         res.append("")
         res.extend(DIdentity.format_identity_list(self.identities))
@@ -3011,7 +3014,7 @@ def yang_typename_to_acton_type(type_name: str) -> str:
     elif type_name == "instance-identifier":
         return "str"
     elif type_name in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return "int"
+        return "bigint"
     elif type_name == "leafref":
         return "str"
     elif type_name == "string":
@@ -3068,12 +3071,12 @@ def yang_type_to_acton_type(t: ?Type) -> str:
                 max_size = max(list(map(lambda x: int(x[3:]), unique_base_types)))
                 # TODO: once we have integer subtyping, return largest necessary iXX type
                 #return "i{max_size}"
-                return "int"
+                return "bigint"
             elif all(map(lambda x: x in {"uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
                 max_size = max(list(map(lambda x: int(x[4:]), unique_base_types)))
                 # TODO: once we have integer subtyping, return largest necessary uXX type
                 #return "u{max_size}"
-                return "int"
+                return "bigint"
             elif all(map(lambda x: x in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
                 # We have a union of a mix of signed and unsigned integers, so let's find the largest
                 int_sizes = filter(lambda x: x in {"int8", "int16", "int32", "int64"}, unique_base_types)
@@ -3089,10 +3092,10 @@ def yang_type_to_acton_type(t: ?Type) -> str:
                 max_size = max([max_int_size, max_int_mapped_uint_size])
                 if max_size > 64:
                     # Need to use our int (a.k.a. "bigint")
-                    return "int"
+                    return "bigint"
                 # TODO: once we have integer subtyping, return largest necessary iXX type
                 #return "i{max_size}"
-                return "int"
+                return "bigint"
 
             # TODO: use atom when union consists of types that we represent with Acton built-in types
             # TODO: use Acton union
@@ -3111,7 +3114,7 @@ def prsrc_literal(ytype: str, value: str) -> str:
     elif ytype == "identityref":
         return value
     elif ytype in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return value
+        return "bigint(" + value + ")"
     elif ytype == "binary":
         # Binary values are encoded as base64 strings in YANG and NETCONF, but
         # stored as Acton bytes, so we need to decode it first

--- a/test/golden/test_yang/augment_with_uses_refine
+++ b/test/golden/test_yang/augment_with_uses_refine
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -163,12 +166,12 @@ mut def from_data_base__system_capabilities__subscription_capabilities__supporte
     return yang.gdata.LeafList('string', val)
 
 class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
-    max_nodes: int
+    max_nodes: bigint
     supported_excluded_change_type: list[str]
 
-    mut def __init__(self, max_nodes: ?int=None, supported_excluded_change_type: ?list[str]=None):
+    mut def __init__(self, max_nodes: ?bigint=None, supported_excluded_change_type: ?list[str]=None):
         self._ns = 'http://example.com/augmenter'
-        self.max_nodes = max_nodes if max_nodes is not None else 42
+        self.max_nodes = max_nodes if max_nodes is not None else bigint(42)
         self.supported_excluded_change_type = supported_excluded_change_type if supported_excluded_change_type is not None else []
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -184,7 +187,7 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__system_capabilities__subscription_capabilities:
         if n is not None:
-            return base__system_capabilities__subscription_capabilities(max_nodes=n.get_opt_int('max-nodes'), supported_excluded_change_type=n.get_opt_strs('supported-excluded-change-type'))
+            return base__system_capabilities__subscription_capabilities(max_nodes=n.get_opt_bigint('max-nodes'), supported_excluded_change_type=n.get_opt_strs('supported-excluded-change-type'))
         return base__system_capabilities__subscription_capabilities()
 
     def copy(self):
@@ -199,10 +202,10 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
         leaves = []
         _max_nodes = self.max_nodes
         if _max_nodes is not None:
-            leaves.append('{self_name}.max_nodes = {repr(_max_nodes)}')
+            leaves.append('{self_name}.max_nodes = {repr_yang(_max_nodes)}')
         _supported_excluded_change_type = self.supported_excluded_change_type
         if len(_supported_excluded_change_type) != 0:
-            leaves.append('{self_name}.supported_excluded_change_type = {repr(_supported_excluded_change_type)}')
+            leaves.append('{self_name}.supported_excluded_change_type = {repr_yang(_supported_excluded_change_type)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /system-capabilities/subscription-capabilities'] + leaves + res
@@ -218,7 +221,7 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
 
 mut def from_xml_base__system_capabilities__subscription_capabilities(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_max_nodes = yang.gdata.from_xml_opt_int(node, 'max-nodes')
+    child_max_nodes = yang.gdata.from_xml_opt_bigint(node, 'max-nodes')
     yang.gdata.maybe_add(children, 'max-nodes', from_data_base__system_capabilities__subscription_capabilities__max_nodes, child_max_nodes)
     child_supported_excluded_change_type = yang.gdata.from_xml_opt_strs(node, 'supported-excluded-change-type')
     yang.gdata.maybe_add(children, 'supported-excluded-change-type', from_data_base__system_capabilities__subscription_capabilities__supported_excluded_change_type, child_supported_excluded_change_type)
@@ -244,7 +247,7 @@ mut def from_json_path_base__system_capabilities__subscription_capabilities(jd: 
 
 mut def from_json_base__system_capabilities__subscription_capabilities(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_max_nodes = yang.gdata.take_json_opt_int(jd, 'max-nodes')
+    child_max_nodes = yang.gdata.take_json_opt_bigint(jd, 'max-nodes')
     yang.gdata.maybe_add(children, 'max-nodes', from_data_base__system_capabilities__subscription_capabilities__max_nodes, child_max_nodes)
     child_supported_excluded_change_type = yang.gdata.take_json_opt_strs(jd, 'supported-excluded-change-type')
     yang.gdata.maybe_add(children, 'supported-excluded-change-type', from_data_base__system_capabilities__subscription_capabilities__supported_excluded_change_type, child_supported_excluded_change_type)

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/compile_augment_augmented_node
+++ b/test/golden/test_yang/compile_augment_augmented_node
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -26,12 +29,12 @@ mut def from_data_base__native__voice__service__voip__sip__port(val: value) -> y
 
 class base__native__voice__service__voip__sip(yang.adata.MNode):
     bind: ?str
-    port: int
+    port: bigint
 
-    mut def __init__(self, bind: ?str, port: ?int=None):
+    mut def __init__(self, bind: ?str, port: ?bigint=None):
         self._ns = 'http://example.com/voice'
         self.bind = bind
-        self.port = port if port is not None else 5060
+        self.port = port if port is not None else bigint(5060)
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -46,7 +49,7 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__native__voice__service__voip__sip:
         if n is not None:
-            return base__native__voice__service__voip__sip(bind=n.get_opt_str('bind'), port=n.get_opt_int('port'))
+            return base__native__voice__service__voip__sip(bind=n.get_opt_str('bind'), port=n.get_opt_bigint('port'))
         return base__native__voice__service__voip__sip()
 
     def copy(self):
@@ -61,10 +64,10 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
         leaves = []
         _bind = self.bind
         if _bind is not None:
-            leaves.append('{self_name}.bind = {repr(_bind)}')
+            leaves.append('{self_name}.bind = {repr_yang(_bind)}')
         _port = self.port
         if _port is not None:
-            leaves.append('{self_name}.port = {repr(_port)}')
+            leaves.append('{self_name}.port = {repr_yang(_port)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /native/voice/service/voip/sip'] + leaves + res
@@ -82,7 +85,7 @@ mut def from_xml_base__native__voice__service__voip__sip(node: xml.Node) -> yang
     children = {}
     child_bind = yang.gdata.from_xml_opt_str(node, 'bind')
     yang.gdata.maybe_add(children, 'bind', from_data_base__native__voice__service__voip__sip__bind, child_bind)
-    child_port = yang.gdata.from_xml_opt_int(node, 'port')
+    child_port = yang.gdata.from_xml_opt_bigint(node, 'port')
     yang.gdata.maybe_add(children, 'port', from_data_base__native__voice__service__voip__sip__port, child_port)
     return yang.gdata.Container(children)
 
@@ -108,7 +111,7 @@ mut def from_json_base__native__voice__service__voip__sip(jd: dict[str, ?value])
     children = {}
     child_bind = yang.gdata.take_json_opt_str(jd, 'bind')
     yang.gdata.maybe_add(children, 'bind', from_data_base__native__voice__service__voip__sip__bind, child_bind)
-    child_port = yang.gdata.take_json_opt_int(jd, 'port')
+    child_port = yang.gdata.take_json_opt_bigint(jd, 'port')
     yang.gdata.maybe_add(children, 'port', from_data_base__native__voice__service__voip__sip__port, child_port)
     return yang.gdata.Container(children)
 
@@ -149,7 +152,7 @@ class base__native__voice__service__voip(yang.adata.MNode):
         leaves = []
         _enabled = self.enabled
         if _enabled is not None:
-            leaves.append('{self_name}.enabled = {repr(_enabled)}')
+            leaves.append('{self_name}.enabled = {repr_yang(_enabled)}')
         _sip = self.sip
         if _sip is not None:
             res.extend(_sip.prsrc('{self_name}.sip', False).splitlines())

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -186,7 +189,7 @@ class foo__r1__input__c3(yang.adata.MNode):
         leaves = []
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /r1/input/c3'] + leaves + res
@@ -338,7 +341,7 @@ class foo__r1__output(yang.adata.MNode):
         leaves = []
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append('{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr_yang(_l4)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /r1/output'] + leaves + res

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -61,10 +64,10 @@ class foo__c1__c2(yang.adata.MNode):
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/c2'] + leaves + res
@@ -149,7 +152,7 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -61,10 +64,10 @@ class foo__c1__c2(yang.adata.MNode):
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/c2'] + leaves + res
@@ -149,7 +152,7 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class foo__c1__c2(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/c2'] + leaves + res

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -52,11 +55,11 @@ class foo__c1__things_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/things')
-            res.append('{self_name} = foo__c1__things({repr(self.name)})')
+            res.append('{self_name} = foo__c1__things({repr_yang(self.name)})')
         leaves = []
         _id = self.id
         if _id is not None:
-            leaves.append('{self_name}.id = {repr(_id)}')
+            leaves.append('{self_name}.id = {repr_yang(_id)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/things'] + leaves + res
@@ -222,7 +225,7 @@ class foo__c1(yang.adata.MNode):
         for _element in _things:
             res.append('')
             res.append("# List /c1/things element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'things_element = {self_name}.things.create({repr(_element.name)})'
+            list_elem = 'things_element = {self_name}.things.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('things_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class acme_foo_bar__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -44,7 +47,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/li1')
-            res.append('{self_name} = bar__c1__li1({repr(self.l1)})')
+            res.append('{self_name} = bar__c1__li1({repr_yang(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -205,7 +208,7 @@ class bar__c1(yang.adata.MNode):
         for _element in _li1:
             res.append('')
             res.append("# List /c1/li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr_yang(_element.l1)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if len(_l1) != 0:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/compile_submodule_conflicting_import_prefix
+++ b/test/golden/test_yang/compile_submodule_conflicting_import_prefix
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class parent__parent_container(yang.adata.MNode):
         leaves = []
         _parent_leaf = self.parent_leaf
         if _parent_leaf is not None:
-            leaves.append('{self_name}.parent_leaf = {repr(_parent_leaf)}')
+            leaves.append('{self_name}.parent_leaf = {repr_yang(_parent_leaf)}')
         _augmented_leaf = self.augmented_leaf
         if _augmented_leaf is not None:
-            leaves.append('{self_name}.augmented_leaf = {repr(_augmented_leaf)}')
+            leaves.append('{self_name}.augmented_leaf = {repr_yang(_augmented_leaf)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /parent-container'] + leaves + res
@@ -152,10 +155,10 @@ class parent__sub_container(yang.adata.MNode):
         leaves = []
         _sub_leaf = self.sub_leaf
         if _sub_leaf is not None:
-            leaves.append('{self_name}.sub_leaf = {repr(_sub_leaf)}')
+            leaves.append('{self_name}.sub_leaf = {repr_yang(_sub_leaf)}')
         _another_leaf = self.another_leaf
         if _another_leaf is not None:
-            leaves.append('{self_name}.another_leaf = {repr(_another_leaf)}')
+            leaves.append('{self_name}.another_leaf = {repr_yang(_another_leaf)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /sub-container'] + leaves + res

--- a/test/golden/test_yang/compile_submodule_different_prefix
+++ b/test/golden/test_yang/compile_submodule_different_prefix
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -53,7 +56,7 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
         leaves = []
         _sub_group_leaf = self.sub_group_leaf
         if _sub_group_leaf is not None:
-            leaves.append('{self_name}.sub_group_leaf = {repr(_sub_group_leaf)}')
+            leaves.append('{self_name}.sub_group_leaf = {repr_yang(_sub_group_leaf)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /main-container/sub-group-container'] + leaves + res
@@ -143,14 +146,14 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /main-container/sub-list')
-            res.append('{self_name} = main_module__main_container__sub_list({repr(self.name)})')
+            res.append('{self_name} = main_module__main_container__sub_list({repr_yang(self.name)})')
         leaves = []
         _sub_value = self.sub_value
         if _sub_value is not None:
-            leaves.append('{self_name}.sub_value = {repr(_sub_value)}')
+            leaves.append('{self_name}.sub_value = {repr_yang(_sub_value)}')
         _ref_to_main = self.ref_to_main
         if _ref_to_main is not None:
-            leaves.append('{self_name}.ref_to_main = {repr(_ref_to_main)}')
+            leaves.append('{self_name}.ref_to_main = {repr_yang(_ref_to_main)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /main-container/sub-list'] + leaves + res
@@ -331,10 +334,10 @@ class main_module__main_container__group_container(yang.adata.MNode):
         leaves = []
         _group_leaf = self.group_leaf
         if _group_leaf is not None:
-            leaves.append('{self_name}.group_leaf = {repr(_group_leaf)}')
+            leaves.append('{self_name}.group_leaf = {repr_yang(_group_leaf)}')
         _augmented_in_group = self.augmented_in_group
         if _augmented_in_group is not None:
-            leaves.append('{self_name}.augmented_in_group = {repr(_augmented_in_group)}')
+            leaves.append('{self_name}.augmented_in_group = {repr_yang(_augmented_in_group)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /main-container/group-container'] + leaves + res
@@ -434,18 +437,18 @@ class main_module__main_container(yang.adata.MNode):
         leaves = []
         _main_leaf = self.main_leaf
         if _main_leaf is not None:
-            leaves.append('{self_name}.main_leaf = {repr(_main_leaf)}')
+            leaves.append('{self_name}.main_leaf = {repr_yang(_main_leaf)}')
         _sub_group_container = self.sub_group_container
         if _sub_group_container is not None:
             res.extend(_sub_group_container.prsrc('{self_name}.sub_group_container', False).splitlines())
         _sub_leaf = self.sub_leaf
         if _sub_leaf is not None:
-            leaves.append('{self_name}.sub_leaf = {repr(_sub_leaf)}')
+            leaves.append('{self_name}.sub_leaf = {repr_yang(_sub_leaf)}')
         _sub_list = self.sub_list
         for _element in _sub_list:
             res.append('')
             res.append("# List /main-container/sub-list element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'sub_list_element = {self_name}.sub_list.create({repr(_element.name)})'
+            list_elem = 'sub_list_element = {self_name}.sub_list.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('sub_list_element', False, list_element=True).splitlines())
         _group_container = self.group_container

--- a/test/golden/test_yang/compile_submodule_same_module_different_prefix
+++ b/test/golden/test_yang/compile_submodule_same_module_different_prefix
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class parent__parent_container(yang.adata.MNode):
         leaves = []
         _parent_leaf = self.parent_leaf
         if _parent_leaf is not None:
-            leaves.append('{self_name}.parent_leaf = {repr(_parent_leaf)}')
+            leaves.append('{self_name}.parent_leaf = {repr_yang(_parent_leaf)}')
         _augmented_leaf = self.augmented_leaf
         if _augmented_leaf is not None:
-            leaves.append('{self_name}.augmented_leaf = {repr(_augmented_leaf)}')
+            leaves.append('{self_name}.augmented_leaf = {repr_yang(_augmented_leaf)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /parent-container'] + leaves + res
@@ -152,10 +155,10 @@ class parent__sub_container(yang.adata.MNode):
         leaves = []
         _sub_leaf = self.sub_leaf
         if _sub_leaf is not None:
-            leaves.append('{self_name}.sub_leaf = {repr(_sub_leaf)}')
+            leaves.append('{self_name}.sub_leaf = {repr_yang(_sub_leaf)}')
         _shared_leaf = self.shared_leaf
         if _shared_leaf is not None:
-            leaves.append('{self_name}.shared_leaf = {repr(_shared_leaf)}')
+            leaves.append('{self_name}.shared_leaf = {repr_yang(_shared_leaf)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /sub-container'] + leaves + res

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -127,7 +130,7 @@ class foo__c2(yang.adata.MNode):
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c2'] + leaves + res

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -44,7 +47,7 @@ class foo__c1__li1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/li1')
-            res.append('{self_name} = foo__c1__li1({repr(self.l1)})')
+            res.append('{self_name} = foo__c1__li1({repr_yang(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -205,7 +208,7 @@ class foo__c1(yang.adata.MNode):
         for _element in _li1:
             res.append('')
             res.append("# List /c1/li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr_yang(_element.l1)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/identity_base_resolution_import_prefix
+++ b/test/golden/test_yang/identity_base_resolution_import_prefix
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _base_base_module_PROTOCOL = DIdentity(module='base-module', namespace='http://example.com/base', prefix='base-pfx', name='PROTOCOL', base=[])

--- a/test/golden/test_yang/identityref
+++ b/test/golden/test_yang/identityref
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _base_base_protocol_type = DIdentity(module='base', namespace='http://example.com/base', prefix='base', name='protocol-type', base=[])
@@ -74,7 +77,7 @@ class base__config(yang.adata.MNode):
         leaves = []
         _active_protocol = self.active_protocol
         if _active_protocol is not None:
-            leaves.append('{self_name}.active_protocol = {repr(_active_protocol)}')
+            leaves.append('{self_name}.active_protocol = {repr_yang(_active_protocol)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /config'] + leaves + res

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -52,7 +55,7 @@ class foo__c__li__bar(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c/li/bar')
-            res.append('{self_name} = foo__c__li__bar({repr(self.man)})')
+            res.append('{self_name} = foo__c__li__bar({repr_yang(self.man)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -131,12 +134,12 @@ class foo__c__li_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c/li')
-            res.append('self_bar = foo__c__li__bar({repr(self.bar.man)})')
-            res.append('{self_name} = foo__c__li({repr(self.name)}, self_bar)')
+            res.append('self_bar = foo__c__li__bar({repr_yang(self.bar.man)})')
+            res.append('{self_name} = foo__c__li({repr_yang(self.name)}, self_bar)')
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         _bar = self.bar
         if _bar is not None:
             res.extend(_bar.prsrc('{self_name}.bar', False).splitlines())

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -52,7 +55,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/base:l1')
-            res.append('{self_name} = base__c1__base_l1({repr(self.base_k1)}, {repr(self.foo_k1)})')
+            res.append('{self_name} = base__c1__base_l1({repr_yang(self.base_k1)}, {repr_yang(self.foo_k1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -213,7 +216,7 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/foo:l1')
-            res.append('{self_name} = base__c1__foo_l1({repr(self.k2)})')
+            res.append('{self_name} = base__c1__foo_l1({repr_yang(self.k2)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -379,14 +382,14 @@ class base__c1(yang.adata.MNode):
         for _element in _base_l1:
             res.append('')
             res.append("# List /c1/base:l1 element: {_element.to_gdata().key_str(['k1'])}")
-            list_elem = 'base_l1_element = {self_name}.base_l1.create({repr(_element.base_k1)}, {repr(_element.foo_k1)})'
+            list_elem = 'base_l1_element = {self_name}.base_l1.create({repr_yang(_element.base_k1)}, {repr_yang(_element.foo_k1)})'
             res.append(list_elem)
             res.extend(_element.prsrc('base_l1_element', False, list_element=True).splitlines())
         _foo_l1 = self.foo_l1
         for _element in _foo_l1:
             res.append('')
             res.append("# List /c1/foo:l1 element: {_element.to_gdata().key_str(['k2'])}")
-            list_elem = 'foo_l1_element = {self_name}.foo_l1.create({repr(_element.k2)})'
+            list_elem = 'foo_l1_element = {self_name}.foo_l1.create({repr_yang(_element.k2)})'
             res.append(list_elem)
             res.extend(_element.prsrc('foo_l1_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class base__c1__base_c2(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/base:c2'] + leaves + res
@@ -127,7 +130,7 @@ class base__c1__foo_c2(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/foo:c2'] + leaves + res

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -58,10 +61,10 @@ class base__c1(yang.adata.MNode):
         leaves = []
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
-            leaves.append('{self_name}.bar_foo = {repr(_bar_foo)}')
+            leaves.append('{self_name}.bar_foo = {repr_yang(_bar_foo)}')
         _foo_foo = self.foo_foo
         if _foo_foo is not None:
-            leaves.append('{self_name}.foo_foo = {repr(_foo_foo)}')
+            leaves.append('{self_name}.foo_foo = {repr_yang(_foo_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class foo__ieee_802_3(yang.adata.MNode):
         leaves = []
         _ieee_802_3 = self.ieee_802_3
         if _ieee_802_3 is not None:
-            leaves.append('{self_name}.ieee_802_3 = {repr(_ieee_802_3)}')
+            leaves.append('{self_name}.ieee_802_3 = {repr_yang(_ieee_802_3)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /ieee-802.3'] + leaves + res

--- a/test/golden/test_yang/prdaclass_identityref_list_key
+++ b/test/golden/test_yang/prdaclass_identityref_list_key
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _base_foo_id1 = DIdentity(module='foo', namespace='http://example.com/foo', prefix='foo', name='id1', base=[])
@@ -70,7 +73,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/l1')
-            res.append('{self_name} = foo__c1__l1({repr(self.k1)}, {repr(self.k2)})')
+            res.append('{self_name} = foo__c1__l1({repr_yang(self.k1)}, {repr_yang(self.k2)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -239,7 +242,7 @@ class foo__c1(yang.adata.MNode):
         for _element in _l1:
             res.append('')
             res.append("# List /c1/l1 element: {_element.to_gdata().key_str(['k1', 'k2'])}")
-            list_elem = 'l1_element = {self_name}.l1.create({repr(_element.k1)}, {repr(_element.k2)})'
+            list_elem = 'l1_element = {self_name}.l1.create({repr_yang(_element.k1)}, {repr_yang(_element.k2)})'
             res.append(list_elem)
             res.extend(_element.prsrc('l1_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -82,19 +85,19 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _as_ = self.as_
         if _as_ is not None:
-            leaves.append('{self_name}.as_ = {repr(_as_)}')
+            leaves.append('{self_name}.as_ = {repr_yang(_as_)}')
         _for_ = self.for_
         if _for_ is not None:
-            leaves.append('{self_name}.for_ = {repr(_for_)}')
+            leaves.append('{self_name}.for_ = {repr_yang(_for_)}')
         _import_ = self.import_
         if _import_ is not None:
-            leaves.append('{self_name}.import_ = {repr(_import_)}')
+            leaves.append('{self_name}.import_ = {repr_yang(_import_)}')
         _in_ = self.in_
         if _in_ is not None:
-            leaves.append('{self_name}.in_ = {repr(_in_)}')
+            leaves.append('{self_name}.in_ = {repr_yang(_in_)}')
         _with_ = self.with_
         if _with_ is not None:
-            leaves.append('{self_name}.with_ = {repr(_with_)}')
+            leaves.append('{self_name}.with_ = {repr_yang(_with_)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -44,7 +47,7 @@ class foo__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /l1')
-            res.append('{self_name} = foo__l1({repr(self.name)})')
+            res.append('{self_name} = foo__l1({repr_yang(self.name)})')
         leaves = []
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -52,11 +55,11 @@ class foo__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /l1')
-            res.append('{self_name} = foo__l1({repr(self.name)})')
+            res.append('{self_name} = foo__l1({repr_yang(self.name)})')
         leaves = []
         _id = self.id
         if _id is not None:
-            leaves.append('{self_name}.id = {repr(_id)}')
+            leaves.append('{self_name}.id = {repr_yang(_id)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /l1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class foo__foo__bar(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/bar'] + leaves + res

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -53,7 +56,7 @@ class foo__foo__bar(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/bar'] + leaves + res

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -44,7 +47,7 @@ class foo__li1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /li1')
-            res.append('{self_name} = foo__li1({repr(self.l1)})')
+            res.append('{self_name} = foo__li1({repr_yang(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -213,12 +216,12 @@ class root(yang.adata.MNode):
         for _element in _li1:
             res.append('')
             res.append("# List /li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr_yang(_element.l1)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         _ll1 = self.ll1
         if len(_ll1) != 0:
-            leaves.append('{self_name}.ll1 = {repr(_ll1)}')
+            leaves.append('{self_name}.ll1 = {repr_yang(_ll1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /'] + leaves + res

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -44,7 +47,7 @@ class foo__li1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /li1')
-            res.append('{self_name} = foo__li1({repr(self.l1)})')
+            res.append('{self_name} = foo__li1({repr_yang(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -213,12 +216,12 @@ class root(yang.adata.MNode):
         for _element in _li1:
             res.append('')
             res.append("# List /li1 element: {_element.to_gdata().key_str(['l1'])}")
-            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.l1)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr_yang(_element.l1)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         _ll1 = self.ll1
         if len(_ll1) != 0:
-            leaves.append('{self_name}.ll1 = {repr(_ll1)}')
+            leaves.append('{self_name}.ll1 = {repr_yang(_ll1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /'] + leaves + res

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -56,7 +59,7 @@ class foo__l1__bar(yang.adata.MNode):
         leaves = []
         _hi = self.hi
         if _hi is not None:
-            leaves.append('{self_name}.hi = {repr(_hi)}')
+            leaves.append('{self_name}.hi = {repr_yang(_hi)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /l1/bar'] + leaves + res
@@ -134,11 +137,11 @@ class foo__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /l1')
-            res.append('{self_name} = foo__l1({repr(self.name)})')
+            res.append('{self_name} = foo__l1({repr_yang(self.name)})')
         leaves = []
         _id = self.id
         if _id is not None:
-            leaves.append('{self_name}.id = {repr(_id)}')
+            leaves.append('{self_name}.id = {repr_yang(_id)}')
         _bar = self.bar
         if _bar is not None:
             res.extend(_bar.prsrc('{self_name}.bar', False).splitlines())
@@ -313,7 +316,7 @@ class root(yang.adata.MNode):
         for _element in _l1:
             res.append('')
             res.append("# List /l1 element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'l1_element = {self_name}.l1.create({repr(_element.name)})'
+            list_elem = 'l1_element = {self_name}.l1.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('l1_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -83,9 +86,9 @@ mut def from_data_yangrpc__foo__input__woo__woo_b(val: value) -> yang.gdata.Leaf
     return yang.gdata.Leaf('int64', val)
 
 class yangrpc__foo__input__woo(yang.adata.MNode):
-    woo_b: ?int
+    woo_b: ?bigint
 
-    mut def __init__(self, woo_b: ?int):
+    mut def __init__(self, woo_b: ?bigint):
         self._ns = 'http://example.com/yangrpc'
         self.woo_b = woo_b
 
@@ -99,7 +102,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input__woo:
         if n is not None:
-            return yangrpc__foo__input__woo(woo_b=n.get_opt_int('woo_b'))
+            return yangrpc__foo__input__woo(woo_b=n.get_opt_bigint('woo_b'))
         return yangrpc__foo__input__woo()
 
     def copy(self):
@@ -114,7 +117,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
         leaves = []
         _woo_b = self.woo_b
         if _woo_b is not None:
-            leaves.append('{self_name}.woo_b = {repr(_woo_b)}')
+            leaves.append('{self_name}.woo_b = {repr_yang(_woo_b)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/input/woo'] + leaves + res
@@ -130,7 +133,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
 
 mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_woo_b = yang.gdata.from_xml_opt_int(node, 'woo_b')
+    child_woo_b = yang.gdata.from_xml_opt_bigint(node, 'woo_b')
     yang.gdata.maybe_add(children, 'woo_b', from_data_yangrpc__foo__input__woo__woo_b, child_woo_b)
     return yang.gdata.Container(children)
 
@@ -193,7 +196,7 @@ class yangrpc__foo__input(yang.adata.MNode):
         leaves = []
         _a = self.a
         if _a is not None:
-            leaves.append('{self_name}.a = {repr(_a)}')
+            leaves.append('{self_name}.a = {repr_yang(_a)}')
         _woo = self.woo
         if _woo is not None:
             res.extend(_woo.prsrc('{self_name}.woo', False).splitlines())
@@ -280,7 +283,7 @@ class yangrpc__foo__output(yang.adata.MNode):
         leaves = []
         _outoo = self.outoo
         if _outoo is not None:
-            leaves.append('{self_name}.outoo = {repr(_outoo)}')
+            leaves.append('{self_name}.outoo = {repr_yang(_outoo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/output'] + leaves + res

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -52,7 +55,7 @@ class foo__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /l1')
-            res.append('{self_name} = foo__l1({repr(self.name)}, {repr(self.id)})')
+            res.append('{self_name} = foo__l1({repr_yang(self.name)}, {repr_yang(self.id)})')
         leaves = []
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -52,7 +55,7 @@ class foo__l1__bar(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /l1/bar')
-            res.append('{self_name} = foo__l1__bar({repr(self.hi)})')
+            res.append('{self_name} = foo__l1__bar({repr_yang(self.hi)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -134,13 +137,13 @@ class foo__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /l1')
-            res.append('{self_name} = foo__l1({repr(self.name)})')
+            res.append('{self_name} = foo__l1({repr_yang(self.name)})')
         leaves = []
         _bar = self.bar
         if _bar is not None:
             res.append('')
             res.append('# P-container: /l1/bar')
-            res.append('bar = {self_name}.create_bar({repr(_bar.hi)})')
+            res.append('bar = {self_name}.create_bar({repr_yang(_bar.hi)})')
             res.extend(_bar.prsrc('bar', False).splitlines())
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -65,7 +68,7 @@ class foo__foo__bar(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /foo/bar')
-            res.append('{self_name} = foo__foo__bar({repr(self.foo_l1)}, {repr(self.bar_l1)}, {repr(self.l2)})')
+            res.append('{self_name} = foo__foo__bar({repr_yang(self.foo_l1)}, {repr_yang(self.bar_l1)}, {repr_yang(self.l2)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -165,7 +168,7 @@ class foo__foo(yang.adata.MNode):
         if _bar is not None:
             res.append('')
             res.append('# P-container: /foo/bar')
-            res.append('bar = {self_name}.create_bar({repr(_bar.foo_l1)}, {repr(_bar.bar_l1)}, {repr(_bar.l2)})')
+            res.append('bar = {self_name}.create_bar({repr_yang(_bar.foo_l1)}, {repr_yang(_bar.bar_l1)}, {repr_yang(_bar.l2)})')
             res.extend(_bar.prsrc('bar', False).splitlines())
         if leaves:
             if not list_element:

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class bar__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /bar:c1'] + leaves + res
@@ -127,7 +130,7 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo:c1'] + leaves + res

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -127,7 +130,7 @@ class foo__pc1__foo(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1/foo'] + leaves + res

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -60,7 +63,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/l1')
-            res.append('{self_name} = foo__c1__l1({repr(self.k1)}, {repr(self.k2)}, {repr(self.l1)})')
+            res.append('{self_name} = foo__c1__l1({repr_yang(self.k1)}, {repr_yang(self.k2)}, {repr_yang(self.l1)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -88,7 +91,7 @@ class foo__c1__l1(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, int) and isinstance(k2, int):
+            if isinstance(e_k2, bigint) and isinstance(k2, bigint):
                 if e_k2 != k2:
                     match = False
                     continue
@@ -242,7 +245,7 @@ class foo__c1(yang.adata.MNode):
         for _element in _l1:
             res.append('')
             res.append("# List /c1/l1 element: {_element.to_gdata().key_str(['k1', 'k2'])}")
-            list_elem = 'l1_element = {self_name}.l1.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.l1)})'
+            list_elem = 'l1_element = {self_name}.l1.create({repr_yang(_element.k1)}, {repr_yang(_element.k2)}, {repr_yang(_element.l1)})'
             res.append(list_elem)
             res.extend(_element.prsrc('l1_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -28,12 +31,12 @@ mut def from_data_foo__l4(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('union', val, ns='http://example.com/foo', module='foo')
 
 class root(yang.adata.MNode):
-    l1: ?int
-    l2: ?int
-    l3: ?int
-    l4: ?int
+    l1: ?bigint
+    l2: ?bigint
+    l3: ?bigint
+    l4: ?bigint
 
-    mut def __init__(self, l1: ?int, l2: ?int, l3: ?int, l4: ?int):
+    mut def __init__(self, l1: ?bigint, l2: ?bigint, l3: ?bigint, l4: ?bigint):
         self._ns = ''
         self.l1 = l1
         self.l2 = l2
@@ -59,7 +62,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(l1=n.get_opt_int('l1'), l2=n.get_opt_int('l2'), l3=n.get_opt_int('l3'), l4=n.get_opt_int('l4'))
+            return root(l1=n.get_opt_bigint('l1'), l2=n.get_opt_bigint('l2'), l3=n.get_opt_bigint('l3'), l4=n.get_opt_bigint('l4'))
         return root()
 
     def copy(self):
@@ -74,16 +77,16 @@ class root(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append('{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr_yang(_l4)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /'] + leaves + res
@@ -99,13 +102,13 @@ class root(yang.adata.MNode):
 
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_l1 = yang.gdata.from_xml_opt_int(node, 'l1', 'http://example.com/foo')
+    child_l1 = yang.gdata.from_xml_opt_bigint(node, 'l1', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'l1', from_data_foo__l1, child_l1)
-    child_l2 = yang.gdata.from_xml_opt_int(node, 'l2', 'http://example.com/foo')
+    child_l2 = yang.gdata.from_xml_opt_bigint(node, 'l2', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'l2', from_data_foo__l2, child_l2)
-    child_l3 = yang.gdata.from_xml_opt_int(node, 'l3', 'http://example.com/foo')
+    child_l3 = yang.gdata.from_xml_opt_bigint(node, 'l3', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'l3', from_data_foo__l3, child_l3)
-    child_l4 = yang.gdata.from_xml_opt_int(node, 'l4', 'http://example.com/foo')
+    child_l4 = yang.gdata.from_xml_opt_bigint(node, 'l4', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'l4', from_data_foo__l4, child_l4)
     return yang.gdata.Container(children)
 
@@ -133,13 +136,13 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
 
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
-    child_l1 = yang.gdata.take_json_opt_int(jd, 'l1', 'foo')
+    child_l1 = yang.gdata.take_json_opt_bigint(jd, 'l1', 'foo')
     yang.gdata.maybe_add(children, 'l1', from_data_foo__l1, child_l1)
-    child_l2 = yang.gdata.take_json_opt_int(jd, 'l2', 'foo')
+    child_l2 = yang.gdata.take_json_opt_bigint(jd, 'l2', 'foo')
     yang.gdata.maybe_add(children, 'l2', from_data_foo__l2, child_l2)
-    child_l3 = yang.gdata.take_json_opt_int(jd, 'l3', 'foo')
+    child_l3 = yang.gdata.take_json_opt_bigint(jd, 'l3', 'foo')
     yang.gdata.maybe_add(children, 'l3', from_data_foo__l3, child_l3)
-    child_l4 = yang.gdata.take_json_opt_int(jd, 'l4', 'foo')
+    child_l4 = yang.gdata.take_json_opt_bigint(jd, 'l4', 'foo')
     yang.gdata.maybe_add(children, 'l4', from_data_foo__l4, child_l4)
     return yang.gdata.Container(children)
 

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class root(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /'] + leaves + res

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -5,11 +5,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -50,7 +53,7 @@ class root(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /'] + leaves + res

--- a/test/golden/yang.gdata/prsrc
+++ b/test/golden/yang.gdata/prsrc
@@ -1,15 +1,15 @@
 Container({
   'foo': Container({
-    'a': Leaf('int', 1),
+    'a': Leaf('int', bigint(1)),
     'l1': List(['name'], elements=[
       Container({
         'name': Leaf('str', 'k1'),
-        'n1': Leaf('int', 1),
-        'n2': Leaf('int', 2)
+        'n1': Leaf('int', bigint(1)),
+        'n2': Leaf('int', bigint(2))
       }),
       Container({
         'name': Leaf('str', 'k4'),
-        'n4': Leaf('int', 4)
+        'n4': Leaf('int', bigint(4))
       })
     ])
   }, ns='http://example.com/acme', module='acme')

--- a/test/golden/yang.gdata/prsrc_absent
+++ b/test/golden/yang.gdata/prsrc_absent
@@ -7,7 +7,7 @@ Container({
       }),
       Container({
         'name': Leaf('str', 'k4'),
-        'n4': Leaf('int', 4)
+        'n4': Leaf('int', bigint(4))
       })
     ])
   }, ns='http://example.com/acme', module='acme')

--- a/test/golden/yang.gdata/prsrc_leaf_ns
+++ b/test/golden/yang.gdata/prsrc_leaf_ns
@@ -1,6 +1,6 @@
 Container({
   'foo': Container({
-    'a': Leaf('int', 1, ns='http://example.com/foo', module='foo'),
-    'b': Leaf('int', 2)
+    'a': Leaf('int', bigint(1), ns='http://example.com/foo', module='foo'),
+    'b': Leaf('int', bigint(2))
   }, ns='http://example.com/acme', module='acme')
 })

--- a/test/golden/yang.gdata/prsrc_root
+++ b/test/golden/yang.gdata/prsrc_root
@@ -1,6 +1,6 @@
 Container({
   'foo': Container({
-    'a': Leaf('int', 1),
+    'a': Leaf('int', bigint(1)),
     'b': LeafList('str', ['a', 'b', 'c'])
   }, ns='http://example.com/acme', module='acme')
 })

--- a/test/golden/yang.gen3/pradata
+++ b/test/golden/yang.gen3/pradata
@@ -5,7 +5,7 @@ ad.top_level_leaf = 'root value'
 ad = root()
 
 # Container: /c1
-ad.c1.optional_leaf = 42
+ad.c1.optional_leaf = bigint(42)
 
 # P-container: /c1/c2
 c2 = ad.c1.create_c2('required value')
@@ -14,12 +14,12 @@ c2 = ad.c1.create_c2('required value')
 c2.l1 = 'inner value'
 
 # List /c1/li1 element: item1,1
-li1_element = ad.c1.li1.create('item1', 1)
-li1_element.value = 100
+li1_element = ad.c1.li1.create('item1', bigint(1))
+li1_element.value = bigint(100)
 
 # List /c1/li1 element: item2,2
-li1_element = ad.c1.li1.create('item2', 2)
-li1_element.value = 200
+li1_element = ad.c1.li1.create('item2', bigint(2))
+li1_element.value = bigint(200)
 
 # Container: /c1/li1[name='item2',extra-key='2']/c3
 li1_element.c3.nested_leaf = 'birb'

--- a/test/golden/yang.gen3/pradata_root_path
+++ b/test/golden/yang.gen3/pradata_root_path
@@ -5,4 +5,4 @@ ad.value1 = 'test value'
 ad = test__outer__middle()
 
 # Container: /outer/middle/inner
-ad.inner.value2 = 42
+ad.inner.value2 = bigint(42)

--- a/test/golden/yang.gen3/union_int_json
+++ b/test/golden/yang.gen3/union_int_json
@@ -1,3 +1,3 @@
 Container({
-  'u': Leaf('union', 7, ns='urn:example:y', module='y')
+  'u': Leaf('union', bigint(7), ns='urn:example:y', module='y')
 })

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -465,7 +465,7 @@ def _test_foo_from_gdata_int():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml_gen3(xml_in)
     l3 = gd2.get_cnt("c1").get_leaf("l3").val
-    if isinstance(l3, int):
+    if isinstance(l3, bigint):
         testing.assertEqual(l3, 1337)
     else:
         testing.error("l3 in gdata is not an int")

--- a/test/test_data_classes/src/test_data_classes_gen2.act
+++ b/test/test_data_classes/src/test_data_classes_gen2.act
@@ -475,7 +475,7 @@ def _test_foo_from_gdata_int():
     xml_in = xml.decode(xml_text)
     gd2 = yang_foo.from_xml(xml_in)
     l3 = gd2.get_cnt("c1").get_leaf("l3").val
-    if isinstance(l3, int):
+    if isinstance(l3, bigint):
         testing.assertEqual(l3, 1337)
     else:
         testing.error("l3 in gdata is not an int")

--- a/test/test_data_classes/src/test_rpc_exec.act
+++ b/test/test_data_classes/src/test_rpc_exec.act
@@ -169,7 +169,7 @@ def _test_rpc_input_serialization():
     # Check nested container
     woo_gdata = gdata.get_cnt("woo")
     testing.assertNotNone(woo_gdata, "Container 'woo' should exist")
-    testing.assertEqual(woo_gdata.get_int("woo_b"), 123, "Leaf 'woo_b' should have correct value")
+    testing.assertEqual(woo_gdata.get_bigint("woo_b"), 123, "Leaf 'woo_b' should have correct value")
 
     # Convert to XML string
     xml_str = gdata.to_xmlstr()

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -6,11 +6,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities = [
@@ -131,7 +134,7 @@ mut def from_data_basics__c__l_identityref_def(val: value) -> yang.gdata.Leaf:
 class basics__c(yang.adata.MNode):
     l_str_def: str
     l_str_def_quoted: str
-    l_uint64_def: int
+    l_uint64_def: bigint
     l_union_def_str: value
     l_union_def_int: value
     l_union_def_float: value
@@ -140,11 +143,11 @@ class basics__c(yang.adata.MNode):
     l_binary_def: bytes
     l_identityref_def: Identityref
 
-    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?int=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None):
+    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?bigint=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None):
         self._ns = 'http://example.com/basics'
         self.l_str_def = l_str_def if l_str_def is not None else "foo"
         self.l_str_def_quoted = l_str_def_quoted if l_str_def_quoted is not None else "\"foo\""
-        self.l_uint64_def = l_uint64_def if l_uint64_def is not None else 1234567890
+        self.l_uint64_def = l_uint64_def if l_uint64_def is not None else bigint(1234567890)
         self.l_union_def_str = l_union_def_str if l_union_def_str is not None else "foo"
         self.l_union_def_int = l_union_def_int if l_union_def_int is not None else 1234567890
         self.l_union_def_float = l_union_def_float if l_union_def_float is not None else 1.23
@@ -199,7 +202,7 @@ class basics__c(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> basics__c:
         if n is not None:
-            return basics__c(l_str_def=n.get_opt_str('l_str_def'), l_str_def_quoted=n.get_opt_str('l_str_def_quoted'), l_uint64_def=n.get_opt_int('l_uint64_def'), l_union_def_str=n.get_opt_value('l_union_def_str'), l_union_def_int=n.get_opt_value('l_union_def_int'), l_union_def_float=n.get_opt_value('l_union_def_float'), l_union_def_bool=n.get_opt_value('l_union_def_bool'), l_union_def_enumeration=n.get_opt_value('l_union_def_enumeration'), l_binary_def=n.get_opt_bytes('l_binary_def'), l_identityref_def=n.get_opt_Identityref('l_identityref_def'))
+            return basics__c(l_str_def=n.get_opt_str('l_str_def'), l_str_def_quoted=n.get_opt_str('l_str_def_quoted'), l_uint64_def=n.get_opt_bigint('l_uint64_def'), l_union_def_str=n.get_opt_value('l_union_def_str'), l_union_def_int=n.get_opt_value('l_union_def_int'), l_union_def_float=n.get_opt_value('l_union_def_float'), l_union_def_bool=n.get_opt_value('l_union_def_bool'), l_union_def_enumeration=n.get_opt_value('l_union_def_enumeration'), l_binary_def=n.get_opt_bytes('l_binary_def'), l_identityref_def=n.get_opt_Identityref('l_identityref_def'))
         return basics__c()
 
     def copy(self):
@@ -214,34 +217,34 @@ class basics__c(yang.adata.MNode):
         leaves = []
         _l_str_def = self.l_str_def
         if _l_str_def is not None:
-            leaves.append('{self_name}.l_str_def = {repr(_l_str_def)}')
+            leaves.append('{self_name}.l_str_def = {repr_yang(_l_str_def)}')
         _l_str_def_quoted = self.l_str_def_quoted
         if _l_str_def_quoted is not None:
-            leaves.append('{self_name}.l_str_def_quoted = {repr(_l_str_def_quoted)}')
+            leaves.append('{self_name}.l_str_def_quoted = {repr_yang(_l_str_def_quoted)}')
         _l_uint64_def = self.l_uint64_def
         if _l_uint64_def is not None:
-            leaves.append('{self_name}.l_uint64_def = {repr(_l_uint64_def)}')
+            leaves.append('{self_name}.l_uint64_def = {repr_yang(_l_uint64_def)}')
         _l_union_def_str = self.l_union_def_str
         if _l_union_def_str is not None:
-            leaves.append('{self_name}.l_union_def_str = {repr(_l_union_def_str)}')
+            leaves.append('{self_name}.l_union_def_str = {repr_yang(_l_union_def_str)}')
         _l_union_def_int = self.l_union_def_int
         if _l_union_def_int is not None:
-            leaves.append('{self_name}.l_union_def_int = {repr(_l_union_def_int)}')
+            leaves.append('{self_name}.l_union_def_int = {repr_yang(_l_union_def_int)}')
         _l_union_def_float = self.l_union_def_float
         if _l_union_def_float is not None:
-            leaves.append('{self_name}.l_union_def_float = {repr(_l_union_def_float)}')
+            leaves.append('{self_name}.l_union_def_float = {repr_yang(_l_union_def_float)}')
         _l_union_def_bool = self.l_union_def_bool
         if _l_union_def_bool is not None:
-            leaves.append('{self_name}.l_union_def_bool = {repr(_l_union_def_bool)}')
+            leaves.append('{self_name}.l_union_def_bool = {repr_yang(_l_union_def_bool)}')
         _l_union_def_enumeration = self.l_union_def_enumeration
         if _l_union_def_enumeration is not None:
-            leaves.append('{self_name}.l_union_def_enumeration = {repr(_l_union_def_enumeration)}')
+            leaves.append('{self_name}.l_union_def_enumeration = {repr_yang(_l_union_def_enumeration)}')
         _l_binary_def = self.l_binary_def
         if _l_binary_def is not None:
-            leaves.append('{self_name}.l_binary_def = {repr(_l_binary_def)}')
+            leaves.append('{self_name}.l_binary_def = {repr_yang(_l_binary_def)}')
         _l_identityref_def = self.l_identityref_def
         if _l_identityref_def is not None:
-            leaves.append('{self_name}.l_identityref_def = {repr(_l_identityref_def)}')
+            leaves.append('{self_name}.l_identityref_def = {repr_yang(_l_identityref_def)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c'] + leaves + res
@@ -261,7 +264,7 @@ mut def from_xml_basics__c(node: xml.Node) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'l_str_def', from_data_basics__c__l_str_def, child_l_str_def)
     child_l_str_def_quoted = yang.gdata.from_xml_opt_str(node, 'l_str_def_quoted')
     yang.gdata.maybe_add(children, 'l_str_def_quoted', from_data_basics__c__l_str_def_quoted, child_l_str_def_quoted)
-    child_l_uint64_def = yang.gdata.from_xml_opt_int(node, 'l_uint64_def')
+    child_l_uint64_def = yang.gdata.from_xml_opt_bigint(node, 'l_uint64_def')
     yang.gdata.maybe_add(children, 'l_uint64_def', from_data_basics__c__l_uint64_def, child_l_uint64_def)
     child_l_union_def_str = yang.gdata.from_xml_opt_value(node, 'l_union_def_str')
     yang.gdata.maybe_add(children, 'l_union_def_str', from_data_basics__c__l_union_def_str, child_l_union_def_str)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -6,11 +6,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _base_foo_basey = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='basey', base=[])
@@ -359,7 +362,7 @@ class foo__c1__li__c4(yang.adata.MNode):
         leaves = []
         _l5 = self.l5
         if _l5 is not None:
-            leaves.append('{self_name}.l5 = {repr(_l5)}')
+            leaves.append('{self_name}.l5 = {repr_yang(_l5)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/li/c4'] + leaves + res
@@ -437,11 +440,11 @@ class foo__c1__li_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/li')
-            res.append('{self_name} = foo__c1__li({repr(self.name)})')
+            res.append('{self_name} = foo__c1__li({repr_yang(self.name)})')
         leaves = []
         _val = self.val
         if _val is not None:
-            leaves.append('{self_name}.val = {repr(_val)}')
+            leaves.append('{self_name}.val = {repr_yang(_val)}')
         _c4 = self.c4
         if _c4 is not None:
             res.extend(_c4.prsrc('{self_name}.c4', False).splitlines())
@@ -616,10 +619,10 @@ mut def from_data_foo__c1__l2(val: value) -> yang.gdata.Leaf:
 
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
-    l3: ?int
+    l3: ?bigint
     l_empty: ?bool
     li: foo__c1__li
-    ll_uint64: list[int]
+    ll_uint64: list[bigint]
     ll_str: list[str]
     l_identityref: ?Identityref
     ll_identityref: list[Identityref]
@@ -627,7 +630,7 @@ class foo__c1(yang.adata.MNode):
     bar_l1: ?str
     l2: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[int]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l4: ?str, bar_l1: ?str, l2: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?bigint, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[bigint]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l4: ?str, bar_l1: ?str, l2: ?str):
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -694,7 +697,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l_identityref=n.get_opt_Identityref('l_identityref'), ll_identityref=n.get_opt_Identityrefs('ll_identityref'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
+            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_bigint('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_bigints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l_identityref=n.get_opt_Identityref('l_identityref'), ll_identityref=n.get_opt_Identityrefs('ll_identityref'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
     def copy(self):
@@ -709,41 +712,41 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _f_l1 = self.f_l1
         if _f_l1 is not None:
-            leaves.append('{self_name}.f_l1 = {repr(_f_l1)}')
+            leaves.append('{self_name}.f_l1 = {repr_yang(_f_l1)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         _l_empty = self.l_empty
         if _l_empty is not None:
-            leaves.append('{self_name}.l_empty = {repr(_l_empty)}')
+            leaves.append('{self_name}.l_empty = {repr_yang(_l_empty)}')
         _li = self.li
         for _element in _li:
             res.append('')
             res.append("# List /c1/li element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'li_element = {self_name}.li.create({repr(_element.name)})'
+            list_elem = 'li_element = {self_name}.li.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         _ll_uint64 = self.ll_uint64
         if len(_ll_uint64) != 0:
-            leaves.append('{self_name}.ll_uint64 = {repr(_ll_uint64)}')
+            leaves.append('{self_name}.ll_uint64 = {repr_yang(_ll_uint64)}')
         _ll_str = self.ll_str
         if len(_ll_str) != 0:
-            leaves.append('{self_name}.ll_str = {repr(_ll_str)}')
+            leaves.append('{self_name}.ll_str = {repr_yang(_ll_str)}')
         _l_identityref = self.l_identityref
         if _l_identityref is not None:
-            leaves.append('{self_name}.l_identityref = {repr(_l_identityref)}')
+            leaves.append('{self_name}.l_identityref = {repr_yang(_l_identityref)}')
         _ll_identityref = self.ll_identityref
         if len(_ll_identityref) != 0:
-            leaves.append('{self_name}.ll_identityref = {repr(_ll_identityref)}')
+            leaves.append('{self_name}.ll_identityref = {repr_yang(_ll_identityref)}')
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append('{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr_yang(_l4)}')
         _bar_l1 = self.bar_l1
         if _bar_l1 is not None:
-            leaves.append('{self_name}.bar_l1 = {repr(_bar_l1)}')
+            leaves.append('{self_name}.bar_l1 = {repr_yang(_bar_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -761,13 +764,13 @@ mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_f_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
     yang.gdata.maybe_add(children, 'f:l1', from_data_foo__c1__f_l1, child_f_l1)
-    child_l3 = yang.gdata.from_xml_opt_int(node, 'l3')
+    child_l3 = yang.gdata.from_xml_opt_bigint(node, 'l3')
     yang.gdata.maybe_add(children, 'l3', from_data_foo__c1__l3, child_l3)
     child_l_empty = yang.gdata.from_xml_opt_empty(node, 'l_empty')
     yang.gdata.maybe_add(children, 'l_empty', from_data_foo__c1__l_empty, child_l_empty)
     child_li = yang.gdata.from_xml_opt_list(node, 'li')
     yang.gdata.maybe_add(children, 'li', from_xml_foo__c1__li, child_li)
-    child_ll_uint64 = yang.gdata.from_xml_opt_ints(node, 'll_uint64')
+    child_ll_uint64 = yang.gdata.from_xml_opt_bigints(node, 'll_uint64')
     yang.gdata.maybe_add(children, 'll_uint64', from_data_foo__c1__ll_uint64, child_ll_uint64)
     child_ll_str = yang.gdata.from_xml_opt_strs(node, 'll_str')
     yang.gdata.maybe_add(children, 'll_str', from_data_foo__c1__ll_str, child_ll_str)
@@ -881,7 +884,7 @@ class foo__pc1__foo(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if len(_l1) != 0:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1/foo'] + leaves + res
@@ -1032,7 +1035,7 @@ class foo__pc2__foo(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /pc2/foo')
-            res.append('{self_name} = foo__pc2__foo({repr(self.l_mandatory)})')
+            res.append('{self_name} = foo__pc2__foo({repr_yang(self.l_mandatory)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1106,7 +1109,7 @@ class foo__pc2(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /pc2')
-            res.append('self_foo = foo__pc2__foo({repr(self.foo.l_mandatory)})')
+            res.append('self_foo = foo__pc2__foo({repr_yang(self.foo.l_mandatory)})')
             res.append('{self_name} = foo__pc2(self_foo)')
         leaves = []
         _foo = self.foo
@@ -1205,11 +1208,11 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /pc3/level1/level2/level3')
-            res.append('{self_name} = foo__pc3__level1__level2__level3({repr(self.l3)})')
+            res.append('{self_name} = foo__pc3__level1__level2__level3({repr_yang(self.l3)})')
         leaves = []
         _l3_optional = self.l3_optional
         if _l3_optional is not None:
-            leaves.append('{self_name}.l3_optional = {repr(_l3_optional)}')
+            leaves.append('{self_name}.l3_optional = {repr_yang(_l3_optional)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1/level2/level3'] + leaves + res
@@ -1295,12 +1298,12 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /pc3/level1/level2')
-            res.append('self_level3 = foo__pc3__level1__level2__level3({repr(self.level3.l3)})')
-            res.append('{self_name} = foo__pc3__level1__level2({repr(self.l2)}, self_level3)')
+            res.append('self_level3 = foo__pc3__level1__level2__level3({repr_yang(self.level3.l3)})')
+            res.append('{self_name} = foo__pc3__level1__level2({repr_yang(self.l2)}, self_level3)')
         leaves = []
         _l2_optional = self.l2_optional
         if _l2_optional is not None:
-            leaves.append('{self_name}.l2_optional = {repr(_l2_optional)}')
+            leaves.append('{self_name}.l2_optional = {repr_yang(_l2_optional)}')
         _level3 = self.level3
         if _level3 is not None:
             res.extend(_level3.prsrc('{self_name}.level3', False).splitlines())
@@ -1396,13 +1399,13 @@ class foo__pc3__level1(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /pc3/level1')
-            res.append('self_level2_level3 = foo__pc3__level1__level2__level3({repr(self.level2.level3.l3)})')
-            res.append('self_level2 = foo__pc3__level1__level2({repr(self.level2.l2)}, self_level2_level3)')
-            res.append('{self_name} = foo__pc3__level1({repr(self.l1)}, self_level2)')
+            res.append('self_level2_level3 = foo__pc3__level1__level2__level3({repr_yang(self.level2.level3.l3)})')
+            res.append('self_level2 = foo__pc3__level1__level2({repr_yang(self.level2.l2)}, self_level2_level3)')
+            res.append('{self_name} = foo__pc3__level1({repr_yang(self.l1)}, self_level2)')
         leaves = []
         _l1_optional = self.l1_optional
         if _l1_optional is not None:
-            leaves.append('{self_name}.l1_optional = {repr(_l1_optional)}')
+            leaves.append('{self_name}.l1_optional = {repr_yang(_l1_optional)}')
         _level2 = self.level2
         if _level2 is not None:
             res.extend(_level2.prsrc('{self_name}.level2', False).splitlines())
@@ -1491,9 +1494,9 @@ class foo__pc3(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /pc3')
-            res.append('self_level1_level2_level3 = foo__pc3__level1__level2__level3({repr(self.level1.level2.level3.l3)})')
-            res.append('self_level1_level2 = foo__pc3__level1__level2({repr(self.level1.level2.l2)}, self_level1_level2_level3)')
-            res.append('self_level1 = foo__pc3__level1({repr(self.level1.l1)}, self_level1_level2)')
+            res.append('self_level1_level2_level3 = foo__pc3__level1__level2__level3({repr_yang(self.level1.level2.level3.l3)})')
+            res.append('self_level1_level2 = foo__pc3__level1__level2({repr_yang(self.level1.level2.l2)}, self_level1_level2_level3)')
+            res.append('self_level1 = foo__pc3__level1({repr_yang(self.level1.l1)}, self_level1_level2)')
             res.append('{self_name} = foo__pc3(self_level1)')
         leaves = []
         _level1 = self.level1
@@ -1648,10 +1651,10 @@ class foo__c_dot(yang.adata.MNode):
         leaves = []
         _l_dot1 = self.l_dot1
         if _l_dot1 is not None:
-            leaves.append('{self_name}.l_dot1 = {repr(_l_dot1)}')
+            leaves.append('{self_name}.l_dot1 = {repr_yang(_l_dot1)}')
         _l_dot2 = self.l_dot2
         if _l_dot2 is not None:
-            leaves.append('{self_name}.l_dot2 = {repr(_l_dot2)}')
+            leaves.append('{self_name}.l_dot2 = {repr_yang(_l_dot2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c.dot'] + leaves + res
@@ -1731,7 +1734,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /cc/death')
-            res.append('{self_name} = foo__cc__death({repr(self.name)})')
+            res.append('{self_name} = foo__cc__death({repr_yang(self.name)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1895,12 +1898,12 @@ class foo__cc(yang.adata.MNode):
         leaves = []
         _cake = self.cake
         if _cake is not None:
-            leaves.append('{self_name}.cake = {repr(_cake)}')
+            leaves.append('{self_name}.cake = {repr_yang(_cake)}')
         _death = self.death
         for _element in _death:
             res.append('')
             res.append("# List /cc/death element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'death_element = {self_name}.death.create({repr(_element.name)})'
+            list_elem = 'death_element = {self_name}.death.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('death_element', False, list_element=True).splitlines())
         if leaves:
@@ -2148,7 +2151,7 @@ class foo__conflict(yang.adata.MNode):
         leaves = []
         _f_foo = self.f_foo
         if _f_foo is not None:
-            leaves.append('{self_name}.f_foo = {repr(_f_foo)}')
+            leaves.append('{self_name}.f_foo = {repr_yang(_f_foo)}')
         _f_inner = self.f_inner
         if _f_inner is not None:
             res.append('')
@@ -2157,7 +2160,7 @@ class foo__conflict(yang.adata.MNode):
             res.extend(_f_inner.prsrc('f_inner', False).splitlines())
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
-            leaves.append('{self_name}.bar_foo = {repr(_bar_foo)}')
+            leaves.append('{self_name}.bar_foo = {repr_yang(_bar_foo)}')
         _bar_inner = self.bar_inner
         if _bar_inner is not None:
             res.append('')
@@ -2254,7 +2257,7 @@ class foo__special_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /special')
-            res.append('{self_name} = foo__special({repr(self.yes)})')
+            res.append('{self_name} = foo__special({repr_yang(self.yes)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -2435,11 +2438,11 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /nested/f:inner/li1/li2')
-            res.append('{self_name} = foo__nested__f_inner__li1__li2({repr(self.key1)}, {repr(self.key2)})')
+            res.append('{self_name} = foo__nested__f_inner__li1__li2({repr_yang(self.key1)}, {repr_yang(self.key2)})')
         leaves = []
         _baz = self.baz
         if _baz is not None:
-            leaves.append('{self_name}.baz = {repr(_baz)}')
+            leaves.append('{self_name}.baz = {repr_yang(_baz)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1/li2'] + leaves + res
@@ -2623,21 +2626,21 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /nested/f:inner/li1')
-            res.append('{self_name} = foo__nested__f_inner__li1({repr(self.name)})')
+            res.append('{self_name} = foo__nested__f_inner__li1({repr_yang(self.name)})')
         leaves = []
         _f_bar = self.f_bar
         if _f_bar is not None:
-            leaves.append('{self_name}.f_bar = {repr(_f_bar)}')
+            leaves.append('{self_name}.f_bar = {repr_yang(_f_bar)}')
         _li2 = self.li2
         for _element in _li2:
             res.append('')
             res.append("# List /nested/f:inner/li1/li2 element: {_element.to_gdata().key_str(['key1', 'key2'])}")
-            list_elem = 'li2_element = {self_name}.li2.create({repr(_element.key1)}, {repr(_element.key2)})'
+            list_elem = 'li2_element = {self_name}.li2.create({repr_yang(_element.key1)}, {repr_yang(_element.key2)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li2_element', False, list_element=True).splitlines())
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
-            leaves.append('{self_name}.bar_bar = {repr(_bar_bar)}')
+            leaves.append('{self_name}.bar_bar = {repr_yang(_bar_bar)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1'] + leaves + res
@@ -2818,12 +2821,12 @@ class foo__nested__f_inner(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         _li1 = self.li1
         for _element in _li1:
             res.append('')
             res.append("# List /nested/f:inner/li1 element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.name)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:
@@ -2909,7 +2912,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/bar:inner'] + leaves + res
@@ -3086,7 +3089,7 @@ class foo__li_union_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /li-union')
-            res.append('{self_name} = foo__li_union({repr(self.k1)}, {repr(self.k2)}, {repr(self.k3)})')
+            res.append('{self_name} = foo__li_union({repr_yang(self.k1)}, {repr_yang(self.k2)}, {repr_yang(self.k3)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -3114,7 +3117,7 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, int) and isinstance(k2, int):
+            if isinstance(e_k2, bigint) and isinstance(k2, bigint):
                 if e_k2 != k2:
                     match = False
                     continue
@@ -3284,10 +3287,10 @@ class foo__state__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /state/c1'] + leaves + res
@@ -3448,7 +3451,7 @@ class foo__c2(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c2'] + leaves + res
@@ -3540,7 +3543,7 @@ class bar__test_idref(yang.adata.MNode):
         leaves = []
         _idref = self.idref
         if len(_idref) != 0:
-            leaves.append('{self_name}.idref = {repr(_idref)}')
+            leaves.append('{self_name}.idref = {repr_yang(_idref)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /test-idref'] + leaves + res
@@ -3617,7 +3620,7 @@ class bar__conflict(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /bar:conflict'] + leaves + res
@@ -3809,16 +3812,16 @@ class root(yang.adata.MNode):
         if _pc2 is not None:
             res.append('')
             res.append('# P-container: /pc2')
-            res.append('pc2_foo = foo__pc2__foo({repr(_pc2.foo.l_mandatory)})')
+            res.append('pc2_foo = foo__pc2__foo({repr_yang(_pc2.foo.l_mandatory)})')
             res.append('pc2 = {self_name}.create_pc2(pc2_foo)')
             res.extend(_pc2.prsrc('pc2', False).splitlines())
         _pc3 = self.pc3
         if _pc3 is not None:
             res.append('')
             res.append('# P-container: /pc3')
-            res.append('pc3_level1_level2_level3 = foo__pc3__level1__level2__level3({repr(_pc3.level1.level2.level3.l3)})')
-            res.append('pc3_level1_level2 = foo__pc3__level1__level2({repr(_pc3.level1.level2.l2)}, pc3_level1_level2_level3)')
-            res.append('pc3_level1 = foo__pc3__level1({repr(_pc3.level1.l1)}, pc3_level1_level2)')
+            res.append('pc3_level1_level2_level3 = foo__pc3__level1__level2__level3({repr_yang(_pc3.level1.level2.level3.l3)})')
+            res.append('pc3_level1_level2 = foo__pc3__level1__level2({repr_yang(_pc3.level1.level2.l2)}, pc3_level1_level2_level3)')
+            res.append('pc3_level1 = foo__pc3__level1({repr_yang(_pc3.level1.l1)}, pc3_level1_level2)')
             res.append('pc3 = {self_name}.create_pc3(pc3_level1)')
             res.extend(_pc3.prsrc('pc3', False).splitlines())
         _empty_presence = self.empty_presence
@@ -3840,7 +3843,7 @@ class root(yang.adata.MNode):
         for _element in _special:
             res.append('')
             res.append("# List /special element: {_element.to_gdata().key_str(['yes'])}")
-            list_elem = 'special_element = {self_name}.special.create({repr(_element.yes)})'
+            list_elem = 'special_element = {self_name}.special.create({repr_yang(_element.yes)})'
             res.append(list_elem)
             res.extend(_element.prsrc('special_element', False, list_element=True).splitlines())
         _nested = self.nested
@@ -3850,7 +3853,7 @@ class root(yang.adata.MNode):
         for _element in _li_union:
             res.append('')
             res.append("# List /li-union element: {_element.to_gdata().key_str(['k1', 'k2', 'k3'])}")
-            list_elem = 'li_union_element = {self_name}.li_union.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.k3)})'
+            list_elem = 'li_union_element = {self_name}.li_union.create({repr_yang(_element.k1)}, {repr_yang(_element.k2)}, {repr_yang(_element.k3)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li_union_element', False, list_element=True).splitlines())
         _state = self.state
@@ -3858,7 +3861,7 @@ class root(yang.adata.MNode):
             res.extend(_state.prsrc('{self_name}.state', False).splitlines())
         _ll_empty = self.ll_empty
         if len(_ll_empty) != 0:
-            leaves.append('{self_name}.ll_empty = {repr(_ll_empty)}')
+            leaves.append('{self_name}.ll_empty = {repr_yang(_ll_empty)}')
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -6,11 +6,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _base_foo_basey = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='basey', base=[])
@@ -359,7 +362,7 @@ class foo__c1__li__c4(yang.adata.MNode):
         leaves = []
         _l5 = self.l5
         if _l5 is not None:
-            leaves.append('{self_name}.l5 = {repr(_l5)}')
+            leaves.append('{self_name}.l5 = {repr_yang(_l5)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1/li/c4'] + leaves + res
@@ -437,11 +440,11 @@ class foo__c1__li_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /c1/li')
-            res.append('{self_name} = foo__c1__li({repr(self.name)})')
+            res.append('{self_name} = foo__c1__li({repr_yang(self.name)})')
         leaves = []
         _val = self.val
         if _val is not None:
-            leaves.append('{self_name}.val = {repr(_val)}')
+            leaves.append('{self_name}.val = {repr_yang(_val)}')
         _c4 = self.c4
         if _c4 is not None:
             res.extend(_c4.prsrc('{self_name}.c4', False).splitlines())
@@ -616,10 +619,10 @@ mut def from_data_foo__c1__l2(val: value) -> yang.gdata.Leaf:
 
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
-    l3: ?int
+    l3: ?bigint
     l_empty: ?bool
     li: foo__c1__li
-    ll_uint64: list[int]
+    ll_uint64: list[bigint]
     ll_str: list[str]
     l_identityref: ?Identityref
     ll_identityref: list[Identityref]
@@ -627,7 +630,7 @@ class foo__c1(yang.adata.MNode):
     bar_l1: ?str
     l2: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?int, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[int]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l4: ?str, bar_l1: ?str, l2: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?bigint, l_empty: ?bool, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[bigint]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l4: ?str, bar_l1: ?str, l2: ?str):
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -694,7 +697,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_int('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_ints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l_identityref=n.get_opt_Identityref('l_identityref'), ll_identityref=n.get_opt_Identityrefs('ll_identityref'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
+            return foo__c1(f_l1=n.get_opt_str('f:l1'), l3=n.get_opt_bigint('l3'), l_empty=n.get_opt_empty('l_empty'), li=foo__c1__li.from_gdata(n.get_opt_list('li')), ll_uint64=n.get_opt_bigints('ll_uint64'), ll_str=n.get_opt_strs('ll_str'), l_identityref=n.get_opt_Identityref('l_identityref'), ll_identityref=n.get_opt_Identityrefs('ll_identityref'), l4=n.get_opt_str('l4'), bar_l1=n.get_opt_str('bar:l1'), l2=n.get_opt_str('l2'))
         return foo__c1()
 
     def copy(self):
@@ -709,41 +712,41 @@ class foo__c1(yang.adata.MNode):
         leaves = []
         _f_l1 = self.f_l1
         if _f_l1 is not None:
-            leaves.append('{self_name}.f_l1 = {repr(_f_l1)}')
+            leaves.append('{self_name}.f_l1 = {repr_yang(_f_l1)}')
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         _l_empty = self.l_empty
         if _l_empty is not None:
-            leaves.append('{self_name}.l_empty = {repr(_l_empty)}')
+            leaves.append('{self_name}.l_empty = {repr_yang(_l_empty)}')
         _li = self.li
         for _element in _li:
             res.append('')
             res.append("# List /c1/li element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'li_element = {self_name}.li.create({repr(_element.name)})'
+            list_elem = 'li_element = {self_name}.li.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         _ll_uint64 = self.ll_uint64
         if len(_ll_uint64) != 0:
-            leaves.append('{self_name}.ll_uint64 = {repr(_ll_uint64)}')
+            leaves.append('{self_name}.ll_uint64 = {repr_yang(_ll_uint64)}')
         _ll_str = self.ll_str
         if len(_ll_str) != 0:
-            leaves.append('{self_name}.ll_str = {repr(_ll_str)}')
+            leaves.append('{self_name}.ll_str = {repr_yang(_ll_str)}')
         _l_identityref = self.l_identityref
         if _l_identityref is not None:
-            leaves.append('{self_name}.l_identityref = {repr(_l_identityref)}')
+            leaves.append('{self_name}.l_identityref = {repr_yang(_l_identityref)}')
         _ll_identityref = self.ll_identityref
         if len(_ll_identityref) != 0:
-            leaves.append('{self_name}.ll_identityref = {repr(_ll_identityref)}')
+            leaves.append('{self_name}.ll_identityref = {repr_yang(_ll_identityref)}')
         _l4 = self.l4
         if _l4 is not None:
-            leaves.append('{self_name}.l4 = {repr(_l4)}')
+            leaves.append('{self_name}.l4 = {repr_yang(_l4)}')
         _bar_l1 = self.bar_l1
         if _bar_l1 is not None:
-            leaves.append('{self_name}.bar_l1 = {repr(_bar_l1)}')
+            leaves.append('{self_name}.bar_l1 = {repr_yang(_bar_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c1'] + leaves + res
@@ -761,13 +764,13 @@ mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_f_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
     yang.gdata.maybe_add(children, 'f:l1', from_data_foo__c1__f_l1, child_f_l1)
-    child_l3 = yang.gdata.from_xml_opt_int(node, 'l3')
+    child_l3 = yang.gdata.from_xml_opt_bigint(node, 'l3')
     yang.gdata.maybe_add(children, 'l3', from_data_foo__c1__l3, child_l3)
     child_l_empty = yang.gdata.from_xml_opt_empty(node, 'l_empty')
     yang.gdata.maybe_add(children, 'l_empty', from_data_foo__c1__l_empty, child_l_empty)
     child_li = yang.gdata.from_xml_opt_list(node, 'li')
     yang.gdata.maybe_add(children, 'li', from_xml_foo__c1__li, child_li)
-    child_ll_uint64 = yang.gdata.from_xml_opt_ints(node, 'll_uint64')
+    child_ll_uint64 = yang.gdata.from_xml_opt_bigints(node, 'll_uint64')
     yang.gdata.maybe_add(children, 'll_uint64', from_data_foo__c1__ll_uint64, child_ll_uint64)
     child_ll_str = yang.gdata.from_xml_opt_strs(node, 'll_str')
     yang.gdata.maybe_add(children, 'll_str', from_data_foo__c1__ll_str, child_ll_str)
@@ -881,7 +884,7 @@ class foo__pc1__foo(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if len(_l1) != 0:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc1/foo'] + leaves + res
@@ -1036,7 +1039,7 @@ class foo__pc2__foo(yang.adata.MNode):
         leaves = []
         _l_mandatory = self.l_mandatory
         if _l_mandatory is not None:
-            leaves.append('{self_name}.l_mandatory = {repr(_l_mandatory)}')
+            leaves.append('{self_name}.l_mandatory = {repr_yang(_l_mandatory)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc2/foo'] + leaves + res
@@ -1211,10 +1214,10 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         leaves = []
         _l3 = self.l3
         if _l3 is not None:
-            leaves.append('{self_name}.l3 = {repr(_l3)}')
+            leaves.append('{self_name}.l3 = {repr_yang(_l3)}')
         _l3_optional = self.l3_optional
         if _l3_optional is not None:
-            leaves.append('{self_name}.l3_optional = {repr(_l3_optional)}')
+            leaves.append('{self_name}.l3_optional = {repr_yang(_l3_optional)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /pc3/level1/level2/level3'] + leaves + res
@@ -1304,10 +1307,10 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         _l2_optional = self.l2_optional
         if _l2_optional is not None:
-            leaves.append('{self_name}.l2_optional = {repr(_l2_optional)}')
+            leaves.append('{self_name}.l2_optional = {repr_yang(_l2_optional)}')
         _level3 = self.level3
         if _level3 is not None:
             res.extend(_level3.prsrc('{self_name}.level3', False).splitlines())
@@ -1407,10 +1410,10 @@ class foo__pc3__level1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l1_optional = self.l1_optional
         if _l1_optional is not None:
-            leaves.append('{self_name}.l1_optional = {repr(_l1_optional)}')
+            leaves.append('{self_name}.l1_optional = {repr_yang(_l1_optional)}')
         _level2 = self.level2
         if _level2 is not None:
             res.extend(_level2.prsrc('{self_name}.level2', False).splitlines())
@@ -1653,10 +1656,10 @@ class foo__c_dot(yang.adata.MNode):
         leaves = []
         _l_dot1 = self.l_dot1
         if _l_dot1 is not None:
-            leaves.append('{self_name}.l_dot1 = {repr(_l_dot1)}')
+            leaves.append('{self_name}.l_dot1 = {repr_yang(_l_dot1)}')
         _l_dot2 = self.l_dot2
         if _l_dot2 is not None:
-            leaves.append('{self_name}.l_dot2 = {repr(_l_dot2)}')
+            leaves.append('{self_name}.l_dot2 = {repr_yang(_l_dot2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c.dot'] + leaves + res
@@ -1736,7 +1739,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /cc/death')
-            res.append('{self_name} = foo__cc__death({repr(self.name)})')
+            res.append('{self_name} = foo__cc__death({repr_yang(self.name)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -1900,12 +1903,12 @@ class foo__cc(yang.adata.MNode):
         leaves = []
         _cake = self.cake
         if _cake is not None:
-            leaves.append('{self_name}.cake = {repr(_cake)}')
+            leaves.append('{self_name}.cake = {repr_yang(_cake)}')
         _death = self.death
         for _element in _death:
             res.append('')
             res.append("# List /cc/death element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'death_element = {self_name}.death.create({repr(_element.name)})'
+            list_elem = 'death_element = {self_name}.death.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('death_element', False, list_element=True).splitlines())
         if leaves:
@@ -2153,7 +2156,7 @@ class foo__conflict(yang.adata.MNode):
         leaves = []
         _f_foo = self.f_foo
         if _f_foo is not None:
-            leaves.append('{self_name}.f_foo = {repr(_f_foo)}')
+            leaves.append('{self_name}.f_foo = {repr_yang(_f_foo)}')
         _f_inner = self.f_inner
         if _f_inner is not None:
             res.append('')
@@ -2162,7 +2165,7 @@ class foo__conflict(yang.adata.MNode):
             res.extend(_f_inner.prsrc('f_inner', False).splitlines())
         _bar_foo = self.bar_foo
         if _bar_foo is not None:
-            leaves.append('{self_name}.bar_foo = {repr(_bar_foo)}')
+            leaves.append('{self_name}.bar_foo = {repr_yang(_bar_foo)}')
         _bar_inner = self.bar_inner
         if _bar_inner is not None:
             res.append('')
@@ -2259,7 +2262,7 @@ class foo__special_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /special')
-            res.append('{self_name} = foo__special({repr(self.yes)})')
+            res.append('{self_name} = foo__special({repr_yang(self.yes)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -2440,11 +2443,11 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /nested/f:inner/li1/li2')
-            res.append('{self_name} = foo__nested__f_inner__li1__li2({repr(self.key1)}, {repr(self.key2)})')
+            res.append('{self_name} = foo__nested__f_inner__li1__li2({repr_yang(self.key1)}, {repr_yang(self.key2)})')
         leaves = []
         _baz = self.baz
         if _baz is not None:
-            leaves.append('{self_name}.baz = {repr(_baz)}')
+            leaves.append('{self_name}.baz = {repr_yang(_baz)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1/li2'] + leaves + res
@@ -2628,21 +2631,21 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /nested/f:inner/li1')
-            res.append('{self_name} = foo__nested__f_inner__li1({repr(self.name)})')
+            res.append('{self_name} = foo__nested__f_inner__li1({repr_yang(self.name)})')
         leaves = []
         _f_bar = self.f_bar
         if _f_bar is not None:
-            leaves.append('{self_name}.f_bar = {repr(_f_bar)}')
+            leaves.append('{self_name}.f_bar = {repr_yang(_f_bar)}')
         _li2 = self.li2
         for _element in _li2:
             res.append('')
             res.append("# List /nested/f:inner/li1/li2 element: {_element.to_gdata().key_str(['key1', 'key2'])}")
-            list_elem = 'li2_element = {self_name}.li2.create({repr(_element.key1)}, {repr(_element.key2)})'
+            list_elem = 'li2_element = {self_name}.li2.create({repr_yang(_element.key1)}, {repr_yang(_element.key2)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li2_element', False, list_element=True).splitlines())
         _bar_bar = self.bar_bar
         if _bar_bar is not None:
-            leaves.append('{self_name}.bar_bar = {repr(_bar_bar)}')
+            leaves.append('{self_name}.bar_bar = {repr_yang(_bar_bar)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/f:inner/li1'] + leaves + res
@@ -2823,12 +2826,12 @@ class foo__nested__f_inner(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         _li1 = self.li1
         for _element in _li1:
             res.append('')
             res.append("# List /nested/f:inner/li1 element: {_element.to_gdata().key_str(['name'])}")
-            list_elem = 'li1_element = {self_name}.li1.create({repr(_element.name)})'
+            list_elem = 'li1_element = {self_name}.li1.create({repr_yang(_element.name)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li1_element', False, list_element=True).splitlines())
         if leaves:
@@ -2914,7 +2917,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /nested/bar:inner'] + leaves + res
@@ -3091,7 +3094,7 @@ class foo__li_union_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /li-union')
-            res.append('{self_name} = foo__li_union({repr(self.k1)}, {repr(self.k2)}, {repr(self.k3)})')
+            res.append('{self_name} = foo__li_union({repr_yang(self.k1)}, {repr_yang(self.k2)}, {repr_yang(self.k3)})')
         leaves = []
         if leaves:
             if not list_element:
@@ -3119,7 +3122,7 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, int) and isinstance(k2, int):
+            if isinstance(e_k2, bigint) and isinstance(k2, bigint):
                 if e_k2 != k2:
                     match = False
                     continue
@@ -3289,10 +3292,10 @@ class foo__state__c1(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /state/c1'] + leaves + res
@@ -3453,7 +3456,7 @@ class foo__c2(yang.adata.MNode):
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
-            leaves.append('{self_name}.l1 = {repr(_l1)}')
+            leaves.append('{self_name}.l1 = {repr_yang(_l1)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /c2'] + leaves + res
@@ -3545,7 +3548,7 @@ class bar__test_idref(yang.adata.MNode):
         leaves = []
         _idref = self.idref
         if len(_idref) != 0:
-            leaves.append('{self_name}.idref = {repr(_idref)}')
+            leaves.append('{self_name}.idref = {repr_yang(_idref)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /test-idref'] + leaves + res
@@ -3622,7 +3625,7 @@ class bar__conflict(yang.adata.MNode):
         leaves = []
         _foo = self.foo
         if _foo is not None:
-            leaves.append('{self_name}.foo = {repr(_foo)}')
+            leaves.append('{self_name}.foo = {repr_yang(_foo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /bar:conflict'] + leaves + res
@@ -3841,7 +3844,7 @@ class root(yang.adata.MNode):
         for _element in _special:
             res.append('')
             res.append("# List /special element: {_element.to_gdata().key_str(['yes'])}")
-            list_elem = 'special_element = {self_name}.special.create({repr(_element.yes)})'
+            list_elem = 'special_element = {self_name}.special.create({repr_yang(_element.yes)})'
             res.append(list_elem)
             res.extend(_element.prsrc('special_element', False, list_element=True).splitlines())
         _nested = self.nested
@@ -3851,7 +3854,7 @@ class root(yang.adata.MNode):
         for _element in _li_union:
             res.append('')
             res.append("# List /li-union element: {_element.to_gdata().key_str(['k1', 'k2', 'k3'])}")
-            list_elem = 'li_union_element = {self_name}.li_union.create({repr(_element.k1)}, {repr(_element.k2)}, {repr(_element.k3)})'
+            list_elem = 'li_union_element = {self_name}.li_union.create({repr_yang(_element.k1)}, {repr_yang(_element.k2)}, {repr_yang(_element.k3)})'
             res.append(list_elem)
             res.extend(_element.prsrc('li_union_element', False, list_element=True).splitlines())
         _state = self.state
@@ -3859,7 +3862,7 @@ class root(yang.adata.MNode):
             res.extend(_state.prsrc('{self_name}.state', False).splitlines())
         _ll_empty = self.ll_empty
         if len(_ll_empty) != 0:
-            leaves.append('{self_name}.ll_empty = {repr(_ll_empty)}')
+            leaves.append('{self_name}.ll_empty = {repr_yang(_ll_empty)}')
         _c2 = self.c2
         if _c2 is not None:
             res.extend(_c2.prsrc('{self_name}.c2', False).splitlines())

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -6,11 +6,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _base_foo_basey = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='basey', base=[])
@@ -103,11 +106,11 @@ class foo__tc1(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /tc1')
-            res.append('{self_name} = foo__tc1({repr(self.l1)})')
+            res.append('{self_name} = foo__tc1({repr_yang(self.l1)})')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /tc1'] + leaves + res
@@ -197,11 +200,11 @@ class foo__li__c1(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /li/c1')
-            res.append('{self_name} = foo__li__c1({repr(self.l1)})')
+            res.append('{self_name} = foo__li__c1({repr_yang(self.l1)})')
         leaves = []
         _l2 = self.l2
         if _l2 is not None:
-            leaves.append('{self_name}.l2 = {repr(_l2)}')
+            leaves.append('{self_name}.l2 = {repr_yang(_l2)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /li/c1'] + leaves + res
@@ -280,8 +283,8 @@ class foo__li_entry(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /li')
-            res.append('self_c1 = foo__li__c1({repr(self.c1.l1)})')
-            res.append('{self_name} = foo__li({repr(self.name)}, self_c1)')
+            res.append('self_c1 = foo__li__c1({repr_yang(self.c1.l1)})')
+            res.append('{self_name} = foo__li({repr_yang(self.name)}, self_c1)')
         leaves = []
         _c1 = self.c1
         if _c1 is not None:
@@ -450,7 +453,7 @@ class root(yang.adata.MNode):
         res = []
         if top:
             res.append('# Top node: /')
-            res.append('self_tc1 = foo__tc1({repr(self.tc1.l1)})')
+            res.append('self_tc1 = foo__tc1({repr_yang(self.tc1.l1)})')
             res.append('{self_name} = root(self_tc1)')
         leaves = []
         _tc1 = self.tc1
@@ -460,8 +463,8 @@ class root(yang.adata.MNode):
         for _element in _li:
             res.append('')
             res.append("# List /li element: {_element.to_gdata().key_str(['name'])}")
-            res.append('element_c1 = foo__li__c1({repr(_element.c1.l1)})')
-            list_elem = 'li_element = {self_name}.li.create({repr(_element.name)}, element_c1)'
+            res.append('element_c1 = foo__li__c1({repr_yang(_element.c1.l1)})')
+            list_elem = 'li_element = {self_name}.li.create({repr_yang(_element.name)}, element_c1)'
             res.append(list_elem)
             res.extend(_element.prsrc('li_element', False, list_element=True).splitlines())
         if leaves:

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -6,11 +6,14 @@ import yang
 import yang.adata
 import yang.gdata
 import yang.gen3
+from yang.gdata import repr_yang
 from yang.identity import complete_and_validate_identityref
 from yang.identityref import Identityref, PartialIdentityref
 from yang.schema import DIdentity
 
 # == This file is generated ==
+
+
 
 
 _identities: list[DIdentity] = []
@@ -106,9 +109,9 @@ mut def from_data_yangrpc__foo__input__woo__woo_b(val: value) -> yang.gdata.Leaf
     return yang.gdata.Leaf('int64', val)
 
 class yangrpc__foo__input__woo(yang.adata.MNode):
-    woo_b: ?int
+    woo_b: ?bigint
 
-    mut def __init__(self, woo_b: ?int):
+    mut def __init__(self, woo_b: ?bigint):
         self._ns = 'http://example.com/yangrpc'
         self.woo_b = woo_b
 
@@ -122,7 +125,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input__woo:
         if n is not None:
-            return yangrpc__foo__input__woo(woo_b=n.get_opt_int('woo_b'))
+            return yangrpc__foo__input__woo(woo_b=n.get_opt_bigint('woo_b'))
         return yangrpc__foo__input__woo()
 
     def copy(self):
@@ -137,7 +140,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
         leaves = []
         _woo_b = self.woo_b
         if _woo_b is not None:
-            leaves.append('{self_name}.woo_b = {repr(_woo_b)}')
+            leaves.append('{self_name}.woo_b = {repr_yang(_woo_b)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/input/woo'] + leaves + res
@@ -153,7 +156,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
 
 mut def from_xml_yangrpc__foo__input__woo(node: xml.Node) -> yang.gdata.Container:
     children = {}
-    child_woo_b = yang.gdata.from_xml_opt_int(node, 'woo_b')
+    child_woo_b = yang.gdata.from_xml_opt_bigint(node, 'woo_b')
     yang.gdata.maybe_add(children, 'woo_b', from_data_yangrpc__foo__input__woo__woo_b, child_woo_b)
     return yang.gdata.Container(children)
 
@@ -216,7 +219,7 @@ class yangrpc__foo__input(yang.adata.MNode):
         leaves = []
         _a = self.a
         if _a is not None:
-            leaves.append('{self_name}.a = {repr(_a)}')
+            leaves.append('{self_name}.a = {repr_yang(_a)}')
         _woo = self.woo
         if _woo is not None:
             res.extend(_woo.prsrc('{self_name}.woo', False).splitlines())
@@ -303,7 +306,7 @@ class yangrpc__foo__output(yang.adata.MNode):
         leaves = []
         _outoo = self.outoo
         if _outoo is not None:
-            leaves.append('{self_name}.outoo = {repr(_outoo)}')
+            leaves.append('{self_name}.outoo = {repr_yang(_outoo)}')
         if leaves:
             if not list_element:
                res = ['', '# Container: /foo/output'] + leaves + res

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'li': List(['name'], user_order=True, elements=[
       Container({
         'name': Leaf('string', 'tuta'),
@@ -11,7 +11,7 @@ Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l4': Leaf('string', 'foo-qux'),
     'bar:l1': Leaf('string', 'foo-bar', ns='http://example.com/bar', module='bar'),
@@ -65,7 +65,7 @@ Container({
   'li-union': List(['k1', 'k2', 'k3'], ns='http://example.com/foo', module='foo', elements=[
     Container({
       'k1': Leaf('string', 'first'),
-      'k2': Leaf('union', 4),
+      'k2': Leaf('union', bigint(4)),
       'k3': Leaf('binary', b'Hello Acton \xf0\x9f\xab\xa1')
     }),
     Container({

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'l_empty': Leaf('empty', True),
     'li': List(['name'], user_order=True, elements=[
       Container({
@@ -12,7 +12,7 @@ Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l_identityref': Leaf('identityref', Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     'll_identityref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),

--- a/test/test_data_classes/test/golden/test_data_classes/gen3_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/gen3_from_xml_full
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'l_empty': Leaf('empty', True),
     'li': List(['name'], user_order=True, elements=[
       Container({
@@ -12,7 +12,7 @@ Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l_identityref': Leaf('identityref', Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     'll_identityref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),

--- a/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'li': List(['name'], user_order=True, elements=[
       Container({
         'name': Leaf('string', 'tuta'),
@@ -12,7 +12,7 @@ Container({
         'val': Leaf('string', 'baba')
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'bar:l1': Leaf('string', 'foo-bar', ns='http://example.com/bar', module='bar'),
     'l2': Leaf('string', 'bar', ns='http://example.com/bar', module='bar')

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_json_full
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'li': List(['name'], user_order=True, elements=[
       Container({
         'name': Leaf('string', 'tuta'),
@@ -11,7 +11,7 @@ Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l4': Leaf('string', 'foo-qux'),
     'bar:l1': Leaf('string', 'foo-bar', ns='http://example.com/bar', module='bar'),

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/foo_from_xml_full
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'l_empty': Leaf('empty', True),
     'li': List(['name'], user_order=True, elements=[
       Container({
@@ -12,7 +12,7 @@ Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l_identityref': Leaf('identityref', Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     'll_identityref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),

--- a/test/test_data_classes/test/golden/test_data_classes_gen2/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes_gen2/json_to_gdata
@@ -1,7 +1,7 @@
 Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'li': List(['name'], user_order=True, elements=[
       Container({
         'name': Leaf('string', 'tuta'),
@@ -12,7 +12,7 @@ Container({
         'val': Leaf('string', 'baba')
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'bar:l1': Leaf('string', 'foo-bar', ns='http://example.com/bar', module='bar'),
     'l2': Leaf('string', 'bar', ns='http://example.com/bar', module='bar')

--- a/test/test_data_source_roundtrip/src/xml_full_adata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata.act
@@ -7,9 +7,9 @@ def adata():
     
     # Container: /c1
     ad.c1.f_l1 = 'foo-foo'
-    ad.c1.l3 = 18446744073709551615
+    ad.c1.l3 = bigint(18446744073709551615)
     ad.c1.l_empty = True
-    ad.c1.ll_uint64 = [4, 42]
+    ad.c1.ll_uint64 = [bigint(4), bigint(42)]
     ad.c1.ll_str = ['kava', 'čaj']
     ad.c1.l_identityref = Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')
     ad.c1.ll_identityref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]

--- a/test/test_data_source_roundtrip/src/xml_full_adata_gen2.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_gen2.act
@@ -7,9 +7,9 @@ def adata():
     
     # Container: /c1
     ad.c1.f_l1 = 'foo-foo'
-    ad.c1.l3 = 18446744073709551615
+    ad.c1.l3 = bigint(18446744073709551615)
     ad.c1.l_empty = True
-    ad.c1.ll_uint64 = [4, 42]
+    ad.c1.ll_uint64 = [bigint(4), bigint(42)]
     ad.c1.ll_str = ['kava', 'čaj']
     ad.c1.l_identityref = Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')
     ad.c1.ll_identityref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]

--- a/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
@@ -7,9 +7,9 @@ def adata():
     
     # Container: /c1
     ad.c1.f_l1 = 'foo-foo'
-    ad.c1.l3 = 18446744073709551615
+    ad.c1.l3 = bigint(18446744073709551615)
     ad.c1.l_empty = True
-    ad.c1.ll_uint64 = [4, 42]
+    ad.c1.ll_uint64 = [bigint(4), bigint(42)]
     ad.c1.ll_str = ['kava', 'čaj']
     ad.c1.l_identityref = Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')
     ad.c1.ll_identityref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]

--- a/test/test_data_source_roundtrip/src/xml_full_adata_loose_gen2.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_loose_gen2.act
@@ -7,9 +7,9 @@ def adata():
     
     # Container: /c1
     ad.c1.f_l1 = 'foo-foo'
-    ad.c1.l3 = 18446744073709551615
+    ad.c1.l3 = bigint(18446744073709551615)
     ad.c1.l_empty = True
-    ad.c1.ll_uint64 = [4, 42]
+    ad.c1.ll_uint64 = [bigint(4), bigint(42)]
     ad.c1.ll_str = ['kava', 'čaj']
     ad.c1.l_identityref = Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')
     ad.c1.ll_identityref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]

--- a/test/test_data_source_roundtrip/src/xml_full_gdata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_gdata.act
@@ -4,7 +4,7 @@ from yang.identityref import Identityref
 xml_full = Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'l_empty': Leaf('empty', True),
     'li': List(['name'], user_order=True, elements=[
       Container({
@@ -15,7 +15,7 @@ xml_full = Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l_identityref': Leaf('identityref', Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     'll_identityref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),

--- a/test/test_data_source_roundtrip/src/xml_full_gdata_gen2.act
+++ b/test/test_data_source_roundtrip/src/xml_full_gdata_gen2.act
@@ -4,7 +4,7 @@ from yang.identityref import Identityref
 xml_full = Container({
   'c1': Container({
     'f:l1': Leaf('string', 'foo-foo'),
-    'l3': Leaf('uint64', 18446744073709551615),
+    'l3': Leaf('uint64', bigint(18446744073709551615)),
     'l_empty': Leaf('empty', True),
     'li': List(['name'], user_order=True, elements=[
       Container({
@@ -15,7 +15,7 @@ xml_full = Container({
         })
       })
     ]),
-    'll_uint64': LeafList('uint64', [4, 42]),
+    'll_uint64': LeafList('uint64', [bigint(4), bigint(42)]),
     'll_str': LeafList('string', ['kava', 'čaj']),
     'l_identityref': Leaf('identityref', Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     'll_identityref': LeafList('identityref', [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),


### PR DESCRIPTION
All numeric values in gdata are now explict bigints. This is essentially the same behavior as before, when "int" was "bigint". Now "int" is i64, so we remain with the same semantics by switching to the type "bigint".

Going a little overboard with conversion of negative i64 -9223372036854775808 but I actually saw a crash from one occurrence. I want to fix proper parsing before digging deeper into those, but we really should be using the literal -9223372036854775808 and not the workaround -9223372036854775807-1..