### PR TITLE
Refactor get_path_name to use list[DNode] path

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -492,8 +492,11 @@ class DNodeInner(DNode):
         def usname(n) -> str:
             return unique_namer.unique_safe_name(n.name, n.prefix)
 
-        def pname(n):
-            return get_path_name(n)
+        def pname(n: ?DNode=None):
+            if n is not None:
+                return get_path_name(spath + [n])
+            else:
+                return get_path_name(spath)
 
         def us_list_key():
             """Convert list key names (DList.key) to their unique safe names
@@ -518,9 +521,9 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list entry class, the list itself comes later
-            res.append("class {pname(self)}_entry(yang.adata.MNode):")
+            res.append("class {pname()}_entry(yang.adata.MNode):")
         else:
-            res.append("class {pname(self)}(yang.adata.MNode):")
+            res.append("class {pname()}(yang.adata.MNode):")
 
         for child in self.children:
             if isinstance(child, DLeaf):
@@ -699,40 +702,40 @@ class DNodeInner(DNode):
         from_gdata_args = ", ".join(from_gdata_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
-            res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname(self)}_entry:")
-            res.append("        return {pname(self)}_entry({from_gdata_args})")
+            res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname()}_entry:")
+            res.append("        return {pname()}_entry({from_gdata_args})")
         else:
             opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname(self)}:")
+            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
             res.append("        if n is not None:")
-            res.append("            return {pname(self)}({from_gdata_args})")
+            res.append("            return {pname()}({from_gdata_args})")
             if opt_cnt:
                 res.append("        return None")
             elif optional_subtree(self):
-                res.append("        return {pname(self)}()")
+                res.append("        return {pname()}()")
             else:
-                res.append("        raise ValueError('Missing required subtree {pname(self)}')")
+                res.append("        raise ValueError('Missing required subtree {pname()}')")
         res.append("")
 
         # .copy() method
         res.append("    def copy(self):")
         res.append('        """Create a deep copy of this adata object"""')
         if isinstance(self, DList):
-            res.append("        return {pname(self)}_entry.from_gdata(self.to_gdata())")
+            res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
         else:
             opt_cnt = True if isinstance(self, DContainer) and self.presence else False
             # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
             # But since we're copying an instance, the output of .copy() is non-optional.
             if opt_cnt:
-                res.append("        ad = {pname(self)}.from_gdata(self.to_gdata())")
+                res.append("        ad = {pname()}.from_gdata(self.to_gdata())")
                 res.append("        if ad is not None:")
                 res.append("            return ad")
-                res.append("        raise Exception('Unreachable in {pname(self)}.copy()')")
+                res.append("        raise Exception('Unreachable in {pname()}.copy()')")
             else:
-                res.append("        return {pname(self)}.from_gdata(self.to_gdata())")
+                res.append("        return {pname()}.from_gdata(self.to_gdata())")
         res.append("")
 
-        def find_non_optional_subtree(container: DNodeInner, path: list[str], local_prefix="_") -> (list[str], list[str]):
+        def find_non_optional_subtree(container: DNodeInner, spath: list[DNode], path: list[str], local_prefix="_") -> (list[str], list[str]):
             r"""Discover the non-optional descendants of a container
 
             The container here is either a DContainer or a DList (representing
@@ -778,7 +781,7 @@ class DNodeInner(DNode):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
 
                         # Recursively build subtree for non-optional children
-                        sub_args, sub_containers = find_non_optional_subtree(cchild, path + [cchild_safe_name], local_prefix)
+                        sub_args, sub_containers = find_non_optional_subtree(cchild, spath + [cchild], path + [cchild_safe_name], local_prefix)
 
                         # Create variable declaration for this container
                         mcchild_var = "{'_'.join(path)}_{cchild_safe_name}"
@@ -787,7 +790,7 @@ class DNodeInner(DNode):
                             sub_args_str = ", ".join(sub_args)
                             non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}({sub_args_str})')")
                         else:
-                            non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}()')")
+                            non_optional_containers.append("            res.append('{mcchild_var} = {get_path_name(spath + [cchild])}()')")
 
                         # Add nested variable declarations
                         non_optional_containers.extend(sub_containers)
@@ -811,7 +814,7 @@ class DNodeInner(DNode):
         res.append("        if top:")
         res.append("            res.append('# Top node: {get_path(spath)}')")
         # Build constructor arguments for non-optional children (same logic as in __init__)
-        constructor_args, constructor_containers = find_non_optional_subtree(self, ["self"], local_prefix="")
+        constructor_args, constructor_containers = find_non_optional_subtree(self, spath, ["self"], local_prefix="")
 
         if constructor_args:
             # Add variable declarations in reverse order to ensure dependencies are declared before use.
@@ -820,9 +823,9 @@ class DNodeInner(DNode):
             # Since find_non_optional_subtree() builds the list depth-first, we reverse it.
             res.extend(list(reversed(constructor_containers)))
             args_str = ", ".join(constructor_args)
-            res.append("            res.append('{{self_name}} = {pname(self)}({args_str})')")
+            res.append("            res.append('{{self_name}} = {pname()}({args_str})')")
         else:
-            res.append("            res.append('{{self_name}} = {pname(self)}()')")
+            res.append("            res.append('{{self_name}} = {pname()}()')")
         res.append("        leaves = []")
         for child in self.children:
             if isinstance(child, DNodeLeaf):
@@ -846,7 +849,7 @@ class DNodeInner(DNode):
                     res.append("            res.append('')")
                     res.append("            res.append('# P-container: {get_path(path_with_child(child))}')")
                     # Build .prsrc() code for this P-container
-                    pc_args, pc_var_declarations = find_non_optional_subtree(child, [usname(child)])
+                    pc_args, pc_var_declarations = find_non_optional_subtree(child, spath + [child], [usname(child)])
 
                     # Add variable declarations in reverse order to ensure the prerequisites are met
                     res.extend(list(reversed(pc_var_declarations)))
@@ -872,7 +875,7 @@ class DNodeInner(DNode):
                 child_unique_namer = _UniqueNamer(child)
                 list_create_args = []
 
-                non_optional_args, non_optional_containers = find_non_optional_subtree(child, ["element"])
+                non_optional_args, non_optional_containers = find_non_optional_subtree(child, spath + [child], ["element"])
 
                 res.extend(list(reversed(non_optional_containers)))
                 list_create_args.extend(non_optional_args)
@@ -918,8 +921,8 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list class, list entry class was created above
-            res.append("class {pname(self)}(yang.adata.MNode):")
-            res.append("    elements: list[{pname(self)}_entry]")
+            res.append("class {pname()}(yang.adata.MNode):")
+            res.append("    elements: list[{pname()}_entry]")
 
             init_args = ["self"]
             init_args.append("elements=[]")
@@ -977,7 +980,7 @@ class DNodeInner(DNode):
             res.append("                return e")
             res.append("")
             list_key_args_str = ", ".join(list_key_args)
-            res.append("        res = {pname(self)}_entry({list_key_args_str})")
+            res.append("        res = {pname()}_entry({list_key_args_str})")
             res.append("        self.elements.append(res)")
             res.append("        return res")
             res.append("")
@@ -997,11 +1000,11 @@ class DNodeInner(DNode):
 #            # .from_gdata()
 #            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
             res.append("    @staticmethod")
-            res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname(self)}_entry]:")
+            res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname()}_entry]:")
             res.append("        if n is not None:")
-            res.append("            return [{pname(self)}_entry.from_gdata(e) for e in n.elements]")
+            res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
             res.append("        return []")
-            #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname(self))
+            #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
             # TODO: trying to use list(map(lambda)) here results in an error,
             # why? Above code that iterates over n.elements works fine... Error is:
             # ERROR: Error when compiling y_cfs module: Type error
@@ -1017,11 +1020,11 @@ class DNodeInner(DNode):
             res.append("            ce = e.copy()")
             res.append("            if ce is not None:")
             res.append("                copied_elements.append(ce)")
-            res.append("        return {pname(self)}(elements=copied_elements)")
+            res.append("        return {pname()}(elements=copied_elements)")
             res.append("")
             # Generate Iterable extension for the list class
-            res.append("extension {pname(self)}(Iterable[{pname(self)}_entry]):")
-            res.append("    def __iter__(self) -> Iterator[{pname(self)}_entry]:")
+            res.append("extension {pname()}(Iterable[{pname()}_entry]):")
+            res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
             res.append("        return self.elements.__iter__()")
         res.append("")
 
@@ -1031,7 +1034,7 @@ class DNodeInner(DNode):
         if gen_xml and isinstance(self, DNodeInner):
             fname = "from_xml"
             if not top:
-                fname += "_{pname(self)}"
+                fname += "_{pname()}"
 
             if isinstance(self, DList):
                 res.append("mut def {fname}_element(node: xml.Node) -> yang.gdata.Node:")
@@ -1060,8 +1063,8 @@ class DNodeInner(DNode):
             res.append("")
 
         if gen_xml and isinstance(self, DList):
-            res.append("mut def from_xml_{pname(self)}(nodes: list[xml.Node]) -> yang.gdata.List:")
-            res.append("    elements = [from_xml_{pname(self)}_element(e) for e in nodes]")
+            res.append("mut def from_xml_{pname()}(nodes: list[xml.Node]) -> yang.gdata.List:")
+            res.append("    elements = [from_xml_{pname()}_element(e) for e in nodes]")
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
@@ -1071,7 +1074,7 @@ class DNodeInner(DNode):
         if gen_json and isinstance(self, DNodeInner):
             fname = "from_json_path"
             if not top:
-                fname += "_{pname(self)}"
+                fname += "_{pname()}"
 
             if isinstance(self, DList):
                 res += ["mut def {fname}_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:"]
@@ -1083,7 +1086,7 @@ class DNodeInner(DNode):
                 res += ["        point = path[0]"]
                 res += ["        keys = point.split(\",\")"]
                 res += ["        jd_dict = yang.gdata.unwrap_dict(jd)"]
-                res += ["        val = from_json_{pname(self)}_element(jd_dict)"]
+                res += ["        val = from_json_{pname()}_element(jd_dict)"]
                 res += ["        if op == \"merge\":"]
                 res += ["            return val"]
                 res += ["        elif op == \"remove\":"]
@@ -1130,7 +1133,7 @@ class DNodeInner(DNode):
                 res.append("            else:")
                 res.append("                if str(jd_dict[key]) != keys.pop(0):")
                 res.append("                    raise ValueError(\"Key value mismatch between path and payload\")")
-                res.append("        element = from_json_{pname(self)}_element(jd_dict)")
+                res.append("        element = from_json_{pname()}_element(jd_dict)")
                 res.append("        elements = []")
                 res.append("        if op == \"merge\":")
                 res.append("            elements.append(element)")
@@ -1138,7 +1141,7 @@ class DNodeInner(DNode):
                 res.append("            elements.append(yang.gdata.Absent(element.key_children({repr(self.key)})))")
                 res.append("        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    elif len(path) > 1:")
-                res.append("        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
+                res.append("        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname()}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    raise ValueError(\"Unable to resolve path, no keys provided\")")
 
             else:
@@ -1159,7 +1162,7 @@ class DNodeInner(DNode):
                         res.append("            raise ValueError(\"Invalid json path to non-inner node\")")
                 res.append("        raise ValueError(\"Invalid path\")")
                 res.append("    elif len(path) == 0:")
-                valfname = "from_json_{pname(self)}" if not top else "from_json"
+                valfname = "from_json_{pname()}" if not top else "from_json"
                 val_farg = "[jd]" if isinstance(self, DList) else "yang.gdata.unwrap_dict(jd)"
                 res += ["        if op == \"merge\":"]
                 res += ["            return {valfname}({val_farg})"]
@@ -1173,7 +1176,7 @@ class DNodeInner(DNode):
         if gen_json and isinstance(self, DNodeInner):
             fname = "from_json"
             if not top:
-                fname += "_{pname(self)}"
+                fname += "_{pname()}"
 
             if isinstance(self, DList):
                 res.append("mut def {fname}_element(jd: dict[str, ?value]) -> yang.gdata.Node:")
@@ -1202,8 +1205,8 @@ class DNodeInner(DNode):
             res.append("")
 
         if gen_json and isinstance(self, DList):
-            res.append("mut def from_json_{pname(self)}(jd: list[dict[str, ?value]]) -> yang.gdata.List:")
-            res.append("    elements = [from_json_{pname(self)}_element(e) for e in jd if isinstance(e, dict)]")
+            res.append("mut def from_json_{pname()}(jd: list[dict[str, ?value]]) -> yang.gdata.List:")
+            res.append("    elements = [from_json_{pname()}_element(e) for e in jd if isinstance(e, dict)]")
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
@@ -1229,13 +1232,13 @@ class DNodeInner(DNode):
                 # - no output: no output adata parameter in the callback signature
                 if input_node is not None and output_node is not None:
                     # RPC with both input and output
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(spath + [rpc, output_node])}, ?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(spath + [rpc, input_node])}, gen3: bool=False):")
                 elif input_node is not None and output_node is None:
                     # RPC with only input (no output)
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(spath + [rpc, input_node])}, gen3: bool=False):")
                 elif input_node is None and output_node is not None:
                     # RPC with only output (no input)
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, gen3: bool=False):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(spath + [rpc, output_node])}, ?Exception) -> None, gen3: bool=False):")
                 else:
                     # RPC with neither input nor output
                     res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, gen3: bool=False):")
@@ -1247,8 +1250,8 @@ class DNodeInner(DNode):
                     res.append("                if gen3:")
                     res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                else:")
-                    res.append("                    gdata_res = from_xml_{get_path_name(output_node)}(res)")
-                    res.append("                adata_res = {get_path_name(output_node)}.from_gdata(gdata_res)")
+                    res.append("                    gdata_res = from_xml_{get_path_name(spath + [rpc, output_node])}(res)")
+                    res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                     res.append("            else:")
                     res.append("                cb(None, err)")
@@ -1601,13 +1604,13 @@ class DLeaf(DNodeLeaf):
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return []
-        def pname(n):
-            return get_path_name(n)
+        def pname():
+            return get_path_name(spath)
         # Include namespace qualifier(s) iff our namespace is different than our parent
         gdata_nsq = ", ns='{self.namespace}', module='{self.module}'" if set_ns else ""
         res = []
         if gen_json or gen_xml:
-            res.append("mut def from_data_{pname(self)}(val: value) -> yang.gdata.Leaf:")
+            res.append("mut def from_data_{pname()}(val: value) -> yang.gdata.Leaf:")
             if self.type_.name == "identityref":
                 res.append("    new_val, error = complete_and_validate_identityref(val, _identities, {repr(self.type_.base)}, {repr(self.module)})")
                 res.append("    if new_val is not None:")
@@ -1654,15 +1657,15 @@ class DLeafList(DNodeLeaf):
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return []
-        def pname(n):
-            return get_path_name(n)
+        def pname():
+            return get_path_name(spath)
         maybe_user_order = ", user_order=True" if self.ordered_by == "user" else ""
         # Include namespace qualifier(s) iff our namespace is different than our
         # parent
         gdata_nsq = ", ns='{self.namespace}', module='{self.module}'" if set_ns else ""
         res = []
         if gen_json or gen_xml:
-            res.append("mut def from_data_{pname(self)}(val: list[value]) -> yang.gdata.LeafList:")
+            res.append("mut def from_data_{pname()}(val: list[value]) -> yang.gdata.LeafList:")
             if self.type_.name == "identityref":
                 res.append("    new_val = []")
                 res.append("    for v in val:")
@@ -3195,7 +3198,7 @@ class _UniqueNamer(object):
         unique_name = self.unique_name(name, prefix)
         return _safe_name(unique_name, safe_kw).replace(":", "_")
 
-def get_path_name(dnode: DNode) -> str:
+def get_path_name(path: list[DNode]) -> str:
     r"""Build the adata path name for a data node
 
     For example, for the following YANG model:
@@ -3231,28 +3234,29 @@ def get_path_name(dnode: DNode) -> str:
     not necessary. An exception to this is if we are the top node without
     children - then the path is just our name.
     """
-    path = []
-    parent = dnode.parent
-    if parent is None and isinstance(dnode, DNodeInner):
-        top_solo = True if not dnode.children else False
-    else:
-        top_solo = False
-    while True:
-        self_unique_safe_name = _safe_name(dnode.name, safe_kw=not top_solo)
-        parent = dnode.parent
-        if parent is not None:
-            unique_namer = _UniqueNamer(parent)
-            self_unique_safe_name = unique_namer.unique_safe_name(dnode.name, dnode.prefix, safe_kw=False)
-            dnode = parent
-        path.append(self_unique_safe_name)
-        if parent is None:
-            break
+    return "__".join(get_path_usnames(path))
 
-    # This never happens, we always get at least our name!
-    if len(path) == 0:
-        raise ValueError("No path for DNode {dnode}")
 
-    return "__".join(reversed(path))
+def get_path_usnames(path: list[DNode]) -> list[str]:
+    if len(path) == 1:
+        return [_safe_name(path[0].name, safe_kw=False)]
+
+    res = []
+    for i, node in enumerate(path):
+        if i > 0:
+            prev = path[i-1]
+            if isinstance(prev, DRoot):
+                res.append(_safe_name(node.module, safe_kw=False))
+            if isinstance(prev, DNodeInner):
+                un = _UniqueNamer(prev)
+                res.append(un.unique_safe_name(node.name, node.prefix, safe_kw=False))
+        elif isinstance(node, DRoot):
+            continue
+        else:
+            # Relative path
+            res.append(_safe_name(node.name, safe_kw=False))
+    return res
+
 
 def get_path(path: list[DNode]) -> str:
     r"""Get the path of a data node

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -956,10 +956,10 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
             return _pradata_recursive(child, node, self_name, loose, top, list_element, root_path, spath + [PathElement(child)])
         raise ValueError("Node at {format_schema_path(spath + [PathElement(child)])} is not inner: {type(child)}")
 
-    def pname(n):
-        return yang.schema.get_path_name(n)
+    def pname(pe: list[PathElement]):
+        return yang.schema.get_path_name([e.node for e in pe])
 
-    def _find_non_optional_subtree(container: yang.schema.DNodeInner, node: yang.gdata.Node, path: list[str], local_prefix="_") -> (list[str], list[str]):
+    def _find_non_optional_subtree(container: yang.schema.DNodeInner, spath: list[PathElement], node: yang.gdata.Node, path: list[str], local_prefix="_") -> (list[str], list[str]):
         r"""Discover the non-optional descendants of a container
 
         The container here is either a DContainer or a DList (representing
@@ -993,6 +993,9 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
         unique_namer = yang.schema._UniqueNamer(container)
 
         for cchild in container.children:
+            def path_with_child():
+                return spath + [PathElement(cchild)]
+
             if not (isinstance(cchild, yang.schema.DNodeLeaf) or isinstance(cchild, yang.schema.DContainer) or isinstance(cchild, yang.schema.DList)):
                 continue
             if isinstance(cchild, yang.schema.DLeaf):
@@ -1006,16 +1009,16 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
 
                     # Recursively build subtree for non-optional children
-                    sub_args, sub_containers = _find_non_optional_subtree(cchild, node.get_cnt(cchild.name), path + [cchild_safe_name], local_prefix)
+                    sub_args, sub_containers = _find_non_optional_subtree(cchild, path_with_child(), node.get_cnt(cchild.name), path + [cchild_safe_name], local_prefix)
 
                     # Create variable declaration for this container
                     mcchild_var = "{'_'.join(path)}_{cchild_safe_name}"
 
                     if sub_args:
                         sub_args_str = ", ".join(sub_args)
-                        non_optional_containers.append("{mcchild_var} = {pname(cchild)}({sub_args_str})")
+                        non_optional_containers.append("{mcchild_var} = {pname(path_with_child())}({sub_args_str})")
                     else:
-                        non_optional_containers.append("{mcchild_var} = {pname(cchild)}()")
+                        non_optional_containers.append("{mcchild_var} = {pname(path_with_child())}()")
 
                     # Add nested variable declarations
                     non_optional_containers.extend(sub_containers)
@@ -1033,7 +1036,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
     if top:
         res.append('# Top node: {format_schema_path(spath)}')
         # Build constructor arguments for non-optional children (same logic as in __init__)
-        constructor_args, constructor_containers = _find_non_optional_subtree(s, node, ["self"], local_prefix="")
+        constructor_args, constructor_containers = _find_non_optional_subtree(s, spath, node, ["self"], local_prefix="")
         if constructor_args:
             # Add variable declarations in reverse order to ensure dependencies are declared before use.
             # For example, if container C needs argument from container B, which needs argument from A,
@@ -1041,9 +1044,9 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
             # Since find_non_optional_subtree() builds the list depth-first, we reverse it.
             res.extend(list(reversed(constructor_containers)))
             args_str = ", ".join(constructor_args)
-            res.append("{self_name} = {pname(s)}({args_str})")
+            res.append("{self_name} = {pname(spath)}({args_str})")
         else:
-            res.append("{self_name} = {pname(s)}()")
+            res.append("{self_name} = {pname(spath)}()")
     leaves = []
     for child in s.children:
         # Only process data nodes
@@ -1074,7 +1077,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     res.append("")
                     res.append("# P-container: {format_schema_path(path_with_child())}")
                     # Build .pradata() code for this P-container
-                    pc_args, pc_var_declarations = _find_non_optional_subtree(child, container, [usname(child)])
+                    pc_args, pc_var_declarations = _find_non_optional_subtree(child, path_with_child(), container, [usname(child)])
 
                     # Add variable declarations in reverse order to ensure the prerequisites are met
                     res.extend(list(reversed(pc_var_declarations)))
@@ -1096,7 +1099,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     # Build the list of arguments for create() method
                     list_create_args = []
 
-                    non_optional_args, non_optional_containers = _find_non_optional_subtree(child, element, ["element"])
+                    non_optional_args, non_optional_containers = _find_non_optional_subtree(child, path_with_child(), element, ["element"])
 
                     res.extend(list(reversed(non_optional_containers)))
                     list_create_args.extend(non_optional_args)

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -488,8 +488,11 @@ class DNodeInner(DNode):
         def usname(n) -> str:
             return unique_namer.unique_safe_name(n.name, n.prefix)
 
-        def pname(n):
-            return get_path_name(n)
+        def pname(n: ?DNode=None):
+            if n is not None:
+                return get_path_name(spath + [n])
+            else:
+                return get_path_name(spath)
 
         def us_list_key():
             """Convert list key names (DList.key) to their unique safe names
@@ -514,9 +517,9 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list entry class, the list itself comes later
-            res.append("class {pname(self)}_entry(yang.adata.MNode):")
+            res.append("class {pname()}_entry(yang.adata.MNode):")
         else:
-            res.append("class {pname(self)}(yang.adata.MNode):")
+            res.append("class {pname()}(yang.adata.MNode):")
 
         for child in self.children:
             if isinstance(child, DLeaf):
@@ -695,40 +698,40 @@ class DNodeInner(DNode):
         from_gdata_args = ", ".join(from_gdata_args_list)
         res.append("    @staticmethod")
         if isinstance(self, DList):
-            res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname(self)}_entry:")
-            res.append("        return {pname(self)}_entry({from_gdata_args})")
+            res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname()}_entry:")
+            res.append("        return {pname()}_entry({from_gdata_args})")
         else:
             opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname(self)}:")
+            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
             res.append("        if n is not None:")
-            res.append("            return {pname(self)}({from_gdata_args})")
+            res.append("            return {pname()}({from_gdata_args})")
             if opt_cnt:
                 res.append("        return None")
             elif optional_subtree(self):
-                res.append("        return {pname(self)}()")
+                res.append("        return {pname()}()")
             else:
-                res.append("        raise ValueError('Missing required subtree {pname(self)}')")
+                res.append("        raise ValueError('Missing required subtree {pname()}')")
         res.append("")
 
         # .copy() method
         res.append("    def copy(self):")
         res.append('        """Create a deep copy of this adata object"""')
         if isinstance(self, DList):
-            res.append("        return {pname(self)}_entry.from_gdata(self.to_gdata())")
+            res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
         else:
             opt_cnt = True if isinstance(self, DContainer) and self.presence else False
             # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
             # But since we're copying an instance, the output of .copy() is non-optional.
             if opt_cnt:
-                res.append("        ad = {pname(self)}.from_gdata(self.to_gdata())")
+                res.append("        ad = {pname()}.from_gdata(self.to_gdata())")
                 res.append("        if ad is not None:")
                 res.append("            return ad")
-                res.append("        raise Exception('Unreachable in {pname(self)}.copy()')")
+                res.append("        raise Exception('Unreachable in {pname()}.copy()')")
             else:
-                res.append("        return {pname(self)}.from_gdata(self.to_gdata())")
+                res.append("        return {pname()}.from_gdata(self.to_gdata())")
         res.append("")
 
-        def find_non_optional_subtree(container: DNodeInner, path: list[str], local_prefix="_") -> (list[str], list[str]):
+        def find_non_optional_subtree(container: DNodeInner, spath: list[DNode], path: list[str], local_prefix="_") -> (list[str], list[str]):
             r"""Discover the non-optional descendants of a container
 
             The container here is either a DContainer or a DList (representing
@@ -774,7 +777,7 @@ class DNodeInner(DNode):
                         cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
 
                         # Recursively build subtree for non-optional children
-                        sub_args, sub_containers = find_non_optional_subtree(cchild, path + [cchild_safe_name], local_prefix)
+                        sub_args, sub_containers = find_non_optional_subtree(cchild, spath + [cchild], path + [cchild_safe_name], local_prefix)
 
                         # Create variable declaration for this container
                         mcchild_var = "{'_'.join(path)}_{cchild_safe_name}"
@@ -783,7 +786,7 @@ class DNodeInner(DNode):
                             sub_args_str = ", ".join(sub_args)
                             non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}({sub_args_str})')")
                         else:
-                            non_optional_containers.append("            res.append('{mcchild_var} = {pname(cchild)}()')")
+                            non_optional_containers.append("            res.append('{mcchild_var} = {get_path_name(spath + [cchild])}()')")
 
                         # Add nested variable declarations
                         non_optional_containers.extend(sub_containers)
@@ -807,7 +810,7 @@ class DNodeInner(DNode):
         res.append("        if top:")
         res.append("            res.append('# Top node: {get_path(spath)}')")
         # Build constructor arguments for non-optional children (same logic as in __init__)
-        constructor_args, constructor_containers = find_non_optional_subtree(self, ["self"], local_prefix="")
+        constructor_args, constructor_containers = find_non_optional_subtree(self, spath, ["self"], local_prefix="")
 
         if constructor_args:
             # Add variable declarations in reverse order to ensure dependencies are declared before use.
@@ -816,9 +819,9 @@ class DNodeInner(DNode):
             # Since find_non_optional_subtree() builds the list depth-first, we reverse it.
             res.extend(list(reversed(constructor_containers)))
             args_str = ", ".join(constructor_args)
-            res.append("            res.append('{{self_name}} = {pname(self)}({args_str})')")
+            res.append("            res.append('{{self_name}} = {pname()}({args_str})')")
         else:
-            res.append("            res.append('{{self_name}} = {pname(self)}()')")
+            res.append("            res.append('{{self_name}} = {pname()}()')")
         res.append("        leaves = []")
         for child in self.children:
             if isinstance(child, DNodeLeaf):
@@ -842,7 +845,7 @@ class DNodeInner(DNode):
                     res.append("            res.append('')")
                     res.append("            res.append('# P-container: {get_path(path_with_child(child))}')")
                     # Build .prsrc() code for this P-container
-                    pc_args, pc_var_declarations = find_non_optional_subtree(child, [usname(child)])
+                    pc_args, pc_var_declarations = find_non_optional_subtree(child, spath + [child], [usname(child)])
 
                     # Add variable declarations in reverse order to ensure the prerequisites are met
                     res.extend(list(reversed(pc_var_declarations)))
@@ -868,7 +871,7 @@ class DNodeInner(DNode):
                 child_unique_namer = _UniqueNamer(child)
                 list_create_args = []
 
-                non_optional_args, non_optional_containers = find_non_optional_subtree(child, ["element"])
+                non_optional_args, non_optional_containers = find_non_optional_subtree(child, spath + [child], ["element"])
 
                 res.extend(list(reversed(non_optional_containers)))
                 list_create_args.extend(non_optional_args)
@@ -914,8 +917,8 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list class, list entry class was created above
-            res.append("class {pname(self)}(yang.adata.MNode):")
-            res.append("    elements: list[{pname(self)}_entry]")
+            res.append("class {pname()}(yang.adata.MNode):")
+            res.append("    elements: list[{pname()}_entry]")
 
             init_args = ["self"]
             init_args.append("elements=[]")
@@ -973,7 +976,7 @@ class DNodeInner(DNode):
             res.append("                return e")
             res.append("")
             list_key_args_str = ", ".join(list_key_args)
-            res.append("        res = {pname(self)}_entry({list_key_args_str})")
+            res.append("        res = {pname()}_entry({list_key_args_str})")
             res.append("        self.elements.append(res)")
             res.append("        return res")
             res.append("")
@@ -993,11 +996,11 @@ class DNodeInner(DNode):
 #            # .from_gdata()
 #            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
             res.append("    @staticmethod")
-            res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname(self)}_entry]:")
+            res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname()}_entry]:")
             res.append("        if n is not None:")
-            res.append("            return [{pname(self)}_entry.from_gdata(e) for e in n.elements]")
+            res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
             res.append("        return []")
-            #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname(self))
+            #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
             # TODO: trying to use list(map(lambda)) here results in an error,
             # why? Above code that iterates over n.elements works fine... Error is:
             # ERROR: Error when compiling y_cfs module: Type error
@@ -1013,11 +1016,11 @@ class DNodeInner(DNode):
             res.append("            ce = e.copy()")
             res.append("            if ce is not None:")
             res.append("                copied_elements.append(ce)")
-            res.append("        return {pname(self)}(elements=copied_elements)")
+            res.append("        return {pname()}(elements=copied_elements)")
             res.append("")
             # Generate Iterable extension for the list class
-            res.append("extension {pname(self)}(Iterable[{pname(self)}_entry]):")
-            res.append("    def __iter__(self) -> Iterator[{pname(self)}_entry]:")
+            res.append("extension {pname()}(Iterable[{pname()}_entry]):")
+            res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
             res.append("        return self.elements.__iter__()")
         res.append("")
 
@@ -1027,7 +1030,7 @@ class DNodeInner(DNode):
         if gen_xml and isinstance(self, DNodeInner):
             fname = "from_xml"
             if not top:
-                fname += "_{pname(self)}"
+                fname += "_{pname()}"
 
             if isinstance(self, DList):
                 res.append("mut def {fname}_element(node: xml.Node) -> yang.gdata.Node:")
@@ -1056,8 +1059,8 @@ class DNodeInner(DNode):
             res.append("")
 
         if gen_xml and isinstance(self, DList):
-            res.append("mut def from_xml_{pname(self)}(nodes: list[xml.Node]) -> yang.gdata.List:")
-            res.append("    elements = [from_xml_{pname(self)}_element(e) for e in nodes]")
+            res.append("mut def from_xml_{pname()}(nodes: list[xml.Node]) -> yang.gdata.List:")
+            res.append("    elements = [from_xml_{pname()}_element(e) for e in nodes]")
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
@@ -1067,7 +1070,7 @@ class DNodeInner(DNode):
         if gen_json and isinstance(self, DNodeInner):
             fname = "from_json_path"
             if not top:
-                fname += "_{pname(self)}"
+                fname += "_{pname()}"
 
             if isinstance(self, DList):
                 res += ["mut def {fname}_element(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:"]
@@ -1079,7 +1082,7 @@ class DNodeInner(DNode):
                 res += ["        point = path[0]"]
                 res += ["        keys = point.split(\",\")"]
                 res += ["        jd_dict = yang.gdata.unwrap_dict(jd)"]
-                res += ["        val = from_json_{pname(self)}_element(jd_dict)"]
+                res += ["        val = from_json_{pname()}_element(jd_dict)"]
                 res += ["        if op == \"merge\":"]
                 res += ["            return val"]
                 res += ["        elif op == \"remove\":"]
@@ -1126,7 +1129,7 @@ class DNodeInner(DNode):
                 res.append("            else:")
                 res.append("                if str(jd_dict[key]) != keys.pop(0):")
                 res.append("                    raise ValueError(\"Key value mismatch between path and payload\")")
-                res.append("        element = from_json_{pname(self)}_element(jd_dict)")
+                res.append("        element = from_json_{pname()}_element(jd_dict)")
                 res.append("        elements = []")
                 res.append("        if op == \"merge\":")
                 res.append("            elements.append(element)")
@@ -1134,7 +1137,7 @@ class DNodeInner(DNode):
                 res.append("            elements.append(yang.gdata.Absent(element.key_children({repr(self.key)})))")
                 res.append("        return yang.gdata.List({repr(self.key)}, elements{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    elif len(path) > 1:")
-                res.append("        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname(self)}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
+                res.append("        return yang.gdata.List({repr(self.key)}, [from_json_path_{pname()}_element(jd, path, op)]{maybe_user_order(self)}{gdata_nsq})")
                 res.append("    raise ValueError(\"Unable to resolve path, no keys provided\")")
 
             else:
@@ -1155,7 +1158,7 @@ class DNodeInner(DNode):
                         res.append("            raise ValueError(\"Invalid json path to non-inner node\")")
                 res.append("        raise ValueError(\"Invalid path\")")
                 res.append("    elif len(path) == 0:")
-                valfname = "from_json_{pname(self)}" if not top else "from_json"
+                valfname = "from_json_{pname()}" if not top else "from_json"
                 val_farg = "[jd]" if isinstance(self, DList) else "yang.gdata.unwrap_dict(jd)"
                 res += ["        if op == \"merge\":"]
                 res += ["            return {valfname}({val_farg})"]
@@ -1169,7 +1172,7 @@ class DNodeInner(DNode):
         if gen_json and isinstance(self, DNodeInner):
             fname = "from_json"
             if not top:
-                fname += "_{pname(self)}"
+                fname += "_{pname()}"
 
             if isinstance(self, DList):
                 res.append("mut def {fname}_element(jd: dict[str, ?value]) -> yang.gdata.Node:")
@@ -1198,8 +1201,8 @@ class DNodeInner(DNode):
             res.append("")
 
         if gen_json and isinstance(self, DList):
-            res.append("mut def from_json_{pname(self)}(jd: list[dict[str, ?value]]) -> yang.gdata.List:")
-            res.append("    elements = [from_json_{pname(self)}_element(e) for e in jd if isinstance(e, dict)]")
+            res.append("mut def from_json_{pname()}(jd: list[dict[str, ?value]]) -> yang.gdata.List:")
+            res.append("    elements = [from_json_{pname()}_element(e) for e in jd if isinstance(e, dict)]")
             res.append("    return yang.gdata.List(keys={repr(self.key)}, elements=elements{maybe_user_order(self)}{gdata_nsq})")
             res.append("")
 
@@ -1225,13 +1228,13 @@ class DNodeInner(DNode):
                 # - no output: no output adata parameter in the callback signature
                 if input_node is not None and output_node is not None:
                     # RPC with both input and output
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(spath + [rpc, output_node])}, ?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(spath + [rpc, input_node])}, gen3: bool=False):")
                 elif input_node is not None and output_node is None:
                     # RPC with only input (no output)
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(input_node)}, gen3: bool=False):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, inp: {'?' if optional_subtree(input_node) else ''}{get_path_name(spath + [rpc, input_node])}, gen3: bool=False):")
                 elif input_node is None and output_node is not None:
                     # RPC with only output (no input)
-                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(output_node)}, ?Exception) -> None, gen3: bool=False):")
+                    res.append("    def {_safe_name(rpc.name)}(cb: action(?{get_path_name(spath + [rpc, output_node])}, ?Exception) -> None, gen3: bool=False):")
                 else:
                     # RPC with neither input nor output
                     res.append("    def {_safe_name(rpc.name)}(cb: action(?Exception) -> None, gen3: bool=False):")
@@ -1243,8 +1246,8 @@ class DNodeInner(DNode):
                     res.append("                if gen3:")
                     res.append('                    gdata_res = from_xml_gen3(res, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                else:")
-                    res.append("                    gdata_res = from_xml_{get_path_name(output_node)}(res)")
-                    res.append("                adata_res = {get_path_name(output_node)}.from_gdata(gdata_res)")
+                    res.append("                    gdata_res = from_xml_{get_path_name(spath + [rpc, output_node])}(res)")
+                    res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                     res.append("            else:")
                     res.append("                cb(None, err)")
@@ -1597,13 +1600,13 @@ class DLeaf(DNodeLeaf):
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return []
-        def pname(n):
-            return get_path_name(n)
+        def pname():
+            return get_path_name(spath)
         # Include namespace qualifier(s) iff our namespace is different than our parent
         gdata_nsq = ", ns='{self.namespace}', module='{self.module}'" if set_ns else ""
         res = []
         if gen_json or gen_xml:
-            res.append("mut def from_data_{pname(self)}(val: value) -> yang.gdata.Leaf:")
+            res.append("mut def from_data_{pname()}(val: value) -> yang.gdata.Leaf:")
             if self.type_.name == "identityref":
                 res.append("    new_val, error = complete_and_validate_identityref(val, _identities, {repr(self.type_.base)}, {repr(self.module)})")
                 res.append("    if new_val is not None:")
@@ -1650,15 +1653,15 @@ class DLeafList(DNodeLeaf):
             schema_ns.add(self.namespace)
         if include_state == False and self.config == False:
             return []
-        def pname(n):
-            return get_path_name(n)
+        def pname():
+            return get_path_name(spath)
         maybe_user_order = ", user_order=True" if self.ordered_by == "user" else ""
         # Include namespace qualifier(s) iff our namespace is different than our
         # parent
         gdata_nsq = ", ns='{self.namespace}', module='{self.module}'" if set_ns else ""
         res = []
         if gen_json or gen_xml:
-            res.append("mut def from_data_{pname(self)}(val: list[value]) -> yang.gdata.LeafList:")
+            res.append("mut def from_data_{pname()}(val: list[value]) -> yang.gdata.LeafList:")
             if self.type_.name == "identityref":
                 res.append("    new_val = []")
                 res.append("    for v in val:")
@@ -3191,7 +3194,7 @@ class _UniqueNamer(object):
         unique_name = self.unique_name(name, prefix)
         return _safe_name(unique_name, safe_kw).replace(":", "_")
 
-def get_path_name(dnode: DNode) -> str:
+def get_path_name(path: list[DNode]) -> str:
     r"""Build the adata path name for a data node
 
     For example, for the following YANG model:
@@ -3227,28 +3230,29 @@ def get_path_name(dnode: DNode) -> str:
     not necessary. An exception to this is if we are the top node without
     children - then the path is just our name.
     """
-    path = []
-    parent = dnode.parent
-    if parent is None and isinstance(dnode, DNodeInner):
-        top_solo = True if not dnode.children else False
-    else:
-        top_solo = False
-    while True:
-        self_unique_safe_name = _safe_name(dnode.name, safe_kw=not top_solo)
-        parent = dnode.parent
-        if parent is not None:
-            unique_namer = _UniqueNamer(parent)
-            self_unique_safe_name = unique_namer.unique_safe_name(dnode.name, dnode.prefix, safe_kw=False)
-            dnode = parent
-        path.append(self_unique_safe_name)
-        if parent is None:
-            break
+    return "__".join(get_path_usnames(path))
 
-    # This never happens, we always get at least our name!
-    if len(path) == 0:
-        raise ValueError("No path for DNode {dnode}")
 
-    return "__".join(reversed(path))
+def get_path_usnames(path: list[DNode]) -> list[str]:
+    if len(path) == 1:
+        return [_safe_name(path[0].name, safe_kw=False)]
+
+    res = []
+    for i, node in enumerate(path):
+        if i > 0:
+            prev = path[i-1]
+            if isinstance(prev, DRoot):
+                res.append(_safe_name(node.module, safe_kw=False))
+            if isinstance(prev, DNodeInner):
+                un = _UniqueNamer(prev)
+                res.append(un.unique_safe_name(node.name, node.prefix, safe_kw=False))
+        elif isinstance(node, DRoot):
+            continue
+        else:
+            # Relative path
+            res.append(_safe_name(node.name, safe_kw=False))
+    return res
+
 
 def get_path(path: list[DNode]) -> str:
     r"""Get the path of a data node

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -18,10 +18,10 @@ from yang.schema import DIdentity
 _identities: list[DIdentity] = []
 
 
-mut def from_data_bar__c1__l1(val: value) -> yang.gdata.Leaf:
+mut def from_data_bar__bar_c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class bar__c1(yang.adata.MNode):
+class bar__bar_c1(yang.adata.MNode):
     l1: ?str
 
     mut def __init__(self, l1: ?str):
@@ -36,20 +36,20 @@ class bar__c1(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__c1:
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__bar_c1:
         if n is not None:
-            return bar__c1(l1=n.get_opt_str('l1'))
-        return bar__c1()
+            return bar__bar_c1(l1=n.get_opt_str('l1'))
+        return bar__bar_c1()
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        return bar__c1.from_gdata(self.to_gdata())
+        return bar__bar_c1.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /bar:c1')
-            res.append('{self_name} = bar__c1()')
+            res.append('{self_name} = bar__bar_c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
@@ -67,13 +67,13 @@ class bar__c1(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:c1'])
 
 
-mut def from_xml_bar__c1(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_bar__bar_c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
-    yang.gdata.maybe_add(children, 'l1', from_data_bar__c1__l1, child_l1)
+    yang.gdata.maybe_add(children, 'l1', from_data_bar__bar_c1__l1, child_l1)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
-mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_bar__bar_c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -83,22 +83,22 @@ mut def from_json_path_bar__c1(jd: value, path: list[str]=[], op: ?str='merge') 
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_bar__c1(yang.gdata.unwrap_dict(jd))
+            return from_json_bar__bar_c1(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_bar__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_bar__bar_c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_l1 = yang.gdata.take_json_opt_str(jd, 'l1')
-    yang.gdata.maybe_add(children, 'l1', from_data_bar__c1__l1, child_l1)
+    yang.gdata.maybe_add(children, 'l1', from_data_bar__bar_c1__l1, child_l1)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
-mut def from_data_foo__c1__l1(val: value) -> yang.gdata.Leaf:
+mut def from_data_foo__foo_c1__l1(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class foo__c1(yang.adata.MNode):
+class foo__foo_c1(yang.adata.MNode):
     l1: ?str
 
     mut def __init__(self, l1: ?str):
@@ -113,20 +113,20 @@ class foo__c1(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__foo_c1:
         if n is not None:
-            return foo__c1(l1=n.get_opt_str('l1'))
-        return foo__c1()
+            return foo__foo_c1(l1=n.get_opt_str('l1'))
+        return foo__foo_c1()
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        return foo__c1.from_gdata(self.to_gdata())
+        return foo__foo_c1.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /foo:c1')
-            res.append('{self_name} = foo__c1()')
+            res.append('{self_name} = foo__foo_c1()')
         leaves = []
         _l1 = self.l1
         if _l1 is not None:
@@ -144,13 +144,13 @@ class foo__c1(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
-mut def from_xml_foo__c1(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__foo_c1(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_l1 = yang.gdata.from_xml_opt_str(node, 'l1')
-    yang.gdata.maybe_add(children, 'l1', from_data_foo__c1__l1, child_l1)
+    yang.gdata.maybe_add(children, 'l1', from_data_foo__foo_c1__l1, child_l1)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
-mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__foo_c1(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -160,26 +160,26 @@ mut def from_json_path_foo__c1(jd: value, path: list[str]=[], op: ?str='merge') 
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__c1(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__foo_c1(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__c1(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__foo_c1(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_l1 = yang.gdata.take_json_opt_str(jd, 'l1')
-    yang.gdata.maybe_add(children, 'l1', from_data_foo__c1__l1, child_l1)
+    yang.gdata.maybe_add(children, 'l1', from_data_foo__foo_c1__l1, child_l1)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 class root(yang.adata.MNode):
-    bar_c1: bar__c1
-    foo_c1: foo__c1
+    bar_c1: bar__bar_c1
+    foo_c1: foo__foo_c1
 
-    mut def __init__(self, bar_c1: ?bar__c1=None, foo_c1: ?foo__c1=None):
+    mut def __init__(self, bar_c1: ?bar__bar_c1=None, foo_c1: ?foo__foo_c1=None):
         self._ns = ''
-        self.bar_c1 = bar_c1 if bar_c1 is not None else bar__c1()
-        self.foo_c1 = foo_c1 if foo_c1 is not None else foo__c1()
+        self.bar_c1 = bar_c1 if bar_c1 is not None else bar__bar_c1()
+        self.foo_c1 = foo_c1 if foo_c1 is not None else foo__foo_c1()
 
     mut def to_gdata(self) -> yang.gdata.Node:
         children = {}
@@ -194,7 +194,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(bar_c1=bar__c1.from_gdata(n.get_opt_cnt('bar:c1')), foo_c1=foo__c1.from_gdata(n.get_opt_cnt('foo:c1')))
+            return root(bar_c1=bar__bar_c1.from_gdata(n.get_opt_cnt('bar:c1')), foo_c1=foo__foo_c1.from_gdata(n.get_opt_cnt('foo:c1')))
         return root()
 
     def copy(self):
@@ -229,9 +229,9 @@ class root(yang.adata.MNode):
 mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_bar_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:c1', from_xml_bar__c1, child_bar_c1)
+    yang.gdata.maybe_add(children, 'bar:c1', from_xml_bar__bar_c1, child_bar_c1)
     child_foo_c1 = yang.gdata.from_xml_opt_cnt(node, 'c1', 'http://example.com/foo')
-    yang.gdata.maybe_add(children, 'foo:c1', from_xml_foo__c1, child_foo_c1)
+    yang.gdata.maybe_add(children, 'foo:c1', from_xml_foo__foo_c1, child_foo_c1)
     return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
@@ -240,10 +240,10 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
         point = path[0]
         rest_path = path[1:]
         if point == 'bar:c1':
-            child = {'bar:c1': from_json_path_bar__c1(jd, rest_path, op) }
+            child = {'bar:c1': from_json_path_bar__bar_c1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:c1':
-            child = {'foo:c1': from_json_path_foo__c1(jd, rest_path, op) }
+            child = {'foo:c1': from_json_path_foo__foo_c1(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -257,9 +257,9 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
 mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_bar_c1 = yang.gdata.take_json_opt_cnt(jd, 'c1', 'bar')
-    yang.gdata.maybe_add(children, 'bar:c1', from_json_bar__c1, child_bar_c1)
+    yang.gdata.maybe_add(children, 'bar:c1', from_json_bar__bar_c1, child_bar_c1)
     child_foo_c1 = yang.gdata.take_json_opt_cnt(jd, 'c1', 'foo')
-    yang.gdata.maybe_add(children, 'foo:c1', from_json_foo__c1, child_foo_c1)
+    yang.gdata.maybe_add(children, 'foo:c1', from_json_foo__foo_c1, child_foo_c1)
     return yang.gdata.Container(children)
 
 def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -1954,10 +1954,10 @@ mut def from_json_foo__cc(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'death', from_json_foo__cc__death, child_death)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
-mut def from_data_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
+mut def from_data_foo__f_conflict__f_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class foo__conflict__f_inner(yang.adata.MNode):
+class foo__f_conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = 'http://example.com/foo'
@@ -1968,23 +1968,23 @@ class foo__conflict__f_inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__f_inner:
         if n is not None:
-            return foo__conflict__f_inner()
+            return foo__f_conflict__f_inner()
         return None
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        ad = foo__conflict__f_inner.from_gdata(self.to_gdata())
+        ad = foo__f_conflict__f_inner.from_gdata(self.to_gdata())
         if ad is not None:
             return ad
-        raise Exception('Unreachable in foo__conflict__f_inner.copy()')
+        raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /f:conflict/f:inner')
-            res.append('{self_name} = foo__conflict__f_inner()')
+            res.append('{self_name} = foo__f_conflict__f_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -1999,11 +1999,11 @@ class foo__conflict__f_inner(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:conflict', 'inner'])
 
 
-mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__f_conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True)
 
-mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__f_conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -2011,20 +2011,20 @@ mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op:
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__f_inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__f_conflict__f_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__f_conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True)
 
-mut def from_data_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
+mut def from_data_foo__f_conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
-class foo__conflict__bar_inner(yang.adata.MNode):
+class foo__f_conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = 'http://example.com/bar'
@@ -2035,23 +2035,23 @@ class foo__conflict__bar_inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__bar_inner:
         if n is not None:
-            return foo__conflict__bar_inner()
+            return foo__f_conflict__bar_inner()
         return None
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        ad = foo__conflict__bar_inner.from_gdata(self.to_gdata())
+        ad = foo__f_conflict__bar_inner.from_gdata(self.to_gdata())
         if ad is not None:
             return ad
-        raise Exception('Unreachable in foo__conflict__bar_inner.copy()')
+        raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /f:conflict/bar:inner')
-            res.append('{self_name} = foo__conflict__bar_inner()')
+            res.append('{self_name} = foo__f_conflict__bar_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -2066,11 +2066,11 @@ class foo__conflict__bar_inner(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:conflict', 'bar:inner'])
 
 
-mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__f_conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
-mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__f_conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -2078,23 +2078,23 @@ mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], o
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__bar_inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__f_conflict__bar_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__f_conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
-class foo__conflict(yang.adata.MNode):
+class foo__f_conflict(yang.adata.MNode):
     f_foo: ?str
-    f_inner: ?foo__conflict__f_inner
+    f_inner: ?foo__f_conflict__f_inner
     bar_foo: ?str
-    bar_inner: ?foo__conflict__bar_inner
+    bar_inner: ?foo__f_conflict__bar_inner
 
-    mut def __init__(self, f_foo: ?str, f_inner: ?foo__conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
+    mut def __init__(self, f_foo: ?str, f_inner: ?foo__f_conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__f_conflict__bar_inner=None):
         self._ns = 'http://example.com/foo'
         self.f_foo = f_foo
         self.f_inner = f_inner
@@ -2105,7 +2105,7 @@ class foo__conflict(yang.adata.MNode):
         existing = self.f_inner
         if existing is not None:
             return existing
-        res = foo__conflict__f_inner()
+        res = foo__f_conflict__f_inner()
         self.f_inner = res
         return res
 
@@ -2113,7 +2113,7 @@ class foo__conflict(yang.adata.MNode):
         existing = self.bar_inner
         if existing is not None:
             return existing
-        res = foo__conflict__bar_inner()
+        res = foo__f_conflict__bar_inner()
         self.bar_inner = res
         return res
 
@@ -2134,20 +2134,20 @@ class foo__conflict(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__f_conflict:
         if n is not None:
-            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
-        return foo__conflict()
+            return foo__f_conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
+        return foo__f_conflict()
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        return foo__conflict.from_gdata(self.to_gdata())
+        return foo__f_conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /f:conflict')
-            res.append('{self_name} = foo__conflict()')
+            res.append('{self_name} = foo__f_conflict()')
         leaves = []
         _f_foo = self.f_foo
         if _f_foo is not None:
@@ -2180,19 +2180,19 @@ class foo__conflict(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['foo:conflict'])
 
 
-mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__f_conflict(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_f_foo = yang.gdata.from_xml_opt_str(node, 'foo')
-    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__conflict__f_foo, child_f_foo)
+    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__f_conflict__f_foo, child_f_foo)
     child_f_inner = yang.gdata.from_xml_opt_cnt(node, 'inner')
-    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__conflict__f_inner, child_f_inner)
+    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__f_conflict__f_inner, child_f_inner)
     child_bar_foo = yang.gdata.from_xml_opt_str(node, 'foo', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__conflict__bar_foo, child_bar_foo)
+    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__f_conflict__bar_foo, child_bar_foo)
     child_bar_inner = yang.gdata.from_xml_opt_cnt(node, 'inner', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__conflict__bar_inner, child_bar_inner)
+    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__f_conflict__bar_inner, child_bar_inner)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
-mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__f_conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -2200,32 +2200,32 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
         if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'inner':
-            child = {'f:inner': from_json_path_foo__conflict__f_inner(jd, rest_path, op) }
+            child = {'f:inner': from_json_path_foo__f_conflict__f_inner(jd, rest_path, op) }
             return yang.gdata.Container(child, ns='http://example.com/foo', module='foo')
         if point == 'bar:foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:inner':
-            child = {'bar:inner': from_json_path_foo__conflict__bar_inner(jd, rest_path, op) }
+            child = {'bar:inner': from_json_path_foo__f_conflict__bar_inner(jd, rest_path, op) }
             return yang.gdata.Container(child, ns='http://example.com/foo', module='foo')
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__f_conflict(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__f_conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_f_foo = yang.gdata.take_json_opt_str(jd, 'foo')
-    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__conflict__f_foo, child_f_foo)
+    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__f_conflict__f_foo, child_f_foo)
     child_f_inner = yang.gdata.take_json_opt_cnt(jd, 'inner')
-    yang.gdata.maybe_add(children, 'f:inner', from_json_foo__conflict__f_inner, child_f_inner)
+    yang.gdata.maybe_add(children, 'f:inner', from_json_foo__f_conflict__f_inner, child_f_inner)
     child_bar_foo = yang.gdata.take_json_opt_str(jd, 'foo', 'bar')
-    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__conflict__bar_foo, child_bar_foo)
+    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__f_conflict__bar_foo, child_bar_foo)
     child_bar_inner = yang.gdata.take_json_opt_cnt(jd, 'inner', 'bar')
-    yang.gdata.maybe_add(children, 'bar:inner', from_json_foo__conflict__bar_inner, child_bar_inner)
+    yang.gdata.maybe_add(children, 'bar:inner', from_json_foo__f_conflict__bar_inner, child_bar_inner)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_data_foo__special__yes(val: value) -> yang.gdata.Leaf:
@@ -3585,10 +3585,10 @@ mut def from_json_bar__test_idref(jd: dict[str, ?value]) -> yang.gdata.Container
     yang.gdata.maybe_add(children, 'idref', from_data_bar__test_idref__idref, child_idref)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
-mut def from_data_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
+mut def from_data_bar__bar_conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class bar__conflict(yang.adata.MNode):
+class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
     mut def __init__(self, foo: ?str):
@@ -3603,20 +3603,20 @@ class bar__conflict(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__conflict:
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__bar_conflict:
         if n is not None:
-            return bar__conflict(foo=n.get_opt_str('foo'))
-        return bar__conflict()
+            return bar__bar_conflict(foo=n.get_opt_str('foo'))
+        return bar__bar_conflict()
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        return bar__conflict.from_gdata(self.to_gdata())
+        return bar__bar_conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /bar:conflict')
-            res.append('{self_name} = bar__conflict()')
+            res.append('{self_name} = bar__bar_conflict()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
@@ -3634,13 +3634,13 @@ class bar__conflict(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=False, root_path=['bar:conflict'])
 
 
-mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_bar__bar_conflict(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
-    yang.gdata.maybe_add(children, 'foo', from_data_bar__conflict__foo, child_foo)
+    yang.gdata.maybe_add(children, 'foo', from_data_bar__bar_conflict__foo, child_foo)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
-mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_bar__bar_conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -3650,16 +3650,16 @@ mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='me
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_bar__conflict(yang.gdata.unwrap_dict(jd))
+            return from_json_bar__bar_conflict(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_bar__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_bar__bar_conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_opt_str(jd, 'foo')
-    yang.gdata.maybe_add(children, 'foo', from_data_bar__conflict__foo, child_foo)
+    yang.gdata.maybe_add(children, 'foo', from_data_bar__bar_conflict__foo, child_foo)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 class root(yang.adata.MNode):
@@ -3670,7 +3670,7 @@ class root(yang.adata.MNode):
     empty_presence: ?foo__empty_presence
     c_dot: foo__c_dot
     cc: foo__cc
-    f_conflict: foo__conflict
+    f_conflict: foo__f_conflict
     special: foo__special
     nested: foo__nested
     li_union: foo__li_union
@@ -3678,9 +3678,9 @@ class root(yang.adata.MNode):
     ll_empty: list[str]
     c2: foo__c2
     test_idref: bar__test_idref
-    bar_conflict: bar__conflict
+    bar_conflict: bar__bar_conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__f_conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__bar_conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -3689,7 +3689,7 @@ class root(yang.adata.MNode):
         self.empty_presence = empty_presence
         self.c_dot = c_dot if c_dot is not None else foo__c_dot()
         self.cc = cc if cc is not None else foo__cc()
-        self.f_conflict = f_conflict if f_conflict is not None else foo__conflict()
+        self.f_conflict = f_conflict if f_conflict is not None else foo__f_conflict()
         self.special = foo__special(elements=special)
         self.nested = nested if nested is not None else foo__nested()
         self.li_union = foo__li_union(elements=li_union)
@@ -3697,7 +3697,7 @@ class root(yang.adata.MNode):
         self.ll_empty = ll_empty if ll_empty is not None else []
         self.c2 = c2 if c2 is not None else foo__c2()
         self.test_idref = test_idref if test_idref is not None else bar__test_idref()
-        self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
+        self.bar_conflict = bar_conflict if bar_conflict is not None else bar__bar_conflict()
 
     mut def create_pc1(self):
         existing = self.pc1
@@ -3786,7 +3786,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt('test-idref')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt('test-idref')), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def copy(self):
@@ -3901,7 +3901,7 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     child_cc = yang.gdata.from_xml_opt_cnt(node, 'cc', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'cc', from_xml_foo__cc, child_cc)
     child_f_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/foo')
-    yang.gdata.maybe_add(children, 'f:conflict', from_xml_foo__conflict, child_f_conflict)
+    yang.gdata.maybe_add(children, 'f:conflict', from_xml_foo__f_conflict, child_f_conflict)
     child_special = yang.gdata.from_xml_opt_list(node, 'special', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'special', from_xml_foo__special, child_special)
     child_nested = yang.gdata.from_xml_opt_cnt(node, 'nested', 'http://example.com/foo')
@@ -3917,7 +3917,7 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     child_test_idref = yang.gdata.from_xml_opt_cnt(node, 'test-idref', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'test-idref', from_xml_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
+    yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__bar_conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
@@ -3947,7 +3947,7 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
             child = {'cc': from_json_path_foo__cc(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:conflict':
-            child = {'f:conflict': from_json_path_foo__conflict(jd, rest_path, op) }
+            child = {'f:conflict': from_json_path_foo__f_conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:special':
             child = {'special': from_json_path_foo__special(jd, rest_path, op) }
@@ -3970,7 +3970,7 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
             child = {'test-idref': from_json_path_bar__test_idref(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:conflict':
-            child = {'bar:conflict': from_json_path_bar__conflict(jd, rest_path, op) }
+            child = {'bar:conflict': from_json_path_bar__bar_conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -3998,7 +3998,7 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_cc = yang.gdata.take_json_opt_cnt(jd, 'cc', 'foo')
     yang.gdata.maybe_add(children, 'cc', from_json_foo__cc, child_cc)
     child_f_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'foo')
-    yang.gdata.maybe_add(children, 'f:conflict', from_json_foo__conflict, child_f_conflict)
+    yang.gdata.maybe_add(children, 'f:conflict', from_json_foo__f_conflict, child_f_conflict)
     child_special = yang.gdata.take_json_opt_list(jd, 'special', 'foo')
     yang.gdata.maybe_add(children, 'special', from_json_foo__special, child_special)
     child_nested = yang.gdata.take_json_opt_cnt(jd, 'nested', 'foo')
@@ -4014,7 +4014,7 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_test_idref = yang.gdata.take_json_opt_cnt(jd, 'test-idref', 'bar')
     yang.gdata.maybe_add(children, 'test-idref', from_json_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'bar')
-    yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__conflict, child_bar_conflict)
+    yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__bar_conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
 def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -1959,10 +1959,10 @@ mut def from_json_foo__cc(jd: dict[str, ?value]) -> yang.gdata.Container:
     yang.gdata.maybe_add(children, 'death', from_json_foo__cc__death, child_death)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
-mut def from_data_foo__conflict__f_foo(val: value) -> yang.gdata.Leaf:
+mut def from_data_foo__f_conflict__f_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class foo__conflict__f_inner(yang.adata.MNode):
+class foo__f_conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = 'http://example.com/foo'
@@ -1973,23 +1973,23 @@ class foo__conflict__f_inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__f_inner:
         if n is not None:
-            return foo__conflict__f_inner()
+            return foo__f_conflict__f_inner()
         return None
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        ad = foo__conflict__f_inner.from_gdata(self.to_gdata())
+        ad = foo__f_conflict__f_inner.from_gdata(self.to_gdata())
         if ad is not None:
             return ad
-        raise Exception('Unreachable in foo__conflict__f_inner.copy()')
+        raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /f:conflict/f:inner')
-            res.append('{self_name} = foo__conflict__f_inner()')
+            res.append('{self_name} = foo__f_conflict__f_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -2004,11 +2004,11 @@ class foo__conflict__f_inner(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:conflict', 'inner'])
 
 
-mut def from_xml_foo__conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__f_conflict__f_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True)
 
-mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__f_conflict__f_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -2016,20 +2016,20 @@ mut def from_json_path_foo__conflict__f_inner(jd: value, path: list[str]=[], op:
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__f_inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__f_conflict__f_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__f_conflict__f_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True)
 
-mut def from_data_foo__conflict__bar_foo(val: value) -> yang.gdata.Leaf:
+mut def from_data_foo__f_conflict__bar_foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val, ns='http://example.com/bar', module='bar')
 
-class foo__conflict__bar_inner(yang.adata.MNode):
+class foo__f_conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
         self._ns = 'http://example.com/bar'
@@ -2040,23 +2040,23 @@ class foo__conflict__bar_inner(yang.adata.MNode):
         return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__conflict__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__bar_inner:
         if n is not None:
-            return foo__conflict__bar_inner()
+            return foo__f_conflict__bar_inner()
         return None
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        ad = foo__conflict__bar_inner.from_gdata(self.to_gdata())
+        ad = foo__f_conflict__bar_inner.from_gdata(self.to_gdata())
         if ad is not None:
             return ad
-        raise Exception('Unreachable in foo__conflict__bar_inner.copy()')
+        raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /f:conflict/bar:inner')
-            res.append('{self_name} = foo__conflict__bar_inner()')
+            res.append('{self_name} = foo__f_conflict__bar_inner()')
         leaves = []
         if leaves:
             if not list_element:
@@ -2071,11 +2071,11 @@ class foo__conflict__bar_inner(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:conflict', 'bar:inner'])
 
 
-mut def from_xml_foo__conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__f_conflict__bar_inner(node: xml.Node) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
-mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__f_conflict__bar_inner(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -2083,23 +2083,23 @@ mut def from_json_path_foo__conflict__bar_inner(jd: value, path: list[str]=[], o
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict__bar_inner(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__f_conflict__bar_inner(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__f_conflict__bar_inner(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     return yang.gdata.Container(children, presence=True, ns='http://example.com/bar', module='bar')
 
-class foo__conflict(yang.adata.MNode):
+class foo__f_conflict(yang.adata.MNode):
     f_foo: ?str
-    f_inner: ?foo__conflict__f_inner
+    f_inner: ?foo__f_conflict__f_inner
     bar_foo: ?str
-    bar_inner: ?foo__conflict__bar_inner
+    bar_inner: ?foo__f_conflict__bar_inner
 
-    mut def __init__(self, f_foo: ?str, f_inner: ?foo__conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__conflict__bar_inner=None):
+    mut def __init__(self, f_foo: ?str, f_inner: ?foo__f_conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__f_conflict__bar_inner=None):
         self._ns = 'http://example.com/foo'
         self.f_foo = f_foo
         self.f_inner = f_inner
@@ -2110,7 +2110,7 @@ class foo__conflict(yang.adata.MNode):
         existing = self.f_inner
         if existing is not None:
             return existing
-        res = foo__conflict__f_inner()
+        res = foo__f_conflict__f_inner()
         self.f_inner = res
         return res
 
@@ -2118,7 +2118,7 @@ class foo__conflict(yang.adata.MNode):
         existing = self.bar_inner
         if existing is not None:
             return existing
-        res = foo__conflict__bar_inner()
+        res = foo__f_conflict__bar_inner()
         self.bar_inner = res
         return res
 
@@ -2139,20 +2139,20 @@ class foo__conflict(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__conflict:
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__f_conflict:
         if n is not None:
-            return foo__conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
-        return foo__conflict()
+            return foo__f_conflict(f_foo=n.get_opt_str('f:foo'), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt('f:inner')), bar_foo=n.get_opt_str('bar:foo'), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt('bar:inner')))
+        return foo__f_conflict()
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        return foo__conflict.from_gdata(self.to_gdata())
+        return foo__f_conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /f:conflict')
-            res.append('{self_name} = foo__conflict()')
+            res.append('{self_name} = foo__f_conflict()')
         leaves = []
         _f_foo = self.f_foo
         if _f_foo is not None:
@@ -2185,19 +2185,19 @@ class foo__conflict(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['foo:conflict'])
 
 
-mut def from_xml_foo__conflict(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_foo__f_conflict(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_f_foo = yang.gdata.from_xml_opt_str(node, 'foo')
-    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__conflict__f_foo, child_f_foo)
+    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__f_conflict__f_foo, child_f_foo)
     child_f_inner = yang.gdata.from_xml_opt_cnt(node, 'inner')
-    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__conflict__f_inner, child_f_inner)
+    yang.gdata.maybe_add(children, 'f:inner', from_xml_foo__f_conflict__f_inner, child_f_inner)
     child_bar_foo = yang.gdata.from_xml_opt_str(node, 'foo', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__conflict__bar_foo, child_bar_foo)
+    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__f_conflict__bar_foo, child_bar_foo)
     child_bar_inner = yang.gdata.from_xml_opt_cnt(node, 'inner', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__conflict__bar_inner, child_bar_inner)
+    yang.gdata.maybe_add(children, 'bar:inner', from_xml_foo__f_conflict__bar_inner, child_bar_inner)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
-mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_foo__f_conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -2205,32 +2205,32 @@ mut def from_json_path_foo__conflict(jd: value, path: list[str]=[], op: ?str='me
         if point == 'foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'inner':
-            child = {'f:inner': from_json_path_foo__conflict__f_inner(jd, rest_path, op) }
+            child = {'f:inner': from_json_path_foo__f_conflict__f_inner(jd, rest_path, op) }
             return yang.gdata.Container(child, ns='http://example.com/foo', module='foo')
         if point == 'bar:foo':
             raise ValueError("Invalid json path to non-inner node")
         if point == 'bar:inner':
-            child = {'bar:inner': from_json_path_foo__conflict__bar_inner(jd, rest_path, op) }
+            child = {'bar:inner': from_json_path_foo__f_conflict__bar_inner(jd, rest_path, op) }
             return yang.gdata.Container(child, ns='http://example.com/foo', module='foo')
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_foo__conflict(yang.gdata.unwrap_dict(jd))
+            return from_json_foo__f_conflict(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_foo__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_foo__f_conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_f_foo = yang.gdata.take_json_opt_str(jd, 'foo')
-    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__conflict__f_foo, child_f_foo)
+    yang.gdata.maybe_add(children, 'f:foo', from_data_foo__f_conflict__f_foo, child_f_foo)
     child_f_inner = yang.gdata.take_json_opt_cnt(jd, 'inner')
-    yang.gdata.maybe_add(children, 'f:inner', from_json_foo__conflict__f_inner, child_f_inner)
+    yang.gdata.maybe_add(children, 'f:inner', from_json_foo__f_conflict__f_inner, child_f_inner)
     child_bar_foo = yang.gdata.take_json_opt_str(jd, 'foo', 'bar')
-    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__conflict__bar_foo, child_bar_foo)
+    yang.gdata.maybe_add(children, 'bar:foo', from_data_foo__f_conflict__bar_foo, child_bar_foo)
     child_bar_inner = yang.gdata.take_json_opt_cnt(jd, 'inner', 'bar')
-    yang.gdata.maybe_add(children, 'bar:inner', from_json_foo__conflict__bar_inner, child_bar_inner)
+    yang.gdata.maybe_add(children, 'bar:inner', from_json_foo__f_conflict__bar_inner, child_bar_inner)
     return yang.gdata.Container(children, ns='http://example.com/foo', module='foo')
 
 mut def from_data_foo__special__yes(val: value) -> yang.gdata.Leaf:
@@ -3590,10 +3590,10 @@ mut def from_json_bar__test_idref(jd: dict[str, ?value]) -> yang.gdata.Container
     yang.gdata.maybe_add(children, 'idref', from_data_bar__test_idref__idref, child_idref)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
-mut def from_data_bar__conflict__foo(val: value) -> yang.gdata.Leaf:
+mut def from_data_bar__bar_conflict__foo(val: value) -> yang.gdata.Leaf:
     return yang.gdata.Leaf('string', val)
 
-class bar__conflict(yang.adata.MNode):
+class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
     mut def __init__(self, foo: ?str):
@@ -3608,20 +3608,20 @@ class bar__conflict(yang.adata.MNode):
         return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__conflict:
+    mut def from_gdata(n: ?yang.gdata.Node) -> bar__bar_conflict:
         if n is not None:
-            return bar__conflict(foo=n.get_opt_str('foo'))
-        return bar__conflict()
+            return bar__bar_conflict(foo=n.get_opt_str('foo'))
+        return bar__bar_conflict()
 
     def copy(self):
         """Create a deep copy of this adata object"""
-        return bar__conflict.from_gdata(self.to_gdata())
+        return bar__bar_conflict.from_gdata(self.to_gdata())
 
     def prsrc(self, self_name='ad', top=True, list_element=False):
         res = []
         if top:
             res.append('# Top node: /bar:conflict')
-            res.append('{self_name} = bar__conflict()')
+            res.append('{self_name} = bar__bar_conflict()')
         leaves = []
         _foo = self.foo
         if _foo is not None:
@@ -3639,13 +3639,13 @@ class bar__conflict(yang.adata.MNode):
         return yang.gen3.pradata(s, self.to_gdata(), self_name, loose=True, root_path=['bar:conflict'])
 
 
-mut def from_xml_bar__conflict(node: xml.Node) -> yang.gdata.Container:
+mut def from_xml_bar__bar_conflict(node: xml.Node) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.from_xml_opt_str(node, 'foo')
-    yang.gdata.maybe_add(children, 'foo', from_data_bar__conflict__foo, child_foo)
+    yang.gdata.maybe_add(children, 'foo', from_data_bar__bar_conflict__foo, child_foo)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
-mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
+mut def from_json_path_bar__bar_conflict(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
     # path handling
     if len(path) > 0:
         point = path[0]
@@ -3655,16 +3655,16 @@ mut def from_json_path_bar__conflict(jd: value, path: list[str]=[], op: ?str='me
         raise ValueError("Invalid path")
     elif len(path) == 0:
         if op == "merge":
-            return from_json_bar__conflict(yang.gdata.unwrap_dict(jd))
+            return from_json_bar__bar_conflict(yang.gdata.unwrap_dict(jd))
         elif op == "remove":
             return yang.gdata.Absent()
         raise ValueError("Invalid operation")
     raise ValueError("Unable to resolve path")
 
-mut def from_json_bar__conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
+mut def from_json_bar__bar_conflict(jd: dict[str, ?value]) -> yang.gdata.Container:
     children = {}
     child_foo = yang.gdata.take_json_opt_str(jd, 'foo')
-    yang.gdata.maybe_add(children, 'foo', from_data_bar__conflict__foo, child_foo)
+    yang.gdata.maybe_add(children, 'foo', from_data_bar__bar_conflict__foo, child_foo)
     return yang.gdata.Container(children, ns='http://example.com/bar', module='bar')
 
 class root(yang.adata.MNode):
@@ -3675,7 +3675,7 @@ class root(yang.adata.MNode):
     empty_presence: ?foo__empty_presence
     c_dot: foo__c_dot
     cc: foo__cc
-    f_conflict: foo__conflict
+    f_conflict: foo__f_conflict
     special: foo__special
     nested: foo__nested
     li_union: foo__li_union
@@ -3683,9 +3683,9 @@ class root(yang.adata.MNode):
     ll_empty: list[str]
     c2: foo__c2
     test_idref: bar__test_idref
-    bar_conflict: bar__conflict
+    bar_conflict: bar__bar_conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__f_conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__bar_conflict=None):
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -3694,7 +3694,7 @@ class root(yang.adata.MNode):
         self.empty_presence = empty_presence
         self.c_dot = c_dot if c_dot is not None else foo__c_dot()
         self.cc = cc if cc is not None else foo__cc()
-        self.f_conflict = f_conflict if f_conflict is not None else foo__conflict()
+        self.f_conflict = f_conflict if f_conflict is not None else foo__f_conflict()
         self.special = foo__special(elements=special)
         self.nested = nested if nested is not None else foo__nested()
         self.li_union = foo__li_union(elements=li_union)
@@ -3702,7 +3702,7 @@ class root(yang.adata.MNode):
         self.ll_empty = ll_empty if ll_empty is not None else []
         self.c2 = c2 if c2 is not None else foo__c2()
         self.test_idref = test_idref if test_idref is not None else bar__test_idref()
-        self.bar_conflict = bar_conflict if bar_conflict is not None else bar__conflict()
+        self.bar_conflict = bar_conflict if bar_conflict is not None else bar__bar_conflict()
 
     mut def create_pc1(self):
         existing = self.pc1
@@ -3791,7 +3791,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt('test-idref')), bar_conflict=bar__conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt('c1')), pc1=foo__pc1.from_gdata(n.get_opt_cnt('pc1')), pc2=foo__pc2.from_gdata(n.get_opt_cnt('pc2')), pc3=foo__pc3.from_gdata(n.get_opt_cnt('pc3')), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt('empty-presence')), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt('c.dot')), cc=foo__cc.from_gdata(n.get_opt_cnt('cc')), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt('f:conflict')), special=foo__special.from_gdata(n.get_opt_list('special')), nested=foo__nested.from_gdata(n.get_opt_cnt('nested')), li_union=foo__li_union.from_gdata(n.get_opt_list('li-union')), state=foo__state.from_gdata(n.get_opt_cnt('state')), ll_empty=n.get_opt_strs('ll-empty'), c2=foo__c2.from_gdata(n.get_opt_cnt('c2')), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt('test-idref')), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt('bar:conflict')))
         return root()
 
     def copy(self):
@@ -3902,7 +3902,7 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     child_cc = yang.gdata.from_xml_opt_cnt(node, 'cc', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'cc', from_xml_foo__cc, child_cc)
     child_f_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/foo')
-    yang.gdata.maybe_add(children, 'f:conflict', from_xml_foo__conflict, child_f_conflict)
+    yang.gdata.maybe_add(children, 'f:conflict', from_xml_foo__f_conflict, child_f_conflict)
     child_special = yang.gdata.from_xml_opt_list(node, 'special', 'http://example.com/foo')
     yang.gdata.maybe_add(children, 'special', from_xml_foo__special, child_special)
     child_nested = yang.gdata.from_xml_opt_cnt(node, 'nested', 'http://example.com/foo')
@@ -3918,7 +3918,7 @@ mut def from_xml(node: xml.Node) -> yang.gdata.Container:
     child_test_idref = yang.gdata.from_xml_opt_cnt(node, 'test-idref', 'http://example.com/bar')
     yang.gdata.maybe_add(children, 'test-idref', from_xml_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.from_xml_opt_cnt(node, 'conflict', 'http://example.com/bar')
-    yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__conflict, child_bar_conflict)
+    yang.gdata.maybe_add(children, 'bar:conflict', from_xml_bar__bar_conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
 mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
@@ -3948,7 +3948,7 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
             child = {'cc': from_json_path_foo__cc(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:conflict':
-            child = {'f:conflict': from_json_path_foo__conflict(jd, rest_path, op) }
+            child = {'f:conflict': from_json_path_foo__f_conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'foo:special':
             child = {'special': from_json_path_foo__special(jd, rest_path, op) }
@@ -3971,7 +3971,7 @@ mut def from_json_path(jd: value, path: list[str]=[], op: ?str='merge') -> yang.
             child = {'test-idref': from_json_path_bar__test_idref(jd, rest_path, op) }
             return yang.gdata.Container(child)
         if point == 'bar:conflict':
-            child = {'bar:conflict': from_json_path_bar__conflict(jd, rest_path, op) }
+            child = {'bar:conflict': from_json_path_bar__bar_conflict(jd, rest_path, op) }
             return yang.gdata.Container(child)
         raise ValueError("Invalid path")
     elif len(path) == 0:
@@ -3999,7 +3999,7 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_cc = yang.gdata.take_json_opt_cnt(jd, 'cc', 'foo')
     yang.gdata.maybe_add(children, 'cc', from_json_foo__cc, child_cc)
     child_f_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'foo')
-    yang.gdata.maybe_add(children, 'f:conflict', from_json_foo__conflict, child_f_conflict)
+    yang.gdata.maybe_add(children, 'f:conflict', from_json_foo__f_conflict, child_f_conflict)
     child_special = yang.gdata.take_json_opt_list(jd, 'special', 'foo')
     yang.gdata.maybe_add(children, 'special', from_json_foo__special, child_special)
     child_nested = yang.gdata.take_json_opt_cnt(jd, 'nested', 'foo')
@@ -4015,7 +4015,7 @@ mut def from_json(jd: dict[str, ?value]) -> yang.gdata.Container:
     child_test_idref = yang.gdata.take_json_opt_cnt(jd, 'test-idref', 'bar')
     yang.gdata.maybe_add(children, 'test-idref', from_json_bar__test_idref, child_test_idref)
     child_bar_conflict = yang.gdata.take_json_opt_cnt(jd, 'conflict', 'bar')
-    yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__conflict, child_bar_conflict)
+    yang.gdata.maybe_add(children, 'bar:conflict', from_json_bar__bar_conflict, child_bar_conflict)
     return yang.gdata.Container(children)
 
 def from_xml_gen3(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:


### PR DESCRIPTION
The function to compute an adata class name given a path to a DNode now accepts the entire list of DNode nodes, instead of traversing the nodes in the direction of the root using the parent attribute. With that, the DNode.parent attribute can be removed!

A neat side effect of this change is that we now apply the rules for avoiding naming conflicts consistently for all nodes, including top-level nodes - the module prefix is always used to disambiguate the conflicting names.

Part of #199