### PR TITLE
Stop generating legacy gen2 wrappers

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -363,7 +363,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -483,7 +483,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -544,7 +544,7 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -679,6 +679,9 @@ class DNodeInner(DNode):
 
         # .to_gdata()
         res.append("    mut def to_gdata(self) -> yang.gdata.Node:")
+        # TODO: we do an isinstance check to give a hint to the compiler that
+        # this class implements the YangData protocol. But the compiler should
+        # know self inherits from MNode?!
         res.append("        if isinstance(self, yang.adata.MNode):")
         if isinstance(self, DRoot):
             res.append("            return yang.gen3.from_data(src_dnode(), self, loose={loose})")
@@ -730,14 +733,6 @@ class DNodeInner(DNode):
                 res.append("        raise Exception('Unreachable in {pname()}.copy()')")
             else:
                 res.append("        return {pname()}.from_gdata(self.to_gdata())")
-        res.append("")
-
-        res.append("    def prsrc(self, self_name='ad'):")
-        if isinstance(self, DRoot):
-            res.append("        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose={loose})")
-        else:
-            root_path = ["{'{node.module}:' if prev.module != node.module else ''}{node.name}" if node is not None else None for prev, node in zip(spath, spath[1:] + [None])]
-            res.append("        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose={loose}, root_path={repr(root_path[:-1])})")
         res.append("")
 
         if isinstance(self, DList):
@@ -848,7 +843,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
+                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, include_state=True)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -878,7 +873,7 @@ class DNodeInner(DNode):
                 if output_node is not None:
                     res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
                     res.append("            if res is not None:")
-                    res.append('                gdata_res = from_xml(res, ["{rpc.module}:{rpc.name}", "output"])')
+                    res.append('                gdata_res = yang.gen3.from_data(src_dnode(), res, {loose}, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                     res.append("            else:")
@@ -889,7 +884,8 @@ class DNodeInner(DNode):
                 res.append("        rpc_xml = xml.Node({repr(rpc.name)}, nsdefs=[(None, {repr(rpc.namespace)})])")
                 if input_node is not None:
                     res.append("        if inp is not None:")
-                    res.append("            rpc_xml.children.extend(inp.to_gdata().to_xml())")
+                    res.append('            gdata_inp = yang.gen3.from_data(src_dnode(), inp, {loose}, ["{rpc.module}:{rpc.name}", "input"])')
+                    res.append('            rpc_xml.children.extend(gdata_inp.to_xml())')
 
                 # Call tp.rpc_xml with appropriate callback
                 if output_node is not None:
@@ -1583,7 +1579,7 @@ class DRoot(DNodeInner):
             ("identities", self.identities),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, gen_json=True, gen_xml=True, include_state=False, top=True, root_path: list[str]=[]) -> str:
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[]) -> str:
         def build_spath(spath: list[DNode]):
             if len(root_path) == len(spath) - 1:
                 return spath
@@ -1632,27 +1628,12 @@ class DRoot(DNodeInner):
 
         spath = build_spath([self])
         schema_ns = set()
-        res.extend(spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+        res.extend(spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, schema_ns=schema_ns, include_state=include_state))
 
         # TODO: module constant when we switch to DType
         # TODO: reuse namespace qualifiers from schema_namespaces to avoid allocating many new string
         res.append("def src_dnode():")
         res.append("    return {self.prsrc()}")
-        res.append("")
-
-        if gen_xml:
-            res.append("def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    return yang.gen3.from_data(src_dnode(), node, loose={loose}, root_path=root_path)")
-            res.append("")
-        if gen_json:
-            res.append("def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    return yang.gen3.from_data(src_dnode(), jd, loose={loose}, root_path=root_path)")
-            res.append("")
-            res.append("def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:")
-            res.append("    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose={loose})")
-            res.append("")
-        res.append("def prsrc(data, self_name='ad'):")
-        res.append("    return yang.gen3.pradata(src_dnode(), data, self_name, loose={loose})")
         res.append("")
 
         res.append("schema_namespaces: set[str] = {{")
@@ -1826,7 +1807,7 @@ class SchemaNode(object):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -11,10 +11,6 @@ class MNode(object):
     mut def to_gdata(self) -> yang.gdata.Node:
         raise NotImplementedError("to_gdata")
 
-    # TODO: remove mut effect once the compiler is fixed to not leak mut effect out of functions
-    mut def prsrc(self, self_name='ad') -> str:
-        raise NotImplementedError("prsrc not implemented for {type(self)}")
-
     mut def copy(self) -> Self:
         """Create a deep copy of this adata object"""
         raise NotImplementedError()

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -359,7 +359,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -479,7 +479,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, schema_ns=set(), include_state=False) -> list[str]:
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -540,7 +540,7 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, schema_ns=schema_ns, include_state=include_state))
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -675,6 +675,9 @@ class DNodeInner(DNode):
 
         # .to_gdata()
         res.append("    mut def to_gdata(self) -> yang.gdata.Node:")
+        # TODO: we do an isinstance check to give a hint to the compiler that
+        # this class implements the YangData protocol. But the compiler should
+        # know self inherits from MNode?!
         res.append("        if isinstance(self, yang.adata.MNode):")
         if isinstance(self, DRoot):
             res.append("            return yang.gen3.from_data(src_dnode(), self, loose={loose})")
@@ -726,14 +729,6 @@ class DNodeInner(DNode):
                 res.append("        raise Exception('Unreachable in {pname()}.copy()')")
             else:
                 res.append("        return {pname()}.from_gdata(self.to_gdata())")
-        res.append("")
-
-        res.append("    def prsrc(self, self_name='ad'):")
-        if isinstance(self, DRoot):
-            res.append("        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose={loose})")
-        else:
-            root_path = ["{'{node.module}:' if prev.module != node.module else ''}{node.name}" if node is not None else None for prev, node in zip(spath, spath[1:] + [None])]
-            res.append("        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose={loose}, root_path={repr(root_path[:-1])})")
         res.append("")
 
         if isinstance(self, DList):
@@ -844,7 +839,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=True)
+                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, schema_ns=schema_ns, include_state=True)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -874,7 +869,7 @@ class DNodeInner(DNode):
                 if output_node is not None:
                     res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
                     res.append("            if res is not None:")
-                    res.append('                gdata_res = from_xml(res, ["{rpc.module}:{rpc.name}", "output"])')
+                    res.append('                gdata_res = yang.gen3.from_data(src_dnode(), res, {loose}, ["{rpc.module}:{rpc.name}", "output"])')
                     res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(gdata_res)")
                     res.append("                cb(adata_res, err)")
                     res.append("            else:")
@@ -885,7 +880,8 @@ class DNodeInner(DNode):
                 res.append("        rpc_xml = xml.Node({repr(rpc.name)}, nsdefs=[(None, {repr(rpc.namespace)})])")
                 if input_node is not None:
                     res.append("        if inp is not None:")
-                    res.append("            rpc_xml.children.extend(inp.to_gdata().to_xml())")
+                    res.append('            gdata_inp = yang.gen3.from_data(src_dnode(), inp, {loose}, ["{rpc.module}:{rpc.name}", "input"])')
+                    res.append('            rpc_xml.children.extend(gdata_inp.to_xml())')
 
                 # Call tp.rpc_xml with appropriate callback
                 if output_node is not None:
@@ -1579,7 +1575,7 @@ class DRoot(DNodeInner):
             ("identities", self.identities),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, gen_json=True, gen_xml=True, include_state=False, top=True, root_path: list[str]=[]) -> str:
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[]) -> str:
         def build_spath(spath: list[DNode]):
             if len(root_path) == len(spath) - 1:
                 return spath
@@ -1628,27 +1624,12 @@ class DRoot(DNodeInner):
 
         spath = build_spath([self])
         schema_ns = set()
-        res.extend(spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, schema_ns=schema_ns, gen_json=gen_json, gen_xml=gen_xml, include_state=include_state))
+        res.extend(spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, schema_ns=schema_ns, include_state=include_state))
 
         # TODO: module constant when we switch to DType
         # TODO: reuse namespace qualifiers from schema_namespaces to avoid allocating many new string
         res.append("def src_dnode():")
         res.append("    return {self.prsrc()}")
-        res.append("")
-
-        if gen_xml:
-            res.append("def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    return yang.gen3.from_data(src_dnode(), node, loose={loose}, root_path=root_path)")
-            res.append("")
-        if gen_json:
-            res.append("def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:")
-            res.append("    return yang.gen3.from_data(src_dnode(), jd, loose={loose}, root_path=root_path)")
-            res.append("")
-            res.append("def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:")
-            res.append("    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose={loose})")
-            res.append("")
-        res.append("def prsrc(data, self_name='ad'):")
-        res.append("    return yang.gen3.pradata(src_dnode(), data, self_name, loose={loose})")
         res.append("")
 
         res.append("schema_namespaces: set[str] = {{")
@@ -1822,7 +1803,7 @@ class SchemaNode(object):
             res.append(_ind(indent) + "])")
         return "\n".join(res)
 
-    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), gen_json=True, gen_xml=True, include_state=False) -> str:
+    def prdaclass(self, loose=False, top=True, set_ns=True, schema_ns=set(), include_state=False) -> str:
         """Print the data class for this schema node
         """
         raise NotImplementedError('SchemaNode pdc')

--- a/test/golden/test_yang/augment_with_uses_refine
+++ b/test/golden/test_yang/augment_with_uses_refine
@@ -37,9 +37,6 @@ class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__system_capabilities__per_node_capabilities_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:system-capabilities', 'per-node-capabilities'])
-
 class base__system_capabilities__per_node_capabilities(yang.adata.MNode):
     elements: list[base__system_capabilities__per_node_capabilities_entry]
     mut def __init__(self, elements=[]):
@@ -108,9 +105,6 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__system_capabilities__subscription_capabilities.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:system-capabilities', 'augmenter:subscription-capabilities'])
-
 
 class base__system_capabilities(yang.adata.MNode):
     per_node_capabilities: base__system_capabilities__per_node_capabilities
@@ -143,9 +137,6 @@ class base__system_capabilities(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__system_capabilities.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:system-capabilities'])
-
 
 class root(yang.adata.MNode):
     system_capabilities: base__system_capabilities
@@ -174,9 +165,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -190,18 +178,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/augmenter',

--- a/test/golden/test_yang/compile_augment
+++ b/test/golden/test_yang/compile_augment
@@ -49,9 +49,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -80,9 +77,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -91,18 +85,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='l2', config=True, description='leaf 2', mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_augment_augmented_node
+++ b/test/golden/test_yang/compile_augment_augmented_node
@@ -49,9 +49,6 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__native__voice__service__voip__sip.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:native', 'voice:voice', 'service', 'voip', 'sip'])
-
 
 class base__native__voice__service__voip(yang.adata.MNode):
     enabled: bool
@@ -84,9 +81,6 @@ class base__native__voice__service__voip(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__native__voice__service__voip.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:native', 'voice:voice', 'service', 'voip'])
-
 
 class base__native__voice__service(yang.adata.MNode):
     voip: base__native__voice__service__voip
@@ -114,9 +108,6 @@ class base__native__voice__service(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return base__native__voice__service.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:native', 'voice:voice', 'service'])
 
 
 class base__native__voice(yang.adata.MNode):
@@ -146,9 +137,6 @@ class base__native__voice(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__native__voice.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:native', 'voice:voice'])
-
 
 class base__native(yang.adata.MNode):
     voice: base__native__voice
@@ -176,9 +164,6 @@ class base__native(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return base__native.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:native'])
 
 
 class root(yang.adata.MNode):
@@ -208,9 +193,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -228,18 +210,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/base',

--- a/test/golden/test_yang/compile_augment_implicit_input_output
+++ b/test/golden/test_yang/compile_augment_implicit_input_output
@@ -39,9 +39,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -69,9 +66,6 @@ class root(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
 
 
 class foo__r1__input__c3(yang.adata.MNode):
@@ -101,9 +95,6 @@ class foo__r1__input__c3(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__r1__input__c3.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:r1', 'input', 'c3'])
-
 
 class foo__r1__input(yang.adata.MNode):
     c3: foo__r1__input__c3
@@ -131,9 +122,6 @@ class foo__r1__input(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__r1__input.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:r1', 'input'])
 
 
 class foo__r1__output(yang.adata.MNode):
@@ -163,15 +151,12 @@ class foo__r1__output(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__r1__output.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:r1', 'output'])
-
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
     def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
-                gdata_res = from_xml(res, ["foo:r1", "output"])
+                gdata_res = yang.gen3.from_data(src_dnode(), res, False, ["foo:r1", "output"])
                 adata_res = foo__r1__output.from_gdata(gdata_res)
                 cb(adata_res, err)
             else:
@@ -179,7 +164,8 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
         rpc_xml = xml.Node('r1', nsdefs=[(None, 'http://example.com/foo')])
         if inp is not None:
-            rpc_xml.children.extend(inp.to_gdata().to_xml())
+            gdata_inp = yang.gen3.from_data(src_dnode(), inp, False, ["foo:r1", "input"])
+            rpc_xml.children.extend(gdata_inp.to_xml())
         tp.rpc_xml(cb_wrap, rpc_xml)
 
 
@@ -205,18 +191,6 @@ def src_dnode():
     ], children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='foo', name='c1', config=True, presence=False)
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_augment_import
+++ b/test/golden/test_yang/compile_augment_import
@@ -49,9 +49,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -80,9 +77,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -91,18 +85,6 @@ def src_dnode():
         DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l2', config=True, description='leaf 2', mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_augment_on_augment
+++ b/test/golden/test_yang/compile_augment_on_augment
@@ -49,9 +49,6 @@ class foo__c1__c2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__c2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'c2'])
-
 
 class foo__c1(yang.adata.MNode):
     l1: ?str
@@ -84,9 +81,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -115,9 +109,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -129,18 +120,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_augment_on_augment_across_modules
+++ b/test/golden/test_yang/compile_augment_on_augment_across_modules
@@ -49,9 +49,6 @@ class foo__c1__c2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__c2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'bar:c2'])
-
 
 class foo__c1(yang.adata.MNode):
     l1: ?str
@@ -84,9 +81,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -115,9 +109,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -129,18 +120,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/bar',

--- a/test/golden/test_yang/compile_augment_uses
+++ b/test/golden/test_yang/compile_augment_uses
@@ -45,9 +45,6 @@ class foo__c1__c2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__c2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'c2'])
-
 
 class foo__c1(yang.adata.MNode):
     c2: foo__c1__c2
@@ -75,9 +72,6 @@ class foo__c1(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 class root(yang.adata.MNode):
@@ -107,9 +101,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -121,18 +112,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_bundle1
+++ b/test/golden/test_yang/compile_bundle1
@@ -49,9 +49,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -80,9 +77,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -91,18 +85,6 @@ def src_dnode():
         DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l2', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_extension
+++ b/test/golden/test_yang/compile_extension
@@ -47,9 +47,6 @@ class foo__c1__things_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__things_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'things'])
-
 class foo__c1__things(yang.adata.MNode):
     elements: list[foo__c1__things_entry]
     mut def __init__(self, elements=[]):
@@ -117,9 +114,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -148,9 +142,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -163,18 +154,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_import_hyphenated_prefix
+++ b/test/golden/test_yang/compile_import_hyphenated_prefix
@@ -45,9 +45,6 @@ class acme_foo_bar__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return acme_foo_bar__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['acme_foo-bar:c1'])
-
 
 class root(yang.adata.MNode):
     c1: acme_foo_bar__c1
@@ -76,9 +73,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -86,18 +80,6 @@ def src_dnode():
         DLeaf(module='acme_foo-bar', namespace='http://example.com/foo', prefix='acme_foo-bar', name='l1', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_imported_grouping
+++ b/test/golden/test_yang/compile_imported_grouping
@@ -43,9 +43,6 @@ class bar__c1__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return bar__c1__li1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['bar:c1', 'li1'])
-
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -113,9 +110,6 @@ class bar__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return bar__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['bar:c1'])
-
 
 class root(yang.adata.MNode):
     c1: bar__c1
@@ -144,9 +138,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -156,18 +147,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/bar',

--- a/test/golden/test_yang/compile_refine
+++ b/test/golden/test_yang/compile_refine
@@ -45,9 +45,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -76,9 +73,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -91,18 +85,6 @@ def src_dnode():
             ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_submodule_conflicting_import_prefix
+++ b/test/golden/test_yang/compile_submodule_conflicting_import_prefix
@@ -49,9 +49,6 @@ class parent__parent_container(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return parent__parent_container.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['parent:parent-container'])
-
 
 class parent__sub_container(yang.adata.MNode):
     sub_leaf: ?str
@@ -83,9 +80,6 @@ class parent__sub_container(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return parent__sub_container.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['parent:sub-container'])
 
 
 class root(yang.adata.MNode):
@@ -119,9 +113,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -138,18 +129,6 @@ def src_dnode():
         DLeaf(module='parent', namespace='http://example.com/parent', prefix='parent', name='another-leaf', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/parent',

--- a/test/golden/test_yang/compile_submodule_different_prefix
+++ b/test/golden/test_yang/compile_submodule_different_prefix
@@ -45,9 +45,6 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return main_module__main_container__sub_group_container.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container', 'sub-group-container'])
-
 
 class main_module__main_container__sub_list_entry(yang.adata.MNode):
     name: str
@@ -81,9 +78,6 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container', 'sub-list'])
 
 class main_module__main_container__sub_list(yang.adata.MNode):
     elements: list[main_module__main_container__sub_list_entry]
@@ -156,9 +150,6 @@ class main_module__main_container__group_container(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return main_module__main_container__group_container.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container', 'group-container'])
-
 
 class main_module__main_container(yang.adata.MNode):
     main_leaf: ?str
@@ -203,9 +194,6 @@ class main_module__main_container(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return main_module__main_container.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['main-module:main-container'])
-
 
 class root(yang.adata.MNode):
     main_container: main_module__main_container
@@ -234,9 +222,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -261,18 +246,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/main',

--- a/test/golden/test_yang/compile_submodule_same_module_different_prefix
+++ b/test/golden/test_yang/compile_submodule_same_module_different_prefix
@@ -49,9 +49,6 @@ class parent__parent_container(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return parent__parent_container.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['parent:parent-container'])
-
 
 class parent__sub_container(yang.adata.MNode):
     sub_leaf: ?str
@@ -83,9 +80,6 @@ class parent__sub_container(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return parent__sub_container.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['parent:sub-container'])
 
 
 class root(yang.adata.MNode):
@@ -119,9 +113,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -134,18 +125,6 @@ def src_dnode():
         DLeaf(module='parent', namespace='http://example.com/parent', prefix='parent', name='shared-leaf', config=True, default='from-shared', mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/parent',

--- a/test/golden/test_yang/compile_submodules1
+++ b/test/golden/test_yang/compile_submodules1
@@ -45,9 +45,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class foo__c2(yang.adata.MNode):
     l2: ?str
@@ -75,9 +72,6 @@ class foo__c2(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__c2.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c2'])
 
 
 class root(yang.adata.MNode):
@@ -111,9 +105,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -124,18 +115,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='l2', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_uses
+++ b/test/golden/test_yang/compile_uses
@@ -43,9 +43,6 @@ class foo__c1__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__li1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'li1'])
-
 class foo__c1__li1(yang.adata.MNode):
     elements: list[foo__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -113,9 +110,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -144,9 +138,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -156,18 +147,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/compile_uses_augment
+++ b/test/golden/test_yang/compile_uses_augment
@@ -49,9 +49,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -80,9 +77,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -93,18 +87,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='l2', config=True, description='leaf 2', mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/identity_base_resolution_import_prefix
+++ b/test/golden/test_yang/identity_base_resolution_import_prefix
@@ -54,9 +54,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(identities=[
@@ -77,18 +74,6 @@ def src_dnode():
                     ])
             ])
     ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
 }

--- a/test/golden/test_yang/identityref
+++ b/test/golden/test_yang/identityref
@@ -60,9 +60,6 @@ class base__config(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__config.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:config'])
-
 
 class root(yang.adata.MNode):
     config: base__config
@@ -91,9 +88,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(identities=[
@@ -117,18 +111,6 @@ def src_dnode():
     ]))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/base',

--- a/test/golden/test_yang/mixed_req_args
+++ b/test/golden/test_yang/mixed_req_args
@@ -45,9 +45,6 @@ class foo__c__li__bar(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c__li__bar.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c', 'li', 'bar'])
-
 
 class foo__c__li_entry(yang.adata.MNode):
     name: str
@@ -81,9 +78,6 @@ class foo__c__li_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__c__li_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c', 'li'])
 
 class foo__c__li(yang.adata.MNode):
     elements: list[foo__c__li_entry]
@@ -137,18 +131,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_augment_inner_list_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_list_conflict
@@ -47,9 +47,6 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1__base_l1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1', 'l1'])
-
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
     mut def __init__(self, elements=[]):
@@ -114,9 +111,6 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return base__c1__foo_l1_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1', 'foo:l1'])
 
 class base__c1__foo_l1(yang.adata.MNode):
     elements: list[base__c1__foo_l1_entry]
@@ -189,9 +183,6 @@ class base__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1'])
-
 
 class root(yang.adata.MNode):
     c1: base__c1
@@ -220,9 +211,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -236,18 +224,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/base',

--- a/test/golden/test_yang/prdaclass_augment_inner_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_inner_name_conflict
@@ -45,9 +45,6 @@ class base__c1__base_c2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1__base_c2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1', 'c2'])
-
 
 class base__c1__foo_c2(yang.adata.MNode):
     foo: ?str
@@ -75,9 +72,6 @@ class base__c1__foo_c2(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return base__c1__foo_c2.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1', 'foo:c2'])
 
 
 class base__c1(yang.adata.MNode):
@@ -111,9 +105,6 @@ class base__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1'])
-
 
 class root(yang.adata.MNode):
     c1: base__c1
@@ -142,9 +133,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -157,18 +145,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/base',

--- a/test/golden/test_yang/prdaclass_augment_name_conflict
+++ b/test/golden/test_yang/prdaclass_augment_name_conflict
@@ -49,9 +49,6 @@ class base__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['base:c1'])
-
 
 def src_dnode():
     return DRoot(children=[
@@ -60,18 +57,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='foo', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/base',

--- a/test/golden/test_yang/prdaclass_dot
+++ b/test/golden/test_yang/prdaclass_dot
@@ -45,9 +45,6 @@ class foo__ieee_802_3(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__ieee_802_3.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:ieee-802.3'])
-
 
 class root(yang.adata.MNode):
     ieee_802_3: foo__ieee_802_3
@@ -76,9 +73,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -86,18 +80,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='ieee-802.3', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_identityref_list_key
+++ b/test/golden/test_yang/prdaclass_identityref_list_key
@@ -56,9 +56,6 @@ class foo__c1__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'l1'])
-
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -129,9 +126,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -160,9 +154,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(identities=[
@@ -181,18 +172,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_keyword_name_import
+++ b/test/golden/test_yang/prdaclass_keyword_name_import
@@ -61,9 +61,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 def src_dnode():
     return DRoot(children=[
@@ -75,18 +72,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='with', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_list_key_mandatory
+++ b/test/golden/test_yang/prdaclass_list_key_mandatory
@@ -43,9 +43,6 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -92,18 +89,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='name', config=True, mandatory=True, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_list_key_reorder
+++ b/test/golden/test_yang/prdaclass_list_key_reorder
@@ -47,9 +47,6 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -97,18 +94,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='id', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_loose_container_in_container
+++ b/test/golden/test_yang/prdaclass_loose_container_in_container
@@ -45,9 +45,6 @@ class foo__foo__bar(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__foo__bar.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:foo', 'bar'])
-
 
 class foo__foo(yang.adata.MNode):
     bar: foo__foo__bar
@@ -76,9 +73,6 @@ class foo__foo(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__foo.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:foo'])
-
 
 def src_dnode():
     return DRoot(children=[
@@ -88,18 +82,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=True, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=True, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=True)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=True)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -48,9 +48,6 @@ class foo__foo__bar(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__foo__bar.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:foo', 'bar'])
-
 
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
@@ -90,9 +87,6 @@ class foo__foo(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__foo.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:foo'])
-
 
 def src_dnode():
     return DRoot(children=[
@@ -102,18 +96,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=True, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=True, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=True)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=True)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_max_elements_unbounded
+++ b/test/golden/test_yang/prdaclass_max_elements_unbounded
@@ -43,9 +43,6 @@ class foo__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:li1'])
-
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -117,9 +114,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -128,18 +122,6 @@ def src_dnode():
     ]),
     DLeafList(module='foo', namespace='http://example.com/foo', prefix='foo', name='ll1', config=True, min_elements=0, ordered_by='system', type_=Type('string'))
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_min_elements
+++ b/test/golden/test_yang/prdaclass_min_elements
@@ -43,9 +43,6 @@ class foo__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:li1'])
-
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -117,9 +114,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -128,18 +122,6 @@ def src_dnode():
     ]),
     DLeafList(module='foo', namespace='http://example.com/foo', prefix='foo', name='ll1', config=True, min_elements=1, ordered_by='system', type_=Type('string'))
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_req_arg
+++ b/test/golden/test_yang/prdaclass_req_arg
@@ -45,9 +45,6 @@ class foo__l1__bar(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1__bar.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:l1', 'bar'])
-
 
 class foo__l1_entry(yang.adata.MNode):
     name: str
@@ -81,9 +78,6 @@ class foo__l1_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
@@ -152,9 +146,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -166,18 +157,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=True, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=True, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=True)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=True)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -39,9 +39,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 class yangrpc__foo__input__woo(yang.adata.MNode):
     woo_b: ?bigint
@@ -69,9 +66,6 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
 
 
 class yangrpc__foo__input(yang.adata.MNode):
@@ -105,9 +99,6 @@ class yangrpc__foo__input(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input'])
-
 
 class yangrpc__foo__output(yang.adata.MNode):
     outoo: ?str
@@ -136,15 +127,12 @@ class yangrpc__foo__output(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return yangrpc__foo__output.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'output'])
-
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
-                gdata_res = from_xml(res, ["yangrpc:foo", "output"])
+                gdata_res = yang.gen3.from_data(src_dnode(), res, False, ["yangrpc:foo", "output"])
                 adata_res = yangrpc__foo__output.from_gdata(gdata_res)
                 cb(adata_res, err)
             else:
@@ -152,7 +140,8 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
         rpc_xml = xml.Node('foo', nsdefs=[(None, 'http://example.com/yangrpc')])
         if inp is not None:
-            rpc_xml.children.extend(inp.to_gdata().to_xml())
+            gdata_inp = yang.gen3.from_data(src_dnode(), inp, False, ["yangrpc:foo", "input"])
+            rpc_xml.children.extend(gdata_inp.to_xml())
         tp.rpc_xml(cb_wrap, rpc_xml)
 
     def silent(cb: action(?Exception) -> None):
@@ -183,18 +172,6 @@ def src_dnode():
         ]),
         DRpc(module='yangrpc', namespace='http://example.com/yangrpc', prefix='yrpc', name='silent')
     ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/yangrpc',

--- a/test/golden/test_yang/prdaclass_strict_list_mandatory
+++ b/test/golden/test_yang/prdaclass_strict_list_mandatory
@@ -47,9 +47,6 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
-
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -97,18 +94,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='id', config=True, mandatory=True, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -48,9 +48,6 @@ class foo__l1__bar(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__l1__bar.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:l1', 'bar'])
-
 
 class foo__l1_entry(yang.adata.MNode):
     name: str
@@ -88,9 +85,6 @@ class foo__l1_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:l1'])
 
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
@@ -141,18 +135,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/test/golden/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -56,9 +56,6 @@ class foo__foo__bar(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__foo__bar.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:foo', 'bar'])
-
 
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
@@ -98,9 +95,6 @@ class foo__foo(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__foo.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:foo'])
-
 
 class root(yang.adata.MNode):
     foo: ?foo__foo
@@ -137,9 +131,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -151,18 +142,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_top_conflict
+++ b/test/golden/test_yang/prdaclass_top_conflict
@@ -45,9 +45,6 @@ class bar__bar_c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return bar__bar_c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['bar:c1'])
-
 
 class foo__foo_c1(yang.adata.MNode):
     l1: ?str
@@ -75,9 +72,6 @@ class foo__foo_c1(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__foo_c1.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
 
 
 class root(yang.adata.MNode):
@@ -111,9 +105,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -124,18 +115,6 @@ def src_dnode():
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='l1', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/bar',

--- a/test/golden/test_yang/prdaclass_top_container_from_xml_opt
+++ b/test/golden/test_yang/prdaclass_top_container_from_xml_opt
@@ -45,9 +45,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class foo__pc1__foo(yang.adata.MNode):
     l1: ?str
@@ -75,9 +72,6 @@ class foo__pc1__foo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc1__foo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc1', 'foo'])
 
 
 class foo__pc1(yang.adata.MNode):
@@ -109,9 +103,6 @@ class foo__pc1(yang.adata.MNode):
         if ad is not None:
             return ad
         raise Exception('Unreachable in foo__pc1.copy()')
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc1'])
 
 
 class root(yang.adata.MNode):
@@ -153,9 +144,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -168,18 +156,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -51,9 +51,6 @@ class foo__c1__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'l1'])
-
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -131,9 +128,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class root(yang.adata.MNode):
     c1: foo__c1
@@ -162,9 +156,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -185,18 +176,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -57,9 +57,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -80,18 +77,6 @@ def src_dnode():
         Type('int16')
     ]))
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
 }

--- a/test/golden/test_yang/resolve_type_union_of_string
+++ b/test/golden/test_yang/resolve_type_union_of_string
@@ -45,9 +45,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -59,18 +56,6 @@ def src_dnode():
         Type('string')
     ]))
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
 }

--- a/test/golden/test_yang/resolve_type_union_of_string_and_int
+++ b/test/golden/test_yang/resolve_type_union_of_string_and_int
@@ -45,9 +45,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(children=[
@@ -56,18 +53,6 @@ def src_dnode():
         Type('int32')
     ]))
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
 }

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -19,11 +19,11 @@ import yang_basics
 
 def _test_mandatory1():
     xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1></data>"""
-    r = yang_one.from_xml(xml.decode(xml_text))
+    r = yang.gen3.from_data(yang_one.src_dnode(), xml.decode(xml_text))
 
 def _test_mandatory2():
     xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1><li xmlns="http://example.com/foo"><name>foo</name><c1><l1>foo</l1></c1></li></data>"""
-    r = yang_one.from_xml(xml.decode(xml_text))
+    r = yang.gen3.from_data(yang_one.src_dnode(), xml.decode(xml_text))
 
 # YANG model used to generate yang_foo
 #
@@ -174,7 +174,7 @@ xml_text_full = """<data>
 
 def _test_foo_from_xml_full():
     xml_in = xml.decode(xml_text_full)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     # In this test we also use the gdata to "fill in" the foo module adata
     # classes and then compare the result of adata.to_gdata() with the input.
     ad = yang_foo_root.from_gdata(gd2)
@@ -208,7 +208,7 @@ def _test_foo_from_xml_full():
 actor _test_gdata_source_roundtrip_xml_full(t: testing.EnvT):
     wfcap = file.WriteFileCap(file.FileCap(t.env.cap))
     xml_in = xml.decode(xml_text_full)
-    gd = yang_foo.from_xml(xml_in)
+    gd = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     wf = file.WriteFile(wfcap, "../test_data_source_roundtrip/src/xml_full_gdata.act")
     await async wf.write("from yang.gdata import *\nfrom yang.identityref import Identityref\n\nxml_full = {gd.prsrc()}".encode())
     await async wf.close()
@@ -228,14 +228,14 @@ def _indent_lines(text, indent=4):
 actor _test_adata_source_roundtrip_xml_full(t: testing.EnvT):
     wfcap = file.WriteFileCap(file.FileCap(t.env.cap))
     xml_in = xml.decode(xml_text_full)
-    gd = yang_foo.from_xml(xml_in)
-    ad = yang_foo_root.from_gdata(gd)
+    gd = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
+    ad = yang.gen3.pradata(yang_foo.src_dnode(), gd)
     wf = file.WriteFile(wfcap, "../test_data_source_roundtrip/src/xml_full_adata.act")
     await async wf.write("""from yang_foo import *
 from yang.identityref import Identityref
 
 def adata():
-{_indent_lines(ad.prsrc("ad"))}
+{_indent_lines(ad)}
     return ad
 """.encode())
     await async wf.close()
@@ -244,14 +244,14 @@ def adata():
 actor _test_adata_source_roundtrip_xml_full_loose(t: testing.EnvT):
     wfcap = file.WriteFileCap(file.FileCap(t.env.cap))
     xml_in = xml.decode(xml_text_full)
-    gd = yang_foo.from_xml(xml_in)
-    ad = yang_foo_loose.root.from_gdata(gd)
+    gd = yang.gen3.from_data(yang_foo.src_dnode(), xml_in, loose=True)
+    ad = yang.gen3.pradata(yang_foo.src_dnode(), gd, loose=True)
     wf = file.WriteFile(wfcap, "../test_data_source_roundtrip/src/xml_full_adata_loose.act")
     await async wf.write("""from yang_foo_loose import *
 from yang.identityref import Identityref
 
 def adata():
-{_indent_lines(ad.prsrc("ad"))}
+{_indent_lines(ad)}
     return ad
 """.encode())
     await async wf.close()
@@ -267,7 +267,7 @@ def _test_foo_from_xml1():
 </pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     xml_out_text = gd2.to_xmlstr()
     xml_out = xml.decode("<data>\n{xml_out_text}\n</data>")
     testing.assertEqual(xml_in.encode(), xml_out.encode())
@@ -278,7 +278,7 @@ def _test_foo_from_xml_pc1():
 <pc1 xmlns="http://example.com/foo"></pc1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     print(gd2.prsrc(), err=True)
     pc1_gdata = gd2.get_opt_cnt("pc1")
     if pc1_gdata is not None:
@@ -300,7 +300,7 @@ def _test_foo_from_xml_pc2():
 </data>"""
     xml_in = xml.decode(xml_text)
     try:
-        d = yang_foo.from_xml(xml_in)
+        d = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
         testing.error("Expected exception on missing mandatory leaf")
     except ValueError as e:
         testing.assertIn("Cannot find xml child with name foo", e.error_message)
@@ -313,7 +313,7 @@ def _test_foo_from_xml2():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     print(gd2.prsrc(), err=True)
     # The sibling presence container pc1 must not appear here
     pc1_gdata = gd2.get_opt_cnt("pc1")
@@ -335,7 +335,7 @@ def _test_foo_from_xml_leaf_ns():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     xml_out_text = gd2.to_xmlstr()
     xml_out = xml.decode("<data>\n{xml_out_text}\n</data>")
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
@@ -349,7 +349,7 @@ def _test_foo_from_xml_named_ns():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     xml_out_text = gd2.to_xmlstr()
     xml_out = xml.decode("<data>\n{xml_out_text}\n</data>")
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
@@ -363,7 +363,7 @@ def _test_foo_from_xml_dots():
 </c.dot>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     xml_out_text = gd2.to_xmlstr()
     xml_out = xml.decode("<data>\n{xml_out_text}</data>")
     #testing.assertEqual(xml_in.encode(), xml_out.encode())
@@ -391,7 +391,7 @@ def _test_foo_from_xml_li_union():
 </li-union>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     root = yang_foo_root.from_gdata(gd2)
 
     li1 = root.li_union.elements[0]
@@ -430,7 +430,7 @@ def _test_foo_from_xml_empty_leaf():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     ad = yang_foo_root.from_gdata(gd2)
     testing.assertNotNone(ad.c1.l_empty)
     l_empty = ad.c1.l_empty
@@ -463,7 +463,7 @@ def _test_foo_from_gdata_int():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     l3 = gd2.get_cnt("c1").get_leaf("l3").val
     if isinstance(l3, bigint):
         testing.assertEqual(l3, 1337)
@@ -479,12 +479,12 @@ def _test_foo_from_gdata_empty():
 
 def _test_foo_from_xml_empty():
     xml_in = xml.decode("<data/>")
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     return gd2.prsrc()
 
 def _test_foo_from_json_empty():
     json_in = json.decode(r"{}")
-    gd2 = yang_foo.from_json(json_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_in)
     return gd2.prsrc()
 
 def _test_foo_from_gdata_c1_l1():
@@ -551,14 +551,14 @@ def _test_leaf_defaults():
 def _test_leaf_default_from_xml():
     xml_text = """<data><c xmlns="http://example.com/basics"/></data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_basics.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_basics.src_dnode(), xml_in)
     r = yang_basics.root.from_gdata(gd2)
     basics_leaf_defaults(r)
 
 def _test_leaf_default_from_json():
     json_text = r"""{"basics:c": {}}"""
     json_in = json.decode(json_text)
-    gd2 = yang_basics.from_json(json_in)
+    gd2 = yang.gen3.from_data(yang_basics.src_dnode(), json_in)
     r = yang_basics.root.from_gdata(gd2)
     basics_leaf_defaults(r)
 
@@ -580,7 +580,7 @@ def _test_union_default_other_type():
 def _test_empty_presence():
     xml_text = """<data><empty-presence xmlns="http://example.com/foo"/></data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     ad = yang_foo_root.from_gdata(gd2)
     testing.assertNotNone(ad.empty_presence)
     xml_out_text = gd2.to_xmlstr()
@@ -685,7 +685,7 @@ json_full = {
 }
 
 def _test_foo_from_json_full():
-    gd2 = yang_foo.from_json(json_full)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_full)
     print(gd2.prsrc(), err=True)
     json_out = gd2.to_json()
     testing.assertEqual(json.encode(json_full, pretty=True), json_out)
@@ -694,7 +694,7 @@ def _test_foo_from_json_full():
 def _test_foo_from_json_empty_leaf():
     json_text = r"""{"foo:c1":{"l_empty":[null]}}"""
     json_in = json.decode(json_text)
-    gd2 = yang_foo.from_json(json_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_in)
     ad = yang_foo_root.from_gdata(gd2)
     testing.assertNotNone(ad.c1.l_empty)
     l_empty = ad.c1.l_empty
@@ -711,7 +711,7 @@ def _test_from_json():
         }
     }
     # Should successfully parse since mandatory field is present
-    gd2 = yang_one.from_json(json_data)
+    gd2 = yang.gen3.from_data(yang_one.src_dnode(), json_data)
     #root = yang_one.root.from_gdata(gd2)
     #testing.assertEqual(root.children["tc1"].children["l1"].val, "foo")
     return gd2.to_xmlstr()
@@ -751,12 +751,12 @@ jd1 = {
 
 def _test_json_to_gdata():
     """Test JSON to GData conversion"""
-    gd2 = yang_foo.from_json(jd1)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), jd1)
     return gd2.prsrc()
 
 def _test_json_roundtrip():
     """Test JSON roundtrip"""
-    gd2 = yang_foo.from_json(jd1)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), jd1)
     json_out = gd2.to_json()
     testing.assertEqual(json.encode(jd1, pretty=True), json_out)
 
@@ -769,12 +769,12 @@ def _test_json_path():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "foo": "WINNING"
         }
-    gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "inner"])
+    gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "inner"])
 
     testing.assertEqual(gda.prsrc(), gdb2.prsrc())
 
@@ -791,13 +791,13 @@ def _test_json_path_nested_key_in_payload():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "name": "AAA",
         "bar": "WINNING"
         }
-    gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "inner", "li1", "AAA"])
+    gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "inner", "li1", "AAA"])
 
     testing.assertEqual(gda.prsrc(), gdb2.prsrc())
     return gdb2.prsrc()
@@ -815,12 +815,12 @@ def _test_json_path_nested_no_key_in_payload():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "bar": "WINNING"
         }
-    gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "inner", "li1", "AAA"])
+    gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "inner", "li1", "AAA"])
 
     testing.assertEqual(gda.prsrc(), gdb2.prsrc())
     return gdb2.prsrc()
@@ -838,23 +838,17 @@ def _test_json_path_nested_key_mismatch():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "name": "banana",
         "bar": "WINNING"
         }
     try:
-        gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "inner", "li1", "AAA"])
+        gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "inner", "li1", "AAA"])
         testing.error("Expected exception on key mismatch")
     except ValueError:
         pass
-    # Also test with gen3 - should fail the same way
-    try:
-        gdb3 = yang_foo.from_json_path(jdb, ["foo:nested", "inner", "li1", "AAA"])
-        testing.error("Expected exception on key mismatch from gen3")
-    except ValueError:
-        return
 
 def _test_json_path_nested():
     jda = {
@@ -875,12 +869,12 @@ def _test_json_path_nested():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "baz": "WINNING"
         }
-    gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "inner", "li1", "AAA", "li2", "BBB,CCC"])
+    gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "inner", "li1", "AAA", "li2", "BBB,CCC"])
 
     testing.assertEqual(gda.prsrc(), gdb2.prsrc())
     return gdb2.prsrc()
@@ -899,13 +893,13 @@ def _test_json_path_conflict():
             },
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "bar": "WINNING",
         "bar:bar": "WINNING2"
     }
-    gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "inner", "li1", "AAA"])
+    gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "inner", "li1", "AAA"])
     testing.assertEqual(gda.prsrc(), gdb2.prsrc())
     return gdb2.prsrc()
 
@@ -917,12 +911,12 @@ def _test_json_path_conflict_other():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
+    gda = yang.gen3.from_data(yang_foo.src_dnode(), jda)
 
     jdb = {
         "foo": "WINNING"
     }
-    gdb2 = yang_foo.from_json_path(jdb, ["foo:nested", "bar:inner"])
+    gdb2 = yang.gen3.from_json_path(yang_foo.src_dnode(), jdb, ["foo:nested", "bar:inner"])
     testing.assertEqual(gda.prsrc(), gdb2.prsrc())
     return gdb2.prsrc()
 
@@ -934,32 +928,31 @@ def _test_json_path_conflict_supefluous_namespace_qualifier():
             }
         }
     }
-    gda = yang_foo.from_json(jda)
     try:
         # We must not use the namespace qualifier on the inner container
         # because it is defined in the same module as its parent
-        yang_foo.from_json_path({}, ["foo:nested", "foo:inner"])
+        yang.gen3.from_json_path(yang_foo.src_dnode(), jda, ["foo:nested", "foo:inner"])
     except ValueError as e:
         if str(e) != "ValueError: Invalid path":
             testing.error("Expected exception on invalid path")
 
 def _test_json_path_remove():
-    gd2 = yang_foo.from_json_path({}, ["foo:nested", "inner"], "remove")
+    gd2 = yang.gen3.from_json_path(yang_foo.src_dnode(), {}, ["foo:nested", "inner"], "remove")
     return gd2.prsrc()
 
 def _test_json_path_remove_list_element():
-    gd2 = yang_foo.from_json_path({}, ["foo:nested", "inner", "li1", "AAA"], "remove")
+    gd2 = yang.gen3.from_json_path(yang_foo.src_dnode(), {}, ["foo:nested", "inner", "li1", "AAA"], "remove")
     return gd2.prsrc()
 
 def _test_json_ops():
-    ds1 = yang_foo.from_json({})
-    p1_2 = yang_foo.from_json_path({"bar": "p1"}, ["foo:nested", "inner", "li1", "AAA"])
+    ds1 = yang.gen3.from_data(yang_foo.src_dnode(), {})
+    p1_2 = yang.gen3.from_json_path(yang_foo.src_dnode(), {"bar": "p1"}, ["foo:nested", "inner", "li1", "AAA"])
     ds2 = yang.gdata.patch(ds1, p1_2)
     if ds2 is not None:
-        p2_2 = yang_foo.from_json_path({"bar": "p2"}, ["foo:nested", "inner", "li1", "BBB"])
+        p2_2 = yang.gen3.from_json_path(yang_foo.src_dnode(), {"bar": "p2"}, ["foo:nested", "inner", "li1", "BBB"])
         ds3 = yang.gdata.patch(ds2, p2_2)
         if ds3 is not None:
-            p3_2 = yang_foo.from_json_path({}, ["foo:nested", "inner", "li1", "AAA"], "remove")
+            p3_2 = yang.gen3.from_json_path(yang_foo.src_dnode(), {}, ["foo:nested", "inner", "li1", "AAA"], "remove")
             ds4 = yang.gdata.patch(ds3, p3_2)
             if ds4 is not None:
                 return ds4.prsrc()
@@ -973,7 +966,7 @@ def _test_validate_identityref_xml_qual():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     return gd2.prsrc()
 
 def _test_validate_identityref_xml_no_qual():
@@ -984,7 +977,7 @@ def _test_validate_identityref_xml_no_qual():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     return gd2.prsrc()
 
 def _test_validate_identityref_xml_invalid():
@@ -996,7 +989,7 @@ def _test_validate_identityref_xml_invalid():
 </data>"""
     xml_in = xml.decode(xml_text_invalid)
     try:
-        d = yang_foo.from_xml(xml_in)
+        d = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
         testing.error("Expected ValueError for invalid identityref value")
     except ValueError as exc:
         if "Invalid value for identityref" not in exc.error_message:
@@ -1011,7 +1004,7 @@ def _test_validate_identityref_leaflist_xml_qual():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     return gd2.prsrc()
 
 def _test_validate_identityref_leaflist_xml_no_qual():
@@ -1022,7 +1015,7 @@ def _test_validate_identityref_leaflist_xml_no_qual():
 </c1>
 </data>"""
     xml_in = xml.decode(xml_text)
-    gd2 = yang_foo.from_xml(xml_in)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     return gd2.prsrc()
 
 def _test_validate_identityref_leaflist_xml_invalid():
@@ -1035,7 +1028,7 @@ def _test_validate_identityref_leaflist_xml_invalid():
 </data>"""
     xml_in = xml.decode(xml_text_invalid)
     try:
-        gd2 = yang_foo.from_xml(xml_in)
+        gd2 = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
         ad = yang_foo_root.from_gdata(gd2)
         # Try to convert back to gdata to trigger validation
         gd_out = ad.to_gdata()
@@ -1053,7 +1046,7 @@ def _test_validate_identityref_json_qual():
             "l_identityref": "foo:fooy"
         }
     }
-    gd2 = yang_foo.from_json(json_text)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_text)
     return gd2.prsrc()
 
 def _test_validate_identityref_json_no_qual():
@@ -1063,7 +1056,7 @@ def _test_validate_identityref_json_no_qual():
             "l_identityref": "fooy"
         }
     }
-    gd2 = yang_foo.from_json(json_text)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_text)
     return gd2.prsrc()
 
 def _test_validate_identityref_json_invalid():
@@ -1074,7 +1067,7 @@ def _test_validate_identityref_json_invalid():
         }
     }
     try:
-        gd2 = yang_foo.from_json(json_text)
+        gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_text)
         ad = yang_foo_root.from_gdata(gd2)
         # Try to convert back to gdata to trigger validation
         gd_out = ad.to_gdata()
@@ -1093,7 +1086,7 @@ def _test_validate_identityref_leaflist_json_qual():
             "ll_identityref": ["foo:fooy", "bar:bary"]
         }
     }
-    gd2 = yang_foo.from_json(json_text)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_text)
     return gd2.prsrc()
 
 def _test_validate_identityref_leaflist_json_no_qual():
@@ -1103,7 +1096,7 @@ def _test_validate_identityref_leaflist_json_no_qual():
             "ll_identityref": ["fooy"]
         }
     }
-    gd2 = yang_foo.from_json(json_text)
+    gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_text)
     return gd2.prsrc()
 
 def _test_validate_identityref_leaflist_json_invalid():
@@ -1114,7 +1107,7 @@ def _test_validate_identityref_leaflist_json_invalid():
         }
     }
     try:
-        gd2 = yang_foo.from_json(json_text)
+        gd2 = yang.gen3.from_data(yang_foo.src_dnode(), json_text)
         ad = yang_foo_root.from_gdata(gd2)
         # Try to convert back to gdata to trigger validation
         gd_out = ad.to_gdata()
@@ -1130,7 +1123,7 @@ def _test_gen3_from_xml_full():
 
 def _test_copy_full_xml_tree():
     """Test copying a full XML tree and comparing gdata outputs"""
-    gd = yang_foo.from_xml(xml.decode(xml_text_full))
+    gd = yang.gen3.from_data(yang_foo.src_dnode(), xml.decode(xml_text_full))
     original = yang_foo_root.from_gdata(gd)
 
     copied = original.copy()

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -163,9 +163,6 @@ class basics__c(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return basics__c.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['basics:c'])
-
 
 class root(yang.adata.MNode):
     c: basics__c
@@ -193,9 +190,6 @@ class root(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
 
 
 def src_dnode():
@@ -232,18 +226,6 @@ def src_dnode():
         DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_identityref_def', config=True, default='id1', mandatory=False, type_=Type('identityref', base=['b:id1']))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/basics',

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -349,9 +349,6 @@ class foo__c1__li__c4(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__li__c4.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'li', 'c4'])
-
 
 class foo__c1__li_entry(yang.adata.MNode):
     name: str
@@ -385,9 +382,6 @@ class foo__c1__li_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__c1__li_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1', 'li'])
 
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
@@ -496,9 +490,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c1'])
-
 
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
@@ -526,9 +517,6 @@ class foo__pc1__foo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc1__foo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc1', 'foo'])
 
 
 class foo__pc1(yang.adata.MNode):
@@ -561,9 +549,6 @@ class foo__pc1(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__pc1.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc1'])
-
 
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: str
@@ -591,9 +576,6 @@ class foo__pc2__foo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc2__foo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc2', 'foo'])
 
 
 class foo__pc2(yang.adata.MNode):
@@ -626,9 +608,6 @@ class foo__pc2(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__pc2.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc2'])
-
 
 class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: str
@@ -660,9 +639,6 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
 
 class foo__pc3__level1__level2(yang.adata.MNode):
@@ -700,9 +676,6 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc3', 'level1', 'level2'])
-
 
 class foo__pc3__level1(yang.adata.MNode):
     l1: str
@@ -739,9 +712,6 @@ class foo__pc3__level1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc3', 'level1'])
-
 
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
@@ -773,9 +743,6 @@ class foo__pc3(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__pc3.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:pc3'])
-
 
 class foo__empty_presence(yang.adata.MNode):
 
@@ -800,9 +767,6 @@ class foo__empty_presence(yang.adata.MNode):
         if ad is not None:
             return ad
         raise Exception('Unreachable in foo__empty_presence.copy()')
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:empty-presence'])
 
 
 class foo__c_dot(yang.adata.MNode):
@@ -836,9 +800,6 @@ class foo__c_dot(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c_dot.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c.dot'])
-
 
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
@@ -864,9 +825,6 @@ class foo__cc__death_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:cc', 'death'])
 
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
@@ -939,9 +897,6 @@ class foo__cc(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__cc.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:cc'])
-
 
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
@@ -967,9 +922,6 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:conflict', 'inner'])
-
 
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
@@ -994,9 +946,6 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         if ad is not None:
             return ad
         raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:conflict', 'bar:inner'])
 
 
 class foo__f_conflict(yang.adata.MNode):
@@ -1054,9 +1003,6 @@ class foo__f_conflict(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__f_conflict.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:conflict'])
-
 
 class foo__special_entry(yang.adata.MNode):
     yes: bool
@@ -1082,9 +1028,6 @@ class foo__special_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:special'])
 
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
@@ -1158,9 +1101,6 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
@@ -1242,9 +1182,6 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'inner', 'li1'])
-
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1316,9 +1253,6 @@ class foo__nested__f_inner(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'inner'])
-
 
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
@@ -1346,9 +1280,6 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:nested', 'bar:inner'])
 
 
 class foo__nested(yang.adata.MNode):
@@ -1381,9 +1312,6 @@ class foo__nested(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:nested'])
 
 
 class foo__li_union_entry(yang.adata.MNode):
@@ -1422,9 +1350,6 @@ class foo__li_union_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:li-union'])
 
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
@@ -1515,9 +1440,6 @@ class foo__state__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__state__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:state', 'c1'])
-
 
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
@@ -1545,9 +1467,6 @@ class foo__state(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__state.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:state'])
 
 
 class foo__c2(yang.adata.MNode):
@@ -1577,9 +1496,6 @@ class foo__c2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:c2'])
-
 
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
@@ -1608,9 +1524,6 @@ class bar__test_idref(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return bar__test_idref.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['bar:test-idref'])
-
 
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
@@ -1638,9 +1551,6 @@ class bar__bar_conflict(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return bar__bar_conflict.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['bar:conflict'])
 
 
 class root(yang.adata.MNode):
@@ -1761,9 +1671,6 @@ class root(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
 
 
 def src_dnode():
@@ -1897,18 +1804,6 @@ def src_dnode():
         DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='foo', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/bar',

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -349,9 +349,6 @@ class foo__c1__li__c4(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__li__c4.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:c1', 'li', 'c4'])
-
 
 class foo__c1__li_entry(yang.adata.MNode):
     name: str
@@ -385,9 +382,6 @@ class foo__c1__li_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__c1__li_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:c1', 'li'])
 
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
@@ -496,9 +490,6 @@ class foo__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:c1'])
-
 
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
@@ -526,9 +517,6 @@ class foo__pc1__foo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc1__foo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc1', 'foo'])
 
 
 class foo__pc1(yang.adata.MNode):
@@ -561,9 +549,6 @@ class foo__pc1(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__pc1.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc1'])
-
 
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: ?str
@@ -591,9 +576,6 @@ class foo__pc2__foo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc2__foo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc2', 'foo'])
 
 
 class foo__pc2(yang.adata.MNode):
@@ -626,9 +608,6 @@ class foo__pc2(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__pc2.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc2'])
-
 
 class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: ?str
@@ -660,9 +639,6 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
 
 class foo__pc3__level1__level2(yang.adata.MNode):
@@ -700,9 +676,6 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc3', 'level1', 'level2'])
-
 
 class foo__pc3__level1(yang.adata.MNode):
     l1: ?str
@@ -739,9 +712,6 @@ class foo__pc3__level1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc3', 'level1'])
-
 
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
@@ -773,9 +743,6 @@ class foo__pc3(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__pc3.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:pc3'])
-
 
 class foo__empty_presence(yang.adata.MNode):
 
@@ -800,9 +767,6 @@ class foo__empty_presence(yang.adata.MNode):
         if ad is not None:
             return ad
         raise Exception('Unreachable in foo__empty_presence.copy()')
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:empty-presence'])
 
 
 class foo__c_dot(yang.adata.MNode):
@@ -836,9 +800,6 @@ class foo__c_dot(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c_dot.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:c.dot'])
-
 
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
@@ -864,9 +825,6 @@ class foo__cc__death_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:cc', 'death'])
 
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
@@ -939,9 +897,6 @@ class foo__cc(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__cc.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:cc'])
-
 
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
@@ -967,9 +922,6 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
             return ad
         raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:conflict', 'inner'])
-
 
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
@@ -994,9 +946,6 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         if ad is not None:
             return ad
         raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:conflict', 'bar:inner'])
 
 
 class foo__f_conflict(yang.adata.MNode):
@@ -1054,9 +1003,6 @@ class foo__f_conflict(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__f_conflict.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:conflict'])
-
 
 class foo__special_entry(yang.adata.MNode):
     yes: bool
@@ -1082,9 +1028,6 @@ class foo__special_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:special'])
 
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
@@ -1158,9 +1101,6 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
@@ -1242,9 +1182,6 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'inner', 'li1'])
-
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1316,9 +1253,6 @@ class foo__nested__f_inner(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'inner'])
-
 
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
@@ -1346,9 +1280,6 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:nested', 'bar:inner'])
 
 
 class foo__nested(yang.adata.MNode):
@@ -1381,9 +1312,6 @@ class foo__nested(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:nested'])
 
 
 class foo__li_union_entry(yang.adata.MNode):
@@ -1422,9 +1350,6 @@ class foo__li_union_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:li-union'])
 
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
@@ -1515,9 +1440,6 @@ class foo__state__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__state__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:state', 'c1'])
-
 
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
@@ -1545,9 +1467,6 @@ class foo__state(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__state.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:state'])
 
 
 class foo__c2(yang.adata.MNode):
@@ -1577,9 +1496,6 @@ class foo__c2(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c2.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['foo:c2'])
-
 
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
@@ -1608,9 +1524,6 @@ class bar__test_idref(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return bar__test_idref.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['bar:test-idref'])
-
 
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
@@ -1638,9 +1551,6 @@ class bar__bar_conflict(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return bar__bar_conflict.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True, root_path=['bar:conflict'])
 
 
 class root(yang.adata.MNode):
@@ -1761,9 +1671,6 @@ class root(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=True)
 
 
 def src_dnode():
@@ -1897,18 +1804,6 @@ def src_dnode():
         DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='foo', config=True, mandatory=False, type_=Type('string'))
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=True, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=True, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=True)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=True)
 
 schema_namespaces: set[str] = {
     'http://example.com/bar',

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -97,9 +97,6 @@ class foo__tc1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__tc1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:tc1'])
-
 
 class foo__li__c1(yang.adata.MNode):
     l1: str
@@ -132,9 +129,6 @@ class foo__li__c1(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li__c1.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:li', 'c1'])
-
 
 class foo__li_entry(yang.adata.MNode):
     name: str
@@ -164,9 +158,6 @@ class foo__li_entry(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_entry.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['foo:li'])
 
 class foo__li(yang.adata.MNode):
     elements: list[foo__li_entry]
@@ -239,9 +230,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 def src_dnode():
     return DRoot(identities=[
@@ -262,18 +250,6 @@ def src_dnode():
         ])
     ])
 ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/foo',

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -61,9 +61,6 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False)
-
 
 class yangrpc__foo__input__woo(yang.adata.MNode):
     woo_b: ?bigint
@@ -91,9 +88,6 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     def copy(self):
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
-
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
 
 
 class yangrpc__foo__input(yang.adata.MNode):
@@ -127,9 +121,6 @@ class yangrpc__foo__input(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'input'])
-
 
 class yangrpc__foo__output(yang.adata.MNode):
     outoo: ?str
@@ -158,15 +149,12 @@ class yangrpc__foo__output(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return yangrpc__foo__output.from_gdata(self.to_gdata())
 
-    def prsrc(self, self_name='ad'):
-        return yang.gen3.pradata(src_dnode(), self.to_gdata(), self_name, loose=False, root_path=['yangrpc:foo', 'output'])
-
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
-                gdata_res = from_xml(res, ["yangrpc:foo", "output"])
+                gdata_res = yang.gen3.from_data(src_dnode(), res, False, ["yangrpc:foo", "output"])
                 adata_res = yangrpc__foo__output.from_gdata(gdata_res)
                 cb(adata_res, err)
             else:
@@ -174,7 +162,8 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
         rpc_xml = xml.Node('foo', nsdefs=[(None, 'http://example.com/yangrpc')])
         if inp is not None:
-            rpc_xml.children.extend(inp.to_gdata().to_xml())
+            gdata_inp = yang.gen3.from_data(src_dnode(), inp, False, ["yangrpc:foo", "input"])
+            rpc_xml.children.extend(gdata_inp.to_xml())
         tp.rpc_xml(cb_wrap, rpc_xml)
 
     def silent(cb: action(?Exception) -> None):
@@ -205,18 +194,6 @@ def src_dnode():
         ]),
         DRpc(module='yangrpc', namespace='http://example.com/yangrpc', prefix='yrpc', name='silent')
     ])
-
-def from_xml(node: xml.Node, root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), node, loose=False, root_path=root_path)
-
-def from_json(jd: dict[str, ?value], root_path: list[str]=[]) -> yang.gdata.Container:
-    return yang.gen3.from_data(src_dnode(), jd, loose=False, root_path=root_path)
-
-def from_json_path(jd: dict[str, ?value], path: list[str]=[], op: ?str='merge') -> yang.gdata.Node:
-    return yang.gen3.from_json_path(src_dnode(), jd, path, op, loose=False)
-
-def prsrc(data, self_name='ad'):
-    return yang.gen3.pradata(src_dnode(), data, self_name, loose=False)
 
 schema_namespaces: set[str] = {
     'http://example.com/yangrpc',

--- a/test/test_data_source_roundtrip/src/test_data_source_roundtrip.act
+++ b/test/test_data_source_roundtrip/src/test_data_source_roundtrip.act
@@ -4,6 +4,7 @@ import testing
 import xml
 
 import yang.gdata
+import yang.gen3
 
 import yang_foo
 import test_data_classes
@@ -19,7 +20,7 @@ def _test_xml_full():
 
 def _test_gdata_full():
     xml_in = xml.decode(test_data_classes.xml_text_full)
-    gd = yang_foo.from_xml(xml_in)
+    gd = yang.gen3.from_data(yang_foo.src_dnode(), xml_in)
     testing.assertEqual(gd, xml_full_gdata.xml_full)
 
 def _test_adata_full():


### PR DESCRIPTION
We want to encourage proper usage of the gen3 parsers via YangData protocol, so let's use yang.gen3.from_data directly.