### PR TITLE
Resolve mnode leaf value union int to bigint

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2066,12 +2066,6 @@ class DTypeInteger(DType):
             if ranges is not None:
                 return Ranges.match(ranges, val)
             return True
-        # FIXME: Only allow bigint once all instances of int are removed from sorespo
-        if isinstance(val, int):
-            ranges = self.ranges
-            if ranges is not None:
-                return Ranges.match(ranges, bigint(val))
-            return True
         return False
 
     def format_hints(self) -> list[str]:

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -412,9 +412,9 @@ extension yang.adata.MNode (YangData):
         maybe_attr = self._get_attr(usname)
         if maybe_attr is not None:
             schema_type = schema.type_
-            concrete_type = validate_mnode_value(maybe_attr, schema_type)
-            if concrete_type is not None:
-                return (t=concrete_type, val=maybe_attr)
+            tv = try_validate_mnode_value(maybe_attr, schema_type)
+            if tv is not None:
+                return tv
             raise YangValidationError(path, schema_type, maybe_attr)
 
     def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(t: str, val: ?value)]:
@@ -425,23 +425,31 @@ extension yang.adata.MNode (YangData):
         if isinstance(children, list):
             schema_type = schema.type_
             for child in children:
-                concrete_type = validate_mnode_value(child, schema_type)
-                if concrete_type is not None:
-                    values.append((t=concrete_type, val=child))
+                tv = try_validate_mnode_value(child, schema_type)
+                if tv is not None:
+                    values.append(tv)
                 else:
                     raise YangValidationError(path, schema_type, child)
         return values
 
 
-def validate_mnode_value(val: value, schema_type: yang.schema.DType) -> ?str:
+def try_validate_mnode_value(val: value, schema_type: yang.schema.DType) -> ?(t: str, val: value):
     if isinstance(schema_type, yang.schema.DTypeUnion):
+        if isinstance(val, int):
+            # Handle case where mnode leaf value type is 'value'
+            # where an assigned integer literal is by default interpreted as int rather than the bigint we want
+            _val = bigint(val)
+        else:
+            _val = val
         for alt_type in schema_type.types:
-            if alt_type.validate_value(val):
-                return alt_type.builtin_type
+            tv = try_validate_mnode_value(_val, alt_type)
+            if tv is not None:
+                return tv
     else:
         if schema_type.validate_value(val):
-            return schema_type.builtin_type
+            return (t=schema_type.builtin_type, val=val)
     return None
+
 
 
 def _user_order(ordered_by):

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -2062,12 +2062,6 @@ class DTypeInteger(DType):
             if ranges is not None:
                 return Ranges.match(ranges, val)
             return True
-        # FIXME: Only allow bigint once all instances of int are removed from sorespo
-        if isinstance(val, int):
-            ranges = self.ranges
-            if ranges is not None:
-                return Ranges.match(ranges, bigint(val))
-            return True
         return False
 
     def format_hints(self) -> list[str]:


### PR DESCRIPTION
Handle case where mnode leaf value type is 'value' where an assigned integer literal is by default interpreted as int rather than the bigint we want