### PR TITLE
Use re.match

### DIFF
--- a/src/yang/pattern.act
+++ b/src/yang/pattern.act
@@ -277,7 +277,7 @@ class _XmlRegexToRe(object):
         return self.input[s.0:s.1]
 
     def try_get_substr_re(self, pattern) -> ?str:
-        m = re._match(pattern, self.input, self.i)
+        m = re.match(pattern, self.input, start_pos=self.i)
         # print("DEBUG81", self.input, self.i)
         if m is not None:
             s = self.input[self.i:m.end_pos]


### PR DESCRIPTION
re.match (and not just re._match) now exposes the start_pos arg, so we use it. We should not call private functions (it will stop working very soon).