### PR TITLE
Use fixed-size int types in gdata

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -98,6 +98,7 @@ import yang.xpath as xpath
 from yang.identityref import Identityref, PartialIdentityref
 from yang.pattern import YangPattern
 from yang.type import Decimal, Ranges, RangesBuilder
+from yang.type import SIGNED_INT_TYPES, UNSIGNED_INT_TYPES
 
 RECURSION_LIMIT = 512
 
@@ -2064,11 +2065,17 @@ class DTypeInteger(DType):
         return DTypeInteger(t.name, resolver.description, resolver.reference, resolver.units, t.exts, resolver.builtin_type, resolver.default, resolver.integer_ranges)
 
     def validate_value(self, val: value) -> bool:
-        if isinstance(val, bigint):
-            ranges = self.ranges
-            if ranges is not None:
-                return Ranges.match(ranges, val)
-            return True
+        ranges = self.ranges
+        if self.builtin_type in SIGNED_INT_TYPES:
+            if isinstance(val, int):
+                if ranges is not None:
+                    return Ranges.match(ranges, bigint(val))
+                return True
+        if self.builtin_type in UNSIGNED_INT_TYPES:
+            if isinstance(val, u64):
+                if ranges is not None:
+                    return Ranges.match(ranges, bigint(val))
+                return True
         return False
 
     def format_hints(self) -> list[str]:
@@ -3638,8 +3645,10 @@ def yang_typename_to_acton_type(type_name: str) -> str:
         return "Identityref"
     elif type_name == "instance-identifier":
         return "str"
-    elif type_name in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return "bigint"
+    elif type_name in SIGNED_INT_TYPES:
+        return "int"
+    elif type_name in UNSIGNED_INT_TYPES:
+        return "u64"
     elif type_name == "leafref":
         # You should use yang_type_to_acton_type which can expand the union type for you!
         raise ValueError("Leafref type not supported")
@@ -3692,36 +3701,12 @@ def yang_type_to_acton_type(t: ?DType) -> str:
             if len(unique_base_types) == 1:
                 return yang_typename_to_acton_type(unique_base_types[0])
 
-            # TODO: should we map in union of say u32 and i32 into i64?
-            if all(map(lambda x: x in {"int8", "int16", "int32", "int64"}, unique_base_types)):
-                max_size = max(list(map(lambda x: int(x[3:]), unique_base_types)))
-                # TODO: once we have integer subtyping, return largest necessary iXX type
-                #return "i{max_size}"
-                return "bigint"
-            elif all(map(lambda x: x in {"uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
-                max_size = max(list(map(lambda x: int(x[4:]), unique_base_types)))
-                # TODO: once we have integer subtyping, return largest necessary uXX type
-                #return "u{max_size}"
-                return "bigint"
-            elif all(map(lambda x: x in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
-                # We have a union of a mix of signed and unsigned integers, so let's find the largest
-                int_sizes = filter(lambda x: x in {"int8", "int16", "int32", "int64"}, unique_base_types)
-                max_int_size = max(list(map(lambda x: int(x[3:]), int_sizes)))
-                uint_sizes = filter(lambda x: x in {"uint8", "uint16", "uint32", "uint64"}, unique_base_types)
-                max_uint_size = max(list(map(lambda x: int(x[4:]), uint_sizes)))
-                # To map a uint into an signed int, we need twice the number of
-                # bits, i.e. uint8 fits in int16 or uint32 fits in int64, so
-                # just double the max size...
-                max_int_mapped_uint_size = max_uint_size * 2
-                # Total max size is the max between signed int and
-                # integer-mapped-uint (which is already 2*uint max)
-                max_size = max([max_int_size, max_int_mapped_uint_size])
-                if max_size > 64:
-                    # Need to use our int (a.k.a. "bigint")
-                    return "bigint"
-                # TODO: once we have integer subtyping, return largest necessary iXX type
-                #return "i{max_size}"
-                return "bigint"
+            # Normalize to int or u64 Acton type, but only if the union consists
+            # of base integer types on the same side of 0
+            if all(map(lambda x: x in SIGNED_INT_TYPES, unique_base_types)):
+                return "int"
+            elif all(map(lambda x: x in UNSIGNED_INT_TYPES, unique_base_types)):
+                return "u64"
 
             # TODO: use atom when union consists of types that we represent with Acton built-in types
             # TODO: use Acton union
@@ -3745,8 +3730,10 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return '"' + value + '"'
     elif ytype == "identityref":
         return value
-    elif ytype in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return "bigint(" + value + ")"
+    elif ytype in SIGNED_INT_TYPES:
+        return str(value)
+    elif ytype in UNSIGNED_INT_TYPES:
+        return "u64(" + value + ")"
     elif ytype == "decimal64":
         a = Decimal.parse(value)
         return repr(a)

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1396,27 +1396,19 @@ def _test_resolve_type_union_of_intX():
 
     if isinstance(l1, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l1, None)
-        # TODO: once we have integer subtyping, expect...
-        #testing.assertEqual(acton_type, "?i32")
-        testing.assertEqual(acton_type, "?bigint")
+        testing.assertEqual(acton_type, "?int")
 
     if isinstance(l2, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l2, None)
-        # TODO: once we have integer subtyping, expect...
-        #testing.assertEqual(acton_type, "?u32")
-        testing.assertEqual(acton_type, "?bigint")
+        testing.assertEqual(acton_type, "?u64")
 
     if isinstance(l3, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l3, None)
-        # TODO: once we have integer subtyping, expect...
-        #testing.assertEqual(acton_type, "?i16")
-        testing.assertEqual(acton_type, "?bigint")
+        testing.assertEqual(acton_type, "?value")
 
     if isinstance(l4, yang.schema.DLeaf):
         acton_type = yang.schema.yang_leaf_to_acton_type(l4, None)
-        # TODO: once we have integer subtyping, expect...
-        #testing.assertEqual(acton_type, "?i64")
-        testing.assertEqual(acton_type, "?bigint")
+        testing.assertEqual(acton_type, "?value")
     return root.prdaclass()
 
 def _test_resolve_type_union_of_string_and_int():

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -205,22 +205,11 @@ def yang_str(v) -> str:
     return s
 
 
-_min_i64 = bigint(-9223372036854775807-1)
-_max_i64 = bigint(9223372036854775807)
-_max_u64 = bigint(18446744073709551615)
 def json_val(v: value) -> ?value:
     if isinstance(v, bytes):
         return base64.encode(v).decode()
     if isinstance(v, Identityref):
         return "{v.mod}:{v.val}"
-    # JSON encoder doesn't handle bigint, so we convert to a fixed size int, else a string
-    if isinstance(v, bigint):
-        if v >= _min_i64 and v <= _max_i64:
-            return int(v)
-        elif v >= 0 and v <= _max_u64:
-            return u64(v)
-        else:
-            return str(v)
     if isinstance(v, Decimal):
         return str(v)
     return v
@@ -233,10 +222,9 @@ def fmt_json_name(name: Id, module=None):
 
 
 def repr_gdata(v) -> str:
-    # All numeric gdata values are bigint, so include an explicit cast because
-    # these printed values are assigned to the "value" type when compiled
-    if isinstance(v, bigint):
-        return "bigint({v})"
+    # Include explicit casts for integer values to preserve types in "value"
+    if isinstance(v, u64):
+        return "u64({v})"
     elif isinstance(v, list):
         return "[" + ", ".join([repr_gdata(e) for e in v]) + "]"
     return repr(v)
@@ -688,34 +676,65 @@ class Node(value):
             if isinstance(childval, Decimal):
                 return childval
 
-    def get_bigint(self, name) -> bigint:
+    def get_int(self, name) -> int:
         child = self.get_leaf(name)
         childval = child.val
-        if isinstance(childval, bigint):
+        if isinstance(childval, int):
             return childval
-        raise ValueError("Leaf {name} is not of type bigint")
+        raise ValueError("Leaf {name} is not of type int")
 
-    def get_bigints(self, name) -> list[bigint]:
+    def get_ints(self, name) -> list[int]:
         if isinstance(self, Container):
             for nm,child in self.children.items():
                 if isinstance(child, LeafList) and nm == name:
                     cvals = []
                     for v in child.vals:
-                        if isinstance(v, bigint):
+                        if isinstance(v, int):
                             cvals.append(v)
                     return cvals
         raise ValueError("Cannot find leaf-list child with name {name}")
 
-    def get_opt_bigint(self, name) -> ?bigint:
+    def get_opt_int(self, name) -> ?int:
         child = self.get_opt_leaf(name)
         if child is not None:
             childval = child.val
-            if isinstance(childval, bigint):
+            if isinstance(childval, int):
                 return childval
 
-    def get_opt_bigints(self, name) -> list[bigint]:
+    def get_opt_ints(self, name) -> list[int]:
         try:
-            return self.get_bigints(name)
+            return self.get_ints(name)
+        except ValueError:
+            return []
+
+    def get_u64(self, name) -> u64:
+        child = self.get_leaf(name)
+        childval = child.val
+        if isinstance(childval, u64):
+            return childval
+        raise ValueError("Leaf {name} is not of type u64")
+
+    def get_u64s(self, name) -> list[u64]:
+        if isinstance(self, Container):
+            for nm,child in self.children.items():
+                if isinstance(child, LeafList) and nm == name:
+                    cvals = []
+                    for v in child.vals:
+                        if isinstance(v, u64):
+                            cvals.append(v)
+                    return cvals
+        raise ValueError("Cannot find leaf-list child with name {name}")
+
+    def get_opt_u64(self, name) -> ?u64:
+        child = self.get_opt_leaf(name)
+        if child is not None:
+            childval = child.val
+            if isinstance(childval, u64):
+                return childval
+
+    def get_opt_u64s(self, name) -> list[u64]:
+        try:
+            return self.get_u64s(name)
         except ValueError:
             return []
 
@@ -1047,8 +1066,6 @@ def sorted_elements(elements, key_names: list[Id]):
 
 def vals_equal(a: value, b: value) -> bool:
     # Compare known leaf value types
-    if isinstance(a, bigint) and isinstance(b, bigint):
-        return a == b
     if isinstance(a, bool) and isinstance(b, bool):
         return a == b
     if isinstance(a, float) and isinstance(b, float):
@@ -1059,21 +1076,7 @@ def vals_equal(a: value, b: value) -> bool:
         return a == b
     if isinstance(a, bytes) and isinstance(b, bytes):
         return a == b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, u8) and isinstance(b, u8):
-    #    return a == b
-    if isinstance(a, u16) and isinstance(b, u16):
-        return a == b
-    if isinstance(a, u32) and isinstance(b, u32):
-        return a == b
     if isinstance(a, u64) and isinstance(b, u64):
-        return a == b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, i8) and isinstance(b, i8):
-    #    return a == b
-    if isinstance(a, i16) and isinstance(b, i16):
-        return a == b
-    if isinstance(a, i32) and isinstance(b, i32):
         return a == b
     if isinstance(a, int) and isinstance(b, int):
         return a == b
@@ -1099,8 +1102,6 @@ def vals_list_equal(a: list[value], b: list[value]) -> bool:
 
 def vals_less_than(a: value, b: value) -> bool:
     # Compare known leaf value types
-    if isinstance(a, bigint) and isinstance(b, bigint):
-        return a < b
     if isinstance(a, bool) and isinstance(b, bool):
         return not a  # False (0) before True (1)
     if isinstance(a, float) and isinstance(b, float):
@@ -1111,21 +1112,7 @@ def vals_less_than(a: value, b: value) -> bool:
         return a < b
     if isinstance(a, bytes) and isinstance(b, bytes):
         return a < b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, u8) and isinstance(b, u8):
-    #    return a < b
-    if isinstance(a, u16) and isinstance(b, u16):
-        return a < b
-    if isinstance(a, u32) and isinstance(b, u32):
-        return a < b
     if isinstance(a, u64) and isinstance(b, u64):
-        return a < b
-    # TODO: Add support for u8 and i8
-    #if isinstance(a, i8) and isinstance(b, i8):
-    #    return a < b
-    if isinstance(a, i16) and isinstance(b, i16):
-        return a < b
-    if isinstance(a, i32) and isinstance(b, i32):
         return a < b
     if isinstance(a, int) and isinstance(b, int):
         return a < b
@@ -1738,37 +1725,37 @@ def _test_format_gdata_path():
     path = [
         _PathElement(Id("", "config")),
         _PathElement(Id("", "interfaces")),
-        _PathElement(keys={"name": "eth0", "vlan": bigint(100)}),
+        _PathElement(keys={"name": "eth0", "vlan": u64(100)}),
         _PathElement(Id("", "ipv4")),
-        _PathElement(keys={"ip": "10.0.0.1", "prefix": bigint(24)})
+        _PathElement(keys={"ip": "10.0.0.1", "prefix": u64(24)})
     ]
     testing.assertEqual("/config/interfaces[name='eth0',vlan=100]/ipv4[ip='10.0.0.1',prefix=24]", _format_gdata_path(path))
 
 
 def _test_merge1():
     y1 = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
         Id(NS_acme, "l1"): List([Id(NS_acme, "name")], [
             Container({
                 Id(NS_acme, "name"): Leaf("k1"),
-                Id(NS_acme, "n1"): Leaf(bigint(1)),
-                Id(NS_acme, "n2"): Leaf(bigint(2))
+                Id(NS_acme, "n1"): Leaf(u64(1)),
+                Id(NS_acme, "n2"): Leaf(u64(2))
             }),
             Container({
                 Id(NS_acme, "name"): Leaf("k4"),
-                Id(NS_acme, "n4"): Leaf(bigint(4)),
+                Id(NS_acme, "n4"): Leaf(u64(4)),
             }),
         ])
     }, ns="http://example.com/acme", module="acme")
 
     y2 = Container({
-        Id(NS_acme, "b"): Leaf(bigint(2)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
         Id(NS_acme, "l1"): List([Id(NS_acme, "name")], [
             Container({
                 Id(NS_acme, "name"): Leaf("k2"),
-                Id(NS_acme, "n1"): Leaf(bigint(1)),
-                Id(NS_acme, "n3"): Leaf(bigint(3))
+                Id(NS_acme, "n1"): Leaf(u64(1)),
+                Id(NS_acme, "n3"): Leaf(u64(3))
             }),
         ]),
         Id(NS_acme, "d"): LeafList(["a", "b", "c"])
@@ -1777,23 +1764,23 @@ def _test_merge1():
     res = merge(y1, y2)
 
     exp = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
         Id(NS_acme, "l1"): List([Id(NS_acme, "name")], [
             Container({
                 Id(NS_acme, "name"): Leaf("k1"),
-                Id(NS_acme, "n1"): Leaf(bigint(1)),
-                Id(NS_acme, "n2"): Leaf(bigint(2))
+                Id(NS_acme, "n1"): Leaf(u64(1)),
+                Id(NS_acme, "n2"): Leaf(u64(2))
             }),
             Container({
                 Id(NS_acme, "name"): Leaf("k2"),
-                Id(NS_acme, "n1"): Leaf(bigint(1)),
-                Id(NS_acme, "n3"): Leaf(bigint(3))
+                Id(NS_acme, "n1"): Leaf(u64(1)),
+                Id(NS_acme, "n3"): Leaf(u64(3))
             }),
             Container({
                 Id(NS_acme, "name"): Leaf("k4"),
-                Id(NS_acme, "n4"): Leaf(bigint(4)),
+                Id(NS_acme, "n4"): Leaf(u64(4)),
             }),
         ]),
         Id(NS_acme, "d"): LeafList(["a", "b", "c"])
@@ -1805,23 +1792,23 @@ def _test_merge_list1():
     y1 = List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("first"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("breaker"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("fourth"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("common"),
-            Id(NS_acme, "n2"): Leaf(bigint(2))
+            Id(NS_acme, "n2"): Leaf(u64(2))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("last"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
@@ -1831,15 +1818,15 @@ def _test_merge_list1():
         }),
         Container({
             Id(NS_acme, "name"): Leaf("second"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("third"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("common"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("last")
@@ -1849,32 +1836,32 @@ def _test_merge_list1():
     exp = List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("first"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("breaker"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("fourth"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("common"),
-            Id(NS_acme, "n2"): Leaf(bigint(2)),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n2"): Leaf(u64(2)),
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("last"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("second"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("third"),
-            Id(NS_acme, "n1"): Leaf(bigint(1))
+            Id(NS_acme, "n1"): Leaf(u64(1))
         }),
     ], user_order=True, ns="http://example.com/acme", module="acme")
 
@@ -1882,10 +1869,10 @@ def _test_merge_list1():
 
 def _test_merge_leaf_conflict():
     y1 = Container({
-        Id("", "a"): Leaf(bigint(1))
+        Id("", "a"): Leaf(u64(1))
     })
     y2 = Container({
-        Id("", "a"): Leaf(bigint(2))
+        Id("", "a"): Leaf(u64(2))
     })
 
     try:
@@ -1898,21 +1885,21 @@ def _test_eq_list():
     l1 = List([Id("", "name")], [
         Container({
             Id("", "name"): Leaf("a"),
-            Id("", "x"): Leaf(bigint(1))
+            Id("", "x"): Leaf(u64(1))
         }),
         Container({
             Id("", "name"): Leaf("b"),
-            Id("", "x"): Leaf(bigint(2))
+            Id("", "x"): Leaf(u64(2))
         })
     ])
     l2 = List([Id("", "name")], [
         Container({
             Id("", "name"): Leaf("b"),
-            Id("", "x"): Leaf(bigint(2))
+            Id("", "x"): Leaf(u64(2))
         }),
         Container({
             Id("", "name"): Leaf("a"),
-            Id("", "x"): Leaf(bigint(1))
+            Id("", "x"): Leaf(u64(1))
         })
     ])
     testing.assertEqual(l1, l1)
@@ -1921,18 +1908,18 @@ def _test_eq_list():
 def _test_eq_list_user_order():
     l1 = List([Id("", "name")], user_order=True, elements=[
         Container({
-            Id("", "x"): Leaf(bigint(1))
+            Id("", "x"): Leaf(u64(1))
         }),
         Container({
-            Id("", "x"): Leaf(bigint(2))
+            Id("", "x"): Leaf(u64(2))
         })
     ])
     l2 = List([Id("", "name")], user_order=True, elements=[
         Container({
-            Id("", "x"): Leaf(bigint(2))
+            Id("", "x"): Leaf(u64(2))
         }),
         Container({
-            Id("", "x"): Leaf(bigint(1))
+            Id("", "x"): Leaf(u64(1))
         })
     ])
     testing.assertEqual(l1, l1)
@@ -1955,13 +1942,13 @@ def _test_diff_no_change():
     since there are no differences.
     """
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
@@ -1972,19 +1959,19 @@ def _test_diff_leaf_change():
     with just that leaf changed.
     """
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        Id(NS_acme, "a"): Leaf(bigint(42)), # Changed from 1 to 42
-        Id(NS_acme, "b"): Leaf(bigint(2))
+        Id(NS_acme, "a"): Leaf(u64(42)), # Changed from 1 to 42
+        Id(NS_acme, "b"): Leaf(u64(2))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
 
     exp = Container({
-        Id(NS_acme, "a"): Leaf(bigint(42))
+        Id(NS_acme, "a"): Leaf(u64(42))
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
@@ -1994,14 +1981,14 @@ def _test_diff_node_removal():
     diff at the place where c was.
     """
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
-        Id(NS_acme, "d"): Leaf(bigint(4))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
+        Id(NS_acme, "d"): Leaf(u64(4))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "d"): Leaf(bigint(4))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "d"): Leaf(u64(4))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
@@ -2009,7 +1996,7 @@ def _test_diff_node_removal():
     # c is removed
     exp = Container({
         Id(NS_acme, "c"): Absent({
-            Id(NS_acme, "c"): Leaf(bigint(3))
+            Id(NS_acme, "c"): Leaf(u64(3))
         })
     }, ns="http://example.com/acme", module="acme")
 
@@ -2021,12 +2008,12 @@ def _test_diff_list_removal():
         Id(NS_acme, "l"): List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("k1"),
-            Id(NS_acme, "n1"): Leaf(bigint(1)),
-            Id(NS_acme, "n2"): Leaf(bigint(2)),
+            Id(NS_acme, "n1"): Leaf(u64(1)),
+            Id(NS_acme, "n2"): Leaf(u64(2)),
         }),
         Container({
             Id(NS_acme, "name"): Leaf("k4"),
-            Id(NS_acme, "n4"): Leaf(bigint(4)),
+            Id(NS_acme, "n4"): Leaf(u64(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
     })
@@ -2041,12 +2028,12 @@ def _test_diff_list_removal():
             Id(NS_acme, "l"): List([Id(NS_acme, "name")], [
                 Container({
                     Id(NS_acme, "name"): Leaf("k1"),
-                    Id(NS_acme, "n1"): Leaf(bigint(1)),
-                    Id(NS_acme, "n2"): Leaf(bigint(2)),
+                    Id(NS_acme, "n1"): Leaf(u64(1)),
+                    Id(NS_acme, "n2"): Leaf(u64(2)),
                 }),
                 Container({
                     Id(NS_acme, "name"): Leaf("k4"),
-                    Id(NS_acme, "n4"): Leaf(bigint(4)),
+                    Id(NS_acme, "n4"): Leaf(u64(4)),
                 }),
             ], ns="http://example.com/acme", module="acme")
         }, ns="http://example.com/acme", module="acme")
@@ -2063,19 +2050,19 @@ def _test_diff_elem_removal():
     old = List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("k1"),
-            Id(NS_acme, "n1"): Leaf(bigint(1)),
-            Id(NS_acme, "n2"): Leaf(bigint(2)),
+            Id(NS_acme, "n1"): Leaf(u64(1)),
+            Id(NS_acme, "n2"): Leaf(u64(2)),
         }),
         Container({
             Id(NS_acme, "name"): Leaf("k4"),
-            Id(NS_acme, "n4"): Leaf(bigint(4)),
+            Id(NS_acme, "n4"): Leaf(u64(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
     new = List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("k4"),
-            Id(NS_acme, "n4"): Leaf(bigint(4)),
+            Id(NS_acme, "n4"): Leaf(u64(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
@@ -2094,19 +2081,19 @@ def _test_diff_node_addition():
     """A new node e is added in new. We expect the diff to have that new node.
     """
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1))
+        Id(NS_acme, "a"): Leaf(u64(1))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "e"): Leaf(bigint(5))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "e"): Leaf(u64(5))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
 
     # e is new
     exp = Container({
-        Id(NS_acme, "e"): Leaf(bigint(5))
+        Id(NS_acme, "e"): Leaf(u64(5))
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
@@ -2137,15 +2124,15 @@ def _test_diff_complex_ordering():
     before the new node d in the diff.
     """
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2)),
-        Id(NS_acme, "c"): Leaf(bigint(3))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
+        Id(NS_acme, "c"): Leaf(u64(3))
     }, ns="http://example.com/acme", module="acme")
 
     new = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
-        Id(NS_acme, "d"): Leaf(bigint(4))
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
+        Id(NS_acme, "d"): Leaf(u64(4))
     }, ns="http://example.com/acme", module="acme")
 
     d = diff(old, new)
@@ -2153,17 +2140,17 @@ def _test_diff_complex_ordering():
     # "b" is absent before "d" is introduced
     exp = Container({
         Id(NS_acme, "b"): Absent({
-            Id(NS_acme, "b"): Leaf(bigint(2))
+            Id(NS_acme, "b"): Leaf(u64(2))
         }),
-        Id(NS_acme, "d"): Leaf(bigint(4))
+        Id(NS_acme, "d"): Leaf(u64(4))
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(d, exp)
 
 def _test_diff_union_type():
     old = Container({
-        Id("", "l"): Leaf(bigint(42)),
-        Id("", "ll"): LeafList([bigint(42)])
+        Id("", "l"): Leaf(u64(42)),
+        Id("", "ll"): LeafList([u64(42)])
     })
 
     new = Container({
@@ -2188,8 +2175,8 @@ def _test_diff_empty_leaf_delete():
 
 def _test_patch_no_change():
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
     }, ns="http://example.com/acme", module="acme")
 
     # diff is None means no changes
@@ -2200,28 +2187,28 @@ def _test_patch_no_change():
 
 def _test_patch_leaf_change():
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
     }, ns="http://example.com/acme", module="acme")
 
     # Suppose we want to change leaf 'a' from 1 to 42
     # diff would look like this:
     p = Container({
-        Id(NS_acme, "a"): Leaf(bigint(42)),
+        Id(NS_acme, "a"): Leaf(u64(42)),
     }, ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = Container({
-        Id(NS_acme, "a"): Leaf(bigint(42)),
-        Id(NS_acme, "b"): Leaf(bigint(2)),
+        Id(NS_acme, "a"): Leaf(u64(42)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
 
 def _test_patch_node_removal():
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
     }, ns="http://example.com/acme", module="acme")
 
     # Suppose we remove 'c'
@@ -2232,7 +2219,7 @@ def _test_patch_node_removal():
 
     res = patch(old, p)
     exp = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2241,12 +2228,12 @@ def _test_patch_elem_removal():
     old = List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("k1"),
-            Id(NS_acme, "n1"): Leaf(bigint(1)),
-            Id(NS_acme, "n2"): Leaf(bigint(2))
+            Id(NS_acme, "n1"): Leaf(u64(1)),
+            Id(NS_acme, "n2"): Leaf(u64(2))
         }),
         Container({
             Id(NS_acme, "name"): Leaf("k4"),
-            Id(NS_acme, "n4"): Leaf(bigint(4)),
+            Id(NS_acme, "n4"): Leaf(u64(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
@@ -2262,7 +2249,7 @@ def _test_patch_elem_removal():
     exp = List([Id(NS_acme, "name")], [
         Container({
             Id(NS_acme, "name"): Leaf("k4"),
-            Id(NS_acme, "n4"): Leaf(bigint(4)),
+            Id(NS_acme, "n4"): Leaf(u64(4)),
         }),
     ], ns="http://example.com/acme", module="acme")
 
@@ -2270,8 +2257,8 @@ def _test_patch_elem_removal():
 
 def _test_patch_elem_removal2():
     old = Container({
-        Id("", "n1"): Leaf(bigint(1)),
-        Id("", "n2"): Leaf(bigint(2))
+        Id("", "n1"): Leaf(u64(1)),
+        Id("", "n2"): Leaf(u64(2))
     })
 
     p = Absent({
@@ -2284,18 +2271,18 @@ def _test_patch_elem_removal2():
 
 def _test_patch_node_addition():
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
     }, ns="http://example.com/acme", module="acme")
 
     # Add a new leaf 'e':
     p = Container({
-        Id(NS_acme, "e"): Leaf(bigint(5))
+        Id(NS_acme, "e"): Leaf(u64(5))
     }, ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "e"): Leaf(bigint(5)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "e"): Leaf(u64(5)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2303,23 +2290,23 @@ def _test_patch_node_addition():
 def _test_patch_complex_ordering():
     # old: a, b, c
     old = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "b"): Leaf(bigint(2)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "b"): Leaf(u64(2)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
     }, ns="http://example.com/acme", module="acme")
 
     # new: a, c, d
     # diff: remove b, add d
     p = Container({
         Id(NS_acme, "b"): Absent(),
-        Id(NS_acme, "d"): Leaf(bigint(4))
+        Id(NS_acme, "d"): Leaf(u64(4))
     }, ns="http://example.com/acme", module="acme")
 
     res = patch(old, p)
     exp = Container({
-        Id(NS_acme, "a"): Leaf(bigint(1)),
-        Id(NS_acme, "c"): Leaf(bigint(3)),
-        Id(NS_acme, "d"): Leaf(bigint(4)),
+        Id(NS_acme, "a"): Leaf(u64(1)),
+        Id(NS_acme, "c"): Leaf(u64(3)),
+        Id(NS_acme, "d"): Leaf(u64(4)),
     }, ns="http://example.com/acme", module="acme")
 
     testing.assertEqual(res, exp)
@@ -2344,8 +2331,8 @@ def _test_patch_leaflist():
 
 def _test_patch_union_type():
     old = Container({
-        Id("", "l"): Leaf(bigint(42)),
-        Id("", "ll"): LeafList([bigint(42)])
+        Id("", "l"): Leaf(u64(42)),
+        Id("", "ll"): LeafList([u64(42)])
     })
 
     p = Container({
@@ -2419,13 +2406,13 @@ def _test_diff_and_patch_large_tree():
             Id("http://example.com/yang/mod2", "acl"): Container(children={
                 Id("http://example.com/yang/mod2", "rules"): List([Id("http://example.com/yang/mod2", "id")], elements=[
                     Container({
-                        Id("http://example.com/yang/mod2", "id"): Leaf(bigint(10)),
+                        Id("http://example.com/yang/mod2", "id"): Leaf(u64(10)),
                         Id("http://example.com/yang/mod2", "action"): Leaf("permit"),
                         Id("http://example.com/yang/mod2", "src"): Leaf("10.0.0.0/24"),
                         Id("http://example.com/yang/mod2", "dst"): Leaf("10.0.1.0/24"),
                     }),
                     Container({
-                        Id("http://example.com/yang/mod2", "id"): Leaf(bigint(20)),
+                        Id("http://example.com/yang/mod2", "id"): Leaf(u64(20)),
                         Id("http://example.com/yang/mod2", "action"): Leaf("deny"),
                         Id("http://example.com/yang/mod2", "src"): Leaf("any"),
                         Id("http://example.com/yang/mod2", "dst"): Leaf("any"),
@@ -2471,19 +2458,19 @@ def _test_diff_and_patch_large_tree():
             Id("http://example.com/yang/mod2", "acl"): Container(children={
                 Id("http://example.com/yang/mod2", "rules"): List([Id("http://example.com/yang/mod2", "id")], elements=[
                     Container({
-                        Id("http://example.com/yang/mod2", "id"): Leaf(bigint(10)),
+                        Id("http://example.com/yang/mod2", "id"): Leaf(u64(10)),
                         Id("http://example.com/yang/mod2", "action"): Leaf("permit"),
                         Id("http://example.com/yang/mod2", "src"): Leaf("10.0.0.0/24"),
                         Id("http://example.com/yang/mod2", "dst"): Leaf("10.0.1.0/24"),
                     }),
                     Container({
-                        Id("http://example.com/yang/mod2", "id"): Leaf(bigint(20)),
+                        Id("http://example.com/yang/mod2", "id"): Leaf(u64(20)),
                         Id("http://example.com/yang/mod2", "action"): Leaf("drop"),  # changed from deny
                         Id("http://example.com/yang/mod2", "src"): Leaf("any"),
                         Id("http://example.com/yang/mod2", "dst"): Leaf("any"),
                     }),
                     Container({
-                        Id("http://example.com/yang/mod2", "id"): Leaf(bigint(30)),
+                        Id("http://example.com/yang/mod2", "id"): Leaf(u64(30)),
                         Id("http://example.com/yang/mod2", "action"): Leaf("permit"),
                         Id("http://example.com/yang/mod2", "src"): Leaf("192.0.2.0/24"),
                         Id("http://example.com/yang/mod2", "dst"): Leaf("198.51.100.0/24"),
@@ -2515,16 +2502,16 @@ def _test_diff_and_patch_large_tree():
 def _test_prsrc():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "l1"): List([Id(NS_acme, "name")], [
                 Container({
                     Id(NS_acme, "name"): Leaf("k1"),
-                    Id(NS_acme, "n1"): Leaf(bigint(1)),
-                    Id(NS_acme, "n2"): Leaf(bigint(2))
+                    Id(NS_acme, "n1"): Leaf(u64(1)),
+                    Id(NS_acme, "n2"): Leaf(u64(2))
                 }),
                 Container({
                     Id(NS_acme, "name"): Leaf("k4"),
-                    Id(NS_acme, "n4"): Leaf(bigint(4)),
+                    Id(NS_acme, "n4"): Leaf(u64(4)),
                 }),
             ])
         }, ns="http://example.com/acme", module="acme")
@@ -2542,7 +2529,7 @@ def _test_prsrc_absent():
                 }),
                 Container({
                     Id(NS_acme, "name"): Leaf("k4"),
-                    Id(NS_acme, "n4"): Leaf(bigint(4)),
+                    Id(NS_acme, "n4"): Leaf(u64(4)),
                 }),
             ])
         }, ns="http://example.com/acme", module="acme")
@@ -2553,7 +2540,7 @@ def _test_prsrc_absent():
 def _test_prsrc_root():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "b"): LeafList(["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
@@ -2563,8 +2550,8 @@ def _test_prsrc_root():
 def _test_prsrc_leaf_ns():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1), ns="http://example.com/foo", module="foo"),
-            Id(NS_acme, "b"): Leaf(bigint(2))
+            Id(NS_acme, "a"): Leaf(u64(1), ns="http://example.com/foo", module="foo"),
+            Id(NS_acme, "b"): Leaf(u64(2))
         }, ns="http://example.com/acme", module="acme")
     })
 
@@ -2582,28 +2569,28 @@ def _test_prsrc_identityref():
 def _test_to_jsonstr():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "l1"): List([Id(NS_acme, "name"), Id(NS_acme, "name_two")], [
                 Container({
                     Id(NS_acme, "name"): Leaf("k1"),
                     Id(NS_acme, "name_two"): Leaf("k1a"),
-                    Id(NS_acme, "n1"): Leaf(bigint(1)),
-                    Id(NS_acme, "n2"): Leaf(bigint(2))
+                    Id(NS_acme, "n1"): Leaf(u64(1)),
+                    Id(NS_acme, "n2"): Leaf(u64(2))
                 }),
                 Container({
                     Id(NS_acme, "name"): Leaf("k4"),
                     Id(NS_acme, "name_two"): Leaf("k4a"),
-                    Id(NS_acme, "n4"): Leaf(bigint(4)),
+                    Id(NS_acme, "n4"): Leaf(u64(4)),
                 }),
             ]),
             Id(NS_acme, "b"): Leaf(False),
             Id(NS_acme, "lb"): Leaf(b"Hello Acton \xf0\x9f\xab\xa1"),
             Id(NS_acme, "llb"): LeafList([b"Hello Acton \xf0\x9f\xab\xa1"]),
-            Id(NS_acme, "c"): Leaf(bigint(18446744073709551615)),
+            Id(NS_acme, "c"): Leaf(u64(18446744073709551615)),
             Id(NS_acme, "d"): Leaf(Decimal(314, -2))
         }, ns="http://example.com/acme", module="acme"),
         Id("http://example.com/beep", "foo"): Container({
-            Id("http://example.com/beep", "a"): Leaf(bigint(1))
+            Id("http://example.com/beep", "a"): Leaf(u64(1))
         }, ns="http://example.com/beep", module="beep")
     })
 
@@ -2629,28 +2616,28 @@ def _test_to_jsonstr_identityref():
 def _test_to_xmlstr():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "l1"): List([Id(NS_acme, "name"), Id(NS_acme, "name_two")], [
                 Container({
                     Id(NS_acme, "name"): Leaf("k1"),
                     Id(NS_acme, "name_two"): Leaf("k1a"),
-                    Id(NS_acme, "n1"): Leaf(bigint(1)),
-                    Id(NS_acme, "n2"): Leaf(bigint(2))
+                    Id(NS_acme, "n1"): Leaf(u64(1)),
+                    Id(NS_acme, "n2"): Leaf(u64(2))
                 }),
                 Container({
                     Id(NS_acme, "name"): Leaf("k4"),
                     Id(NS_acme, "name_two"): Leaf("k4a"),
-                    Id(NS_acme, "n4"): Leaf(bigint(4)),
+                    Id(NS_acme, "n4"): Leaf(u64(4)),
                 }),
             ]),
             Id(NS_acme, "b"): Leaf(False),
             Id(NS_acme, "lb"): Leaf(b"Hello Acton \xf0\x9f\xab\xa1"),
             Id(NS_acme, "llb"): LeafList([b"Hello Acton \xf0\x9f\xab\xa1"]),
-            Id(NS_acme, "c"): Leaf(bigint(18446744073709551615)),
+            Id(NS_acme, "c"): Leaf(u64(18446744073709551615)),
             Id(NS_acme, "d"): Leaf(Decimal(314, -2))
         }, ns="http://example.com/acme", module="acme"),
         Id("http://example.com/beep", "foo"): Container({
-            Id("http://example.com/beep", "a"): Leaf(bigint(1))
+            Id("http://example.com/beep", "a"): Leaf(u64(1))
         }, ns="http://example.com/beep", module="beep")
     })
 
@@ -2659,7 +2646,7 @@ def _test_to_xmlstr():
 def _test_to_xmlstr_root():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "b"): LeafList(["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
@@ -2669,7 +2656,7 @@ def _test_to_xmlstr_root():
 def _test_to_xmlstr_module():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "b"): LeafList(["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
@@ -2679,8 +2666,8 @@ def _test_to_xmlstr_module():
 def _test_to_xmlstr_leaf_ns():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1), ns="http://example.com/foo", module="foo"),
-            Id(NS_acme, "b"): Leaf(bigint(2))
+            Id(NS_acme, "a"): Leaf(u64(1), ns="http://example.com/foo", module="foo"),
+            Id(NS_acme, "b"): Leaf(u64(2))
         }, ns="http://example.com/acme", module="acme")
     })
 
@@ -2713,13 +2700,13 @@ def _test_to_xmlstr_mixed():
 def _test_to_xmlstr_root_merge():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1)),
+            Id(NS_acme, "a"): Leaf(u64(1)),
             Id(NS_acme, "b"): LeafList(["a", "b", "c"]),
         }, ns="http://example.com/acme", module="acme")
     })
     y2 = Container({
         Id("http://example.com/bar", "bar"): Container({
-            Id("http://example.com/bar", "b"): Leaf(bigint(42)),
+            Id("http://example.com/bar", "b"): Leaf(u64(42)),
         }, ns="http://example.com/bar", module="bar")
     })
     ym = merge(y1, y2)
@@ -2729,7 +2716,7 @@ def _test_to_xmlstr_root_merge():
 def _test_to_xmlstr_presence():
     y1 = Container({
         Id(NS_acme, "foo"): Container({
-            Id(NS_acme, "a"): Leaf(bigint(1))
+            Id(NS_acme, "a"): Leaf(u64(1))
         }, presence=True, ns="http://example.com/acme", module="acme")
     })
 
@@ -2765,12 +2752,12 @@ def _test_to_xmlstr_list_removal():
             Id(NS_acme, "l"): List([Id(NS_acme, "name")], [
                 Container({
                     Id(NS_acme, "name"): Leaf("k1"),
-                    Id(NS_acme, "n1"): Leaf(bigint(1)),
-                    Id(NS_acme, "n2"): Leaf(bigint(2)),
+                    Id(NS_acme, "n1"): Leaf(u64(1)),
+                    Id(NS_acme, "n2"): Leaf(u64(2)),
                 }),
                 Container({
                     Id(NS_acme, "name"): Leaf("k4"),
-                    Id(NS_acme, "n4"): Leaf(bigint(4)),
+                    Id(NS_acme, "n4"): Leaf(u64(4)),
                 }),
             ], ns="http://example.com/acme", module="acme")
         }, ns="http://example.com/acme", module="acme")

--- a/src/yang/gen3.act
+++ b/src/yang/gen3.act
@@ -15,6 +15,7 @@ import yang.schema
 from yang.identityref import Identityref, PartialIdentityref
 from yang.gdata import repr_adata
 from yang.type import Decimal, Ranges
+from yang.type import SIGNED_INT_TYPES, UNSIGNED_INT_TYPES
 
 
 OP_MERGE = "merge"
@@ -134,6 +135,21 @@ def unwrap_key[T](name: str, val: ?T, spath) -> T:
     raise ValueError("Missing key value at {format_schema_path(spath)}: {name}")
 
 
+def _coerce_integer_value(raw_value: value, schema_type: yang.schema.DTypeInteger, path: list[PathElement]) -> ?value:
+    if isinstance(raw_value, atom):
+        builtin_type = schema_type.builtin_type
+        if builtin_type in SIGNED_INT_TYPES:
+            try:
+                return int(raw_value)
+            except ValueError:
+                pass
+        if builtin_type in UNSIGNED_INT_TYPES:
+            try:
+                return u64(raw_value)
+            except ValueError:
+                pass
+
+
 protocol YangData:
     """Protocol for YANG data nodes
 
@@ -236,10 +252,7 @@ def try_parse_xml_value(text_value: ?str, schema_node: yang.schema.DNodeLeaf, sc
         if isinstance(schema_type, yang.schema.DTypeString):
             val = text_value
         elif isinstance(schema_type, yang.schema.DTypeInteger):
-            try:
-                val = bigint(text_value)
-            except ValueError:
-                raise YangValidationError(path, schema_type, text_value)
+            val = _coerce_integer_value(text_value, schema_type, path)
         elif isinstance(schema_type, yang.schema.DTypeEnum):
             val = text_value
         elif isinstance(schema_type, yang.schema.DTypeDecimal64):
@@ -375,10 +388,7 @@ def try_parse_json_value(leaf_value: ?value, schema_node: yang.schema.DNodeLeaf,
             val = leaf_value
         elif isinstance(schema_type, yang.schema.DTypeInteger):
             if isinstance(leaf_value, atom):
-                try:
-                    val = bigint(leaf_value)
-                except ValueError:
-                    raise YangValidationError(path, schema_type, leaf_value)
+                val = _coerce_integer_value(leaf_value, schema_type, path)
             else:
                 raise YangValidationError(path, schema_type, leaf_value)
         elif isinstance(schema_type, yang.schema.DTypeEnum):
@@ -460,7 +470,7 @@ extension yang.adata.MNode (YangData):
         maybe_attr = self._get_attr(usname)
         if maybe_attr is not None:
             schema_type = schema.type_
-            tv = try_validate_mnode_value(maybe_attr, schema_type)
+            tv = try_validate_mnode_value(maybe_attr, schema_type, new_path)
             if tv is not None:
                 if tv.t == "empty":
                     return (op=None if tv.val else OP_REMOVE, t=tv.t, val=yang.gdata.Present() if tv.val else None)
@@ -475,7 +485,7 @@ extension yang.adata.MNode (YangData):
         if isinstance(children, list):
             schema_type = schema.type_
             for child in children:
-                tv = try_validate_mnode_value(child, schema_type)
+                tv = try_validate_mnode_value(child, schema_type, new_path)
                 if tv is not None:
                     values.append((op=None, t=tv.t, val=tv.val))
                 else:
@@ -483,18 +493,16 @@ extension yang.adata.MNode (YangData):
         return values
 
 
-def try_validate_mnode_value(val: value, schema_type: yang.schema.DType) -> ?(t: str, val: value):
+def try_validate_mnode_value(val: value, schema_type: yang.schema.DType, path: list[PathElement]) -> ?(t: str, val: value):
     if isinstance(schema_type, yang.schema.DTypeUnion):
-        if isinstance(val, int):
-            # Handle case where mnode leaf value type is 'value'
-            # where an assigned integer literal is by default interpreted as int rather than the bigint we want
-            _val = bigint(val)
-        else:
-            _val = val
         for alt_type in schema_type.types:
-            tv = try_validate_mnode_value(_val, alt_type)
+            tv = try_validate_mnode_value(val, alt_type, path)
             if tv is not None:
                 return tv
+    elif isinstance(schema_type, yang.schema.DTypeInteger):
+        intval = _coerce_integer_value(val, schema_type, path)
+        if intval is not None and schema_type.validate_value(intval):
+            return (t=schema_type.builtin_type, val=intval)
     else:
         if schema_type.validate_value(val):
             return (t=schema_type.builtin_type, val=val)
@@ -1672,7 +1680,7 @@ def _test_json_path_nested_lists():
                             yang.gdata.Id("urn:example:y1", "deep"): yang.gdata.List([yang.gdata.Id("urn:example:y1", "deep-key")], elements=[
                                 yang.gdata.Container({
                                     yang.gdata.Id("urn:example:y1", "deep-key"): yang.gdata.Leaf('key3'),
-                                    yang.gdata.Id("urn:example:y1", "data"): yang.gdata.Leaf(bigint(42))
+                                    yang.gdata.Id("urn:example:y1", "data"): yang.gdata.Leaf(int(42))
                                 })
                             ])
                         })
@@ -2174,7 +2182,7 @@ def _test_pradata():
     gdata_tree = yang.gdata.Container({
         yang.gdata.Id("urn:example:test", "top-level-leaf"): yang.gdata.Leaf("root value"),
         yang.gdata.Id("urn:example:test", "c1"): yang.gdata.Container({
-            yang.gdata.Id("urn:example:test", "optional-leaf"): yang.gdata.Leaf(bigint(42)),
+            yang.gdata.Id("urn:example:test", "optional-leaf"): yang.gdata.Leaf(int(42)),
             yang.gdata.Id("urn:example:test", "empty-yes"): yang.gdata.Leaf(yang.gdata.Present()),
             yang.gdata.Id("urn:example:test", "empty-no"): yang.gdata.Absent(),
             yang.gdata.Id("urn:example:test", "decimal"): yang.gdata.Leaf(Decimal(314, -2)),
@@ -2185,13 +2193,13 @@ def _test_pradata():
             yang.gdata.Id("urn:example:test", "li1"): yang.gdata.List([yang.gdata.Id("urn:example:test", "name"), yang.gdata.Id("urn:example:test", "extra-key")], [
                 yang.gdata.Container({
                     yang.gdata.Id("urn:example:test", "name"): yang.gdata.Leaf("item1"),
-                    yang.gdata.Id("urn:example:test", "extra-key"): yang.gdata.Leaf(bigint(1)),
-                    yang.gdata.Id("urn:example:test", "value"): yang.gdata.Leaf(bigint(100))
+                    yang.gdata.Id("urn:example:test", "extra-key"): yang.gdata.Leaf(int(1)),
+                    yang.gdata.Id("urn:example:test", "value"): yang.gdata.Leaf(int(100))
                 }),
                 yang.gdata.Container({
                     yang.gdata.Id("urn:example:test", "name"): yang.gdata.Leaf("item2"),
-                    yang.gdata.Id("urn:example:test", "extra-key"): yang.gdata.Leaf(bigint(2)),
-                    yang.gdata.Id("urn:example:test", "value"): yang.gdata.Leaf(bigint(200)),
+                    yang.gdata.Id("urn:example:test", "extra-key"): yang.gdata.Leaf(int(2)),
+                    yang.gdata.Id("urn:example:test", "value"): yang.gdata.Leaf(int(200)),
                     yang.gdata.Id("urn:example:test", "c3"): yang.gdata.Container({
                         yang.gdata.Id("urn:example:test", "nested-leaf"): yang.gdata.Leaf("birb")
                     })
@@ -2230,7 +2238,7 @@ def _test_pradata_root_path():
             yang.gdata.Id("urn:example:test", "middle"): yang.gdata.Container({
                 yang.gdata.Id("urn:example:test", "value1"): yang.gdata.Leaf("test value"),
                 yang.gdata.Id("urn:example:test", "inner"): yang.gdata.Container({
-                    yang.gdata.Id("urn:example:test", "value2"): yang.gdata.Leaf(bigint(42))
+                    yang.gdata.Id("urn:example:test", "value2"): yang.gdata.Leaf(int(42))
                 })
             })
         })
@@ -2277,7 +2285,7 @@ def _test_json_path_container_list_container():
                     yang.gdata.Id("urn:example:y1", "name"): yang.gdata.Leaf('item1'),
                     yang.gdata.Id("urn:example:y1", "bottom"): yang.gdata.Container({
                         yang.gdata.Id("urn:example:y1", "data"): yang.gdata.Leaf('test'),
-                        yang.gdata.Id("urn:example:y1", "value"): yang.gdata.Leaf(bigint(42))
+                        yang.gdata.Id("urn:example:y1", "value"): yang.gdata.Leaf(int(42))
                     })
                 })
             ])

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -94,6 +94,7 @@ import yang.xpath as xpath
 from yang.identityref import Identityref, PartialIdentityref
 from yang.pattern import YangPattern
 from yang.type import Decimal, Ranges, RangesBuilder
+from yang.type import SIGNED_INT_TYPES, UNSIGNED_INT_TYPES
 
 RECURSION_LIMIT = 512
 
@@ -2060,11 +2061,17 @@ class DTypeInteger(DType):
         return DTypeInteger(t.name, resolver.description, resolver.reference, resolver.units, t.exts, resolver.builtin_type, resolver.default, resolver.integer_ranges)
 
     def validate_value(self, val: value) -> bool:
-        if isinstance(val, bigint):
-            ranges = self.ranges
-            if ranges is not None:
-                return Ranges.match(ranges, val)
-            return True
+        ranges = self.ranges
+        if self.builtin_type in SIGNED_INT_TYPES:
+            if isinstance(val, int):
+                if ranges is not None:
+                    return Ranges.match(ranges, bigint(val))
+                return True
+        if self.builtin_type in UNSIGNED_INT_TYPES:
+            if isinstance(val, u64):
+                if ranges is not None:
+                    return Ranges.match(ranges, bigint(val))
+                return True
         return False
 
     def format_hints(self) -> list[str]:
@@ -3634,8 +3641,10 @@ def yang_typename_to_acton_type(type_name: str) -> str:
         return "Identityref"
     elif type_name == "instance-identifier":
         return "str"
-    elif type_name in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return "bigint"
+    elif type_name in SIGNED_INT_TYPES:
+        return "int"
+    elif type_name in UNSIGNED_INT_TYPES:
+        return "u64"
     elif type_name == "leafref":
         # You should use yang_type_to_acton_type which can expand the union type for you!
         raise ValueError("Leafref type not supported")
@@ -3688,36 +3697,12 @@ def yang_type_to_acton_type(t: ?DType) -> str:
             if len(unique_base_types) == 1:
                 return yang_typename_to_acton_type(unique_base_types[0])
 
-            # TODO: should we map in union of say u32 and i32 into i64?
-            if all(map(lambda x: x in {"int8", "int16", "int32", "int64"}, unique_base_types)):
-                max_size = max(list(map(lambda x: int(x[3:]), unique_base_types)))
-                # TODO: once we have integer subtyping, return largest necessary iXX type
-                #return "i{max_size}"
-                return "bigint"
-            elif all(map(lambda x: x in {"uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
-                max_size = max(list(map(lambda x: int(x[4:]), unique_base_types)))
-                # TODO: once we have integer subtyping, return largest necessary uXX type
-                #return "u{max_size}"
-                return "bigint"
-            elif all(map(lambda x: x in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}, unique_base_types)):
-                # We have a union of a mix of signed and unsigned integers, so let's find the largest
-                int_sizes = filter(lambda x: x in {"int8", "int16", "int32", "int64"}, unique_base_types)
-                max_int_size = max(list(map(lambda x: int(x[3:]), int_sizes)))
-                uint_sizes = filter(lambda x: x in {"uint8", "uint16", "uint32", "uint64"}, unique_base_types)
-                max_uint_size = max(list(map(lambda x: int(x[4:]), uint_sizes)))
-                # To map a uint into an signed int, we need twice the number of
-                # bits, i.e. uint8 fits in int16 or uint32 fits in int64, so
-                # just double the max size...
-                max_int_mapped_uint_size = max_uint_size * 2
-                # Total max size is the max between signed int and
-                # integer-mapped-uint (which is already 2*uint max)
-                max_size = max([max_int_size, max_int_mapped_uint_size])
-                if max_size > 64:
-                    # Need to use our int (a.k.a. "bigint")
-                    return "bigint"
-                # TODO: once we have integer subtyping, return largest necessary iXX type
-                #return "i{max_size}"
-                return "bigint"
+            # Normalize to int or u64 Acton type, but only if the union consists
+            # of base integer types on the same side of 0
+            if all(map(lambda x: x in SIGNED_INT_TYPES, unique_base_types)):
+                return "int"
+            elif all(map(lambda x: x in UNSIGNED_INT_TYPES, unique_base_types)):
+                return "u64"
 
             # TODO: use atom when union consists of types that we represent with Acton built-in types
             # TODO: use Acton union
@@ -3741,8 +3726,10 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return '"' + value + '"'
     elif ytype == "identityref":
         return value
-    elif ytype in {"int8", "int16", "int32", "int64", "uint8", "uint16", "uint32", "uint64"}:
-        return "bigint(" + value + ")"
+    elif ytype in SIGNED_INT_TYPES:
+        return str(value)
+    elif ytype in UNSIGNED_INT_TYPES:
+        return "u64(" + value + ")"
     elif ytype == "decimal64":
         a = Decimal.parse(value)
         return repr(a)

--- a/src/yang/type.act
+++ b/src/yang/type.act
@@ -1,5 +1,10 @@
 import testing
 
+
+SIGNED_INT_TYPES = {"int8", "int16", "int32", "int64"}
+UNSIGNED_INT_TYPES = {"uint8", "uint16", "uint32", "uint64"}
+
+
 class Decimal(object):
     significand: bigint
     exponent: bigint

--- a/test/golden/test_yang/augment_with_uses_refine
+++ b/test/golden/test_yang/augment_with_uses_refine
@@ -92,12 +92,12 @@ extension base__system_capabilities__per_node_capabilities(Iterable[base__system
         return self.elements.__iter__()
 
 class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
-    max_nodes: bigint
+    max_nodes: u64
     supported_excluded_change_type: list[str]
 
-    mut def __init__(self, max_nodes: ?bigint=None, supported_excluded_change_type: ?list[str]=None):
+    mut def __init__(self, max_nodes: ?u64=None, supported_excluded_change_type: ?list[str]=None):
         self._ns = 'http://example.com/augmenter'
-        self.max_nodes = max_nodes if max_nodes is not None else bigint(42)
+        self.max_nodes = max_nodes if max_nodes is not None else u64(42)
         self.supported_excluded_change_type = supported_excluded_change_type if supported_excluded_change_type is not None else []
 
     def _get_attr(self, name: str) -> ?value:
@@ -115,7 +115,7 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__system_capabilities__subscription_capabilities:
         if n is not None:
-            return base__system_capabilities__subscription_capabilities(max_nodes=n.get_opt_bigint(yang.gdata.Id(NS_augmenter, 'max-nodes')), supported_excluded_change_type=n.get_opt_strs(yang.gdata.Id(NS_augmenter, 'supported-excluded-change-type')))
+            return base__system_capabilities__subscription_capabilities(max_nodes=n.get_opt_u64(yang.gdata.Id(NS_augmenter, 'max-nodes')), supported_excluded_change_type=n.get_opt_strs(yang.gdata.Id(NS_augmenter, 'supported-excluded-change-type')))
         return base__system_capabilities__subscription_capabilities()
 
     def copy(self):

--- a/test/golden/test_yang/compile_augment_augmented_node
+++ b/test/golden/test_yang/compile_augment_augmented_node
@@ -41,12 +41,12 @@ NS_voice = 'http://example.com/voice'
 
 class base__native__voice__service__voip__sip(yang.adata.MNode):
     bind: ?str
-    port: bigint
+    port: u64
 
-    mut def __init__(self, bind: ?str, port: ?bigint=None):
+    mut def __init__(self, bind: ?str, port: ?u64=None):
         self._ns = 'http://example.com/voice'
         self.bind = bind
-        self.port = port if port is not None else bigint(5060)
+        self.port = port if port is not None else u64(5060)
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'bind':
@@ -63,7 +63,7 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> base__native__voice__service__voip__sip:
         if n is not None:
-            return base__native__voice__service__voip__sip(bind=n.get_opt_str(yang.gdata.Id(NS_voice, 'bind')), port=n.get_opt_bigint(yang.gdata.Id(NS_voice, 'port')))
+            return base__native__voice__service__voip__sip(bind=n.get_opt_str(yang.gdata.Id(NS_voice, 'bind')), port=n.get_opt_u64(yang.gdata.Id(NS_voice, 'port')))
         return base__native__voice__service__voip__sip()
 
     def copy(self):

--- a/test/golden/test_yang/prdaclass_rpc
+++ b/test/golden/test_yang/prdaclass_rpc
@@ -67,9 +67,9 @@ class root(yang.adata.MNode):
 
 
 class yangrpc__foo__input__woo(yang.adata.MNode):
-    woo_b: ?bigint
+    woo_b: ?int
 
-    mut def __init__(self, woo_b: ?bigint):
+    mut def __init__(self, woo_b: ?int):
         self._ns = 'http://example.com/yangrpc'
         self.woo_b = woo_b
 
@@ -86,7 +86,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input__woo:
         if n is not None:
-            return yangrpc__foo__input__woo(woo_b=n.get_opt_bigint(yang.gdata.Id(NS_yangrpc, 'woo_b')))
+            return yangrpc__foo__input__woo(woo_b=n.get_opt_int(yang.gdata.Id(NS_yangrpc, 'woo_b')))
         return yangrpc__foo__input__woo()
 
     def copy(self):

--- a/test/golden/test_yang/prdaclass_union_list_key
+++ b/test/golden/test_yang/prdaclass_union_list_key
@@ -82,7 +82,7 @@ class foo__c1__l1(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, bigint) and isinstance(k2, bigint):
+            if isinstance(e_k2, u64) and isinstance(k2, u64):
                 if e_k2 != k2:
                     match = False
                     continue

--- a/test/golden/test_yang/resolve_type_union_of_intX
+++ b/test/golden/test_yang/resolve_type_union_of_intX
@@ -30,12 +30,12 @@ NS_foo = 'http://example.com/foo'
 
 
 class root(yang.adata.MNode):
-    l1: ?bigint
-    l2: ?bigint
-    l3: ?bigint
-    l4: ?bigint
+    l1: ?int
+    l2: ?u64
+    l3: ?value
+    l4: ?value
 
-    mut def __init__(self, l1: ?bigint, l2: ?bigint, l3: ?bigint, l4: ?bigint):
+    mut def __init__(self, l1: ?int, l2: ?u64, l3: ?value, l4: ?value):
         self._ns = ''
         self.l1 = l1
         self.l2 = l2
@@ -61,7 +61,7 @@ class root(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> root:
         if n is not None:
-            return root(l1=n.get_opt_bigint(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_bigint(yang.gdata.Id(NS_foo, 'l2')), l3=n.get_opt_bigint(yang.gdata.Id(NS_foo, 'l3')), l4=n.get_opt_bigint(yang.gdata.Id(NS_foo, 'l4')))
+            return root(l1=n.get_opt_int(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l2')), l3=n.get_opt_value(yang.gdata.Id(NS_foo, 'l3')), l4=n.get_opt_value(yang.gdata.Id(NS_foo, 'l4')))
         return root()
 
     def copy(self):

--- a/test/golden/yang.gdata/prsrc
+++ b/test/golden/yang.gdata/prsrc
@@ -1,15 +1,15 @@
 Container({
   Id('http://example.com/acme', 'foo'): Container({
-    Id('http://example.com/acme', 'a'): Leaf(bigint(1)),
+    Id('http://example.com/acme', 'a'): Leaf(u64(1)),
     Id('http://example.com/acme', 'l1'): List([Id('http://example.com/acme', 'name')], elements=[
       Container({
         Id('http://example.com/acme', 'name'): Leaf('k1'),
-        Id('http://example.com/acme', 'n1'): Leaf(bigint(1)),
-        Id('http://example.com/acme', 'n2'): Leaf(bigint(2))
+        Id('http://example.com/acme', 'n1'): Leaf(u64(1)),
+        Id('http://example.com/acme', 'n2'): Leaf(u64(2))
       }),
       Container({
         Id('http://example.com/acme', 'name'): Leaf('k4'),
-        Id('http://example.com/acme', 'n4'): Leaf(bigint(4))
+        Id('http://example.com/acme', 'n4'): Leaf(u64(4))
       })
     ])
   }, ns='http://example.com/acme', module='acme')

--- a/test/golden/yang.gdata/prsrc_absent
+++ b/test/golden/yang.gdata/prsrc_absent
@@ -7,7 +7,7 @@ Container({
       }),
       Container({
         Id('http://example.com/acme', 'name'): Leaf('k4'),
-        Id('http://example.com/acme', 'n4'): Leaf(bigint(4))
+        Id('http://example.com/acme', 'n4'): Leaf(u64(4))
       })
     ])
   }, ns='http://example.com/acme', module='acme')

--- a/test/golden/yang.gdata/prsrc_leaf_ns
+++ b/test/golden/yang.gdata/prsrc_leaf_ns
@@ -1,6 +1,6 @@
 Container({
   Id('http://example.com/acme', 'foo'): Container({
-    Id('http://example.com/acme', 'a'): Leaf(bigint(1), ns='http://example.com/foo', module='foo'),
-    Id('http://example.com/acme', 'b'): Leaf(bigint(2))
+    Id('http://example.com/acme', 'a'): Leaf(u64(1), ns='http://example.com/foo', module='foo'),
+    Id('http://example.com/acme', 'b'): Leaf(u64(2))
   }, ns='http://example.com/acme', module='acme')
 })

--- a/test/golden/yang.gdata/prsrc_root
+++ b/test/golden/yang.gdata/prsrc_root
@@ -1,6 +1,6 @@
 Container({
   Id('http://example.com/acme', 'foo'): Container({
-    Id('http://example.com/acme', 'a'): Leaf(bigint(1)),
+    Id('http://example.com/acme', 'a'): Leaf(u64(1)),
     Id('http://example.com/acme', 'b'): LeafList(['a', 'b', 'c'])
   }, ns='http://example.com/acme', module='acme')
 })

--- a/test/golden/yang.gen3/pradata
+++ b/test/golden/yang.gen3/pradata
@@ -2,7 +2,7 @@
 ad = root()
 
 # Container: /c1
-ad.c1.optional_leaf = bigint(42)
+ad.c1.optional_leaf = 42
 ad.c1.empty_yes = True
 ad.c1.empty_no = False
 ad.c1.decimal = Decimal(bigint("314"), bigint("-2"))
@@ -14,12 +14,12 @@ c2 = ad.c1.create_c2('required value')
 c2.l1 = 'inner value'
 
 # List /c1/li1 element: item1,1
-li1_element = ad.c1.li1.create('item1', bigint(1))
-li1_element.value = bigint(100)
+li1_element = ad.c1.li1.create('item1', 1)
+li1_element.value = 100
 
 # List /c1/li1 element: item2,2
-li1_element = ad.c1.li1.create('item2', bigint(2))
-li1_element.value = bigint(200)
+li1_element = ad.c1.li1.create('item2', 2)
+li1_element.value = 200
 
 # Container: /c1/li1[name='item2',extra-key='2']/c3
 li1_element.c3.nested_leaf = 'birb'

--- a/test/golden/yang.gen3/pradata_root_path
+++ b/test/golden/yang.gen3/pradata_root_path
@@ -2,5 +2,5 @@
 ad = test__outer__middle()
 
 # Container: /outer/middle/inner
-ad.inner.value2 = bigint(42)
+ad.inner.value2 = 42
 ad.value1 = 'test value'

--- a/test/golden/yang.gen3/union_int_json
+++ b/test/golden/yang.gen3/union_int_json
@@ -1,3 +1,3 @@
 Container({
-  Id('urn:example:y', 'u'): Leaf(bigint(7), ns='urn:example:y', module='y')
+  Id('urn:example:y', 'u'): Leaf(7, ns='urn:example:y', module='y')
 })

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -457,12 +457,12 @@ def _test_foo_from_gdata_int():
     xml_in = xml.decode(xml_text)
     gd2 = yang.gen3.from_data(yang_foo.SRC_DNODE, xml_in)
     l3 = gd2.get_cnt(yang.gdata.Id("http://example.com/foo", "c1")).get_leaf(yang.gdata.Id("http://example.com/foo", "l3")).val
-    if isinstance(l3, bigint):
-        testing.assertEqual(l3, 1337)
+    if isinstance(l3, u64):
+        testing.assertEqual(l3, u64(1337))
     else:
-        testing.error("l3 in gdata is not an int")
+        testing.error("l3 in gdata is not u64")
     nr = yang_foo_root.from_gdata(gd2)
-    testing.assertEqual(nr.c1.l3, 1337)
+    testing.assertEqual(nr.c1.l3, u64(1337))
 
 def _test_foo_from_gdata_empty():
     gd = yang.gdata.Container(children={})
@@ -504,7 +504,7 @@ def _test_empty_false():
 
 def basics_leaf_defaults(r):
     testing.assertEqual(r.c.l_str_def, "foo")
-    testing.assertEqual(r.c.l_uint64_def, 1234567890)
+    testing.assertEqual(r.c.l_uint64_def, u64(1234567890))
     testing.assertEqual(r.c.l_decimal64_def, Decimal(123, -2))
     testing.assertEqual(r.c.l_str_def_quoted, '"foo"')
     testing.assertEqual(r.c.l_binary_def, "Hello Acton 🫡".encode())
@@ -685,8 +685,7 @@ def _test_foo_from_json_full():
     json_out = gd2.to_jsonstr()
     # This is not entirely in line with RFC 7951, Section 6.1: A value of the
     # "int64", "uint64", or "decimal64" type is represented as a JSON string ...
-    # json.encode serializes bigint and other numeric types to numeric literals.
-    # TODO: can remove this once we start using fixed-size integers in gdata
+    # json.encode serializes fixed-size numeric types to numeric literals.
     jdiff = r"""@@ -1,7 +1,7 @@
  {
      "foo:c1": {
@@ -780,8 +779,7 @@ def _test_json_roundtrip():
     json_out = gd2.to_jsonstr()
     # This is not entirely in line with RFC 7951, Section 6.1: A value of the
     # "int64", "uint64", or "decimal64" type is represented as a JSON string ...
-    # json.encode serializes bigint and other numeric types to numeric literals.
-    # TODO: can remove this once we start using fixed-size integers in gdata
+    # json.encode serializes fixed-size numeric types to numeric literals.
     jdiff = r"""@@ -1,7 +1,7 @@
  {
      "foo:c1": {

--- a/test/test_data_classes/src/test_rpc_exec.act
+++ b/test/test_data_classes/src/test_rpc_exec.act
@@ -169,7 +169,7 @@ def _test_rpc_input_serialization():
     # Check nested container
     woo_gdata = gdata.get_cnt(yang.gdata.Id("http://example.com/yangrpc", "woo"))
     testing.assertNotNone(woo_gdata, "Container 'woo' should exist")
-    testing.assertEqual(woo_gdata.get_bigint(yang.gdata.Id("http://example.com/yangrpc", "woo_b")), 123, "Leaf 'woo_b' should have correct value")
+    testing.assertEqual(woo_gdata.get_int(yang.gdata.Id("http://example.com/yangrpc", "woo_b")), 123, "Leaf 'woo_b' should have correct value")
 
     # Convert to XML string
     xml_str = gdata.to_xmlstr()

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -139,7 +139,7 @@ NS_basics = 'http://example.com/basics'
 class basics__c(yang.adata.MNode):
     l_str_def: str
     l_str_def_quoted: str
-    l_uint64_def: bigint
+    l_uint64_def: u64
     l_decimal64_def: Decimal
     l_union_def_str: value
     l_union_def_int: value
@@ -149,11 +149,11 @@ class basics__c(yang.adata.MNode):
     l_binary_def: bytes
     l_identityref_def: Identityref
 
-    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?bigint=None, l_decimal64_def: ?Decimal=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None):
+    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?u64=None, l_decimal64_def: ?Decimal=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None):
         self._ns = 'http://example.com/basics'
         self.l_str_def = l_str_def if l_str_def is not None else "foo"
         self.l_str_def_quoted = l_str_def_quoted if l_str_def_quoted is not None else "\"foo\""
-        self.l_uint64_def = l_uint64_def if l_uint64_def is not None else bigint(1234567890)
+        self.l_uint64_def = l_uint64_def if l_uint64_def is not None else u64(1234567890)
         self.l_decimal64_def = l_decimal64_def if l_decimal64_def is not None else Decimal(bigint("123"), bigint("-2"))
         self.l_union_def_str = l_union_def_str if l_union_def_str is not None else "foo"
         self.l_union_def_int = l_union_def_int if l_union_def_int is not None else 1234567890
@@ -200,7 +200,7 @@ class basics__c(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> basics__c:
         if n is not None:
-            return basics__c(l_str_def=n.get_opt_str(yang.gdata.Id(NS_basics, 'l_str_def')), l_str_def_quoted=n.get_opt_str(yang.gdata.Id(NS_basics, 'l_str_def_quoted')), l_uint64_def=n.get_opt_bigint(yang.gdata.Id(NS_basics, 'l_uint64_def')), l_decimal64_def=n.get_opt_Decimal(yang.gdata.Id(NS_basics, 'l_decimal64_def')), l_union_def_str=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_str')), l_union_def_int=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_int')), l_union_def_float=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_float')), l_union_def_bool=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_bool')), l_union_def_enumeration=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_enumeration')), l_binary_def=n.get_opt_bytes(yang.gdata.Id(NS_basics, 'l_binary_def')), l_identityref_def=n.get_opt_Identityref(yang.gdata.Id(NS_basics, 'l_identityref_def')))
+            return basics__c(l_str_def=n.get_opt_str(yang.gdata.Id(NS_basics, 'l_str_def')), l_str_def_quoted=n.get_opt_str(yang.gdata.Id(NS_basics, 'l_str_def_quoted')), l_uint64_def=n.get_opt_u64(yang.gdata.Id(NS_basics, 'l_uint64_def')), l_decimal64_def=n.get_opt_Decimal(yang.gdata.Id(NS_basics, 'l_decimal64_def')), l_union_def_str=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_str')), l_union_def_int=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_int')), l_union_def_float=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_float')), l_union_def_bool=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_bool')), l_union_def_enumeration=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_enumeration')), l_binary_def=n.get_opt_bytes(yang.gdata.Id(NS_basics, 'l_binary_def')), l_identityref_def=n.get_opt_Identityref(yang.gdata.Id(NS_basics, 'l_identityref_def')))
         return basics__c()
 
     def copy(self):

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -576,12 +576,12 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
 
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
-    l3: ?bigint
+    l3: ?u64
     l_empty: ?bool
     l_empty_delete: ?bool
     l_decimal64: ?Decimal
     li: foo__c1__li
-    ll_uint64: list[bigint]
+    ll_uint64: list[u64]
     ll_str: list[str]
     l_identityref: ?Identityref
     ll_identityref: list[Identityref]
@@ -591,7 +591,7 @@ class foo__c1(yang.adata.MNode):
     l2: ?str
     l_leafref: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?bigint, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[bigint]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -650,7 +650,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_bigint(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_bigints(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
+            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
         return foo__c1()
 
     def copy(self):
@@ -1532,7 +1532,7 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, bigint) and isinstance(k2, bigint):
+            if isinstance(e_k2, u64) and isinstance(k2, u64):
                 if e_k2 != k2:
                     match = False
                     continue

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -576,12 +576,12 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
 
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
-    l3: ?bigint
+    l3: ?u64
     l_empty: ?bool
     l_empty_delete: ?bool
     l_decimal64: ?Decimal
     li: foo__c1__li
-    ll_uint64: list[bigint]
+    ll_uint64: list[u64]
     ll_str: list[str]
     l_identityref: ?Identityref
     ll_identityref: list[Identityref]
@@ -591,7 +591,7 @@ class foo__c1(yang.adata.MNode):
     l2: ?str
     l_leafref: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?bigint, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[bigint]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -650,7 +650,7 @@ class foo__c1(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_bigint(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_bigints(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
+            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
         return foo__c1()
 
     def copy(self):
@@ -1532,7 +1532,7 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
-            if isinstance(e_k2, bigint) and isinstance(k2, bigint):
+            if isinstance(e_k2, u64) and isinstance(k2, u64):
                 if e_k2 != k2:
                     match = False
                     continue

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -89,9 +89,9 @@ class root(yang.adata.MNode):
 
 
 class yangrpc__foo__input__woo(yang.adata.MNode):
-    woo_b: ?bigint
+    woo_b: ?int
 
-    mut def __init__(self, woo_b: ?bigint):
+    mut def __init__(self, woo_b: ?int):
         self._ns = 'http://example.com/yangrpc'
         self.woo_b = woo_b
 
@@ -108,7 +108,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     @staticmethod
     mut def from_gdata(n: ?yang.gdata.Node) -> yangrpc__foo__input__woo:
         if n is not None:
-            return yangrpc__foo__input__woo(woo_b=n.get_opt_bigint(yang.gdata.Id(NS_yangrpc, 'woo_b')))
+            return yangrpc__foo__input__woo(woo_b=n.get_opt_int(yang.gdata.Id(NS_yangrpc, 'woo_b')))
         return yangrpc__foo__input__woo()
 
     def copy(self):

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_json_full
@@ -1,7 +1,7 @@
 Container({
   Id('http://example.com/foo', 'c1'): Container({
     Id('http://example.com/foo', 'l1'): Leaf('foo-foo'),
-    Id('http://example.com/foo', 'l3'): Leaf(bigint(18446744073709551615)),
+    Id('http://example.com/foo', 'l3'): Leaf(u64(18446744073709551615)),
     Id('http://example.com/foo', 'l_decimal64'): Leaf(Decimal(bigint("314"), bigint("-2"))),
     Id('http://example.com/foo', 'li'): List([Id('http://example.com/foo', 'name')], user_order=True, elements=[
       Container({
@@ -12,7 +12,7 @@ Container({
         })
       })
     ]),
-    Id('http://example.com/foo', 'll_uint64'): LeafList([bigint(4), bigint(42)]),
+    Id('http://example.com/foo', 'll_uint64'): LeafList([u64(4), u64(42)]),
     Id('http://example.com/foo', 'll_str'): LeafList(['kava', 'čaj']),
     Id('http://example.com/foo', 'l4'): Leaf('foo-qux'),
     Id('http://example.com/bar', 'l1'): Leaf('foo-bar', ns='http://example.com/bar', module='bar'),
@@ -67,15 +67,15 @@ Container({
   Id('http://example.com/foo', 'li-union'): List([Id('http://example.com/foo', 'k1'), Id('http://example.com/foo', 'k2'), Id('http://example.com/foo', 'k3')], ns='http://example.com/foo', module='foo', elements=[
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('first'),
-      Id('http://example.com/foo', 'k2'): Leaf(bigint(4)),
+      Id('http://example.com/foo', 'k2'): Leaf(u64(4)),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(47))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(47))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('second'),
       Id('http://example.com/foo', 'k2'): Leaf('unlimited'),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(1514))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(1514))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('third'),

--- a/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/foo_from_xml_full
@@ -1,7 +1,7 @@
 Container({
   Id('http://example.com/foo', 'c1'): Container({
     Id('http://example.com/foo', 'l1'): Leaf('foo-foo'),
-    Id('http://example.com/foo', 'l3'): Leaf(bigint(18446744073709551615)),
+    Id('http://example.com/foo', 'l3'): Leaf(u64(18446744073709551615)),
     Id('http://example.com/foo', 'l_empty'): Leaf(Present()),
     Id('http://example.com/foo', 'l_empty_delete'): Absent(),
     Id('http://example.com/foo', 'l_decimal64'): Leaf(Decimal(bigint("314"), bigint("-2"))),
@@ -14,7 +14,7 @@ Container({
         })
       })
     ]),
-    Id('http://example.com/foo', 'll_uint64'): LeafList([bigint(4), bigint(42)]),
+    Id('http://example.com/foo', 'll_uint64'): LeafList([u64(4), u64(42)]),
     Id('http://example.com/foo', 'll_str'): LeafList(['kava', 'čaj']),
     Id('http://example.com/foo', 'l_identityref'): Leaf(Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     Id('http://example.com/foo', 'll_identityref'): LeafList([Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),
@@ -70,15 +70,15 @@ Container({
   Id('http://example.com/foo', 'li-union'): List([Id('http://example.com/foo', 'k1'), Id('http://example.com/foo', 'k2'), Id('http://example.com/foo', 'k3')], ns='http://example.com/foo', module='foo', elements=[
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('first'),
-      Id('http://example.com/foo', 'k2'): Leaf(bigint(4)),
+      Id('http://example.com/foo', 'k2'): Leaf(u64(4)),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(47))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(47))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('second'),
       Id('http://example.com/foo', 'k2'): Leaf('unlimited'),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(1514))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(1514))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('third'),

--- a/test/test_data_classes/test/golden/test_data_classes/gen3_from_xml_full
+++ b/test/test_data_classes/test/golden/test_data_classes/gen3_from_xml_full
@@ -1,7 +1,7 @@
 Container({
   Id('http://example.com/foo', 'c1'): Container({
     Id('http://example.com/foo', 'l1'): Leaf('foo-foo'),
-    Id('http://example.com/foo', 'l3'): Leaf(bigint(18446744073709551615)),
+    Id('http://example.com/foo', 'l3'): Leaf(u64(18446744073709551615)),
     Id('http://example.com/foo', 'l_empty'): Leaf(Present()),
     Id('http://example.com/foo', 'l_empty_delete'): Absent(),
     Id('http://example.com/foo', 'l_decimal64'): Leaf(Decimal(bigint("314"), bigint("-2"))),
@@ -14,7 +14,7 @@ Container({
         })
       })
     ]),
-    Id('http://example.com/foo', 'll_uint64'): LeafList([bigint(4), bigint(42)]),
+    Id('http://example.com/foo', 'll_uint64'): LeafList([u64(4), u64(42)]),
     Id('http://example.com/foo', 'll_str'): LeafList(['kava', 'čaj']),
     Id('http://example.com/foo', 'l_identityref'): Leaf(Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     Id('http://example.com/foo', 'll_identityref'): LeafList([Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),
@@ -70,15 +70,15 @@ Container({
   Id('http://example.com/foo', 'li-union'): List([Id('http://example.com/foo', 'k1'), Id('http://example.com/foo', 'k2'), Id('http://example.com/foo', 'k3')], ns='http://example.com/foo', module='foo', elements=[
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('first'),
-      Id('http://example.com/foo', 'k2'): Leaf(bigint(4)),
+      Id('http://example.com/foo', 'k2'): Leaf(u64(4)),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(47))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(47))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('second'),
       Id('http://example.com/foo', 'k2'): Leaf('unlimited'),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(1514))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(1514))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('third'),

--- a/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
+++ b/test/test_data_classes/test/golden/test_data_classes/json_to_gdata
@@ -1,7 +1,7 @@
 Container({
   Id('http://example.com/foo', 'c1'): Container({
     Id('http://example.com/foo', 'l1'): Leaf('foo-foo'),
-    Id('http://example.com/foo', 'l3'): Leaf(bigint(18446744073709551615)),
+    Id('http://example.com/foo', 'l3'): Leaf(u64(18446744073709551615)),
     Id('http://example.com/foo', 'li'): List([Id('http://example.com/foo', 'name')], user_order=True, elements=[
       Container({
         Id('http://example.com/foo', 'name'): Leaf('tuta'),
@@ -12,7 +12,7 @@ Container({
         Id('http://example.com/foo', 'val'): Leaf('baba')
       })
     ]),
-    Id('http://example.com/foo', 'll_uint64'): LeafList([bigint(4), bigint(42)]),
+    Id('http://example.com/foo', 'll_uint64'): LeafList([u64(4), u64(42)]),
     Id('http://example.com/foo', 'll_str'): LeafList(['kava', 'čaj']),
     Id('http://example.com/bar', 'l1'): Leaf('foo-bar', ns='http://example.com/bar', module='bar'),
     Id('http://example.com/bar', 'l2'): Leaf('bar', ns='http://example.com/bar', module='bar')

--- a/test/test_data_source_roundtrip/src/xml_full_adata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata.act
@@ -9,11 +9,11 @@ def adata():
     
     # Container: /c1
     ad.c1.f_l1 = 'foo-foo'
-    ad.c1.l3 = bigint(18446744073709551615)
+    ad.c1.l3 = u64(18446744073709551615)
     ad.c1.l_empty = True
     ad.c1.l_empty_delete = False
     ad.c1.l_decimal64 = Decimal(bigint("314"), bigint("-2"))
-    ad.c1.ll_uint64 = [bigint(4), bigint(42)]
+    ad.c1.ll_uint64 = [u64(4), u64(42)]
     ad.c1.ll_str = ['kava', 'čaj']
     ad.c1.l_identityref = Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')
     ad.c1.ll_identityref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]
@@ -77,12 +77,12 @@ def adata():
     special_element = ad.special.create(True)
     
     # List /li-union element: first,4,b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('first', bigint(4), b'Hello Acton \xf0\x9f\xab\xa1')
-    li_union_element.checker = bigint(47)
+    li_union_element = ad.li_union.create('first', u64(4), b'Hello Acton \xf0\x9f\xab\xa1')
+    li_union_element.checker = u64(47)
     
     # List /li-union element: second,unlimited,b'Hello Acton \xf0\x9f\xab\xa1'
     li_union_element = ad.li_union.create('second', 'unlimited', b'Hello Acton \xf0\x9f\xab\xa1')
-    li_union_element.checker = bigint(1514)
+    li_union_element.checker = u64(1514)
     
     # List /li-union element: third,b'hi',b'Hello Acton \xf0\x9f\xab\xa1'
     li_union_element = ad.li_union.create('third', b'hi', b'Hello Acton \xf0\x9f\xab\xa1')

--- a/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
@@ -9,11 +9,11 @@ def adata():
     
     # Container: /c1
     ad.c1.f_l1 = 'foo-foo'
-    ad.c1.l3 = bigint(18446744073709551615)
+    ad.c1.l3 = u64(18446744073709551615)
     ad.c1.l_empty = True
     ad.c1.l_empty_delete = False
     ad.c1.l_decimal64 = Decimal(bigint("314"), bigint("-2"))
-    ad.c1.ll_uint64 = [bigint(4), bigint(42)]
+    ad.c1.ll_uint64 = [u64(4), u64(42)]
     ad.c1.ll_str = ['kava', 'čaj']
     ad.c1.l_identityref = Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')
     ad.c1.ll_identityref = [Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]
@@ -79,12 +79,12 @@ def adata():
     special_element = ad.special.create(True)
     
     # List /li-union element: first,4,b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('first', bigint(4), b'Hello Acton \xf0\x9f\xab\xa1')
-    li_union_element.checker = bigint(47)
+    li_union_element = ad.li_union.create('first', u64(4), b'Hello Acton \xf0\x9f\xab\xa1')
+    li_union_element.checker = u64(47)
     
     # List /li-union element: second,unlimited,b'Hello Acton \xf0\x9f\xab\xa1'
     li_union_element = ad.li_union.create('second', 'unlimited', b'Hello Acton \xf0\x9f\xab\xa1')
-    li_union_element.checker = bigint(1514)
+    li_union_element.checker = u64(1514)
     
     # List /li-union element: third,b'hi',b'Hello Acton \xf0\x9f\xab\xa1'
     li_union_element = ad.li_union.create('third', b'hi', b'Hello Acton \xf0\x9f\xab\xa1')

--- a/test/test_data_source_roundtrip/src/xml_full_gdata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_gdata.act
@@ -5,7 +5,7 @@ from yang.type import Decimal
 xml_full = Container({
   Id('http://example.com/foo', 'c1'): Container({
     Id('http://example.com/foo', 'l1'): Leaf('foo-foo'),
-    Id('http://example.com/foo', 'l3'): Leaf(bigint(18446744073709551615)),
+    Id('http://example.com/foo', 'l3'): Leaf(u64(18446744073709551615)),
     Id('http://example.com/foo', 'l_empty'): Leaf(Present()),
     Id('http://example.com/foo', 'l_empty_delete'): Absent(),
     Id('http://example.com/foo', 'l_decimal64'): Leaf(Decimal(bigint("314"), bigint("-2"))),
@@ -18,7 +18,7 @@ xml_full = Container({
         })
       })
     ]),
-    Id('http://example.com/foo', 'll_uint64'): LeafList([bigint(4), bigint(42)]),
+    Id('http://example.com/foo', 'll_uint64'): LeafList([u64(4), u64(42)]),
     Id('http://example.com/foo', 'll_str'): LeafList(['kava', 'čaj']),
     Id('http://example.com/foo', 'l_identityref'): Leaf(Identityref('fooy', ns='http://example.com/foo', mod='foo', pfx='f')),
     Id('http://example.com/foo', 'll_identityref'): LeafList([Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')]),
@@ -74,15 +74,15 @@ xml_full = Container({
   Id('http://example.com/foo', 'li-union'): List([Id('http://example.com/foo', 'k1'), Id('http://example.com/foo', 'k2'), Id('http://example.com/foo', 'k3')], ns='http://example.com/foo', module='foo', elements=[
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('first'),
-      Id('http://example.com/foo', 'k2'): Leaf(bigint(4)),
+      Id('http://example.com/foo', 'k2'): Leaf(u64(4)),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(47))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(47))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('second'),
       Id('http://example.com/foo', 'k2'): Leaf('unlimited'),
       Id('http://example.com/foo', 'k3'): Leaf(b'Hello Acton \xf0\x9f\xab\xa1'),
-      Id('http://example.com/foo', 'checker'): Leaf(bigint(1514))
+      Id('http://example.com/foo', 'checker'): Leaf(u64(1514))
     }),
     Container({
       Id('http://example.com/foo', 'k1'): Leaf('third'),


### PR DESCRIPTION
After Acton builtin "int" type was changed from "bigint" to "i64", we temporarily made all integer values explicit bigint. This kept the existing behavior during the migration.

With this change we switch to using fixed-size integers for representing gdata values:
- int (i64) for signed integers
- u64 for unsigned integers

This is also reflected in adata attribute types. We keep the exception for union types where an attempt is made to normalize the base types to one of the two builtin numeric types, if all union base builtin types are on the same side of 0.

When gdata / adata is printed, we print the literal value for signed integers and add an explicit u64() wrapper for unsigned integers.

Closes #326 