### PR TITLE
Skip Absent list elements in gdata.Node.to_dict()

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -469,6 +469,8 @@ class Node(value):
                     for elem in iter_elems:
                         if isinstance(elem, Container):
                             elems.append(elem.to_dict(pretty, deterministic))
+                        elif isinstance(elem, Absent):
+                            continue
                         else:
                             raise ValueError("Unexpected list ({nm}) element type: {type(elem)}")
                     child_dict[fmt_json_name(nm, child.module)] = elems


### PR DESCRIPTION
We can't express element removals in declarative JSON, so we skip those, just like leaves.