### PR TITLE
Add FNode AST, filter() & XML subtree parsing

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1061,6 +1061,120 @@ class Replace(Node):
         self.children = children
         self.txid = None
 
+
+class ValueMatch(value):
+    pass
+
+
+class VWildcard(ValueMatch):
+    pattern: str
+
+    def __init__(self, pattern: str):
+        self.pattern = pattern
+
+    def __repr__(self):
+        return "VWildcard({repr(self.pattern)})"
+
+
+class FNode(value):
+    name: ?Id
+    value_match: ?value
+    children: list[FNode]
+
+    def __init__(self, name: ?Id=None, value_match: ?value=None, children: list[FNode]=[]):
+        self.name = name
+        self.value_match = value_match
+        self.children = children
+
+    def __repr__(self):
+        return self.prsrc(deterministic=False)
+
+    pure def prsrc(self, deterministic=False, indent=0) -> str:
+        child_list = self.children
+        parts: list[str] = []
+        if self.name is not None:
+            parts = parts + [repr(self.name)]
+        if self.value_match is not None:
+            if isinstance(self.value_match, ValueMatch):
+                parts = parts + [repr(self.value_match)]
+            else:
+                parts = parts + [repr_gdata(self.value_match)]
+        if len(child_list) > 0:
+            child_strs = [c.prsrc(deterministic, indent+1) for c in child_list]
+            parts = parts + ["[" + ", ".join(child_strs) + "]"]
+        return "FNode({", ".join(parts)})"
+
+    def _to_filter_xml_rec(self, parent_ns: ?str=None, deterministic=False) -> xml.Node:
+        name = expect(self.name, "filter node")
+        node_ns = name.q if name.q != "" and name.q != parent_ns else None
+        xml_children = [c._to_filter_xml_rec(name.q, deterministic) for c in self.children]
+        text_value: ?str = None
+        v = None
+        vm = self.value_match
+        if vm is not None:
+            if isinstance(vm, ValueMatch):
+                if isinstance(vm, VWildcard):
+                    text_value = vm.pattern
+                else:
+                    raise ValueError("Unknown value match type: {type(vm)}")
+            else:
+                v = vm
+                text_value = yang_str(vm)
+        return xml.Node(name.name, nsdefs=_nsq(node_ns, v), children=xml_children, text=text_value)
+
+    def to_filter_xml(self, deterministic=False) -> list[xml.Node]:
+        if self.name is None:
+            return [c._to_filter_xml_rec(None, deterministic) for c in self.children]
+        return [self._to_filter_xml_rec(None, deterministic)]
+
+    def to_filter_xmlstr(self, pretty=True, deterministic=False) -> str:
+        return xml.encode_nodes(self.to_filter_xml(deterministic), pretty)
+
+
+def expect[T](a: ?T, ctx: str) -> T:
+    if a is not None:
+        return a
+    raise ValueError("expected value (not None) for: {ctx}")
+
+def _value_match_equal(a: value, b: value) -> bool:
+    """Compare filter value matches (plain values vs match operators)."""
+    if isinstance(a, ValueMatch):
+        if isinstance(a, VWildcard):
+            if isinstance(b, VWildcard):
+                return a.pattern == b.pattern
+            return False
+        raise ValueError("Unknown value match type: {type(a)}")
+    if isinstance(b, ValueMatch):
+        return False
+    return vals_equal(a, b)
+
+extension ValueMatch(Eq):
+    def __eq__(self, other: ValueMatch) -> bool:
+        if isinstance(self, VWildcard) and isinstance(other, VWildcard):
+            return self.pattern == other.pattern
+        return False
+
+
+extension FNode(Eq):
+    def __eq__(self, other: FNode) -> bool:
+        if self.name != other.name:
+            return False
+        if self.value_match is None and other.value_match is not None:
+            return False
+        if self.value_match is not None and other.value_match is None:
+            return False
+        if self.value_match is not None and other.value_match is not None:
+            a = expect(self.value_match, "filter value")
+            b = expect(other.value_match, "filter value")
+            if not _value_match_equal(a, b):
+                return False
+        if len(self.children) != len(other.children):
+            return False
+        for i in range(len(self.children)):
+            if self.children[i] != other.children[i]:
+                return False
+        return True
+
 def sorted_elements(elements, key_names: list[Id]):
     keys = list(map(lambda elem: elem.key_str(key_names), elements))
     key_map = dict(zip(keys, elements))
@@ -1554,6 +1668,226 @@ def _diff_rec(old: ?Node, new: Node, path: list[_PathElement]) -> ?Node:
 
 def diff(old: ?Node, new: Node) -> ?Node:
     return _diff_rec(old, new, [])
+
+
+def _wildcard_match(pattern: str, s: str) -> bool:
+    pi = 0
+    si = 0
+    star = -1
+    match = 0
+    while si < len(s):
+        if pi < len(pattern) and pattern[pi] == "*":
+            star = pi
+            match = si
+            pi += 1
+        elif pi < len(pattern) and pattern[pi] == s[si]:
+            pi += 1
+            si += 1
+        elif star != -1:
+            pi = star + 1
+            match += 1
+            si = match
+        else:
+            return False
+    while pi < len(pattern) and pattern[pi] == "*":
+        pi += 1
+    return pi == len(pattern)
+
+
+def _match_value(vm: value, v: value) -> bool:
+    """Return True when value v matches filter value vm."""
+    if isinstance(vm, ValueMatch):
+        if isinstance(vm, VWildcard):
+            return _wildcard_match(vm.pattern, yang_str(v))
+        raise ValueError("Unknown value match type: {type(vm)}")
+    return vals_equal(v, vm)
+
+
+def _group_filter_children(children: list[FNode]) -> dict[Id, list[FNode]]:
+    """Group filter children by name for per-child evaluation."""
+    groups: dict[Id, list[FNode]] = {}
+    for child in children:
+        name = expect(child.name, "filter child")
+        if name in groups:
+            groups[name].append(child)
+        else:
+            groups[name] = [child]
+    return groups
+
+
+def _filter_container_result(data: Node, children: dict[Id, Node]) -> Node:
+    """Rebuild a container-like node with filtered children."""
+    if isinstance(data, Absent):
+        return Absent(children, ns=data.ns, module=data.module)
+    if isinstance(data, Delete):
+        return Delete(children, ns=data.ns, module=data.module)
+    if isinstance(data, Create):
+        return Create(children, ns=data.ns, module=data.module)
+    if isinstance(data, Replace):
+        return Replace(children, ns=data.ns, module=data.module)
+    if isinstance(data, Container):
+        return Container(children, presence=data.presence, ns=data.ns, module=data.module)
+    return Container(children)
+
+
+def _filter_leaf(data: Leaf, flist: list[FNode]) -> (node: ?Node, select: bool):
+    """Apply leaf filters and determine selection status."""
+    matched = False
+    select = False
+    for f in flist:
+        if len(f.children) > 0:
+            raise ValueError("Leaf filter cannot have children")
+        if f.value_match is None:
+            matched = True
+            select = True
+        else:
+            vm = expect(f.value_match, "leaf")
+            if _match_value(vm, data.val):
+                matched = True
+    if not matched:
+        return (node=None, select=False)
+    return (node=data, select=select)
+
+
+def _filter_leaflist(data: LeafList, flist: list[FNode]) -> (node: ?Node, select: bool):
+    """Apply leaf-list filters and determine selection status."""
+    if len(flist) == 0:
+        return (node=data, select=True)
+    select_all = False
+    matches: list[value] = []
+    for f in flist:
+        if len(f.children) > 0:
+            raise ValueError("Leaf-list filter cannot have children")
+        if f.value_match is None:
+            select_all = True
+        else:
+            vm = expect(f.value_match, "leaf-list")
+            matches.append(vm)
+    if select_all:
+        return (node=data, select=True)
+    new_vals: list[value] = []
+    for v in data.vals:
+        for m in matches:
+            if _match_value(m, v):
+                new_vals.append(v)
+                break
+    if len(new_vals) == 0:
+        return (node=None, select=False)
+    return (node=LeafList(new_vals, user_order=data.user_order, ns=data.ns, module=data.module), select=True)
+
+
+def _filter_list_element(elem: Node, fnode: FNode, keys: list[Id]) -> ?Node:
+    """Filter a single list element against a list element predicate."""
+    if not (isinstance(elem, Container) or isinstance(elem, Absent)):
+        return None
+    if fnode.value_match is not None:
+        raise ValueError("List element filter cannot have value match")
+    if len(fnode.children) == 0:
+        return elem
+
+    groups = _group_filter_children(fnode.children)
+    selected_children: dict[Id, Node] = {}
+    has_selection = False
+    for name, flist in groups.items():
+        if name not in elem.children:
+            return None
+        res = _filter_child(elem.children[name], flist)
+        if res.node is None:
+            return None
+        if res.select:
+            selected_children[name] = expect(res.node, "list element selection")
+            has_selection = True
+
+    if not has_selection:
+        return elem
+
+    for key in keys:
+        if key in elem.children and key not in selected_children:
+            selected_children[key] = elem.children[key]
+
+    return _filter_container_result(elem, selected_children)
+
+
+def _filter_list(data: List, flist: list[FNode]) -> (node: ?Node, select: bool):
+    """Apply list predicates to produce a filtered list result."""
+    if len(flist) == 0:
+        return (node=data, select=True)
+    for f in flist:
+        if f.value_match is not None:
+            raise ValueError("List filter cannot have value match")
+    for f in flist:
+        if len(f.children) == 0:
+            return (node=data, select=True)
+    new_elements: list[Node] = []
+    seen = {}
+    for elem in data.elements:
+        for f in flist:
+            res = _filter_list_element(elem, f, data.keys)
+            if res is not None:
+                k = elem.key_str(data.keys)
+                if k not in seen:
+                    new_elements.append(res)
+                    seen[k] = True
+                break
+    if len(new_elements) == 0:
+        return (node=None, select=False)
+    return (node=List(data.keys, elements=new_elements, user_order=data.user_order, ns=data.ns, module=data.module), select=True)
+
+
+def _filter_container_children(data: Node, fchildren: list[FNode]) -> ?Node:
+    """Filter container children and select requested subtrees."""
+    if len(fchildren) == 0:
+        return data
+    if not (isinstance(data, Container) or isinstance(data, Absent) or isinstance(data, Create) or isinstance(data, Delete) or isinstance(data, Replace)):
+        raise ValueError("Filter root expects a container-like node")
+
+    groups = _group_filter_children(fchildren)
+    selected_children: dict[Id, Node] = {}
+    has_selection = False
+    for name, flist in groups.items():
+        if name not in data.children:
+            return None
+        res = _filter_child(data.children[name], flist)
+        if res.node is None:
+            return None
+        if res.select:
+            selected_children[name] = expect(res.node, "container selection")
+            has_selection = True
+
+    if not has_selection:
+        return data
+    return _filter_container_result(data, selected_children)
+
+
+def _filter_child(data: Node, flist: list[FNode]) -> (node: ?Node, select: bool):
+    """Dispatch filter evaluation based on child node type."""
+    if isinstance(data, Container) or isinstance(data, Absent) or isinstance(data, Create) or isinstance(data, Delete) or isinstance(data, Replace):
+        if len(flist) != 1:
+            raise ValueError("Multiple filter nodes for container child")
+        fnode = flist[0]
+        if fnode.value_match is not None:
+            raise ValueError("Container filter cannot have value match")
+        res = _filter_container_children(data, fnode.children)
+        if res is None:
+            return (node=None, select=False)
+        return (node=res, select=True)
+    if isinstance(data, List):
+        return _filter_list(data, flist)
+    if isinstance(data, LeafList):
+        return _filter_leaflist(data, flist)
+    if isinstance(data, Leaf):
+        return _filter_leaf(data, flist)
+    return (node=None, select=False)
+
+
+def filter(data: ?Node, filt: FNode) -> ?Node:
+    if data is None:
+        return None
+    d = expect(data, "filter root")
+    if filt.name is None:
+        return _filter_container_children(d, filt.children)
+    res = _filter_child(d, [filt])
+    return res.node
 
 
 # TODO: Can we make patch return a Node instead of ?Node?
@@ -2766,3 +3100,306 @@ def _test_to_xmlstr_list_removal():
     })
 
     return y1.to_xmlstr()
+
+################################################################################
+# Filter tests
+def _test_filter_container_wildcard():
+    """Select a container without child predicates returns the full subtree."""
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l1"): Leaf(u64(1)),
+            Id(NS_acme, "l2"): Leaf(u64(2)),
+        }, ns=NS_acme, module="acme"),
+        Id(NS_acme, "bar"): Container({
+            Id(NS_acme, "b1"): Leaf(u64(7)),
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo")),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l1"): Leaf(u64(1)),
+                Id(NS_acme, "l2"): Leaf(u64(2)),
+            }, ns=NS_acme, module="acme"),
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_container_leaf_content_match():
+    """Content-match leaf predicates filter by value but do not restrict selected leaves."""
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l1"): Leaf(u64(1)),
+            Id(NS_acme, "l2"): Leaf(u64(2)),
+        }, ns=NS_acme, module="acme"),
+        Id(NS_acme, "bar"): Container({
+            Id(NS_acme, "b1"): Leaf(u64(7)),
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l1"), value_match=u64(1)),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l1"): Leaf(u64(1)),
+                Id(NS_acme, "l2"): Leaf(u64(2)),
+            }, ns=NS_acme, module="acme"),
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_container_leaf_select():
+    """Leaf selection predicate limits output to requested leaves."""
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l1"): Leaf(u64(1)),
+            Id(NS_acme, "l2"): Leaf(u64(2)),
+        }, ns=NS_acme, module="acme"),
+        Id(NS_acme, "bar"): Container({
+            Id(NS_acme, "b1"): Leaf(u64(7)),
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l1")),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l1"): Leaf(u64(1)),
+            }, ns=NS_acme, module="acme"),
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_container_leaf_no_match():
+    """Non-matching content predicate yields no result."""
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l1"): Leaf(u64(1)),
+            Id(NS_acme, "l2"): Leaf(u64(2)),
+        }, ns=NS_acme, module="acme")
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l1"), value_match=u64(3)),
+        ]),
+    ])
+    res = filter(data, filt)
+    testing.assertEqual(res, None)
+
+
+def _test_filter_list_wildcard():
+    """List selection without element predicates returns all list elements."""
+    k = Id(NS_acme, "name")
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l"): List([k], [
+                Container({
+                    Id(NS_acme, "name"): Leaf("a"),
+                    Id(NS_acme, "v"): Leaf(u64(1)),
+                }),
+                Container({
+                    Id(NS_acme, "name"): Leaf("b"),
+                    Id(NS_acme, "v"): Leaf(u64(2)),
+                }),
+            ], ns=NS_acme, module="acme"),
+            Id(NS_acme, "extra"): Leaf(u64(9)),
+        }, ns=NS_acme, module="acme"),
+        Id(NS_acme, "bar"): Container({
+            Id(NS_acme, "b1"): Leaf(u64(7)),
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l")),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l"): List([k], [
+                    Container({
+                        Id(NS_acme, "name"): Leaf("a"),
+                        Id(NS_acme, "v"): Leaf(u64(1)),
+                    }),
+                    Container({
+                        Id(NS_acme, "name"): Leaf("b"),
+                        Id(NS_acme, "v"): Leaf(u64(2)),
+                    }),
+                ], ns=NS_acme, module="acme")
+            }, ns=NS_acme, module="acme")
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_list_keyed_child():
+    """List element predicate on key selects matching element, returns full element subtree."""
+    k = Id(NS_acme, "name")
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l"): List([k], [
+                Container({
+                    Id(NS_acme, "name"): Leaf("a"),
+                    Id(NS_acme, "v"): Leaf(u64(1)),
+                    Id(NS_acme, "x"): Leaf(u64(9)),
+                }),
+                Container({
+                    Id(NS_acme, "name"): Leaf("b"),
+                    Id(NS_acme, "v"): Leaf(u64(2)),
+                }),
+            ], ns=NS_acme, module="acme")
+        }, ns=NS_acme, module="acme"),
+        Id(NS_acme, "bar"): Container({
+            Id(NS_acme, "b1"): Leaf(u64(7)),
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l"), children=[
+                FNode(Id(NS_acme, "name"), value_match="a"),
+            ]),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l"): List([k], [
+                    Container({
+                        Id(NS_acme, "name"): Leaf("a"),
+                        Id(NS_acme, "v"): Leaf(u64(1)),
+                        Id(NS_acme, "x"): Leaf(u64(9)),
+                    }),
+                ], ns=NS_acme, module="acme")
+            }, ns=NS_acme, module="acme")
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_list_select_leaf():
+    """List element predicate plus leaf selection limits fields in matched element."""
+    k = Id(NS_acme, "name")
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l"): List([k], [
+                Container({
+                    Id(NS_acme, "name"): Leaf("a"),
+                    Id(NS_acme, "v"): Leaf(u64(1)),
+                    Id(NS_acme, "x"): Leaf(u64(9)),
+                }),
+                Container({
+                    Id(NS_acme, "name"): Leaf("b"),
+                    Id(NS_acme, "v"): Leaf(u64(2)),
+                    Id(NS_acme, "x"): Leaf(u64(8)),
+                }),
+            ], ns=NS_acme, module="acme")
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l"), children=[
+                FNode(Id(NS_acme, "name"), value_match="a"),
+                FNode(Id(NS_acme, "v")),
+            ]),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l"): List([k], [
+                    Container({
+                        Id(NS_acme, "name"): Leaf("a"),
+                        Id(NS_acme, "v"): Leaf(u64(1)),
+                    }),
+                ], ns=NS_acme, module="acme")
+            }, ns=NS_acme, module="acme")
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_leaflist_values():
+    """Leaf-list content predicates return only matching values."""
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "ll"): LeafList([u64(1), u64(2), u64(3)]),
+            Id(NS_acme, "x"): Leaf(u64(9)),
+        }, ns=NS_acme, module="acme"),
+        Id(NS_acme, "bar"): Container({
+            Id(NS_acme, "b1"): Leaf(u64(7)),
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "ll"), value_match=u64(2)),
+            FNode(Id(NS_acme, "ll"), value_match=u64(3)),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    # NOTE: Hmm, not entirely sure whether the expected LeafList should contain
+    # all elements or just the content-matched ones!? RFC is not super clear...
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "ll"): LeafList([u64(2), u64(3)]),
+            }, ns=NS_acme, module="acme")
+        }).prsrc(deterministic=True)
+    )
+
+
+def _test_filter_wildcard_value_match():
+    """Wildcard value match selects list elements by key pattern."""
+    k = Id(NS_acme, "name")
+    data = Container({
+        Id(NS_acme, "foo"): Container({
+            Id(NS_acme, "l"): List([k], [
+                Container({
+                    Id(NS_acme, "name"): Leaf("alpha"),
+                    Id(NS_acme, "v"): Leaf(u64(1)),
+                }),
+                Container({
+                    Id(NS_acme, "name"): Leaf("beta"),
+                    Id(NS_acme, "v"): Leaf(u64(2)),
+                }),
+            ], ns=NS_acme, module="acme")
+        }, ns=NS_acme, module="acme"),
+    })
+    filt = FNode(None, None, [
+        FNode(Id(NS_acme, "foo"), children=[
+            FNode(Id(NS_acme, "l"), children=[
+                FNode(Id(NS_acme, "name"), value_match=VWildcard("a*")),
+            ]),
+        ]),
+    ])
+    res = expect(filter(data, filt), "filter result")
+    testing.assertEqual(
+        res.prsrc(deterministic=True),
+        Container({
+            Id(NS_acme, "foo"): Container({
+                Id(NS_acme, "l"): List([k], [
+                    Container({
+                        Id(NS_acme, "name"): Leaf("alpha"),
+                        Id(NS_acme, "v"): Leaf(u64(1)),
+                    }),
+                ], ns=NS_acme, module="acme")
+            }, ns=NS_acme, module="acme")
+        }).prsrc(deterministic=True)
+    )

--- a/src/yang/xml.act
+++ b/src/yang/xml.act
@@ -2,6 +2,8 @@ import base64
 import testing
 import xml
 
+import yang
+import yang.data
 from yang.identityref import Identityref, PartialIdentityref
 from yang.type import Decimal
 from yang.data import from_data, YangData, PathElement, YangValidationError
@@ -13,6 +15,11 @@ import yang.schema
 
 NETCONF_OPS = {OP_CREATE, OP_DELETE, OP_REMOVE, OP_REPLACE, OP_MERGE}
 NETCONF_NS = "urn:ietf:params:xml:ns:netconf:base:1.0"
+
+def expect[T](a: ?T, ctx: str) -> T:
+    if a is not None:
+        return a
+    raise ValueError("expected value (not None) for: {ctx}")
 
 
 def _get_netconf_operation(node: xml.Node) -> str:
@@ -191,3 +198,336 @@ def from_xml(root: yang.schema.DRoot, data: xml.Node, loose: bool=False, root_pa
 
     return from_data(root, data, type_narrower, loose, root_path)
 
+
+def _xml_node_ns(n: xml.Node) -> ?str:
+    for nsdef in n.nsdefs:
+        n0 = nsdef.0
+        n1 = nsdef.1
+        if (n.prefix is None and n0 is None) or (n.prefix is not None and n0 == n.prefix):
+            return n1
+    return None
+
+
+def _filter_is_wrapper(n: xml.Node) -> bool:
+    """Return True if node is a NETCONF <filter> wrapper element."""
+    if n.tag != "filter":
+        return False
+    ns = _xml_node_ns(n)
+    return ns is None or ns == NETCONF_NS
+
+
+def _filter_value_match(root: yang.schema.DRoot, schema_leaf: yang.schema.DNodeLeaf, xml_leaf: xml.Node, spath: list[PathElement]) -> ?value:
+    """Parse a leaf/leaf-list text value into a filter value match."""
+    text = xml_leaf.text
+    if text is None or text == "":
+        return None
+    text_val = expect(text, "filter value")
+    if "*" in text_val:
+        return yang.gdata.VWildcard(text_val)
+    tv = try_parse_xml_value(text_val, schema_leaf, schema_leaf.type_, spath, xml_leaf.nsdefs, root)
+    if tv is not None:
+        return tv.val
+    return None
+
+
+def _filter_schema_child(s: yang.schema.DNodeInner, n: xml.Node) -> yang.schema.DNode:
+    """Resolve the schema child that matches the XML node name/namespace."""
+    ns = _xml_node_ns(n)
+    return s.get(n.tag, namespace=ns, allow_unqualified=True)
+
+
+def _filter_parse_children(root: yang.schema.DRoot, s: yang.schema.DNodeInner, data: xml.Node, spath: list[PathElement]) -> list[yang.gdata.FNode]:
+    """Parse XML element children into filter nodes using schema context."""
+    res: list[yang.gdata.FNode] = []
+    for child in data.children:
+        if not isinstance(child, xml.Node):
+            continue
+        schema_child = _filter_schema_child(s, child)
+        res.append(_filter_parse_node(root, schema_child, child, spath + [PathElement(schema_child)]))
+    return res
+
+
+def _filter_parse_node(root: yang.schema.DRoot, s: yang.schema.DNode, data: xml.Node, spath: list[PathElement]) -> yang.gdata.FNode:
+    """Parse a single XML element into a filter node based on schema type."""
+    name_id = yang.gdata.Id(s.namespace, s.name)
+    if isinstance(s, yang.schema.DContainer) or isinstance(s, yang.schema.DList):
+        s_inner = _unwrap_dnode_inner(s, spath)
+        children = _filter_parse_children(root, s_inner, data, spath)
+        return yang.gdata.FNode(name_id, children=children)
+    if isinstance(s, yang.schema.DLeaf):
+        vm = _filter_value_match(root, s, data, spath)
+        return yang.gdata.FNode(name_id, value_match=vm)
+    if isinstance(s, yang.schema.DLeafList):
+        vm = _filter_value_match(root, s, data, spath)
+        return yang.gdata.FNode(name_id, value_match=vm)
+    raise ValueError("Unsupported schema node in filter at {yang.data.format_schema_path(spath)}: {type(s)}")
+
+
+def _unwrap_dnode_leaf(s: yang.schema.DNode, spath: list[PathElement]) -> yang.schema.DNodeLeaf:
+    if isinstance(s, yang.schema.DLeaf):
+        return s
+    if isinstance(s, yang.schema.DLeafList):
+        return s
+    raise ValueError("Expected leaf node at {yang.data.format_schema_path(spath)}: {type(s)}")
+
+
+def _unwrap_dnode_inner(s: yang.schema.DNode, spath: list[PathElement]) -> yang.schema.DNodeInner:
+    if isinstance(s, yang.schema.DNodeInner):
+        inner: yang.schema.DNodeInner = s
+        return inner
+    raise ValueError("Expected inner node at {yang.data.format_schema_path(spath)}: {type(s)}")
+
+
+def from_filter_xml(root: yang.schema.DRoot, data: xml.Node, root_path: list[str]=[]) -> yang.gdata.FNode:
+    """Parse a NETCONF subtree filter XML node into a filter tree."""
+    s: yang.schema.DNodeInner = root
+    spath = [PathElement(root)]
+    while root_path != [] and len(spath) - 1 < len(root_path):
+        next = root_path[len(spath) - 1]
+        local_name, module = yang.data.parse_qualified_name(next)
+        child = s.get(local_name, module=module, allow_unqualified=False)
+        if isinstance(child, yang.schema.DNodeInner):
+            s = child
+            spath = spath + [PathElement(child)]
+        else:
+            raise ValueError("Node at {yang.data.format_schema_path(spath + [PathElement(child)])} is not inner: {type(child)}")
+
+    xml_children: list[xml.Node] = []
+    if _filter_is_wrapper(data):
+        for child in data.children:
+            if isinstance(child, xml.Node):
+                xml_children.append(child)
+    else:
+        xml_children = [data]
+
+    children: list[yang.gdata.FNode] = []
+    for child in xml_children:
+        schema_child = _filter_schema_child(s, child)
+        children.append(_filter_parse_node(root, schema_child, child, spath + [PathElement(schema_child)]))
+
+    return yang.gdata.FNode(None, None, children)
+
+
+def from_filter_xmlstr(root: yang.schema.DRoot, data: str, root_path: list[str]=[]) -> yang.gdata.FNode:
+    """Parse a NETCONF subtree filter XML string into a filter tree."""
+    return from_filter_xml(root, xml.decode(data), root_path)
+
+
+def _filter_test_schema() -> yang.schema.DRoot:
+    """Return a small schema used by filter XML parsing tests."""
+    ys = r"""
+module acme {
+  namespace "http://example.com/acme";
+  prefix a;
+  container foo {
+    leaf l1 { type uint64; }
+    leaf l2 { type uint64; }
+    leaf empty { type empty; }
+    leaf-list ll { type uint64; }
+    list l {
+      key "name";
+      leaf name { type string; }
+      leaf v { type uint64; }
+      leaf x { type uint64; }
+    }
+  }
+}
+"""
+    return yang.compile([ys])
+
+
+def _filter_sorted_indices(keys: list[str]) -> list[int]:
+    """Return stable indices that sort the provided keys."""
+    idxs: list[int] = []
+    for i in range(len(keys)):
+        k = keys[i]
+        inserted = False
+        for j in range(len(idxs)):
+            if k < keys[idxs[j]]:
+                idxs.insert(j, i)
+                inserted = True
+                break
+        if not inserted:
+            idxs.append(i)
+    return idxs
+
+
+def _filter_sort_nsdefs(nsdefs: list[(?str, str)]) -> list[(?str, str)]:
+    """Sort XML namespace definitions to keep canonical output stable."""
+    if len(nsdefs) <= 1:
+        return nsdefs
+    keys: list[str] = []
+    for i in range(len(nsdefs)):
+        pfx = nsdefs[i].0
+        key_pfx = "" if pfx is None else pfx
+        keys.append("{key_pfx}:{nsdefs[i].1}")
+    idxs = _filter_sorted_indices(keys)
+    res: list[(?str, str)] = []
+    for idx in idxs:
+        res.append(nsdefs[idx])
+    return res
+
+
+def _filter_sort_attrs(attrs: list[(str, str)]) -> list[(str, str)]:
+    """Sort XML attributes by name for canonicalization."""
+    if len(attrs) <= 1:
+        return attrs
+    keys: list[str] = []
+    for i in range(len(attrs)):
+        keys.append(attrs[i].0)
+    idxs = _filter_sorted_indices(keys)
+    res: list[(str, str)] = []
+    for idx in idxs:
+        res.append(attrs[idx])
+    return res
+
+
+def _filter_sort_children(children: list[xml.Node]) -> list[xml.Node]:
+    """Sort XML children deterministically for canonicalization."""
+    if len(children) <= 1:
+        return children
+    keys: list[str] = []
+    for i in range(len(children)):
+        c = children[i]
+        text = c.text if c.text is not None else ""
+        enc = xml.encode_nodes([c], pretty=False)
+        keys.append("{c.tag}|{text}|{enc}")
+    idxs = _filter_sorted_indices(keys)
+    res: list[xml.Node] = []
+    for idx in idxs:
+        res.append(children[idx])
+    return res
+
+
+def _filter_canon_node(n: xml.Node) -> xml.Node:
+    """Produce a canonicalized XML node with sorted metadata."""
+    children: list[xml.Node] = []
+    for child in n.children:
+        if isinstance(child, xml.Node):
+            children.append(_filter_canon_node(child))
+    nsdefs = _filter_sort_nsdefs(n.nsdefs)
+    attrs = _filter_sort_attrs(n.attributes)
+    children = _filter_sort_children(children)
+    return xml.Node(n.tag, nsdefs=nsdefs, attributes=attrs, children=children, text=n.text)
+
+
+def _filter_norm_xml(s: str) -> str:
+    """Normalize an XML string into canonical form for comparisons."""
+    return xml.encode_nodes([_filter_canon_node(xml.decode(s))], pretty=False)
+
+
+def _test_from_filter_xml_container_select():
+    """Parse container filter with mixed content match and selection leaves."""
+    root = _filter_test_schema()
+    xml_in = xml.decode('<foo xmlns="http://example.com/acme"><l1>1</l1><l2/></foo>')
+    res = from_filter_xml(root, xml_in)
+    exp = yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "foo"), children=[
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "l1"), value_match=u64(1)),
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "l2")),
+        ]),
+    ])
+    testing.assertEqual(res.prsrc(deterministic=True), exp.prsrc(deterministic=True))
+
+
+def _test_from_filter_xml_list_select_leaf():
+    """Parse list filter with key predicate and a selected leaf."""
+    root = _filter_test_schema()
+    xml_in = xml.decode('<foo xmlns="http://example.com/acme"><l><name>a</name><v/></l></foo>')
+    res = from_filter_xml(root, xml_in)
+    exp = yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "foo"), children=[
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "l"), children=[
+                yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "name"), value_match="a"),
+                yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "v")),
+            ]),
+        ]),
+    ])
+    testing.assertEqual(res.prsrc(deterministic=True), exp.prsrc(deterministic=True))
+
+
+def _test_from_filter_xml_leaflist_values():
+    """Parse leaf-list filter with multiple value predicates."""
+    root = _filter_test_schema()
+    xml_in = xml.decode('<foo xmlns="http://example.com/acme"><ll>2</ll><ll>3</ll></foo>')
+    res = from_filter_xml(root, xml_in)
+    exp = yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "foo"), children=[
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "ll"), value_match=u64(2)),
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "ll"), value_match=u64(3)),
+        ]),
+    ])
+    testing.assertEqual(res.prsrc(deterministic=True), exp.prsrc(deterministic=True))
+
+
+def _test_from_filter_xml_wrapper():
+    """Parse NETCONF <filter> wrapper around subtree content."""
+    root = _filter_test_schema()
+    xml_in = xml.decode('<filter xmlns="urn:ietf:params:xml:ns:netconf:base:1.0"><foo xmlns="http://example.com/acme"><l2/></foo></filter>')
+    res = from_filter_xml(root, xml_in)
+    exp = yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "foo"), children=[
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "l2")),
+        ]),
+    ])
+    testing.assertEqual(res.prsrc(deterministic=True), exp.prsrc(deterministic=True))
+
+
+def _test_from_filter_xml_wildcard():
+    """Parse wildcard value predicate from XML into VWildcard."""
+    root = _filter_test_schema()
+    xml_in = xml.decode('<foo xmlns="http://example.com/acme"><l><name>a*</name></l></foo>')
+    res = from_filter_xml(root, xml_in)
+    exp = yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "foo"), children=[
+            yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "l"), children=[
+                yang.gdata.FNode(yang.gdata.Id("http://example.com/acme", "name"), value_match=yang.gdata.VWildcard("a*")),
+            ]),
+        ]),
+    ])
+    testing.assertEqual(res.prsrc(deterministic=True), exp.prsrc(deterministic=True))
+
+
+def _test_filter_roundtrip_xml():
+    """Round-trip XML -> gdata -> XML preserves subtree filter semantics."""
+    root = _filter_test_schema()
+    xml_in_str = '<foo xmlns="http://example.com/acme"><l1>1</l1><l2/><empty/><ll>2</ll><l><name>a</name><v/></l></foo>'
+    g1 = from_filter_xml(root, xml.decode(xml_in_str))
+    xml_out = g1.to_filter_xmlstr(pretty=False, deterministic=True)
+    testing.assertEqual(_filter_norm_xml(xml_out), _filter_norm_xml(xml_in_str))
+    g2 = from_filter_xml(root, xml.decode(xml_out))
+    testing.assertEqual(g1.prsrc(deterministic=True), g2.prsrc(deterministic=True))
+
+
+def _test_filter_roundtrip_gdata():
+    """Round-trip gdata -> XML -> gdata preserves filter structure."""
+    root = _filter_test_schema()
+    ns = "http://example.com/acme"
+    g1 = yang.gdata.FNode(None, None, [
+        yang.gdata.FNode(yang.gdata.Id(ns, "foo"), children=[
+            yang.gdata.FNode(yang.gdata.Id(ns, "l1"), value_match=u64(1)),
+            yang.gdata.FNode(yang.gdata.Id(ns, "l2")),
+            yang.gdata.FNode(yang.gdata.Id(ns, "empty")),
+            yang.gdata.FNode(yang.gdata.Id(ns, "ll"), value_match=u64(2)),
+            yang.gdata.FNode(yang.gdata.Id(ns, "l"), children=[
+                yang.gdata.FNode(yang.gdata.Id(ns, "name"), value_match="a"),
+                yang.gdata.FNode(yang.gdata.Id(ns, "v")),
+            ]),
+        ]),
+    ])
+    xml_out = g1.to_filter_xmlstr(pretty=False, deterministic=True)
+    expected = xml.encode_nodes([
+        xml.Node("foo", nsdefs=[(None, ns)], children=[
+            xml.Node("l1", nsdefs=[], text="1"),
+            xml.Node("l2", nsdefs=[]),
+            xml.Node("empty", nsdefs=[]),
+            xml.Node("ll", nsdefs=[], text="2"),
+            xml.Node("l", nsdefs=[], children=[
+                xml.Node("name", nsdefs=[], text="a"),
+                xml.Node("v", nsdefs=[]),
+            ]),
+        ])
+    ], pretty=False)
+    testing.assertEqual(_filter_norm_xml(xml_out), _filter_norm_xml(expected))
+    g2 = from_filter_xml(root, xml.decode(xml_out))
+    testing.assertEqual(g1.prsrc(deterministic=True), g2.prsrc(deterministic=True))


### PR DESCRIPTION
This adds a new filter function to complement the existing diff, patch, merge but unlike the others which are entirely Node based, we also introduce a new FNode tree, F for filter, to express the filter. gdata carries more semantics, like it separates containers from lists, which is unnecessary for filters. For example, converting an NETCONF XML subtree filter into gdata would require a schema, whereas turning it into FNode is a schemaless operation. Further, NETCONF XML subtree filters, by virtue of using XML, can easily express both content match nodes as well as selection nodes, i.e.:

  <filter type="subtree">
    <top xmlns="http://example.com/schema/1.2/config">
      <users>
        <user>
          <name>fred</name>
          <name/>
        </user>
      </users>
    </top>
  </filter>

But gdata.Leaf cannot be "empty", so for selection nodes we'd have to have another subclass to Node.. just for the purpose of filters, so using Node would practically require extending Node with filter-specific classes and in addition require a schema-based parser. FNode is instead a new clean class structure just for filters where both containment, content matching as well as node selection is quite natural.

Value matching currently supports equal match or wildcard based using VWildcard. We can introduce regex or similar operations in the future.

We support parsing NETCONF XML subtree filters into FNode and back.