### PR TITLE
Revert "Fix patch for empty leaf removals"

### DIFF
--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -2189,10 +2189,7 @@ def _patch_rec(old: Node, p: ?Node, path: list[_PathElement]) -> ?Node:
                 # Key not in old
                 if isinstance(cpatch, Absent):
                     # Trying to remove something not in old -> ignore
-                    if len(cpatch.children) == 0:
-                        # TODO: reconsider modeling empty leaf removal with something other than Absent?!
-                        # Preserve explicit remove of empty leaf / leaf-list (childless)
-                        new_children[key] = cpatch
+                    pass
                 elif isinstance(cpatch, Delete):
                     # TODO: structured error (error-tag, ...)
                     raise ValueError("data-missing: node does not exist at {_format_gdata_path(path + [_PathElement(key)])}")
@@ -3345,37 +3342,6 @@ def _test_patch_list_elem_create_replace():
             Id("", "v"): Leaf("new")
         })
     ])
-
-    testing.assertEqual(res, exp)
-
-def _test_patch_preserve_empty_leaf():
-    """Remove (Absent) on empty leaf inside list element/container should be preserved."""
-    old = Container({})
-
-    p = Container({
-        Id("", "c"): Container({
-            Id("", "shutdown"): Absent()
-        }),
-        Id("", "l"): List([Id("", "name")], [
-            Container({
-                Id("", "name"): Leaf("a"),
-                Id("", "shutdown"): Absent()
-            })
-        ])
-    })
-
-    res = patch(old, p)
-    exp = Container({
-        Id("", "c"): Container({
-            Id("", "shutdown"): Absent()
-        }),
-        Id("", "l"): List([Id("", "name")], [
-            Container({
-                Id("", "name"): Leaf("a"),
-                Id("", "shutdown"): Absent()
-            })
-        ])
-    })
 
     testing.assertEqual(res, exp)
 


### PR DESCRIPTION
It is conceptually wrong for the patch function to pass over Absent
nodes. The transform may still signal that an empty leaf should be
removed in its intent, but then it comes down to whether the empty leaf
that should be removed is present in the device running config.
This reverts commit 7e0208afe685aad8fdbe90c0a141cb6c6e18033e.