### PR TITLE
Add gdata subscriptions and typed rpc_root wrapper

### DIFF
--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -168,6 +168,7 @@ class foo__r1__output(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
+    var tree: ?yang.gdata.Node = root().to_gdata()
     def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -182,6 +183,28 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
             gdata_inp = yang.adata.from_adata(SRC_DNODE, inp, False, ["foo:r1", "input"])
             rpc_xml.children.extend(gdata_inp.to_xml())
         tp.rpc_xml(cb_wrap, rpc_xml)
+
+    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
+            if n is not None:
+                prev = tree
+                # TODO: fix yang.gdata.patch() to accept None as old tree
+                base = prev if prev is not None else yang.gdata.Container({})
+                tree2 = yang.gdata.patch(base, n)
+
+                if tree2 is not None:
+                    d = yang.gdata.diff(prev, tree2)
+                    if d is not None:
+                        cb(root.from_gdata(tree2), err)
+                    tree = tree2
+                else:
+                    if prev is not None:
+                        cb(root.from_gdata(None), err)
+                    tree = None
+            else:
+                cb(None, err)
+
+        return tp.subscribe(cb_wrap, filt, opts)
 
 
 

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -147,6 +147,7 @@ class yangrpc__foo__output(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
+    var tree: ?yang.gdata.Node = root().to_gdata()
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -165,6 +166,28 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
     def silent(cb: action(?Exception) -> None):
         rpc_xml = xml.Node('silent', nsdefs=[(None, 'http://example.com/yangrpc')])
         tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
+
+    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
+            if n is not None:
+                prev = tree
+                # TODO: fix yang.gdata.patch() to accept None as old tree
+                base = prev if prev is not None else yang.gdata.Container({})
+                tree2 = yang.gdata.patch(base, n)
+
+                if tree2 is not None:
+                    d = yang.gdata.diff(prev, tree2)
+                    if d is not None:
+                        cb(root.from_gdata(tree2), err)
+                    tree = tree2
+                else:
+                    if prev is not None:
+                        cb(root.from_gdata(None), err)
+                    tree = None
+            else:
+                cb(None, err)
+
+        return tp.subscribe(cb_wrap, filt, opts)
 
 
 

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -2577,9 +2577,44 @@ def patch(old: Node, p: ?Node) -> ?Node:
     return _patch_rec(old, p, [])
 
 
+SUB_ON_CHANGE = "on_change"
+SUB_PERIODIC = "periodic"
+
+class SubscriptionOpts(object):
+    """Subscription options for TreeProvider.subscribe."""
+    mode: str
+    period: ?u64 # nanoseconds; 0 means as fast as possible
+
+    def __init__(self, mode: str=SUB_PERIODIC, period: ?u64=None):
+        self.mode = mode
+        self.period = period
+        self._validate()
+
+    def _validate(self):
+        if self.mode not in {SUB_ON_CHANGE, SUB_PERIODIC}:
+            raise ValueError("Unknown subscription mode: {self.mode}")
+        if self.mode == SUB_PERIODIC:
+            if self.period is None:
+                raise ValueError("period (nanoseconds) is required for periodic subscriptions")
+        elif self.period is not None:
+            raise ValueError("period (nanoseconds) is only valid for periodic subscriptions")
+
+
+class SubscriptionHandle(object):
+    """Handle returned by subscribe() for cancellation."""
+    id: int
+    @property
+    cancel: proc() -> None
+
+    def __init__(self, id: int, cancel: proc() -> None):
+        self.id = id
+        self.cancel = cancel
+
+
 class TreeProvider(object):
     rpc: proc(action(?Node, ?Exception) -> None, Node) -> None
     rpc_xml: proc(action(?xml.Node, ?Exception) -> None, xml.Node) -> None
+    subscribe: proc(action(?Node, ?Exception) -> None, ?FNode, SubscriptionOpts) -> SubscriptionHandle
 
 
 def _node_match(n: xml.Node, name: str, ns: ?str) -> bool:

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -853,6 +853,7 @@ class DNodeInner(DNode):
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
             res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
+            res.append("    var tree: ?yang.gdata.Node = root().to_gdata()")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output
@@ -897,6 +898,30 @@ class DNodeInner(DNode):
                 else:
                     res.append("        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)")
                 res.append("")
+
+            res.append("    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:")
+            res.append("        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):")
+            res.append("            if n is not None:")
+            res.append("                prev = tree")
+            res.append("                # TODO: fix yang.gdata.patch() to accept None as old tree")
+            res.append("                base = prev if prev is not None else yang.gdata.Container({{}})")
+            res.append("                tree2 = yang.gdata.patch(base, n)")
+            res.append("")
+            res.append("                if tree2 is not None:")
+            res.append("                    d = yang.gdata.diff(prev, tree2)")
+            res.append("                    if d is not None:")
+            res.append("                        cb(root.from_gdata(tree2), err)")
+            res.append("                    tree = tree2")
+            res.append("                else:")
+            res.append("                    if prev is not None:")
+            res.append("                        cb(root.from_gdata(None), err)")
+            res.append("                    tree = None")
+            res.append("            else:")
+            res.append("                cb(None, err)")
+            res.append("")
+            res.append("        return tp.subscribe(cb_wrap, filt, opts)")
+            res.append("")
+
             res.append("")
             res.append("")
 

--- a/test/test_data_classes/src/test_rpc_exec.act
+++ b/test/test_data_classes/src/test_rpc_exec.act
@@ -22,6 +22,8 @@ class MockTreeProviderSuccess(yang.gdata.TreeProvider):
             yang.gdata.Id("http://example.com/yangrpc", "outoo"): yang.gdata.Leaf("string", "Hello from RPC!")
         }, ns="http://example.com/yangrpc", module="yangrpc")
         cb(output_gdata, None)
+    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+        return yang.gdata.SubscriptionHandle(0, lambda: None)
 
 
 class MockTreeProviderError(yang.gdata.TreeProvider):
@@ -35,6 +37,8 @@ class MockTreeProviderError(yang.gdata.TreeProvider):
 
     proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
         cb(None, ValueError("RPC execution failed"))
+    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+        return yang.gdata.SubscriptionHandle(0, lambda: None)
 
 
 class MockTreeProviderEmpty(yang.gdata.TreeProvider):
@@ -52,6 +56,8 @@ class MockTreeProviderEmpty(yang.gdata.TreeProvider):
     proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
         output_gdata = yang.gdata.Container({}, ns="http://example.com/yangrpc", module="yangrpc")
         cb(output_gdata, None)
+    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+        return yang.gdata.SubscriptionHandle(0, lambda: None)
 
 
 actor _test_rpc_foo_success(t: testing.AsyncT):

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -169,6 +169,7 @@ class yangrpc__foo__output(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
+    var tree: ?yang.gdata.Node = root().to_gdata()
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -187,6 +188,28 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
     def silent(cb: action(?Exception) -> None):
         rpc_xml = xml.Node('silent', nsdefs=[(None, 'http://example.com/yangrpc')])
         tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
+
+    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
+        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
+            if n is not None:
+                prev = tree
+                # TODO: fix yang.gdata.patch() to accept None as old tree
+                base = prev if prev is not None else yang.gdata.Container({})
+                tree2 = yang.gdata.patch(base, n)
+
+                if tree2 is not None:
+                    d = yang.gdata.diff(prev, tree2)
+                    if d is not None:
+                        cb(root.from_gdata(tree2), err)
+                    tree = tree2
+                else:
+                    if prev is not None:
+                        cb(root.from_gdata(None), err)
+                    tree = None
+            else:
+                cb(None, err)
+
+        return tp.subscribe(cb_wrap, filt, opts)
 
 
 


### PR DESCRIPTION
This introduces canonical subscription primitives in yang.gdata so a TreeProvider can express streaming updates in the same module that already owns diff, patch, and filter. We add SUB_* constants, SubscriptionOpts, SubscriptionHandle, and a TreeProvider.subscribe signature so generated model code can depend on a stable, schema‑level API rather than ad‑hoc definitions in downstream repos.

The generator now emits rpc_root.subscribe alongside RPC wrappers. That wrapper maintains a local gdata tree, applies incoming deltas via patch, and only forwards typed adata updates when diff says the tree actually changed. It treats a missing local tree as an empty container for patching, and cleanly handles the “everything deleted” case by setting the tree to None and emitting a root.from_gdata(None) update. A TODO notes that yang.gdata.patch should eventually accept None as the old tree so this shim can be removed.

This gives us a model‑driven subscription facade that mirrors the RPC facade: the transport stays gdata, but the user callback receives typed adata, and the logic for patching/diffing stays in the generated layer.