### PR TITLE
Refactor yang.parser to use explicit mutable state and remove regex

### DIFF
--- a/src/yang/parser.act
+++ b/src/yang/parser.act
@@ -1,8 +1,6 @@
-import re
 import testing
 
 import yang.schema
-import yang.syntax
 
 class EOF(Exception):
     def __init__(self):
@@ -18,7 +16,7 @@ class TokenizerState(object):
     is_1_1: bool
     strict_quoting: bool
     errors: list[str]
-    
+
     def __init__(self, text: str, line_num: int=0, strict_quoting: bool=True):
         self.lines = text.splitlines(True)
         self.buf = ''
@@ -46,7 +44,7 @@ def set_buf(state: TokenizerState, i: int) -> None:
 def skip_whitespace_and_comments(state: TokenizerState) -> None:
     """Skip whitespace and comments, mutating state"""
     buflen = len(state.buf)
-    
+
     # Skip whitespace
     while True:
         state.buf = state.buf.lstrip(" \n\t")
@@ -56,7 +54,7 @@ def skip_whitespace_and_comments(state: TokenizerState) -> None:
         else:
             state.offset += (buflen - len(state.buf))
             break
-    
+
     # Skip comments
     if len(state.buf) >= 2 and state.buf[0] == '/':
         if state.buf[1] == '/':
@@ -72,31 +70,47 @@ def skip_whitespace_and_comments(state: TokenizerState) -> None:
             set_buf(state, i + 2)
             skip_whitespace_and_comments(state)
 
+def _is_identifier_start(c: str) -> bool:
+    """Return True if character can start a YANG identifier"""
+    return (c == '_') or (c.isascii() and c.isalpha())
+
+def _is_identifier_char(c: str) -> bool:
+    """Return True if character can appear after the first position in an identifier"""
+    return _is_identifier_start(c) or (c.isascii() and c.isdecimal()) or c == '.' or c == '-'
+
+def _consume_identifier(buf: str, start: int=0) -> (str, int):
+    """Consume an identifier from buf starting at start, returning (identifier, next_index)."""
+    if start >= len(buf) or not _is_identifier_start(buf[start]):
+        raise ValueError(f"illegal keyword: {buf}")
+
+    i = start + 1
+    while i < len(buf) and _is_identifier_char(buf[i]):
+        i = i + 1
+
+    return (buf[start:i], i)
+
 def parse_keyword(state: TokenizerState) -> (str, ?str):
     """Parse a keyword, returning (identifier, prefix)"""
     skip_whitespace_and_comments(state)
-    
-    m = re.match(yang.syntax.keyword, state.buf)
-    if m is not None:
-        set_buf(state, m.end_pos)
-        # Check separator
-        if (state.buf[0].isspace() or
-            (len(state.buf) >= 2 and state.buf[0] == '/' and state.buf[1] in ['/', '*']) or
-            (state.buf[0] in [';', r'{'])):
-            pass
-        else:
-            raise ValueError(f"expected separator, got: {state.buf[:6]}...")
-        
-        gident = m.group[3]
-        gprefix = m.group[2]
-        prefix = None
-        if gprefix is not None:
-            prefix = gprefix
-        if gident is not None:
-            return (gident, prefix)
-        raise ValueError("identifier or prefix is None")
-    else:
-        raise ValueError(f"illegal keyword: {state.buf}")
+    buf = state.buf
+
+    ident, idx = _consume_identifier(buf, 0)
+    prefix = None
+    if idx < len(buf) and buf[idx] == ':':
+        prefix = ident
+        ident, idx = _consume_identifier(buf, idx + 1)
+
+    set_buf(state, idx)
+
+    # Check separator
+    if len(state.buf) == 0:
+        raise ValueError("expected separator, got: EOF")
+    if (state.buf[0].isspace() or
+        (len(state.buf) >= 2 and state.buf[0] == '/' and state.buf[1] in ['/', '*']) or
+        (state.buf[0] in [';', r'{'])):
+        return (ident, prefix)
+
+    raise ValueError(f"expected separator, got: {state.buf[:6]}...")
 
 def peek_char(state: TokenizerState) -> str:
     """Peek at next character without consuming"""
@@ -113,10 +127,10 @@ def skip_char(state: TokenizerState) -> None:
 def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, str)]:
     """Parse string arguments, returning strings"""
     skip_whitespace_and_comments(state)
-    
+
     if state.buf[0] == ';' or state.buf[0] == r'{' or state.buf[0] == r'}':
         raise ValueError(f"expected argument, got: {state.buf[0]}")
-    
+
     if state.buf[0] == '"' or state.buf[0] == "'":
         # Quoted string
         quote_char = state.buf[0]
@@ -124,7 +138,7 @@ def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, s
         res = []
         indentpos = state.offset
         i = 1
-        
+
         while True:
             buflen = len(state.buf)
             start = i
@@ -134,7 +148,7 @@ def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, s
                     res.append(state.buf[start:i])
                     strs.append((''.join(res), quote_char))
                     set_buf(state, i + 1)
-                    
+
                     # Check for concatenation
                     skip_whitespace_and_comments(state)
                     if state.buf[0] == '+':
@@ -143,7 +157,7 @@ def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, s
                         nstrs = parse_strings(state, need_quote=True)
                         strs.extend(nstrs)
                     return strs
-                
+
                 elif (quote_char == '"' and
                       state.buf[i] == '\\' and i < (buflen - 1)):
                     # Handle escape sequences
@@ -160,14 +174,14 @@ def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, s
                         raise ValueError(f"illegal escape: {state.buf[i+1]}")
                     elif state.strict_quoting:
                         raise ValueError(f"illegal escape: {state.buf[i+1]}")
-                    
+
                     if special is not None:
                         res.append(state.buf[start:i])
                         res.append(special)
                         i = i + 1
                         start = i + 1
                 i = i + 1
-            
+
             # End of line in string
             if i > 2 and state.buf[i-2] == '\r':
                 j = i - 3
@@ -200,7 +214,7 @@ def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, s
                     i = 0
         # Loop continues to next line
         return []  # Should never reach here
-    
+
     elif need_quote == True:
         raise ValueError(f"expected quoted string, got: {state.buf}")
     else:
@@ -227,10 +241,10 @@ def parse_statement(state: TokenizerState, parent: ?yang.schema.Statement) -> ya
     """Parse a single statement using mutable state"""
     # Get keyword
     identifier, prefix = parse_keyword(state)
-    
+
     # Check for argument
     tok = peek_char(state)
-    
+
     if tok == r'{' or tok == ';':
         arg = None
     else:
@@ -239,33 +253,33 @@ def parse_statement(state: TokenizerState, parent: ?yang.schema.Statement) -> ya
         for a in argstrs:
             ass.append(a.0)
         arg = ''.join(ass)
-    
+
     # Check for YANG 1.1
     if identifier == 'yang-version' and arg is not None and arg == '1.1':
         state.is_1_1 = True
         state.strict_quoting = True
-    
+
     stmt = yang.schema.Statement(identifier, arg, prefix)
-    
+
     # Check for substatements
     tok = peek_char(state)
-    
+
     if tok == r'{':
         skip_char(state)  # skip '{'
-        
+
         while True:
             p = peek_char(state)
             if p == r'}':
                 break
             substmt = parse_statement(state, stmt)
             stmt.substatements.append(substmt)
-        
+
         skip_char(state)  # skip '}'
     elif tok == ';':
         skip_char(state)  # skip ';'
     else:
         raise ValueError(f"incomplete statement, expected '{{' or ';', got: {tok}")
-    
+
     return stmt
 
 def parse(text: str, strict_quoting: bool=True) -> yang.schema.Statement:
@@ -280,7 +294,7 @@ def parse(text: str, strict_quoting: bool=True) -> yang.schema.Statement:
 class Position(object):
     ref: ?str
     line: int
-    
+
     def __init__(self, ref):
         self.ref = ref
         self.line = 0
@@ -295,7 +309,7 @@ class YangTokenizer(object):
     offset: int
     is_1_1: bool
     strict_quoting: bool
-    
+
     def __init__(self, text: str, pos, errors=[], strict_quoting: bool=True):
         self.state = TokenizerState(text, strict_quoting=strict_quoting)
         self.state.errors = errors
@@ -305,7 +319,7 @@ class YangTokenizer(object):
         self.is_1_1 = False
         self.strict_quoting = False
         self._sync_properties()
-    
+
     def _sync_properties(self):
         """Sync properties from state"""
         self.buf = self.state.buf
@@ -313,26 +327,26 @@ class YangTokenizer(object):
         self.is_1_1 = self.state.is_1_1
         self.strict_quoting = self.state.strict_quoting
         self.pos.line = self.state.line_num
-    
+
     def skip(self) -> None:
         skip_whitespace_and_comments(self.state)
         self._sync_properties()
-    
+
     def get_keyword(self) -> (identifier: str, prefix: ?str):
         ident, pref = parse_keyword(self.state)
         self._sync_properties()
         return (identifier=ident, prefix=pref)
-    
+
     def get_strings(self, need_quote: bool=False) -> list[(str, str)]:
         strs = parse_strings(self.state, need_quote)
         self._sync_properties()
         return strs
-    
+
     def peek(self) -> str:
         c = peek_char(self.state)
         self._sync_properties()
         return c
-    
+
     def skip_tok(self) -> None:
         skip_char(self.state)
         self._sync_properties()
@@ -343,7 +357,7 @@ class YangParser(object):
     pos: Position
     top: yang.schema.Statement
     last_line: int
-    
+
     def __init__(self, text: str, ref=None, strict_quoting: bool=True):
         self.pos = Position(ref)
         self.last_line = 0
@@ -354,7 +368,7 @@ class YangParser(object):
             self.top = self._parse_statement(None)
         except EOF:
             raise ValueError("Unexpected end of file")
-    
+
     def _parse_statement(self, parent):
         # Use the tokenizer's internal state directly
         stmt = parse_statement(self.tokenizer.state, parent)

--- a/src/yang/parser.act
+++ b/src/yang/parser.act
@@ -1,4 +1,5 @@
 import re
+import testing
 
 import yang.schema
 import yang.syntax
@@ -8,271 +9,342 @@ class EOF(Exception):
         self.msg = "EOF"
         self.error_message = "EOF"
 
+# Mutable parser state representation
+class TokenizerState(object):
+    lines: list[str]
+    buf: str
+    offset: int
+    line_num: int
+    is_1_1: bool
+    strict_quoting: bool
+    errors: list[str]
+    
+    def __init__(self, text: str, line_num: int=0, strict_quoting: bool=True):
+        self.lines = text.splitlines(True)
+        self.buf = ''
+        self.offset = 0
+        self.line_num = line_num
+        self.is_1_1 = False
+        self.strict_quoting = strict_quoting
+        self.errors = []
+
+# Pure parsing functions that mutate state in place
+
+def readline(state: TokenizerState) -> None:
+    """Read next line from input, mutating state"""
+    if len(state.lines) == 0:
+        raise EOF()
+    state.buf = state.lines.pop(0)
+    state.line_num += 1
+    state.offset = 0
+
+def set_buf(state: TokenizerState, i: int) -> None:
+    """Update buffer position, mutating state"""
+    state.offset = state.offset + i
+    state.buf = state.buf[i:]
+
+def skip_whitespace_and_comments(state: TokenizerState) -> None:
+    """Skip whitespace and comments, mutating state"""
+    buflen = len(state.buf)
+    
+    # Skip whitespace
+    while True:
+        state.buf = state.buf.lstrip(" \n\t")
+        if state.buf == '':
+            readline(state)
+            buflen = len(state.buf)
+        else:
+            state.offset += (buflen - len(state.buf))
+            break
+    
+    # Skip comments
+    if len(state.buf) >= 2 and state.buf[0] == '/':
+        if state.buf[1] == '/':
+            # Line comment - skip to next line
+            readline(state)
+            skip_whitespace_and_comments(state)
+        elif state.buf[1] == '*':
+            # Block comment
+            i = state.buf.find('*/')
+            while i == -1:
+                readline(state)
+                i = state.buf.find('*/')
+            set_buf(state, i + 2)
+            skip_whitespace_and_comments(state)
+
+def parse_keyword(state: TokenizerState) -> (str, ?str):
+    """Parse a keyword, returning (identifier, prefix)"""
+    skip_whitespace_and_comments(state)
+    
+    m = re.match(yang.syntax.keyword, state.buf)
+    if m is not None:
+        set_buf(state, m.end_pos)
+        # Check separator
+        if (state.buf[0].isspace() or
+            (len(state.buf) >= 2 and state.buf[0] == '/' and state.buf[1] in ['/', '*']) or
+            (state.buf[0] in [';', r'{'])):
+            pass
+        else:
+            raise ValueError(f"expected separator, got: {state.buf[:6]}...")
+        
+        gident = m.group[3]
+        gprefix = m.group[2]
+        prefix = None
+        if gprefix is not None:
+            prefix = gprefix
+        if gident is not None:
+            return (gident, prefix)
+        raise ValueError("identifier or prefix is None")
+    else:
+        raise ValueError(f"illegal keyword: {state.buf}")
+
+def peek_char(state: TokenizerState) -> str:
+    """Peek at next character without consuming"""
+    skip_whitespace_and_comments(state)
+    if len(state.buf) == 0:
+        raise EOF()
+    return state.buf[0]
+
+def skip_char(state: TokenizerState) -> None:
+    """Skip one character"""
+    skip_whitespace_and_comments(state)
+    set_buf(state, 1)
+
+def parse_strings(state: TokenizerState, need_quote: bool=False) -> list[(str, str)]:
+    """Parse string arguments, returning strings"""
+    skip_whitespace_and_comments(state)
+    
+    if state.buf[0] == ';' or state.buf[0] == r'{' or state.buf[0] == r'}':
+        raise ValueError(f"expected argument, got: {state.buf[0]}")
+    
+    if state.buf[0] == '"' or state.buf[0] == "'":
+        # Quoted string
+        quote_char = state.buf[0]
+        strs = []
+        res = []
+        indentpos = state.offset
+        i = 1
+        
+        while True:
+            buflen = len(state.buf)
+            start = i
+            while i < buflen:
+                if state.buf[i] == quote_char:
+                    # End of string
+                    res.append(state.buf[start:i])
+                    strs.append((''.join(res), quote_char))
+                    set_buf(state, i + 1)
+                    
+                    # Check for concatenation
+                    skip_whitespace_and_comments(state)
+                    if state.buf[0] == '+':
+                        set_buf(state, 1)
+                        skip_whitespace_and_comments(state)
+                        nstrs = parse_strings(state, need_quote=True)
+                        strs.extend(nstrs)
+                    return strs
+                
+                elif (quote_char == '"' and
+                      state.buf[i] == '\\' and i < (buflen - 1)):
+                    # Handle escape sequences
+                    special = None
+                    if state.buf[i+1] == 'n':
+                        special = '\n'
+                    elif state.buf[i+1] == 't':
+                        special = '\t'
+                    elif state.buf[i+1] == '\"':
+                        special = '\"'
+                    elif state.buf[i+1] == '\\':
+                        special = '\\'
+                    elif state.strict_quoting and state.is_1_1:
+                        raise ValueError(f"illegal escape: {state.buf[i+1]}")
+                    elif state.strict_quoting:
+                        raise ValueError(f"illegal escape: {state.buf[i+1]}")
+                    
+                    if special is not None:
+                        res.append(state.buf[start:i])
+                        res.append(special)
+                        i = i + 1
+                        start = i + 1
+                i = i + 1
+            
+            # End of line in string
+            if i > 2 and state.buf[i-2] == '\r':
+                j = i - 3
+            else:
+                j = i - 2
+            k = j
+            while j >= 0 and state.buf[j].isspace():
+                j = j - 1
+            if j != k:
+                s = state.buf[start:j+1] + state.buf[k+1:i]
+            else:
+                s = state.buf[start:i]
+            res.append(s)
+            readline(state)
+            i = 0
+            indent = 0
+            if quote_char == '"':
+                # Skip indentation
+                buflen = len(state.buf)
+                while (i < buflen and state.buf[i].isspace() and
+                       indent <= indentpos):
+                    if state.buf[i] == '\t':
+                        indent = indent + 8
+                    else:
+                        indent = indent + 1
+                    i = i + 1
+                if indent > indentpos + 1:
+                    res.append(' ' * (indent - indentpos - 1))
+                elif i == buflen:
+                    i = 0
+        # Loop continues to next line
+        return []  # Should never reach here
+    
+    elif need_quote == True:
+        raise ValueError(f"expected quoted string, got: {state.buf}")
+    else:
+        # Unquoted string
+        buflen = len(state.buf)
+        i = 0
+        while i < buflen:
+            if (state.buf[i].isspace() or state.buf[i] == ';' or
+                state.buf[i] == '"' or state.buf[i] == "'" or
+                state.buf[i] == r'{' or state.buf[i] == r'}' or
+                (i + 1 < buflen and state.buf[i:i+2] in ['//', '/*', '*/'])):
+                res_str = state.buf[:i]
+                set_buf(state, i)
+                return [(res_str, '')]
+            i = i + 1
+        # End of buffer reached
+        res_str = state.buf
+        set_buf(state, i)
+        return [(res_str, '')]
+
+# Parser functions
+
+def parse_statement(state: TokenizerState, parent: ?yang.schema.Statement) -> yang.schema.Statement:
+    """Parse a single statement using mutable state"""
+    # Get keyword
+    identifier, prefix = parse_keyword(state)
+    
+    # Check for argument
+    tok = peek_char(state)
+    
+    if tok == r'{' or tok == ';':
+        arg = None
+    else:
+        argstrs = parse_strings(state)
+        ass = []
+        for a in argstrs:
+            ass.append(a.0)
+        arg = ''.join(ass)
+    
+    # Check for YANG 1.1
+    if identifier == 'yang-version' and arg is not None and arg == '1.1':
+        state.is_1_1 = True
+        state.strict_quoting = True
+    
+    stmt = yang.schema.Statement(identifier, arg, prefix)
+    
+    # Check for substatements
+    tok = peek_char(state)
+    
+    if tok == r'{':
+        skip_char(state)  # skip '{'
+        
+        while True:
+            p = peek_char(state)
+            if p == r'}':
+                break
+            substmt = parse_statement(state, stmt)
+            stmt.substatements.append(substmt)
+        
+        skip_char(state)  # skip '}'
+    elif tok == ';':
+        skip_char(state)  # skip ';'
+    else:
+        raise ValueError(f"incomplete statement, expected '{{' or ';', got: {tok}")
+    
+    return stmt
+
+def parse(text: str, strict_quoting: bool=True) -> yang.schema.Statement:
+    """Main entry point for parsing YANG text"""
+    state = TokenizerState(text, strict_quoting=strict_quoting)
+    try:
+        return parse_statement(state, None)
+    except EOF:
+        raise ValueError("Unexpected end of file")
+
+# Compatibility layer for existing code
 class Position(object):
     ref: ?str
     line: int
-    top: ?str
-    uses_pos: ?bool
-
+    
     def __init__(self, ref):
         self.ref = ref
         self.line = 0
         self.top = None
         self.uses_pos = None
 
-
 class YangTokenizer(object):
+    """Compatibility wrapper around functional tokenizer"""
+    state: TokenizerState
+    pos: Position
     buf: str
+    offset: int
     is_1_1: bool
-    errors: list[str]
     strict_quoting: bool
-
-    def __init__(self, text: str, pos, errors=[],
-                 strict_quoting: bool=True):
-        self.lines = text.splitlines(True)
+    
+    def __init__(self, text: str, pos, errors=[], strict_quoting: bool=True):
+        self.state = TokenizerState(text, strict_quoting=strict_quoting)
+        self.state.errors = errors
         self.pos = pos
-        self.buf = ''
+        self.buf = ""
         self.offset = 0
-        """Position on line.  Used to remove leading whitespace from strings."""
-
-        self.errors = errors
         self.is_1_1 = False
-        self.strict_quoting = strict_quoting
-
-    def readline(self) -> None:
-        if len(self.lines) == 0:
-            raise EOF()
-        self.buf = self.lines.pop(0)
-        self.pos.line += 1
-        self.offset = 0
-
-    def set_buf(self, i: int) -> None:
-        self.offset = self.offset + i
-        self.buf = self.buf[i:]
-
+        self.strict_quoting = False
+        self._sync_properties()
+    
+    def _sync_properties(self):
+        """Sync properties from state"""
+        self.buf = self.state.buf
+        self.offset = self.state.offset
+        self.is_1_1 = self.state.is_1_1
+        self.strict_quoting = self.state.strict_quoting
+        self.pos.line = self.state.line_num
+    
     def skip(self) -> None:
-        """Skip whitespace and count position"""
-        buflen = len(self.buf)
-
-        while True:
-            self.buf = self.buf.lstrip(" \n\t")
-            if self.buf == '':
-                self.readline()
-                buflen = len(self.buf)
-            else:
-                self.offset += (buflen - len(self.buf))
-                break
-
-        # do not keep comments in the syntax tree
-        # skip line comment
-        if self.buf[0] == '/':
-            if self.buf[1] == '/':
-                self.readline()
-                self.skip()
-        # skip block comment
-            elif self.buf[1] == '*':
-                i = self.buf.find('*/')
-                while i == -1:
-                    self.readline()
-                    i = self.buf.find('*/')
-                self.set_buf(i+2)
-                self.skip()
-
-    def get_comment(self, last_line: int) -> (?str, bool, bool):
-        """ret: string()"""
-        is_multi_line = False
-        is_line_end = False
-        self.skip()
-        offset = self.offset
-        m = re.match(yang.syntax.comment, self.buf)
-        if m is not None:
-            cmt = m.group[0]
-            self.set_buf(m.end_pos)
-            is_line_end = (last_line == self.pos.line)
-            # look for a multiline comment
-            if cmt is not None and cmt[:2] == '/*' and cmt[-2:] != '*/':
-                i = self.buf.find('*/')
-                is_multi_line = True
-                while i == -1:
-                    self.readline()
-                    # remove at most the same number of whitespace as
-                    # the comment start was indented
-                    j = 0
-                    while (j < offset and j < len(self.buf) and
-                           self.buf[j].isspace()):
-                        j = j + 1
-                    self.buf = self.buf[j:]
-                    cmt += '\n'+self.buf.replace('\n','')
-                    i = self.buf.find('*/')
-                self.set_buf(i+2)
-            return cmt, is_line_end, is_multi_line
-        else:
-            return None, is_line_end, is_multi_line
-
+        skip_whitespace_and_comments(self.state)
+        self._sync_properties()
+    
     def get_keyword(self) -> (identifier: str, prefix: ?str):
-        """ret: identifier | (prefix, identifier)"""
-        self.skip()
-
-        m = re.match(yang.syntax.keyword, self.buf)
-        if m is not None:
-            self.set_buf(m.end_pos)
-            # check the separator
-            if (self.buf[0].isspace() or
-                (self.buf[0] == '/' and self.buf[1] in ['/', '*']) or
-                (self.buf[0] in [';', r'{'])):
-                pass
-            else:
-                raise ValueError("expected separator, got: " + self.buf[:6] + "...")
-
-            gident = m.group[3]
-            gprefix = m.group[2]
-            prefix = None
-            if gprefix is not None:
-                prefix = gprefix
-            if gident is not None:
-                return (identifier=gident, prefix=prefix)
-            raise ValueError("identifier or prefix is None")
-        else:
-            raise ValueError("illegal keyword: {self.buf}")
-
-    def peek(self) -> str:
-        """Return next real character in input stream.
-
-        Skips whitespace and comments, and returns next character
-        without consuming it.  Use skip_tok() to consume the characater.
-        """
-        self.skip()
-        try:
-            return self.buf[0]
-        except:
-            raise EOF()
-
-    def skip_tok(self) -> None:
-        self.skip()
-        self.set_buf(1)
-
+        ident, pref = parse_keyword(self.state)
+        self._sync_properties()
+        return (identifier=ident, prefix=pref)
+    
     def get_strings(self, need_quote: bool=False) -> list[(str, str)]:
-        """ret: string"""
-        self.skip()
-
-        if self.buf[0] == ';' or self.buf[0] == r'{' or self.buf[0] == r'}':
-            raise ValueError("expected argument, got: {self.buf[0]}")
-
-        if self.buf[0] == '"' or self.buf[0] == "'":
-            # for double-quoted string,  loop over string and translate
-            # escaped characters.  also strip leading whitespace as
-            # necessary.
-            # for single-quoted string, keep going until end quote is found.
-            quote_char = self.buf[0]
-            # collect output in strs (list of strings)
-            strs = []
-            res = []
-            # remember position of " character
-            indentpos = self.offset
-            i = 1
-            while True:
-                buflen = len(self.buf)
-                start = i
-                while i < buflen:
-                    if self.buf[i] == quote_char:
-                        # end-of-string; copy the buf to output
-                        res.append(self.buf[start:i])
-                        strs.append((''.join(res), quote_char))
-                        # and trim buf
-                        self.set_buf(i+1)
-                        # check for '+' operator
-                        self.skip()
-                        if self.buf[0] == '+':
-                            self.set_buf(1)
-                            self.skip()
-                            nstrs = self.get_strings(need_quote=True)
-                            strs.extend(nstrs)
-                        return strs
-                    elif (quote_char == '"' and
-                          self.buf[i] == '\\' and i < (buflen-1)):
-                        # check for special characters
-                        special = None
-                        if self.buf[i+1] == 'n':
-                            special = '\n'
-                        elif self.buf[i+1] == 't':
-                            special = '\t'
-                        elif self.buf[i+1] == '\"':
-                            special = '\"'
-                        elif self.buf[i+1] == '\\':
-                            special = '\\'
-                        elif self.strict_quoting and self.is_1_1:
-                            raise ValueError("illegal escape: {self.buf[i+1]}")
-                        elif self.strict_quoting:
-                            raise ValueError("illegal escape: {self.buf[i+1]}")
-                        if special is not None:
-                            res.append(self.buf[start:i])
-                            res.append(special)
-                            i = i + 1
-                            start = i + 1
-                    i = i + 1
-                # end-of-line
-                # first strip trailing whitespace in double quoted strings
-                # pre: self.buf[i-1] == '\n'
-                if i > 2 and self.buf[i-2] == '\r':
-                    j = i - 3
-                else:
-                    j = i - 2
-                k = j
-                while j >= 0 and self.buf[j].isspace():
-                    j = j - 1
-                if j != k: # we found trailing whitespace
-                    s = self.buf[start:j+1] + self.buf[k+1:i]
-                else:
-                    s = self.buf[start:i]
-                res.append(s)
-                self.readline()
-                i = 0
-                indent = 0
-                if quote_char == '"':
-                    # skip whitespace used for indentation
-                    buflen = len(self.buf)
-                    while (i < buflen and self.buf[i].isspace() and
-                           indent <= indentpos):
-                        if self.buf[i] == '\t':
-                            indent = indent + 8
-                        else:
-                            indent = indent + 1
-                        i = i + 1
-                    if indent > indentpos + 1:
-                        res.append(' ' * (indent - indentpos - 1))
-                    elif i == buflen:
-                        # whitespace only on this line; keep it as is
-                        i = 0
-        elif need_quote == True:
-            raise ValueError("expected quoted string, got: {self.buf}")
-        else:
-            # unquoted string
-            buflen = len(self.buf)
-            i = 0
-            while i < buflen:
-                if (self.buf[i].isspace() or self.buf[i] == ';' or
-                    self.buf[i] == '"' or self.buf[i] == "'" or
-                    self.buf[i] == r'{' or self.buf[i] == r'}' or
-                    self.buf[i:i+2] == '//' or self.buf[i:i+2] == '/*' or
-                    self.buf[i:i+2] == '*/'):
-                    res = self.buf[:i]
-                    self.set_buf(i)
-                    return [(res, '')]
-                i = i + 1
-        return []
-
-class Context(object):
-    def __init__(self):
-        self.error = []
-
+        strs = parse_strings(self.state, need_quote)
+        self._sync_properties()
+        return strs
+    
+    def peek(self) -> str:
+        c = peek_char(self.state)
+        self._sync_properties()
+        return c
+    
+    def skip_tok(self) -> None:
+        skip_char(self.state)
+        self._sync_properties()
 
 class YangParser(object):
-    pos: Position
+    """Compatibility wrapper around functional parser"""
     tokenizer: YangTokenizer
+    pos: Position
     top: yang.schema.Statement
-
+    last_line: int
+    
     def __init__(self, text: str, ref=None, strict_quoting: bool=True):
-        self.ctx = Context()
         self.pos = Position(ref)
         self.last_line = 0
         self.tokenizer = YangTokenizer(text, self.pos, strict_quoting=strict_quoting)
@@ -282,52 +354,167 @@ class YangParser(object):
             self.top = self._parse_statement(None)
         except EOF:
             raise ValueError("Unexpected end of file")
-
+    
     def _parse_statement(self, parent):
-        keywd = self.tokenizer.get_keyword()
-        # check for argument
-        tok = self.tokenizer.peek()
-        if tok == r'{' or tok == ';':
-            arg = None
-            argstrs = None
-        else:
-            argstrs = self.tokenizer.get_strings()
-            ass = []
-            for a in argstrs:
-                ass.append(a.0)
-            arg = ''.join(ass)
-        # check for YANG 1.1
-        if keywd.identifier == 'yang-version' and arg is not None and arg == '1.1':
-            self.tokenizer.is_1_1 = True
-            self.tokenizer.strict_quoting = True
-
-        #stmt = new_stmt(keywd.identifier, keywd.prefix, arg)
-        stmt = yang.schema.Statement(keywd.identifier, arg, keywd.prefix)
-
-        # check for substatements
-        tok = self.tokenizer.peek()
-        if tok == r'{':
-            self.tokenizer.skip_tok() # skip the '{'
-            self.last_line = self.pos.line
-            # TODO: the commented out while loop here was the original used, how are the following 4 lines not equivalent?
-            #while self.tokenizer.peek() != '}':
-            while True:
-                p = self.tokenizer.peek()
-                if p == r'}':
-                    break
-                substmt = self._parse_statement(stmt)
-                stmt.substatements.append(substmt)
-            self.tokenizer.skip_tok() # skip the '}'
-        elif tok == ';':
-            self.tokenizer.skip_tok() # skip the ';'
-        else:
-#            error.err_add(self.ctx.errors, self.pos, 'INCOMPLETE_STATEMENT',
-#                          (keywd, tok))
-#            raise error.Abort
-            raise ValueError("incomplete statement, expected '{{' or ';', got: {tok}")
-        self.last_line = self.pos.line
+        # Use the tokenizer's internal state directly
+        stmt = parse_statement(self.tokenizer.state, parent)
+        self.tokenizer._sync_properties()
+        self.last_line = self.tokenizer.state.line_num
         return stmt
 
-def parse(text: str, strict_quoting: bool=True) -> yang.schema.Statement:
-    parser = YangParser(text, strict_quoting=strict_quoting)
-    return parser.top
+
+# Unit tests for parser components
+
+def _test_tokenizer_skip_whitespace():
+    """Test whitespace skipping"""
+    text = "   \n  module"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    tok.skip()
+    testing.assertEqual("module", tok.buf, "Should skip whitespace")
+
+def _test_tokenizer_skip_line_comment():
+    """Test line comment skipping"""
+    text = "// this is a comment\nmodule"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    tok.skip()
+    testing.assertEqual("module", tok.buf[:6], "Should skip line comment")
+
+def _test_tokenizer_skip_block_comment():
+    """Test block comment skipping"""
+    text = "/* block\n   comment */module"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    tok.skip()
+    testing.assertEqual("module", tok.buf[:6], "Should skip block comment")
+
+def _test_tokenizer_get_keyword_simple():
+    """Test simple keyword parsing"""
+    text = "module test"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    kw = tok.get_keyword()
+    testing.assertEqual("module", kw.identifier, "Should parse keyword")
+    testing.assertEqual(None, kw.prefix, "Should have no prefix")
+
+def _test_tokenizer_get_keyword_with_prefix():
+    """Test keyword with prefix"""
+    text = "inet:port-number ;"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    kw = tok.get_keyword()
+    testing.assertEqual("port-number", kw.identifier, "Should parse identifier")
+    testing.assertEqual("inet", kw.prefix, "Should parse prefix")
+
+def _test_tokenizer_get_strings_unquoted():
+    """Test unquoted string parsing"""
+    text = "1.1;"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    strs = tok.get_strings()
+    testing.assertEqual(1, len(strs), "Should get one string")
+    testing.assertEqual("1.1", strs[0].0, "Should parse unquoted string")
+    testing.assertEqual("", strs[0].1, "Should have empty quote char")
+
+def _test_tokenizer_get_strings_double_quoted():
+    """Test double-quoted string parsing"""
+    text = '"hello world";'
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    strs = tok.get_strings()
+    testing.assertEqual(1, len(strs), "Should get one string")
+    testing.assertEqual("hello world", strs[0].0, "Should parse double-quoted string")
+    testing.assertEqual('"', strs[0].1, "Should have double quote char")
+
+def _test_tokenizer_get_strings_single_quoted():
+    """Test single-quoted string parsing"""
+    text = "'hello world';"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    strs = tok.get_strings()
+    testing.assertEqual(1, len(strs), "Should get one string")
+    testing.assertEqual("hello world", strs[0].0, "Should parse single-quoted string")
+    testing.assertEqual("'", strs[0].1, "Should have single quote char")
+
+def _test_tokenizer_get_strings_concatenated():
+    """Test string concatenation with + operator"""
+    text = '"hello" + "world";'
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    strs = tok.get_strings()
+    testing.assertEqual(2, len(strs), "Should get two strings")
+    testing.assertEqual("hello", strs[0].0, "First string")
+    testing.assertEqual("world", strs[1].0, "Second string")
+
+def _test_tokenizer_peek():
+    """Test peek functionality"""
+    text = r"  // comment" + "\n  " + r"{ test"
+    pos = Position("test")
+    tok = YangTokenizer(text, pos)
+    c = tok.peek()
+    testing.assertEqual(r"{", c, "Should peek past whitespace and comments")
+    # peek should not consume
+    c2 = tok.peek()
+    testing.assertEqual(r"{", c2, "Peek should not consume")
+
+def _test_parser_simple_statement():
+    """Test parsing a simple statement"""
+    text = 'description "test";'
+    stmt = parse(text)
+    testing.assertEqual("description", stmt.kw, "Should parse keyword")
+    testing.assertEqual("test", stmt.arg, "Should parse argument")
+    testing.assertEqual(0, len(stmt.substatements), "Should have no substatements")
+
+def _test_parser_statement_no_arg():
+    """Test parsing statement without argument"""
+    text = 'input;'
+    stmt = parse(text)
+    testing.assertEqual("input", stmt.kw, "Should parse keyword")
+    testing.assertEqual(None, stmt.arg, "Should have no argument")
+
+def _test_parser_statement_with_substatements():
+    """Test parsing statement with substatements"""
+    text = r'''container test {
+        description "test container";
+        leaf foo {
+            type string;
+        }
+    }'''
+    stmt = parse(text)
+    testing.assertEqual("container", stmt.kw, "Should parse container")
+    testing.assertEqual("test", stmt.arg, "Should parse container name")
+    testing.assertEqual(2, len(stmt.substatements), "Should have 2 substatements")
+    testing.assertEqual("description", stmt.substatements[0].kw, "First should be description")
+    testing.assertEqual("leaf", stmt.substatements[1].kw, "Second should be leaf")
+
+def _test_parser_prefixed_statement():
+    """Test parsing statement with prefix"""
+    text = 'myext:custom-stmt "value";'
+    stmt = parse(text)
+    testing.assertEqual("custom-stmt", stmt.kw, "Should parse keyword")
+    testing.assertEqual("myext", stmt.prefix, "Should parse prefix")
+    testing.assertEqual("value", stmt.arg, "Should parse argument")
+
+def _test_parser_empty_container():
+    """Test parsing empty container"""
+    text = r'container test { }'
+    stmt = parse(text)
+    testing.assertEqual("container", stmt.kw, "Should parse container")
+    testing.assertEqual(0, len(stmt.substatements), "Should have no substatements")
+
+def _test_parser_string_concatenation():
+    """Test parsing concatenated strings"""
+    text = 'description "This is a " + "concatenated " + "string";'
+    stmt = parse(text)
+    testing.assertEqual("description", stmt.kw, "Should parse keyword")
+    testing.assertEqual("This is a concatenated string", stmt.arg, "Should concatenate strings")
+
+def _test_parser_error_unexpected_eof():
+    """Test error handling for unexpected EOF"""
+    text = r'container test {'
+    try:
+        parse(text)
+        testing.error("Should have raised ValueError for unexpected EOF")
+    except ValueError as e:
+        testing.assertIn("end of file", str(e).lower(), "Should mention EOF")

--- a/src/yang/syntax.act
+++ b/src/yang/syntax.act
@@ -1,5 +1,0 @@
-
-identifier = r"[_A-Za-z][._\-A-Za-z0-9]*"
-prefix = identifier
-keyword = '((' + prefix + '):)?(' + identifier + ')'
-comment = r'(/\*([^*]|[\r\n\s]|(\*+([^*/]|[\r\n\s])))*\*+/)|(//.*)|(/\*.*)'


### PR DESCRIPTION
Dug out this old branch. The combined readability refactor with removing regex matching yields a 35% improvement for large schemas (cisco-xr: 45s -> 29s). Part of #249 