### PR TITLE
Refactor from_json_path

### DIFF
--- a/src/yang/json.act
+++ b/src/yang/json.act
@@ -1,4 +1,5 @@
 import base64
+import uri
 
 from yang.identityref import Identityref, PartialIdentityref
 from yang.type import Decimal
@@ -182,14 +183,87 @@ def from_json(root: yang.schema.DRoot, data: dict[str, ?value], loose: bool=Fals
     return from_data(root, data, type_narrower, loose, root_path)
 
 
+def _resolve_json_path_key_leaf(list_node: yang.schema.DList, key_name: str, path: list[PathElement]) -> yang.schema.DNodeLeaf:
+    key_node = list_node.get(key_name, allow_unqualified=False)
+    if isinstance(key_node, yang.schema.DNodeLeaf):
+        return key_node
+    raise ValueError("Invalid list key schema at {format_schema_path(path)}: {key_name}")
+
+
+def _coerce_json_path_key_value(root: yang.schema.DRoot, key_leaf: yang.schema.DNodeLeaf, raw_value: ?value, path: list[PathElement]) -> value:
+    typed_value = try_parse_json_value(raw_value, key_leaf, key_leaf.type_, path, root)
+    if typed_value is not None:
+        return typed_value.val
+    raise YangValidationError(path, key_leaf.type_, raw_value)
+
+
+def resolve_json_path(root: yang.schema.DRoot, path: list[str]) -> list[PathElement]:
+    """Resolve a JSON/RESTCONF path against a schema, returning traversed nodes.
+
+    Each path segment is either a node name (optionally "module:name") or
+    comma-separated key values for list nodes. The function walks the schema
+    tree and returns a PathElement for each resolved node. For list nodes the
+    PathElement includes the schema-coerced key values dict. A list node path
+    segment must include all key values.
+
+    Args:
+        root: Root schema node
+        path: Path segments, e.g. ["mod:c1", "list1", "key1", "inner"]
+
+    Returns:
+        List of PathElement starting with the root, followed by each traversed
+        schema node.
+    """
+    result = [PathElement(root)]
+    s: yang.schema.DNodeInner = root
+    i = 0
+    while i < len(path):
+        point = path[i]
+        local_name, module = parse_qualified_name(point)
+        child = s.get(local_name, module=module, allow_unqualified=False)
+
+        if isinstance(child, yang.schema.DList):
+            # Next segment is comma-separated key values
+            i += 1
+            if i < len(path):
+                key_strs = [uri.unquote(k) for k in path[i].split(",")]
+                # RESTCONF element paths must fully identify a keyed list entry.
+                if len(key_strs) != len(child.key):
+                    raise ValueError("Invalid list key values at {format_schema_path(result + [PathElement(child)])}: expected {len(child.key)} value(s), got {len(key_strs)}")
+                keys_dict = {}
+                for key_name, key_val in zip(child.key, key_strs):
+                    key_leaf = _resolve_json_path_key_leaf(child, key_name, result + [PathElement(child)])
+                    key_path = result + [PathElement(child), PathElement(key_leaf)]
+                    keys_dict[key_name] = _coerce_json_path_key_value(root, key_leaf, key_val, key_path)
+                result.append(PathElement(child, keys=keys_dict))
+            else:
+                # TODO: oper data lists may be keyless
+                # A keyed list node in the path must always be followed by its key tuple.
+                raise ValueError("Missing list key values at {format_schema_path(result + [PathElement(child)])}")
+            s = child
+        elif isinstance(child, yang.schema.DNodeInner):
+            result.append(PathElement(child))
+            s = child
+        else:
+            # Terminal node (leaf, leaf-list) — path must end here
+            if i + 1 < len(path):
+                raise ValueError("Invalid JSON path to non-inner node at {format_schema_path(result + [PathElement(child)])}: {point}")
+            result.append(PathElement(child))
+            i += 1
+            break
+
+        i += 1
+    return result
+
+
 def from_json_path(root: yang.schema.DRoot, data: dict[str, ?value], path: list[str], op: str="merge", loose: bool=False) -> yang.gdata.Container:
     r"""Convert JSON to a gdata tree rooted at the schema root, with data applied
     at the specified path.
 
     Unlike from_data which can create partial trees starting at any schema node,
     this function ALWAYS creates a sparse tree from the root of the schema,
-    meaning that it  only creates containers and list entries required to hold
-    the data at the specified path location. This is useful for NETCONF/RESTCONF
+    meaning that it only creates containers and list entries required to hold
+    the data at the specified path location. This is useful for RESTCONF
     operations where the payload is a subtree rooted in the provided query path.
 
     Args:
@@ -198,6 +272,7 @@ def from_json_path(root: yang.schema.DRoot, data: dict[str, ?value], path: list[
         path: List of path elements to navigate from root, e.g. ["mod1:c1", "list1", "key1", "inner"]
               - Container/List names "name" or "module:name"
               - List entries: comma-separated key values, e.g. "key1,key2"
+              - Keyed lists require an explicit key segment with all key values
         op: Operation to perform - "merge" (default) or "remove"
         loose: Whether to allow missing mandatory fields
 
@@ -219,98 +294,80 @@ def from_json_path(root: yang.schema.DRoot, data: dict[str, ?value], path: list[
             return v
         raise ValueError("Value is not a dict: {type(v)}")
 
-    result = _from_json_path_recursive(root, root, data, type_narrower, path, op, loose, [PathElement(root)], True, True)
-    # The top-level call always returns a Container because:
-    # - If path is empty, from_data returns Container
-    # - If path is non-empty, we wrap in Container
-    if isinstance(result, yang.gdata.Container):
-        return result
+    path_elements = resolve_json_path(root, path)
+    n = len(path_elements)
+
+    def _set_ns(i: int) -> bool:
+        if i == 0:
+            return True
+        return path_elements[i - 1].node.namespace != path_elements[i].node.namespace
+
+    # First build the terminal (innermost) node
+    last = path_elements[n - 1]
+    last_node = last.node
+
+    if isinstance(last_node, yang.schema.DNodeInner) and (isinstance(last_node, yang.schema.DRoot) or isinstance(last_node, yang.schema.DContainer)):
+        if op == "merge":
+            inner = from_data_recursive(root, last_node, data, type_narrower, loose=loose, set_ns=_set_ns(n - 1), spath=path_elements)
+        elif op == "remove":
+            inner = yang.gdata.Absent()
+        else:
+            raise ValueError("Invalid operation at {format_schema_path(path_elements)}: {op}")
+
+    elif isinstance(last_node, yang.schema.DList):
+        data_with_keys = dict(data.items())
+        keys = last.keys
+        if keys is not None:
+            for key_name in last_node.key:
+                key_val = keys.get(key_name)
+                if key_val is not None:
+                    if key_name not in data_with_keys:
+                        # The URI already identifies the target list entry, so a list payload may omit duplicate key leaves.
+                        data_with_keys[key_name] = key_val
+                    else:
+                        key_leaf = _resolve_json_path_key_leaf(last_node, key_name, path_elements)
+                        payload_key_path = path_elements + [PathElement(key_leaf)]
+                        payload_key_val = _coerce_json_path_key_value(root, key_leaf, data_with_keys[key_name], payload_key_path)
+                        # If the payload repeats a key leaf, it must match the value in the URI
+                        if not yang.gdata.vals_equal(payload_key_val, key_val):
+                            raise ValueError("Key value mismatch between path and payload at {format_schema_path(payload_key_path)}")
+        else:
+            raise ValueError("Invalid JSON path invariant at {format_schema_path(path_elements)}: list target is missing key values")
+
+        element_gdata = from_data_recursive(root, last_node, data_with_keys, type_narrower, loose, set_ns=False, spath=path_elements)
+        maybe_ns = _set_ns(n - 1) and last_node.namespace != ""
+        if op == "merge":
+            inner = yang.gdata.List(fq_list_keys(last_node), [element_gdata], user_order(last_node.ordered_by), ns=last_node.namespace if maybe_ns else None, module=last_node.module if maybe_ns else None)
+        elif op == "remove":
+            inner = yang.gdata.List(fq_list_keys(last_node), [yang.gdata.Absent(element_gdata.key_children(fq_list_keys(last_node)))], user_order(last_node.ordered_by), ns=last_node.namespace if maybe_ns else None, module=last_node.module if maybe_ns else None)
+        else:
+            raise ValueError("Invalid operation at {format_schema_path(path_elements)}: {op}")
+    else:
+        raise ValueError("Unknown schema node type at {format_schema_path(path_elements)}: {type(last_node)}")
+
+    # Now wrap the terminal node inside-out from terminal back to root, if there
+    # are more nodes in path_elements before the terminal node. Here "inner" is
+    # guaranteed to be a gdata.Node
+    for i in range(n - 2, -1, -1):
+        s = path_elements[i].node
+        child_node = path_elements[i + 1].node
+        maybe_ns = _set_ns(i) and s.namespace != ""
+
+        if isinstance(s, yang.schema.DNodeInner) and (isinstance(s, yang.schema.DRoot) or isinstance(s, yang.schema.DContainer)):
+            inner = yang.gdata.Container({fqname(child_node): inner}, ns=s.namespace if maybe_ns else None, module=s.module if maybe_ns else None)
+
+        elif isinstance(s, yang.schema.DList):
+            keys = path_elements[i].keys
+            if keys is not None:
+                element_gdata = from_data_recursive(root, s, keys, type_narrower, loose, set_ns=False, spath=path_elements[:i+1])
+                element_gdata.children[fqname(child_node)] = inner
+                inner = yang.gdata.List(fq_list_keys(s), [element_gdata], user_order(s.ordered_by), ns=s.namespace if maybe_ns else None, module=s.module if maybe_ns else None)
+            else:
+                raise ValueError("Invalid JSON path invariant at {format_schema_path(path_elements[:i+1])}: ancestor list is missing key values")
+        else:
+            raise ValueError("Unknown schema node type at {format_schema_path(path_elements[:i+1])}: {type(s)}")
+
+    if isinstance(inner, yang.gdata.Container):
+        return inner
     else:
         raise ValueError("Internal error: expected Container at root level")
-
-
-def _from_json_path_recursive(root: yang.schema.DRoot, s: yang.schema.DNodeInner, data: dict[str, ?value], type_narrower: (?value) -> dict[str, ?value], path: list[str], op: str, loose: bool, current_path: list[PathElement], top: bool, set_ns: bool) -> yang.gdata.Node:
-    if isinstance(s, yang.schema.DRoot) or isinstance(s, yang.schema.DContainer):
-        if len(path) == 0:
-            # Base case: no more path elements, process the data
-            if op == "merge":
-                # TODO: set_ns??
-                return from_data_recursive(root, s, data, type_narrower, loose=loose, set_ns=set_ns, spath=current_path)
-            elif op == "remove":
-                return yang.gdata.Absent()
-            raise ValueError("Invalid operation at {format_schema_path(current_path)}: {op}")
-        else:   # len(path) > 0
-            # More path to traverse - create a container with just the next child
-            point = path[0]
-            rest_path = path[1:]
-
-            local_name, module = parse_qualified_name(point)
-            child = s.get(local_name, module=module, allow_unqualified=False)
-
-            if isinstance(child, yang.schema.DNodeInner):
-                # Recursively process the child node
-                perhaps = True if (top or set_ns) and s.namespace != "" else False
-                cchild = _from_json_path_recursive(root, child, data, type_narrower, rest_path, op, loose, current_path + [PathElement(child)], False, s.namespace != child.namespace)
-                # Create a container with just this one child
-                return yang.gdata.Container({fqname(child): cchild}, ns=s.namespace if perhaps else None, module=s.module if perhaps else None)
-
-            # Path tries to go through a leaf - this is an error
-            raise ValueError("Invalid JSON path to non-inner node at {format_schema_path(current_path + [PathElement(child)])}: {point}")
-    elif isinstance(s, yang.schema.DList):
-        if len(path) == 1:
-            # Base case: keys are the last path element
-            point = path[0]
-            keys = point.split(",")
-            # Check that all keys are present in payload.
-            # If present, they must equal the keys in the path
-            # If not present, fill in from path
-            data_with_keys = dict(data.items())
-            for key in s.key:
-                if key not in data_with_keys:
-                    data_with_keys[key] = keys.pop(0)
-                else:
-                    if str(data_with_keys[key]) != keys.pop(0):
-                        raise ValueError("Key value mismatch between path and payload at {format_schema_path(current_path)}")
-            element_gdata = from_data_recursive(root, s, data_with_keys, type_narrower, loose, set_ns=False, spath=current_path + [PathElement(s, {k: v for k, v in data_with_keys.items() if k in s.key and v is not None})])
-            elements = []
-            if op == "merge":
-                elements.append(element_gdata)
-            elif op == "remove":
-                elements.append(yang.gdata.Absent(element_gdata.key_children(fq_list_keys(s))))
-            else:
-                raise ValueError("Invalid operation at {format_schema_path(current_path)}: {op}")
-            perhaps = True if (top or set_ns) and s.namespace != "" else False
-            return yang.gdata.List(fq_list_keys(s), elements, user_order(s.ordered_by), ns=s.namespace if perhaps else None, module=s.module if perhaps else None)
-        elif len(path) > 1:
-            # The path crosses this list element and references another inner node
-            point = path[0]
-            rest_path = path[1:]
-
-            # First create this list with a single element with only key children.
-            # For nested lists, we always use "merge" for intermediate elements.
-            slist = _from_json_path_recursive(root, s, {}, type_narrower, [point], "merge", loose, current_path, top, set_ns)
-
-            # The return type must be a List, we just requested it
-            if isinstance(slist, yang.gdata.List):
-                # Now process the rest of the path following the structural list keys
-                child_point = rest_path[0]
-                child_rest_path = rest_path[1:]
-
-                local_name, module = parse_qualified_name(child_point)
-
-                lchild = s.get(local_name, module=module, allow_unqualified=False)
-                if isinstance(lchild, yang.schema.DNodeInner):
-                    # Now extract gdata for the rest of the path, from the child point
-                    inner_result = _from_json_path_recursive(root, lchild, data, type_narrower, child_rest_path, op, loose, current_path + [PathElement(lchild)], False, False)
-
-                    # Add it to the structural list element, next to the existing keys
-                    slist.elements[0].children[fqname(lchild)] = inner_result
-                    return slist
-                else:
-                    raise ValueError("Node at {format_schema_path(current_path + [PathElement(lchild)])} is not inner: {type(lchild)}")
-
-            raise ValueError("unreachable")
-        raise ValueError("Unable to resolve path at {format_schema_path(current_path)}: no keys provided")
-
-
-    raise ValueError("Unknown schema node type at {format_schema_path(current_path)}: {type(s)}")

--- a/src/yang/test_data.act
+++ b/src/yang/test_data.act
@@ -5,9 +5,9 @@ import yang
 import yang.adata
 import yang.gdata
 
-from yang.data import YangValidationError
+from yang.data import YangValidationError, format_schema_path
 from yang.xml import from_xml
-from yang.json import from_json, from_json_path
+from yang.json import from_json, from_json_path, resolve_json_path
 from yang.identityref import Identityref, PartialIdentityref
 from yang.type import Decimal, Ranges
 
@@ -557,6 +557,38 @@ def _test_json_path_basic():
     testing.assertEqual(gd.prsrc(), expected.prsrc())
 
 
+def _test_json_path_from_root():
+    """Test from_json_path with empty path queries from root"""
+    y1 = r"""module y1 {
+  namespace "urn:example:y1";
+  prefix y1;
+
+  container c1 {
+    leaf l1 {
+      type string;
+    }
+    container c2 {
+      leaf l2 {
+        type string;
+      }
+    }
+  }
+}"""
+
+    s = yang.compile([y1])
+
+    gd = from_json_path(s, {"y1:c1": {"l1": "hello", "c2": {"l2": "world"}}}, [])
+    expected = yang.gdata.Container({
+        yang.gdata.Id("urn:example:y1", "c1"): yang.gdata.Container({
+            yang.gdata.Id("urn:example:y1", "l1"): yang.gdata.Leaf("hello"),
+            yang.gdata.Id("urn:example:y1", "c2"): yang.gdata.Container({
+                yang.gdata.Id("urn:example:y1", "l2"): yang.gdata.Leaf("world")
+            })
+        }, ns='urn:example:y1', module='y1')
+    })
+    testing.assertEqual(gd.prsrc(), expected.prsrc())
+
+
 def _test_json_path_qualified_names():
     """Test JSON path with module-qualified names"""
     mod1 = r"""module mod1 {
@@ -787,6 +819,41 @@ def _test_json_path_nested_lists():
         }, ns='urn:example:y1', module='y1')
     })
     testing.assertEqual(gd2.prsrc(), expected2.prsrc())
+
+
+def _test_json_path_coerces_list_keys_to_schema_types():
+    y1 = r"""module y1 {
+  namespace "urn:example:y1";
+  prefix y1;
+
+  container c1 {
+    list item {
+      key "id";
+      leaf id {
+        type uint32;
+      }
+      leaf value {
+        type string;
+      }
+    }
+  }
+}"""
+
+    s = yang.compile([y1])
+
+    gd = from_json_path(s, {"id": 42, "value": "typed"}, ["y1:c1", "item", "42"])
+    expected = yang.gdata.Container({
+        yang.gdata.Id("urn:example:y1", "c1"): yang.gdata.Container({
+            yang.gdata.Id("urn:example:y1", "item"): yang.gdata.List([yang.gdata.Id("urn:example:y1", "id")], elements=[
+                yang.gdata.Container({
+                    yang.gdata.Id("urn:example:y1", "id"): yang.gdata.Leaf(u64(42)),
+                    yang.gdata.Id("urn:example:y1", "value"): yang.gdata.Leaf("typed")
+                })
+            ])
+        }, ns='urn:example:y1', module='y1')
+    })
+    testing.assertEqual(gd.prsrc(), expected.prsrc())
+
 
 def _test_netconf_remove_container():
     """NETCONF remove on a container produces Absent"""
@@ -1296,6 +1363,78 @@ def _test_json_path_container_list_container():
         }, ns='urn:example:y1', module='y1')
     })
     testing.assertEqual(gd2.prsrc(), expected2.prsrc())
+
+
+def _test_resolve_json_path_nested_lists():
+    """Test path resolution through nested lists"""
+    y1 = r"""module y1 {
+  namespace "urn:example:y1";
+  prefix y1;
+
+  container c1 {
+    list outer {
+      key "outer-key";
+      leaf outer-key {
+        type string;
+      }
+      list inner {
+        key "inner-key";
+        leaf inner-key {
+          type string;
+        }
+        leaf value {
+          type string;
+        }
+      }
+    }
+  }
+}"""
+    s = yang.compile([y1])
+
+    elems = resolve_json_path(s, ["y1:c1", "outer", "k1", "inner", "k2", "value"])
+    path_str = format_schema_path(elems)
+    testing.assertEqual(path_str, "/c1/outer[outer-key='k1']/inner[inner-key='k2']/value")
+
+
+def _test_resolve_json_path_rejects_under_specified_list_instances():
+    """Reject keyed list paths unless the full key tuple is provided."""
+    y1 = r"""module y1 {
+  namespace "urn:example:y1";
+  prefix y1;
+
+  container c1 {
+    list single {
+      key "name";
+      leaf name {
+        type string;
+      }
+    }
+    list multi {
+      key "k1 k2";
+      leaf k1 {
+        type string;
+      }
+      leaf k2 {
+        type string;
+      }
+    }
+  }
+}"""
+
+    s = yang.compile([y1])
+
+    try:
+        resolve_json_path(s, ["y1:c1", "single"])
+        testing.error("Should have raised ValueError for missing keyed list segment")
+    except ValueError as e:
+        testing.assertIn("Missing list key values", e.error_message)
+
+    try:
+        resolve_json_path(s, ["y1:c1", "multi", "item1"])
+        testing.error("Should have raised ValueError for incomplete list key tuple")
+    except ValueError as e:
+        testing.assertIn("expected 2 value(s), got 1", e.error_message)
+
 
 def _test_identityref():
     # Extended test case from https://github.com/CESNET/libyang/issues/1009


### PR DESCRIPTION
Extract the RESTCONF resource identifier parsing from the query string to a separate function - resolve_json_path. The function builds a list[PathElement] path, ensuring that list nodes also include all required keys.

The from_json_path function uses resolve_json_path to build the sparse gdata tree up to the node before the last node (terminal in the query string). The sparse gdata tree is build from inside out, starting from the last node. This IMHO makes the code easier to reason about because the previous recursive implementation mixed the terminal node logic with recursion.

Part of https://github.com/orchestron-orchestrator/sorespo/issues/228