### PR TITLE
Refactor subscriptions

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -895,7 +895,6 @@ class DNodeInner(DNode):
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
             res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
-            res.append("    var tree: ?yang.gdata.Node = root().to_gdata()")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output
@@ -940,29 +939,6 @@ class DNodeInner(DNode):
                 else:
                     res.append("        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)")
                 res.append("")
-
-            res.append("    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:")
-            res.append("        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):")
-            res.append("            if n is not None:")
-            res.append("                prev = tree")
-            res.append("                # TODO: fix yang.gdata.patch() to accept None as old tree")
-            res.append("                base = prev if prev is not None else yang.gdata.Container({{}})")
-            res.append("                tree2 = yang.gdata.patch(base, n)")
-            res.append("")
-            res.append("                if tree2 is not None:")
-            res.append("                    d = yang.gdata.diff(prev, tree2)")
-            res.append("                    if d is not None:")
-            res.append("                        cb(root.from_gdata(tree2), err)")
-            res.append("                    tree = tree2")
-            res.append("                else:")
-            res.append("                    if prev is not None:")
-            res.append("                        cb(root.from_gdata(None), err)")
-            res.append("                    tree = None")
-            res.append("            else:")
-            res.append("                cb(None, err)")
-            res.append("")
-            res.append("        return tp.subscribe(cb_wrap, filt, opts)")
-            res.append("")
 
             res.append("")
             res.append("")

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -178,7 +178,6 @@ class foo__r1__output(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
-    var tree: ?yang.gdata.Node = root().to_gdata()
     def r1(cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -193,27 +192,5 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
             gdata_inp = yang.adata.from_adata(SRC_DNODE, inp, False, ["foo:r1", "input"])
             rpc_xml.children.extend(gdata_inp.to_xml())
         tp.rpc_xml(cb_wrap, rpc_xml)
-
-    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
-            if n is not None:
-                prev = tree
-                # TODO: fix yang.gdata.patch() to accept None as old tree
-                base = prev if prev is not None else yang.gdata.Container({})
-                tree2 = yang.gdata.patch(base, n)
-
-                if tree2 is not None:
-                    d = yang.gdata.diff(prev, tree2)
-                    if d is not None:
-                        cb(root.from_gdata(tree2), err)
-                    tree = tree2
-                else:
-                    if prev is not None:
-                        cb(root.from_gdata(None), err)
-                    tree = None
-            else:
-                cb(None, err)
-
-        return tp.subscribe(cb_wrap, filt, opts)
 
 

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -157,7 +157,6 @@ class yangrpc__foo__output(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
-    var tree: ?yang.gdata.Node = root().to_gdata()
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -176,27 +175,5 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
     def silent(cb: action(?Exception) -> None):
         rpc_xml = xml.Node('silent', nsdefs=[(None, 'http://example.com/yangrpc')])
         tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
-
-    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
-            if n is not None:
-                prev = tree
-                # TODO: fix yang.gdata.patch() to accept None as old tree
-                base = prev if prev is not None else yang.gdata.Container({})
-                tree2 = yang.gdata.patch(base, n)
-
-                if tree2 is not None:
-                    d = yang.gdata.diff(prev, tree2)
-                    if d is not None:
-                        cb(root.from_gdata(tree2), err)
-                    tree = tree2
-                else:
-                    if prev is not None:
-                        cb(root.from_gdata(None), err)
-                    tree = None
-            else:
-                cb(None, err)
-
-        return tp.subscribe(cb_wrap, filt, opts)
 
 

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -3011,47 +3011,90 @@ def _patch_rec(old: Node, p: ?Node, path: list[_PathElement]) -> ?Node:
 
 
 def patch(old: Node, p: ?Node) -> ?Node:
+    # TODO: Accept None as old tree so callers merging from an empty base do
+    # not need to synthesize Container({}) first.
     return _patch_rec(old, p, [])
 
 
 SUB_ON_CHANGE = "on_change"
 SUB_PERIODIC = "periodic"
 
-class SubscriptionOpts(object):
-    """Subscription options for TreeProvider.subscribe."""
-    mode: str
-    period: ?u64 # nanoseconds; 0 means as fast as possible
+def _normalize_period(period: ?value) -> ?u64:
+    if period is not None:
+        if isinstance(period, float):
+            if period < 0.0:
+                raise ValueError("period (seconds) must be non-negative")
+            return u64(period * 1000000000.0)
+        if isinstance(period, u64):
+            return period
+        if isinstance(period, int):
+            if period < 0:
+                raise ValueError("period (nanoseconds) must be non-negative")
+            return u64(period)
+        raise ValueError("period must be float seconds or integer nanoseconds")
+    return None
 
-    def __init__(self, mode: str=SUB_PERIODIC, period: ?u64=None):
-        self.mode = mode
-        self.period = period
-        self._validate()
+class SubscriptionSpec(value):
+    """Declarative subscription specification."""
+    filt: ?FNode
+    period: ?u64 # normalized to nanoseconds; 0 means as fast as possible
 
-    def _validate(self):
-        if self.mode not in {SUB_ON_CHANGE, SUB_PERIODIC}:
-            raise ValueError("Unknown subscription mode: {self.mode}")
-        if self.mode == SUB_PERIODIC:
-            if self.period is None:
-                raise ValueError("period (nanoseconds) is required for periodic subscriptions")
-        elif self.period is not None:
-            raise ValueError("period (nanoseconds) is only valid for periodic subscriptions")
+    def __init__(self, filt: ?FNode, period: ?value=None):
+        # TODO: Accept a real union type here once Acton supports it. Today
+        # value is the only way to express "float seconds or integer
+        # nanoseconds" in one parameter.
+        self.filt = filt
+        self.period = _normalize_period(period)
+
+    def __str__(self) -> str:
+        filt = self.filt
+        filt_str = filt.prsrc(deterministic=True) if filt is not None else "None"
+        period_str = str(self.period) if self.period is not None else "None"
+        return "SubscriptionSpec(period={period_str}, filt={filt_str})"
+
+    def __repr__(self) -> str:
+        return str(self)
 
 
-class SubscriptionHandle(object):
-    """Handle returned by subscribe() for cancellation."""
-    id: int
-    @property
-    cancel: proc() -> None
+extension SubscriptionSpec(Hashable):
+    def __eq__(self, other: SubscriptionSpec) -> bool:
+        if self.period != other.period:
+            return False
+        if self.filt is None:
+            return other.filt is None
+        if other.filt is None:
+            return False
+        return self.filt == other.filt
 
-    def __init__(self, id: int, cancel: proc() -> None):
-        self.id = id
-        self.cancel = cancel
-
+    def hash(self, hasher):
+        period = self.period
+        if period is not None:
+            "some".hash(hasher)
+            period.hash(hasher)
+        else:
+            "none".hash(hasher)
+        filt = self.filt
+        if filt is not None:
+            "some".hash(hasher)
+            filt.prsrc(deterministic=True).hash(hasher)
+        else:
+            "none".hash(hasher)
 
 class TreeProvider(object):
+    """Imperative transport interface for RPCs and owner-scoped subscriptions."""
     rpc: proc(action(?Node, ?Exception) -> None, Node) -> None
     rpc_xml: proc(action(?xml.Node, ?Exception) -> None, xml.Node) -> None
-    subscribe: proc(action(?Node, ?Exception) -> None, ?FNode, SubscriptionOpts) -> SubscriptionHandle
+    declare_subscriptions: proc(str, action(?Node, ?Exception) -> None, set[SubscriptionSpec]) -> None
+    remove_subscriptions: proc(str) -> None
+
+
+actor SubscriptionManager(tp: TreeProvider, owner_id: str, on_update: action(?Node, ?Exception) -> None):
+    """Declarative subscription owner that reconciles desired subscriptions."""
+    def declare(want: set[SubscriptionSpec]):
+        tp.declare_subscriptions(owner_id, on_update, want)
+
+    def close():
+        tp.remove_subscriptions(owner_id)
 
 
 def _node_match(n: xml.Node, name: str, ns: ?str) -> bool:
@@ -5203,6 +5246,21 @@ def _test_serialization_roundtrip_list():
     ], ns=ns_list, module="list", user_order=True)
 
     return _serde_roundtrip_json(original)
+
+
+def _test_subscription_spec_period_float_seconds():
+    spec = SubscriptionSpec(None, period=0.05)
+    testing.assertEqual(spec.period, u64(50000000))
+
+
+def _test_subscription_spec_period_int_nanoseconds():
+    spec = SubscriptionSpec(None, period=50000000)
+    testing.assertEqual(spec.period, u64(50000000))
+
+
+def _test_subscription_spec_default_on_change():
+    spec = SubscriptionSpec(None)
+    testing.assertEqual(spec.period, None)
 
 
 def _test_serialization_roundtrip_leaflist():

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -891,7 +891,6 @@ class DNodeInner(DNode):
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
             res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
-            res.append("    var tree: ?yang.gdata.Node = root().to_gdata()")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output
@@ -936,29 +935,6 @@ class DNodeInner(DNode):
                 else:
                     res.append("        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)")
                 res.append("")
-
-            res.append("    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:")
-            res.append("        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):")
-            res.append("            if n is not None:")
-            res.append("                prev = tree")
-            res.append("                # TODO: fix yang.gdata.patch() to accept None as old tree")
-            res.append("                base = prev if prev is not None else yang.gdata.Container({{}})")
-            res.append("                tree2 = yang.gdata.patch(base, n)")
-            res.append("")
-            res.append("                if tree2 is not None:")
-            res.append("                    d = yang.gdata.diff(prev, tree2)")
-            res.append("                    if d is not None:")
-            res.append("                        cb(root.from_gdata(tree2), err)")
-            res.append("                    tree = tree2")
-            res.append("                else:")
-            res.append("                    if prev is not None:")
-            res.append("                        cb(root.from_gdata(None), err)")
-            res.append("                    tree = None")
-            res.append("            else:")
-            res.append("                cb(None, err)")
-            res.append("")
-            res.append("        return tp.subscribe(cb_wrap, filt, opts)")
-            res.append("")
 
             res.append("")
             res.append("")

--- a/test/test_data_classes/src/test_rpc_exec.act
+++ b/test/test_data_classes/src/test_rpc_exec.act
@@ -22,8 +22,12 @@ class MockTreeProviderSuccess(yang.gdata.TreeProvider):
             yang.gdata.Id("http://example.com/yangrpc", "outoo"): yang.gdata.Leaf("string", "Hello from RPC!")
         }, ns="http://example.com/yangrpc", module="yangrpc")
         cb(output_gdata, None)
-    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        return yang.gdata.SubscriptionHandle(0, lambda: None)
+
+    proc def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        pass
+
+    proc def remove_subscriptions(self, owner_id: str):
+        pass
 
 
 class MockTreeProviderError(yang.gdata.TreeProvider):
@@ -37,8 +41,12 @@ class MockTreeProviderError(yang.gdata.TreeProvider):
 
     proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
         cb(None, ValueError("RPC execution failed"))
-    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        return yang.gdata.SubscriptionHandle(0, lambda: None)
+
+    proc def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        pass
+
+    proc def remove_subscriptions(self, owner_id: str):
+        pass
 
 
 class MockTreeProviderEmpty(yang.gdata.TreeProvider):
@@ -56,8 +64,12 @@ class MockTreeProviderEmpty(yang.gdata.TreeProvider):
     proc def rpc(self, cb: action(?yang.gdata.Node, ?Exception) -> None, rpc: yang.gdata.Node):
         output_gdata = yang.gdata.Container({}, ns="http://example.com/yangrpc", module="yangrpc")
         cb(output_gdata, None)
-    proc def subscribe(self, cb: action(?yang.gdata.Node, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        return yang.gdata.SubscriptionHandle(0, lambda: None)
+
+    proc def declare_subscriptions(self, owner_id: str, cb: action(?yang.gdata.Node, ?Exception) -> None, want: set[yang.gdata.SubscriptionSpec]):
+        pass
+
+    proc def remove_subscriptions(self, owner_id: str):
+        pass
 
 
 actor _test_rpc_foo_success(t: testing.AsyncT):

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -179,7 +179,6 @@ class yangrpc__foo__output(yang.adata.MNode):
 
 
 actor rpc_root(tp: yang.gdata.TreeProvider):
-    var tree: ?yang.gdata.Node = root().to_gdata()
     def foo(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input):
         def cb_wrap(res: ?xml.Node, err: ?Exception):
             if res is not None:
@@ -198,28 +197,6 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
     def silent(cb: action(?Exception) -> None):
         rpc_xml = xml.Node('silent', nsdefs=[(None, 'http://example.com/yangrpc')])
         tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
-
-    def subscribe(cb: action(?root, ?Exception) -> None, filt: ?yang.gdata.FNode, opts: yang.gdata.SubscriptionOpts) -> yang.gdata.SubscriptionHandle:
-        def cb_wrap(n: ?yang.gdata.Node, err: ?Exception):
-            if n is not None:
-                prev = tree
-                # TODO: fix yang.gdata.patch() to accept None as old tree
-                base = prev if prev is not None else yang.gdata.Container({})
-                tree2 = yang.gdata.patch(base, n)
-
-                if tree2 is not None:
-                    d = yang.gdata.diff(prev, tree2)
-                    if d is not None:
-                        cb(root.from_gdata(tree2), err)
-                    tree = tree2
-                else:
-                    if prev is not None:
-                        cb(root.from_gdata(None), err)
-                    tree = None
-            else:
-                cb(None, err)
-
-        return tp.subscribe(cb_wrap, filt, opts)
 
 
 def src_schema():


### PR DESCRIPTION
The old subscription API was bolted onto rpc_root and returned imperative handles from the transport layer. That mixed one-shot RPCs with long-lived subscription state, and the generated rpc wrappers had to keep ad hoc merged trees just to present typed updates.

This changes yang.gdata to model subscriptions as declarative SubscriptionSpec values owned through SubscriptionManager. TreeProvider now declares and removes whole owner-scoped subscription sets, period is normalized in the spec itself, and the generated rpc_root code drops the subscription wrapper entirely.

That separates RPC execution from subscription management and leaves one clear place to reconcile desired subscriptions. Generated model code no longer carries subscription-specific merge state, and callers can reason about subscriptions as plain data rather than transport-minted handles.