### PR TITLE
Always emit rpc_root

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -882,7 +882,7 @@ class DNodeInner(DNode):
         res.append("")
 
 
-        if isinstance(self, DRoot) and len(self.rpcs) > 0:
+        if isinstance(self, DRoot):
             # First generate data classes for RPC input/output
             for rpc in self.rpcs:
                 # Generate adata classes for DInput, DOutput, but override:
@@ -895,6 +895,8 @@ class DNodeInner(DNode):
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
             res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
+            if len(self.rpcs) == 0:
+                res.append("    pass")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -184,3 +184,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_augment
+++ b/snapshots/expected/test_yang/compile_augment
@@ -91,3 +91,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_augment_augmented_node
+++ b/snapshots/expected/test_yang/compile_augment_augmented_node
@@ -213,3 +213,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_augment_import
+++ b/snapshots/expected/test_yang/compile_augment_import
@@ -92,3 +92,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_augment_on_augment
+++ b/snapshots/expected/test_yang/compile_augment_on_augment
@@ -125,3 +125,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
+++ b/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
@@ -127,3 +127,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_augment_uses
+++ b/snapshots/expected/test_yang/compile_augment_uses
@@ -118,3 +118,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_bundle1
+++ b/snapshots/expected/test_yang/compile_bundle1
@@ -92,3 +92,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -165,3 +165,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_import_hyphenated_prefix
+++ b/snapshots/expected/test_yang/compile_import_hyphenated_prefix
@@ -87,3 +87,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -177,3 +177,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_refine
+++ b/snapshots/expected/test_yang/compile_refine
@@ -92,3 +92,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
@@ -133,3 +133,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -254,3 +254,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
@@ -132,3 +132,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_submodules1
+++ b/snapshots/expected/test_yang/compile_submodules1
@@ -121,3 +121,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -153,3 +153,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/compile_uses_augment
+++ b/snapshots/expected/test_yang/compile_uses_augment
@@ -94,3 +94,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/identity_base_resolution_import_prefix
+++ b/snapshots/expected/test_yang/identity_base_resolution_import_prefix
@@ -86,3 +86,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/identityref
+++ b/snapshots/expected/test_yang/identityref
@@ -125,3 +125,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -195,3 +195,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -325,3 +325,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -223,3 +223,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -232,3 +232,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
@@ -150,3 +150,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_dot
+++ b/snapshots/expected/test_yang/prdaclass_dot
@@ -86,3 +86,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -180,3 +180,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -130,3 +130,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -130,3 +130,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -165,3 +165,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -151,3 +151,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_top_conflict
+++ b/snapshots/expected/test_yang/prdaclass_top_conflict
@@ -122,3 +122,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
+++ b/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
@@ -161,3 +161,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -177,3 +177,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/resolve_type_union_of_intX
+++ b/snapshots/expected/test_yang/resolve_type_union_of_intX
@@ -75,3 +75,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/resolve_type_union_of_string
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string
@@ -57,3 +57,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
@@ -57,3 +57,7 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -878,7 +878,7 @@ class DNodeInner(DNode):
         res.append("")
 
 
-        if isinstance(self, DRoot) and len(self.rpcs) > 0:
+        if isinstance(self, DRoot):
             # First generate data classes for RPC input/output
             for rpc in self.rpcs:
                 # Generate adata classes for DInput, DOutput, but override:
@@ -891,6 +891,8 @@ class DNodeInner(DNode):
             # TODO: unique safe name for RPC function!
             # Generate rpc_root actor
             res.append("actor rpc_root(tp: yang.gdata.TreeProvider):")
+            if len(self.rpcs) == 0:
+                res.append("    pass")
             for rpc in self.rpcs:
                 input_node = rpc.input
                 output_node = rpc.output
@@ -11089,4 +11091,3 @@ def escape_as_fstr(s: str) -> str:
     copy_until(b, s_len)
 
     return "".join(parts)
-

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -239,6 +239,10 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+
 def src_schema():
     res = {}
     res["basics"] = Module('basics', yang_version=1.1, namespace='http://example.com/basics', prefix='b', children=[

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -1848,6 +1848,10 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -1846,6 +1846,10 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', include=[

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -103,6 +103,10 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+
 def src_schema():
     res = {}
     res["loose-required"] = Module('loose-required', yang_version=1.1, namespace='http://example.com/loose-required', prefix='lr', children=[

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -287,6 +287,10 @@ class root(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+
 def src_schema():
     res = {}
     res["foo"] = Module('foo', yang_version=1.1, namespace='http://example.com/foo', prefix='f', children=[


### PR DESCRIPTION
The generator only emitted rpc_root when a module defined one or more RPCs. That made rpc_root disappear entirely for modules without RPCs, which was an awkward interface break for callers that expected the root helper to always exist.

This makes the DRoot generator always emit rpc_root and emits a pass body when there are no RPC methods to attach. That keeps the generated shape stable while preserving valid Acton syntax for empty actors.

Fixes #411 