### PR TITLE
Emit unique null breaker sentinels

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -388,7 +388,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -511,13 +511,16 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
             return spath + [c]
 
         res = []
+
+        def next_breaker_name(i: int) -> (str, int):
+            return ("_breaker{i + 1}", i + 1)
 
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
@@ -567,17 +570,20 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state))
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, breaker_idx=breaker_idx)
+            res.extend(child_res)
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
             # - the list itself
             # - the list entry class
             # Here we create the list entry class, the list itself comes later
-            res.append("_breaker = 1")
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name} = None")
             res.append("class {pname()}_entry(yang.adata.MNode):")
         else:
-            res.append("_breaker = 1")
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name} = None")
             res.append("class {pname()}(yang.adata.MNode):")
 
         for child in self.children:
@@ -770,7 +776,8 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list class, list entry class was created above
-            res.append("_breaker = 1")
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name} = None")
             res.append("class {pname()}(yang.adata.MNode):")
             res.append("    elements: list[{pname()}_entry]")
 
@@ -889,7 +896,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True)
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, breaker_idx=breaker_idx)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -945,7 +952,7 @@ class DNodeInner(DNode):
             res.append("")
             res.append("")
 
-        return res
+        return (res, breaker_idx)
 
     def resolve_references(self, root: DRoot, spath: list[DNode], allow_failure: ?list[str]):
         for child in self.children:
@@ -1695,7 +1702,7 @@ class DRoot(DNodeInner):
         # the SRC_DNODE constant to have the same view of the schema as the
         # adata code generator ...
         spath = build_spath([self])
-        inner = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state)
 
         res = []
         res.append("import base64")

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -40,7 +40,7 @@ NS_augmenter = 'http://example.com/augmenter'
 NS_base = 'http://example.com/base'
 
 
-_breaker = 1
+_breaker1 = None
 class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
 
     mut def __init__(self):
@@ -58,7 +58,7 @@ class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__system_capabilities__per_node_capabilities_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class base__system_capabilities__per_node_capabilities(yang.adata.MNode):
     elements: list[base__system_capabilities__per_node_capabilities_entry]
     mut def __init__(self, elements=[]):
@@ -96,7 +96,7 @@ extension base__system_capabilities__per_node_capabilities(Iterable[base__system
     def __iter__(self) -> Iterator[base__system_capabilities__per_node_capabilities_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
     max_nodes: u64
     supported_excluded_change_type: list[str]
@@ -127,7 +127,7 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
         return base__system_capabilities__subscription_capabilities.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class base__system_capabilities(yang.adata.MNode):
     per_node_capabilities: base__system_capabilities__per_node_capabilities
     subscription_capabilities: base__system_capabilities__subscription_capabilities
@@ -158,7 +158,7 @@ class base__system_capabilities(yang.adata.MNode):
         return base__system_capabilities.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class root(yang.adata.MNode):
     system_capabilities: base__system_capabilities
 

--- a/snapshots/expected/test_yang/compile_augment
+++ b/snapshots/expected/test_yang/compile_augment
@@ -34,7 +34,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -65,7 +65,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_augment_augmented_node
+++ b/snapshots/expected/test_yang/compile_augment_augmented_node
@@ -44,7 +44,7 @@ NS_base = 'http://example.com/base'
 NS_voice = 'http://example.com/voice'
 
 
-_breaker = 1
+_breaker1 = None
 class base__native__voice__service__voip__sip(yang.adata.MNode):
     bind: ?str
     port: u64
@@ -75,7 +75,7 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
         return base__native__voice__service__voip__sip.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class base__native__voice__service__voip(yang.adata.MNode):
     enabled: bool
     sip: base__native__voice__service__voip__sip
@@ -106,7 +106,7 @@ class base__native__voice__service__voip(yang.adata.MNode):
         return base__native__voice__service__voip.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class base__native__voice__service(yang.adata.MNode):
     voip: base__native__voice__service__voip
 
@@ -133,7 +133,7 @@ class base__native__voice__service(yang.adata.MNode):
         return base__native__voice__service.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class base__native__voice(yang.adata.MNode):
     service: base__native__voice__service
 
@@ -160,7 +160,7 @@ class base__native__voice(yang.adata.MNode):
         return base__native__voice.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class base__native(yang.adata.MNode):
     voice: base__native__voice
 
@@ -187,7 +187,7 @@ class base__native(yang.adata.MNode):
         return base__native.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker6 = None
 class root(yang.adata.MNode):
     native: base__native
 

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -48,7 +48,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
 
     mut def __init__(self):
@@ -69,7 +69,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
@@ -96,7 +96,7 @@ class root(yang.adata.MNode):
         return root.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class foo__r1__input__c3(yang.adata.MNode):
     l3: ?str
 
@@ -123,7 +123,7 @@ class foo__r1__input__c3(yang.adata.MNode):
         return foo__r1__input__c3.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class foo__r1__input(yang.adata.MNode):
     c3: foo__r1__input__c3
 
@@ -150,7 +150,7 @@ class foo__r1__input(yang.adata.MNode):
         return foo__r1__input.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class foo__r1__output(yang.adata.MNode):
     l4: ?str
 

--- a/snapshots/expected/test_yang/compile_augment_import
+++ b/snapshots/expected/test_yang/compile_augment_import
@@ -35,7 +35,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -66,7 +66,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_augment_on_augment
+++ b/snapshots/expected/test_yang/compile_augment_on_augment
@@ -37,7 +37,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__c2(yang.adata.MNode):
     l2: ?str
     l3: ?str
@@ -68,7 +68,7 @@ class foo__c1__c2(yang.adata.MNode):
         return foo__c1__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
     c2: foo__c1__c2
@@ -99,7 +99,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
+++ b/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
@@ -39,7 +39,7 @@ NS_baz = 'http://example.com/baz'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__c2(yang.adata.MNode):
     l2: ?str
     l3: ?str
@@ -70,7 +70,7 @@ class foo__c1__c2(yang.adata.MNode):
         return foo__c1__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
     c2: foo__c1__c2
@@ -101,7 +101,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_augment_uses
+++ b/snapshots/expected/test_yang/compile_augment_uses
@@ -38,7 +38,7 @@ NS_foo = 'http://example.com/foo'
 NS_some_ext = 'http://example.com/some-ext'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__c2(yang.adata.MNode):
     l1: ?str
 
@@ -65,7 +65,7 @@ class foo__c1__c2(yang.adata.MNode):
         return foo__c1__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c1(yang.adata.MNode):
     c2: foo__c1__c2
 
@@ -92,7 +92,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_bundle1
+++ b/snapshots/expected/test_yang/compile_bundle1
@@ -35,7 +35,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -66,7 +66,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -41,7 +41,7 @@ NS_foo = 'http://example.com/foo'
 NS_some_ext = 'http://example.com/some-ext'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__things_entry(yang.adata.MNode):
     name: str
     id: ?str
@@ -69,7 +69,7 @@ class foo__c1__things_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__things_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__c1__things(yang.adata.MNode):
     elements: list[foo__c1__things_entry]
     mut def __init__(self, elements=[]):
@@ -112,7 +112,7 @@ extension foo__c1__things(Iterable[foo__c1__things_entry]):
     def __iter__(self) -> Iterator[foo__c1__things_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class foo__c1(yang.adata.MNode):
     things: foo__c1__things
 
@@ -139,7 +139,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_import_hyphenated_prefix
+++ b/snapshots/expected/test_yang/compile_import_hyphenated_prefix
@@ -34,7 +34,7 @@ NS_acme_foo_bar = 'http://example.com/foo'
 NS_acme_qux_baz = 'http://example.com/qux'
 
 
-_breaker = 1
+_breaker1 = None
 class acme_foo_bar__c1(yang.adata.MNode):
     l1: ?str
 
@@ -61,7 +61,7 @@ class acme_foo_bar__c1(yang.adata.MNode):
         return acme_foo_bar__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: acme_foo_bar__c1
 

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -53,7 +53,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class bar__c1__li1_entry(yang.adata.MNode):
     l1: str
     l2: ?Identityref
@@ -81,7 +81,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return bar__c1__li1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -124,7 +124,7 @@ extension bar__c1__li1(Iterable[bar__c1__li1_entry]):
     def __iter__(self) -> Iterator[bar__c1__li1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class bar__c1(yang.adata.MNode):
     li1: bar__c1__li1
 
@@ -151,7 +151,7 @@ class bar__c1(yang.adata.MNode):
         return bar__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: bar__c1
 

--- a/snapshots/expected/test_yang/compile_refine
+++ b/snapshots/expected/test_yang/compile_refine
@@ -39,7 +39,7 @@ NS_foo = 'http://example.com/foo'
 NS_some_ext = 'http://example.com/some-ext'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: list[str]
 
@@ -66,7 +66,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
@@ -41,7 +41,7 @@ NS_other = 'http://example.com/other'
 NS_parent = 'http://example.com/parent'
 
 
-_breaker = 1
+_breaker1 = None
 class parent__parent_container(yang.adata.MNode):
     parent_leaf: ?str
     augmented_leaf: ?str
@@ -72,7 +72,7 @@ class parent__parent_container(yang.adata.MNode):
         return parent__parent_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class parent__sub_container(yang.adata.MNode):
     sub_leaf: ?str
     another_leaf: ?str
@@ -103,7 +103,7 @@ class parent__sub_container(yang.adata.MNode):
         return parent__sub_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     parent_container: parent__parent_container
     sub_container: parent__sub_container

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -50,7 +50,7 @@ SRC_DNODE = DRoot(
 NS_main_module = 'http://example.com/main'
 
 
-_breaker = 1
+_breaker1 = None
 class main_module__main_container__sub_group_container(yang.adata.MNode):
     sub_group_leaf: str
 
@@ -77,7 +77,7 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
         return main_module__main_container__sub_group_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class main_module__main_container__sub_list_entry(yang.adata.MNode):
     name: str
     sub_value: ?str
@@ -109,7 +109,7 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class main_module__main_container__sub_list(yang.adata.MNode):
     elements: list[main_module__main_container__sub_list_entry]
     mut def __init__(self, elements=[]):
@@ -154,7 +154,7 @@ extension main_module__main_container__sub_list(Iterable[main_module__main_conta
     def __iter__(self) -> Iterator[main_module__main_container__sub_list_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker4 = None
 class main_module__main_container__group_container(yang.adata.MNode):
     group_leaf: str
     augmented_in_group: ?str
@@ -185,7 +185,7 @@ class main_module__main_container__group_container(yang.adata.MNode):
         return main_module__main_container__group_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class main_module__main_container(yang.adata.MNode):
     main_leaf: ?str
     sub_group_container: main_module__main_container__sub_group_container
@@ -228,7 +228,7 @@ class main_module__main_container(yang.adata.MNode):
         return main_module__main_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker6 = None
 class root(yang.adata.MNode):
     main_container: main_module__main_container
 

--- a/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
@@ -40,7 +40,7 @@ NS_parent = 'http://example.com/parent'
 NS_shared = 'http://example.com/shared'
 
 
-_breaker = 1
+_breaker1 = None
 class parent__parent_container(yang.adata.MNode):
     parent_leaf: ?str
     augmented_leaf: ?str
@@ -71,7 +71,7 @@ class parent__parent_container(yang.adata.MNode):
         return parent__parent_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class parent__sub_container(yang.adata.MNode):
     sub_leaf: ?str
     shared_leaf: str
@@ -102,7 +102,7 @@ class parent__sub_container(yang.adata.MNode):
         return parent__sub_container.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     parent_container: parent__parent_container
     sub_container: parent__sub_container

--- a/snapshots/expected/test_yang/compile_submodules1
+++ b/snapshots/expected/test_yang/compile_submodules1
@@ -37,7 +37,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
@@ -64,7 +64,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c2(yang.adata.MNode):
     l2: ?str
 
@@ -91,7 +91,7 @@ class foo__c2(yang.adata.MNode):
         return foo__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
     c2: foo__c2

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -35,7 +35,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__li1_entry(yang.adata.MNode):
     l1: str
 
@@ -59,7 +59,7 @@ class foo__c1__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__li1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__c1__li1(yang.adata.MNode):
     elements: list[foo__c1__li1_entry]
     mut def __init__(self, elements=[]):
@@ -100,7 +100,7 @@ extension foo__c1__li1(Iterable[foo__c1__li1_entry]):
     def __iter__(self) -> Iterator[foo__c1__li1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class foo__c1(yang.adata.MNode):
     li1: foo__c1__li1
 
@@ -127,7 +127,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/compile_uses_augment
+++ b/snapshots/expected/test_yang/compile_uses_augment
@@ -37,7 +37,7 @@ NS_foo = 'http://example.com/foo'
 NS_some_ext = 'http://example.com/some-ext'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -68,7 +68,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/identity_base_resolution_import_prefix
+++ b/snapshots/expected/test_yang/identity_base_resolution_import_prefix
@@ -66,7 +66,7 @@ NS_base_module = 'http://example.com/base'
 NS_derived_module = 'http://example.com/derived'
 
 
-_breaker = 1
+_breaker1 = None
 class root(yang.adata.MNode):
 
     mut def __init__(self):

--- a/snapshots/expected/test_yang/identityref
+++ b/snapshots/expected/test_yang/identityref
@@ -72,7 +72,7 @@ NS_base = 'http://example.com/base'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class base__config(yang.adata.MNode):
     active_protocol: ?Identityref
 
@@ -99,7 +99,7 @@ class base__config(yang.adata.MNode):
         return base__config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     config: base__config
 

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -40,7 +40,7 @@ NS_augment_module = 'http://example.com/augment'
 NS_base_module = 'http://example.com/base'
 
 
-_breaker = 1
+_breaker1 = None
 class base_module__network_instances__network_instance__state(yang.adata.MNode):
     id: ?str
 
@@ -67,7 +67,7 @@ class base_module__network_instances__network_instance__state(yang.adata.MNode):
         return base_module__network_instances__network_instance__state.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class base_module__network_instances__network_instance_entry(yang.adata.MNode):
     name: str
     state: base_module__network_instances__network_instance__state
@@ -99,7 +99,7 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class base_module__network_instances__network_instance(yang.adata.MNode):
     elements: list[base_module__network_instances__network_instance_entry]
     mut def __init__(self, elements=[]):
@@ -142,7 +142,7 @@ extension base_module__network_instances__network_instance(Iterable[base_module_
     def __iter__(self) -> Iterator[base_module__network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker4 = None
 class base_module__network_instances(yang.adata.MNode):
     network_instance: base_module__network_instances__network_instance
 
@@ -169,7 +169,7 @@ class base_module__network_instances(yang.adata.MNode):
         return base_module__network_instances.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class root(yang.adata.MNode):
     network_instances: base_module__network_instances
 

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -49,7 +49,7 @@ NS_base_module = 'http://example.com/base'
 NS_other_module = 'http://example.com/other'
 
 
-_breaker = 1
+_breaker1 = None
 class other_module__other_network_instances__network_instance_entry(yang.adata.MNode):
     name: str
 
@@ -73,7 +73,7 @@ class other_module__other_network_instances__network_instance_entry(yang.adata.M
         """Create a deep copy of this adata object"""
         return other_module__other_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class other_module__other_network_instances__network_instance(yang.adata.MNode):
     elements: list[other_module__other_network_instances__network_instance_entry]
     mut def __init__(self, elements=[]):
@@ -114,7 +114,7 @@ extension other_module__other_network_instances__network_instance(Iterable[other
     def __iter__(self) -> Iterator[other_module__other_network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class other_module__other_network_instances(yang.adata.MNode):
     network_instance: other_module__other_network_instances__network_instance
 
@@ -141,7 +141,7 @@ class other_module__other_network_instances(yang.adata.MNode):
         return other_module__other_network_instances.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class base_module__base_network_instances__network_instance__config(yang.adata.MNode):
     name: ?str
 
@@ -168,7 +168,7 @@ class base_module__base_network_instances__network_instance__config(yang.adata.M
         return base_module__base_network_instances__network_instance__config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class base_module__base_network_instances__network_instance_entry(yang.adata.MNode):
     name: str
     config: base_module__base_network_instances__network_instance__config
@@ -196,7 +196,7 @@ class base_module__base_network_instances__network_instance_entry(yang.adata.MNo
         """Create a deep copy of this adata object"""
         return base_module__base_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker6 = None
 class base_module__base_network_instances__network_instance(yang.adata.MNode):
     elements: list[base_module__base_network_instances__network_instance_entry]
     mut def __init__(self, elements=[]):
@@ -237,7 +237,7 @@ extension base_module__base_network_instances__network_instance(Iterable[base_mo
     def __iter__(self) -> Iterator[base_module__base_network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker7 = None
 class base_module__base_network_instances(yang.adata.MNode):
     network_instance: base_module__base_network_instances__network_instance
 
@@ -264,7 +264,7 @@ class base_module__base_network_instances(yang.adata.MNode):
         return base_module__base_network_instances.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class base_module__uses_leafref(yang.adata.MNode):
     ni: ?str
 
@@ -291,7 +291,7 @@ class base_module__uses_leafref(yang.adata.MNode):
         return base_module__uses_leafref.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker9 = None
 class root(yang.adata.MNode):
     other_network_instances: other_module__other_network_instances
     base_network_instances: base_module__base_network_instances

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -43,7 +43,7 @@ NS_base_module = 'http://example.com/base'
 NS_consumer_module = 'http://example.com/consumer'
 
 
-_breaker = 1
+_breaker1 = None
 class base_module__network_instances__network_instance__config(yang.adata.MNode):
     name: ?str
 
@@ -70,7 +70,7 @@ class base_module__network_instances__network_instance__config(yang.adata.MNode)
         return base_module__network_instances__network_instance__config.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class base_module__network_instances__network_instance_entry(yang.adata.MNode):
     name: str
     config: base_module__network_instances__network_instance__config
@@ -98,7 +98,7 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class base_module__network_instances__network_instance(yang.adata.MNode):
     elements: list[base_module__network_instances__network_instance_entry]
     mut def __init__(self, elements=[]):
@@ -139,7 +139,7 @@ extension base_module__network_instances__network_instance(Iterable[base_module_
     def __iter__(self) -> Iterator[base_module__network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker4 = None
 class base_module__network_instances(yang.adata.MNode):
     network_instance: base_module__network_instances__network_instance
 
@@ -166,7 +166,7 @@ class base_module__network_instances(yang.adata.MNode):
         return base_module__network_instances.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class consumer_module__uses_typedef(yang.adata.MNode):
     ni: ?str
 
@@ -193,7 +193,7 @@ class consumer_module__uses_typedef(yang.adata.MNode):
         return consumer_module__uses_typedef.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker6 = None
 class root(yang.adata.MNode):
     network_instances: base_module__network_instances
     uses_typedef: consumer_module__uses_typedef

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -39,7 +39,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c__li__bar(yang.adata.MNode):
     man: str
 
@@ -66,7 +66,7 @@ class foo__c__li__bar(yang.adata.MNode):
         return foo__c__li__bar.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c__li_entry(yang.adata.MNode):
     name: str
     foo: str
@@ -98,7 +98,7 @@ class foo__c__li_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c__li_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class foo__c__li(yang.adata.MNode):
     elements: list[foo__c__li_entry]
     mut def __init__(self, elements=[]):

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -40,7 +40,7 @@ NS_base = 'http://example.com/base'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class base__c1__base_l1_entry(yang.adata.MNode):
     base_k1: str
     foo_k1: str
@@ -68,7 +68,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1__base_l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
     mut def __init__(self, elements=[]):
@@ -110,7 +110,7 @@ extension base__c1__base_l1(Iterable[base__c1__base_l1_entry]):
     def __iter__(self) -> Iterator[base__c1__base_l1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class base__c1__foo_l1_entry(yang.adata.MNode):
     k2: str
 
@@ -134,7 +134,7 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return base__c1__foo_l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class base__c1__foo_l1(yang.adata.MNode):
     elements: list[base__c1__foo_l1_entry]
     mut def __init__(self, elements=[]):
@@ -175,7 +175,7 @@ extension base__c1__foo_l1(Iterable[base__c1__foo_l1_entry]):
     def __iter__(self) -> Iterator[base__c1__foo_l1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class base__c1(yang.adata.MNode):
     base_l1: base__c1__base_l1
     foo_l1: base__c1__foo_l1
@@ -206,7 +206,7 @@ class base__c1(yang.adata.MNode):
         return base__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker6 = None
 class root(yang.adata.MNode):
     c1: base__c1
 

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
@@ -39,7 +39,7 @@ NS_base = 'http://example.com/base'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class base__c1__base_c2(yang.adata.MNode):
     foo: ?str
 
@@ -66,7 +66,7 @@ class base__c1__base_c2(yang.adata.MNode):
         return base__c1__base_c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class base__c1__foo_c2(yang.adata.MNode):
     foo: ?str
 
@@ -93,7 +93,7 @@ class base__c1__foo_c2(yang.adata.MNode):
         return base__c1__foo_c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class base__c1(yang.adata.MNode):
     base_c2: base__c1__base_c2
     foo_c2: base__c1__foo_c2
@@ -124,7 +124,7 @@ class base__c1(yang.adata.MNode):
         return base__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: base__c1
 

--- a/snapshots/expected/test_yang/prdaclass_augment_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_name_conflict
@@ -36,7 +36,7 @@ NS_base = 'http://example.com/base'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class base__c1(yang.adata.MNode):
     bar_foo: ?str
     foo_foo: ?str

--- a/snapshots/expected/test_yang/prdaclass_dot
+++ b/snapshots/expected/test_yang/prdaclass_dot
@@ -33,7 +33,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__ieee_802_3(yang.adata.MNode):
     ieee_802_3: ?str
 
@@ -60,7 +60,7 @@ class foo__ieee_802_3(yang.adata.MNode):
         return foo__ieee_802_3.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     ieee_802_3: foo__ieee_802_3
 

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -55,7 +55,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__l1_entry(yang.adata.MNode):
     k1: str
     k2: Identityref
@@ -83,7 +83,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -127,7 +127,7 @@ extension foo__c1__l1(Iterable[foo__c1__l1_entry]):
     def __iter__(self) -> Iterator[foo__c1__l1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class foo__c1(yang.adata.MNode):
     l1: foo__c1__l1
 
@@ -154,7 +154,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/prdaclass_keyword_name_import
+++ b/snapshots/expected/test_yang/prdaclass_keyword_name_import
@@ -37,7 +37,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     as_: ?str
     for_: ?str

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -33,7 +33,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__l1_entry(yang.adata.MNode):
     name: str
 
@@ -57,7 +57,7 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -34,7 +34,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__l1_entry(yang.adata.MNode):
     name: str
     id: ?str
@@ -62,7 +62,7 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/snapshots/expected/test_yang/prdaclass_loose_container_in_container
+++ b/snapshots/expected/test_yang/prdaclass_loose_container_in_container
@@ -35,7 +35,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__foo__bar(yang.adata.MNode):
     l1: ?str
 
@@ -62,7 +62,7 @@ class foo__foo__bar(yang.adata.MNode):
         return foo__foo__bar.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__foo(yang.adata.MNode):
     bar: foo__foo__bar
 

--- a/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -35,7 +35,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__foo__bar(yang.adata.MNode):
     l1: ?str
 
@@ -65,7 +65,7 @@ class foo__foo__bar(yang.adata.MNode):
         raise Exception('Unreachable in foo__foo__bar.copy()')
 
 
-_breaker = 1
+_breaker2 = None
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
 

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -35,7 +35,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__li1_entry(yang.adata.MNode):
     l1: str
 
@@ -59,7 +59,7 @@ class foo__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -100,7 +100,7 @@ extension foo__li1(Iterable[foo__li1_entry]):
     def __iter__(self) -> Iterator[foo__li1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     li1: foo__li1
     ll1: list[str]

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -35,7 +35,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__li1_entry(yang.adata.MNode):
     l1: str
 
@@ -59,7 +59,7 @@ class foo__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
     mut def __init__(self, elements=[]):
@@ -100,7 +100,7 @@ extension foo__li1(Iterable[foo__li1_entry]):
     def __iter__(self) -> Iterator[foo__li1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     li1: foo__li1
     ll1: list[str]

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -37,7 +37,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__l1__bar(yang.adata.MNode):
     hi: ?str
 
@@ -64,7 +64,7 @@ class foo__l1__bar(yang.adata.MNode):
         return foo__l1__bar.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__l1_entry(yang.adata.MNode):
     name: str
     id: ?str
@@ -96,7 +96,7 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):
@@ -139,7 +139,7 @@ extension foo__l1(Iterable[foo__l1_entry]):
     def __iter__(self) -> Iterator[foo__l1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     l1: foo__l1
 

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -50,7 +50,7 @@ SRC_DNODE = DRoot(
 NS_yangrpc = 'http://example.com/yangrpc'
 
 
-_breaker = 1
+_breaker1 = None
 class root(yang.adata.MNode):
 
     mut def __init__(self):
@@ -71,7 +71,7 @@ class root(yang.adata.MNode):
         return root.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class yangrpc__foo__input__woo(yang.adata.MNode):
     woo_b: ?int
 
@@ -98,7 +98,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
         return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class yangrpc__foo__input(yang.adata.MNode):
     a: ?str
     woo: yangrpc__foo__input__woo
@@ -129,7 +129,7 @@ class yangrpc__foo__input(yang.adata.MNode):
         return yangrpc__foo__input.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class yangrpc__foo__output(yang.adata.MNode):
     outoo: ?str
 

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -34,7 +34,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__l1_entry(yang.adata.MNode):
     name: str
     id: str
@@ -62,7 +62,7 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -36,7 +36,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__l1__bar(yang.adata.MNode):
     hi: str
 
@@ -66,7 +66,7 @@ class foo__l1__bar(yang.adata.MNode):
         raise Exception('Unreachable in foo__l1__bar.copy()')
 
 
-_breaker = 1
+_breaker2 = None
 class foo__l1_entry(yang.adata.MNode):
     name: str
     bar: ?foo__l1__bar
@@ -103,7 +103,7 @@ class foo__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
     mut def __init__(self, elements=[]):

--- a/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -38,7 +38,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__foo__bar(yang.adata.MNode):
     foo_l1: str
     bar_l1: str
@@ -76,7 +76,7 @@ class foo__foo__bar(yang.adata.MNode):
         raise Exception('Unreachable in foo__foo__bar.copy()')
 
 
-_breaker = 1
+_breaker2 = None
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
 
@@ -117,7 +117,7 @@ class foo__foo(yang.adata.MNode):
         raise Exception('Unreachable in foo__foo.copy()')
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     foo: ?foo__foo
 

--- a/snapshots/expected/test_yang/prdaclass_top_conflict
+++ b/snapshots/expected/test_yang/prdaclass_top_conflict
@@ -38,7 +38,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class bar__bar_c1(yang.adata.MNode):
     l1: ?str
 
@@ -65,7 +65,7 @@ class bar__bar_c1(yang.adata.MNode):
         return bar__bar_c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__foo_c1(yang.adata.MNode):
     l1: ?str
 
@@ -92,7 +92,7 @@ class foo__foo_c1(yang.adata.MNode):
         return foo__foo_c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class root(yang.adata.MNode):
     bar_c1: bar__bar_c1
     foo_c1: foo__foo_c1

--- a/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
+++ b/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
@@ -39,7 +39,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
@@ -66,7 +66,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: ?str
 
@@ -93,7 +93,7 @@ class foo__pc1__foo(yang.adata.MNode):
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
@@ -123,7 +123,7 @@ class foo__pc1(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc1.copy()')
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -40,7 +40,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__l1_entry(yang.adata.MNode):
     k1: str
     k2: value
@@ -72,7 +72,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker2 = None
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
     mut def __init__(self, elements=[]):
@@ -124,7 +124,7 @@ extension foo__c1__l1(Iterable[foo__c1__l1_entry]):
     def __iter__(self) -> Iterator[foo__c1__l1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker3 = None
 class foo__c1(yang.adata.MNode):
     l1: foo__c1__l1
 
@@ -151,7 +151,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_intX
+++ b/snapshots/expected/test_yang/resolve_type_union_of_intX
@@ -37,7 +37,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class root(yang.adata.MNode):
     l1: ?int
     l2: ?u64

--- a/snapshots/expected/test_yang/resolve_type_union_of_string
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string
@@ -31,7 +31,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class root(yang.adata.MNode):
     l1: ?str
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
@@ -31,7 +31,7 @@ SRC_DNODE = DRoot(
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class root(yang.adata.MNode):
     l1: value
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -384,7 +384,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -507,13 +507,16 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False) -> list[str]:
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
             return spath + [c]
 
         res = []
+
+        def next_breaker_name(i: int) -> (str, int):
+            return ("_breaker{i + 1}", i + 1)
 
         # Reorder children so that positional arguments, like list keys, come first
         new_children = []
@@ -563,17 +566,20 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            res.extend(child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state))
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, breaker_idx=breaker_idx)
+            res.extend(child_res)
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
             # - the list itself
             # - the list entry class
             # Here we create the list entry class, the list itself comes later
-            res.append("_breaker = 1")
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name} = None")
             res.append("class {pname()}_entry(yang.adata.MNode):")
         else:
-            res.append("_breaker = 1")
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name} = None")
             res.append("class {pname()}(yang.adata.MNode):")
 
         for child in self.children:
@@ -766,7 +772,8 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list class, list entry class was created above
-            res.append("_breaker = 1")
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name} = None")
             res.append("class {pname()}(yang.adata.MNode):")
             res.append("    elements: list[{pname()}_entry]")
 
@@ -885,7 +892,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True)
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, breaker_idx=breaker_idx)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -941,7 +948,7 @@ class DNodeInner(DNode):
             res.append("")
             res.append("")
 
-        return res
+        return (res, breaker_idx)
 
     def resolve_references(self, root: DRoot, spath: list[DNode], allow_failure: ?list[str]):
         for child in self.children:
@@ -1691,7 +1698,7 @@ class DRoot(DNodeInner):
         # the SRC_DNODE constant to have the same view of the schema as the
         # adata code generator ...
         spath = build_spath([self])
-        inner = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state)
 
         res = []
         res.append("import base64")

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -142,7 +142,7 @@ def src_yang():
 NS_basics = 'http://example.com/basics'
 
 
-_breaker = 1
+_breaker1 = None
 class basics__c(yang.adata.MNode):
     l_str_def: str
     l_str_def_quoted: str
@@ -213,7 +213,7 @@ class basics__c(yang.adata.MNode):
         return basics__c.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c: basics__c
 

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -495,7 +495,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__li__c4(yang.adata.MNode):
     l5: ?str
 
@@ -522,7 +522,7 @@ class foo__c1__li__c4(yang.adata.MNode):
         return foo__c1__li__c4.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c1__li_entry(yang.adata.MNode):
     name: str
     val: ?str
@@ -554,7 +554,7 @@ class foo__c1__li_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
     mut def __init__(self, elements=[]):
@@ -597,7 +597,7 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
     def __iter__(self) -> Iterator[foo__c1__li_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker4 = None
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
     l3: ?u64
@@ -680,7 +680,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
@@ -707,7 +707,7 @@ class foo__pc1__foo(yang.adata.MNode):
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker6 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
@@ -737,7 +737,7 @@ class foo__pc1(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc1.copy()')
 
 
-_breaker = 1
+_breaker7 = None
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: str
 
@@ -764,7 +764,7 @@ class foo__pc2__foo(yang.adata.MNode):
         return foo__pc2__foo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
@@ -794,7 +794,7 @@ class foo__pc2(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc2.copy()')
 
 
-_breaker = 1
+_breaker9 = None
 class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: str
     l3_optional: ?str
@@ -825,7 +825,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker10 = None
 class foo__pc3__level1__level2(yang.adata.MNode):
     l2: str
     l2_optional: ?str
@@ -860,7 +860,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker11 = None
 class foo__pc3__level1(yang.adata.MNode):
     l1: str
     l1_optional: ?str
@@ -895,7 +895,7 @@ class foo__pc3__level1(yang.adata.MNode):
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker12 = None
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
 
@@ -925,7 +925,7 @@ class foo__pc3(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc3.copy()')
 
 
-_breaker = 1
+_breaker13 = None
 class foo__empty_presence(yang.adata.MNode):
 
     mut def __init__(self):
@@ -949,7 +949,7 @@ class foo__empty_presence(yang.adata.MNode):
         raise Exception('Unreachable in foo__empty_presence.copy()')
 
 
-_breaker = 1
+_breaker14 = None
 class foo__c_dot(yang.adata.MNode):
     l_dot1: ?str
     l_dot2: ?str
@@ -980,7 +980,7 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
 
@@ -1004,7 +1004,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
     mut def __init__(self, elements=[]):
@@ -1045,7 +1045,7 @@ extension foo__cc__death(Iterable[foo__cc__death_entry]):
     def __iter__(self) -> Iterator[foo__cc__death_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
@@ -1076,7 +1076,7 @@ class foo__cc(yang.adata.MNode):
         return foo__cc.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1100,7 +1100,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
 
-_breaker = 1
+_breaker19 = None
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1124,7 +1124,7 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
 
 
-_breaker = 1
+_breaker20 = None
 class foo__f_conflict(yang.adata.MNode):
     f_foo: ?str
     f_inner: ?foo__f_conflict__f_inner
@@ -1179,7 +1179,7 @@ class foo__f_conflict(yang.adata.MNode):
         return foo__f_conflict.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker21 = None
 class foo__special_entry(yang.adata.MNode):
     yes: bool
 
@@ -1203,7 +1203,7 @@ class foo__special_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker22 = None
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
     mut def __init__(self, elements=[]):
@@ -1244,7 +1244,7 @@ extension foo__special(Iterable[foo__special_entry]):
     def __iter__(self) -> Iterator[foo__special_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker23 = None
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key1: str
     key2: str
@@ -1276,7 +1276,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker24 = None
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -1322,7 +1322,7 @@ extension foo__nested__f_inner__li1__li2(Iterable[foo__nested__f_inner__li1__li2
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1__li2_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker25 = None
 class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     name: str
     f_bar: ?str
@@ -1358,7 +1358,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker26 = None
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1403,7 +1403,7 @@ extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker27 = None
 class foo__nested__f_inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__f_inner__li1
@@ -1434,7 +1434,7 @@ class foo__nested__f_inner(yang.adata.MNode):
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker28 = None
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
@@ -1461,7 +1461,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker29 = None
 class foo__nested(yang.adata.MNode):
     f_inner: foo__nested__f_inner
     bar_inner: foo__nested__bar_inner
@@ -1492,7 +1492,7 @@ class foo__nested(yang.adata.MNode):
         return foo__nested.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker30 = None
 class foo__li_union_entry(yang.adata.MNode):
     k1: str
     k2: value
@@ -1528,7 +1528,7 @@ class foo__li_union_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker31 = None
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
     mut def __init__(self, elements=[]):
@@ -1589,7 +1589,7 @@ extension foo__li_union(Iterable[foo__li_union_entry]):
     def __iter__(self) -> Iterator[foo__li_union_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker32 = None
 class foo__state__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -1620,7 +1620,7 @@ class foo__state__c1(yang.adata.MNode):
         return foo__state__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker33 = None
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
@@ -1647,7 +1647,7 @@ class foo__state(yang.adata.MNode):
         return foo__state.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker34 = None
 class foo__c2(yang.adata.MNode):
     l1: ?str
 
@@ -1674,7 +1674,7 @@ class foo__c2(yang.adata.MNode):
         return foo__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker35 = None
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
 
@@ -1701,7 +1701,7 @@ class bar__test_idref(yang.adata.MNode):
         return bar__test_idref.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker36 = None
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
@@ -1728,7 +1728,7 @@ class bar__bar_conflict(yang.adata.MNode):
         return bar__bar_conflict.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker37 = None
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -495,7 +495,7 @@ NS_bar = 'http://example.com/bar'
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__c1__li__c4(yang.adata.MNode):
     l5: ?str
 
@@ -522,7 +522,7 @@ class foo__c1__li__c4(yang.adata.MNode):
         return foo__c1__li__c4.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__c1__li_entry(yang.adata.MNode):
     name: str
     val: ?str
@@ -554,7 +554,7 @@ class foo__c1__li_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker3 = None
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
     mut def __init__(self, elements=[]):
@@ -597,7 +597,7 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
     def __iter__(self) -> Iterator[foo__c1__li_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker4 = None
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
     l3: ?u64
@@ -680,7 +680,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker5 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
@@ -707,7 +707,7 @@ class foo__pc1__foo(yang.adata.MNode):
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker6 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
@@ -737,7 +737,7 @@ class foo__pc1(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc1.copy()')
 
 
-_breaker = 1
+_breaker7 = None
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: ?str
 
@@ -764,7 +764,7 @@ class foo__pc2__foo(yang.adata.MNode):
         return foo__pc2__foo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker8 = None
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
@@ -794,7 +794,7 @@ class foo__pc2(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc2.copy()')
 
 
-_breaker = 1
+_breaker9 = None
 class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: ?str
     l3_optional: ?str
@@ -825,7 +825,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker10 = None
 class foo__pc3__level1__level2(yang.adata.MNode):
     l2: ?str
     l2_optional: ?str
@@ -860,7 +860,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker11 = None
 class foo__pc3__level1(yang.adata.MNode):
     l1: ?str
     l1_optional: ?str
@@ -895,7 +895,7 @@ class foo__pc3__level1(yang.adata.MNode):
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker12 = None
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
 
@@ -925,7 +925,7 @@ class foo__pc3(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc3.copy()')
 
 
-_breaker = 1
+_breaker13 = None
 class foo__empty_presence(yang.adata.MNode):
 
     mut def __init__(self):
@@ -949,7 +949,7 @@ class foo__empty_presence(yang.adata.MNode):
         raise Exception('Unreachable in foo__empty_presence.copy()')
 
 
-_breaker = 1
+_breaker14 = None
 class foo__c_dot(yang.adata.MNode):
     l_dot1: ?str
     l_dot2: ?str
@@ -980,7 +980,7 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker15 = None
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
 
@@ -1004,7 +1004,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker16 = None
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
     mut def __init__(self, elements=[]):
@@ -1045,7 +1045,7 @@ extension foo__cc__death(Iterable[foo__cc__death_entry]):
     def __iter__(self) -> Iterator[foo__cc__death_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker17 = None
 class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
@@ -1076,7 +1076,7 @@ class foo__cc(yang.adata.MNode):
         return foo__cc.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker18 = None
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1100,7 +1100,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
 
-_breaker = 1
+_breaker19 = None
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1124,7 +1124,7 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
 
 
-_breaker = 1
+_breaker20 = None
 class foo__f_conflict(yang.adata.MNode):
     f_foo: ?str
     f_inner: ?foo__f_conflict__f_inner
@@ -1179,7 +1179,7 @@ class foo__f_conflict(yang.adata.MNode):
         return foo__f_conflict.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker21 = None
 class foo__special_entry(yang.adata.MNode):
     yes: bool
 
@@ -1203,7 +1203,7 @@ class foo__special_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker22 = None
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
     mut def __init__(self, elements=[]):
@@ -1244,7 +1244,7 @@ extension foo__special(Iterable[foo__special_entry]):
     def __iter__(self) -> Iterator[foo__special_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker23 = None
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key1: str
     key2: str
@@ -1276,7 +1276,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker24 = None
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -1322,7 +1322,7 @@ extension foo__nested__f_inner__li1__li2(Iterable[foo__nested__f_inner__li1__li2
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1__li2_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker25 = None
 class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     name: str
     f_bar: ?str
@@ -1358,7 +1358,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker26 = None
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1403,7 +1403,7 @@ extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker27 = None
 class foo__nested__f_inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__f_inner__li1
@@ -1434,7 +1434,7 @@ class foo__nested__f_inner(yang.adata.MNode):
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker28 = None
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
@@ -1461,7 +1461,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker29 = None
 class foo__nested(yang.adata.MNode):
     f_inner: foo__nested__f_inner
     bar_inner: foo__nested__bar_inner
@@ -1492,7 +1492,7 @@ class foo__nested(yang.adata.MNode):
         return foo__nested.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker30 = None
 class foo__li_union_entry(yang.adata.MNode):
     k1: str
     k2: value
@@ -1528,7 +1528,7 @@ class foo__li_union_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker31 = None
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
     mut def __init__(self, elements=[]):
@@ -1589,7 +1589,7 @@ extension foo__li_union(Iterable[foo__li_union_entry]):
     def __iter__(self) -> Iterator[foo__li_union_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker32 = None
 class foo__state__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -1620,7 +1620,7 @@ class foo__state__c1(yang.adata.MNode):
         return foo__state__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker33 = None
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
@@ -1647,7 +1647,7 @@ class foo__state(yang.adata.MNode):
         return foo__state.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker34 = None
 class foo__c2(yang.adata.MNode):
     l1: ?str
 
@@ -1674,7 +1674,7 @@ class foo__c2(yang.adata.MNode):
         return foo__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker35 = None
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
 
@@ -1701,7 +1701,7 @@ class bar__test_idref(yang.adata.MNode):
         return bar__test_idref.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker36 = None
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
@@ -1728,7 +1728,7 @@ class bar__bar_conflict(yang.adata.MNode):
         return bar__bar_conflict.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker37 = None
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -50,7 +50,7 @@ def src_yang():
 NS_loose_required = 'http://example.com/loose-required'
 
 
-_breaker = 1
+_breaker1 = None
 class loose_required__c2(yang.adata.MNode):
     l1: ?str
 
@@ -77,7 +77,7 @@ class loose_required__c2(yang.adata.MNode):
         return loose_required__c2.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class root(yang.adata.MNode):
     c2: loose_required__c2
 

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -125,7 +125,7 @@ def src_yang():
 NS_foo = 'http://example.com/foo'
 
 
-_breaker = 1
+_breaker1 = None
 class foo__tc1(yang.adata.MNode):
     l1: str
     l2: ?str
@@ -156,7 +156,7 @@ class foo__tc1(yang.adata.MNode):
         return foo__tc1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class foo__li__c1(yang.adata.MNode):
     l1: str
     l2: ?str
@@ -187,7 +187,7 @@ class foo__li__c1(yang.adata.MNode):
         return foo__li__c1.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class foo__li_entry(yang.adata.MNode):
     name: str
     c1: foo__li__c1
@@ -215,7 +215,7 @@ class foo__li_entry(yang.adata.MNode):
         """Create a deep copy of this adata object"""
         return foo__li_entry.from_gdata(self.to_gdata())
 
-_breaker = 1
+_breaker4 = None
 class foo__li(yang.adata.MNode):
     elements: list[foo__li_entry]
     mut def __init__(self, elements=[]):
@@ -257,7 +257,7 @@ extension foo__li(Iterable[foo__li_entry]):
     def __iter__(self) -> Iterator[foo__li_entry]:
         return self.elements.__iter__()
 
-_breaker = 1
+_breaker5 = None
 class root(yang.adata.MNode):
     tc1: foo__tc1
     li: foo__li

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -72,7 +72,7 @@ def src_yang():
 NS_yangrpc = 'http://example.com/yangrpc'
 
 
-_breaker = 1
+_breaker1 = None
 class root(yang.adata.MNode):
 
     mut def __init__(self):
@@ -93,7 +93,7 @@ class root(yang.adata.MNode):
         return root.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker2 = None
 class yangrpc__foo__input__woo(yang.adata.MNode):
     woo_b: ?int
 
@@ -120,7 +120,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
         return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker3 = None
 class yangrpc__foo__input(yang.adata.MNode):
     a: ?str
     woo: yangrpc__foo__input__woo
@@ -151,7 +151,7 @@ class yangrpc__foo__input(yang.adata.MNode):
         return yangrpc__foo__input.from_gdata(self.to_gdata())
 
 
-_breaker = 1
+_breaker4 = None
 class yangrpc__foo__output(yang.adata.MNode):
     outoo: ?str
 


### PR DESCRIPTION
We insert _breaker assignmentes between generated classes in order to tickle the compiler into breaking apart large recursive groups into individual declarations but reassigning the same name should actually not be allowed at all, so we now use unique names. Also assign None which maps to C NULL which avoids a tiny bit of allocations.