### PR TITLE
Filter out attributes from adata based on extensions

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -388,7 +388,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -511,7 +511,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -570,8 +570,16 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, breaker_idx=breaker_idx)
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, exclude_ext=exclude_ext, breaker_idx=breaker_idx)
             res.extend(child_res)
+
+        def excluded(n):
+            for eext in exclude_ext:
+                for next in n.exts:
+                    if next.name == eext.name and next.namespace == eext.namespace:
+                        return True
+            return False
+        attr_children = [c for c in self.children if not excluded(c)]
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -586,7 +594,7 @@ class DNodeInner(DNode):
             res.append("{breaker_name} = None")
             res.append("class {pname()}(yang.adata.MNode):")
 
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DLeaf):
                 res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, list_keys(self), loose)}")
             elif isinstance(child, DLeafList):
@@ -615,7 +623,7 @@ class DNodeInner(DNode):
         res.append("")
         req_args = []
         opt_args = []
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
                     opt_args.append("{usname(child)}: ?{pname(child)}=None")
@@ -641,7 +649,7 @@ class DNodeInner(DNode):
         # Set namespace from us
         res.append("        self._ns = '{self.namespace}'")
 
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DContainer):
                 if (loose or optional_subtree(child)) and not child.presence:
                     res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {pname(child)}()")
@@ -668,14 +676,14 @@ class DNodeInner(DNode):
                 res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else []")
             elif isinstance(child, DList):
                 res.append("        self.{usname(child)} = {pname(child)}(elements={usname(child)})")
-        if len(self.children) == 0:
+        if len(attr_children) == 0:
             res.append("        pass")
         res.append("")
 
         # Handle all P-container children, we want a .create_XXX() method
         # for each that takes as arguments the mandatory children of the
         # container
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DContainer) and child.presence:
                 # We must generate unique safe names for this node children too
                 child_unique_namer = UniqueNamer(child)
@@ -707,9 +715,9 @@ class DNodeInner(DNode):
                 res.append("        return res")
                 res.append("")
 
-        if len(self.children) > 0:
+        if len(attr_children) > 0:
             res.append("    def _get_attr(self, name: str) -> ?value:")
-            for child in self.children:
+            for child in attr_children:
                 res.append("        if name == '{usname(child)}':")
                 if isinstance(child, DList):
                     res.append("            return iter(self.{usname(child)})")
@@ -730,7 +738,7 @@ class DNodeInner(DNode):
         # .from_gdata()
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DNodeLeaf):
                 from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
             else:
@@ -798,7 +806,7 @@ class DNodeInner(DNode):
             list_args_req = []
             list_args_opt = []
             list_key_types = {}
-            for child in self.children:
+            for child in attr_children:
                 if isinstance(child, DLeaf):
                     if usname(child) in list_key_args:
                         list_key_types[usname(child)] = child.type_
@@ -896,7 +904,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, breaker_idx=breaker_idx)
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, exclude_ext=exclude_ext, breaker_idx=breaker_idx)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -1685,7 +1693,7 @@ class DRoot(DNodeInner):
             ("module_metadata", self.module_metadata),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[]) -> str:
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[]) -> str:
         def build_spath(spath: list[DNode]):
             if len(root_path) == len(spath) - 1:
                 return spath
@@ -1702,7 +1710,7 @@ class DRoot(DNodeInner):
         # the SRC_DNODE constant to have the same view of the schema as the
         # adata code generator ...
         spath = build_spath([self])
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext)
 
         res = []
         res.append("import base64")

--- a/snapshots/expected/test_yang/prdaclass_exclude_ext
+++ b/snapshots/expected/test_yang/prdaclass_exclude_ext
@@ -1,0 +1,124 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.xml
+import yang.xpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+
+
+_identities: list[DIdentity] = []
+
+
+SRC_DNODE_CHILD_0 = DContainer(module='foo', namespace='http://example.com/foo', prefix='foo', name='c1', config=True, presence=False, children=[
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DContainer(module='foo', namespace='http://example.com/foo', prefix='foo', name='dynstate', config=True, presence=False, exts=[
+            DExt(module='foo', namespace='http://example.com/foo', prefix='foo', name='dynstate', arg=None, exts=[])
+        ], children=[
+        DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='ds1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ])
+])
+
+SRC_DNODE = DRoot(
+    children=[SRC_DNODE_CHILD_0],
+    identities=[],
+    rpcs=[],
+    module_metadata={'http://example.com/foo':('foo', None)},
+)
+
+NS_foo = 'http://example.com/foo'
+
+
+_breaker1 = None
+class foo__c1__dynstate(yang.adata.MNode):
+    ds1: ?str
+
+    mut def __init__(self, ds1: ?str):
+        self._ns = 'http://example.com/foo'
+        self.ds1 = ds1
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'ds1':
+            return self.ds1
+        raise ValueError('Attribute {name} not found in foo__c1__dynstate')
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'dynstate'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__dynstate:
+        if n is not None:
+            return foo__c1__dynstate(ds1=n.get_opt_str(yang.gdata.Id(NS_foo, 'ds1')))
+        return foo__c1__dynstate()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1__dynstate.from_gdata(self.to_gdata())
+
+
+_breaker2 = None
+class foo__c1(yang.adata.MNode):
+    l1: ?str
+
+    mut def __init__(self, l1: ?str):
+        self._ns = 'http://example.com/foo'
+        self.l1 = l1
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'l1':
+            return self.l1
+        raise ValueError('Attribute {name} not found in foo__c1')
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+        if n is not None:
+            return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
+        return foo__c1()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
+
+_breaker3 = None
+class root(yang.adata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None):
+        self._ns = ''
+        self.c1 = c1 if c1 is not None else foo__c1()
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'c1':
+            return self.c1
+        raise ValueError('Attribute {name} not found in root')
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+        if n is not None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
+        return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2691,6 +2691,30 @@ def _test_prdaclass_rpc():
     src = root.prdaclass()
     return src
 
+def _test_prdaclass_exclude_ext():
+    ys = r"""module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    extension dynstate {
+        description "marks a dynamic state container";
+    }
+    container c1 {
+        leaf l1 {
+            type string;
+        }
+        container dynstate {
+            foo:dynstate;
+            leaf ds1 {
+                type string;
+            }
+        }
+    }
+}"""
+    root = yang.compile([ys])
+    src = root.prdaclass(exclude_ext=[(name="dynstate", namespace="http://example.com/foo")])
+    return src
+
 def _test_identityref():
     # Base module with base identity and a leaf that references it
     ys_base = r"""module base {

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -384,7 +384,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -507,7 +507,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, breaker_idx: int=0) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -566,8 +566,16 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, breaker_idx=breaker_idx)
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, exclude_ext=exclude_ext, breaker_idx=breaker_idx)
             res.extend(child_res)
+
+        def excluded(n):
+            for eext in exclude_ext:
+                for next in n.exts:
+                    if next.name == eext.name and next.namespace == eext.namespace:
+                        return True
+            return False
+        attr_children = [c for c in self.children if not excluded(c)]
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -582,7 +590,7 @@ class DNodeInner(DNode):
             res.append("{breaker_name} = None")
             res.append("class {pname()}(yang.adata.MNode):")
 
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DLeaf):
                 res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, list_keys(self), loose)}")
             elif isinstance(child, DLeafList):
@@ -611,7 +619,7 @@ class DNodeInner(DNode):
         res.append("")
         req_args = []
         opt_args = []
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DContainer):
                 if loose or child.presence or optional_subtree(child):
                     opt_args.append("{usname(child)}: ?{pname(child)}=None")
@@ -637,7 +645,7 @@ class DNodeInner(DNode):
         # Set namespace from us
         res.append("        self._ns = '{self.namespace}'")
 
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DContainer):
                 if (loose or optional_subtree(child)) and not child.presence:
                     res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {pname(child)}()")
@@ -664,14 +672,14 @@ class DNodeInner(DNode):
                 res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else []")
             elif isinstance(child, DList):
                 res.append("        self.{usname(child)} = {pname(child)}(elements={usname(child)})")
-        if len(self.children) == 0:
+        if len(attr_children) == 0:
             res.append("        pass")
         res.append("")
 
         # Handle all P-container children, we want a .create_XXX() method
         # for each that takes as arguments the mandatory children of the
         # container
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DContainer) and child.presence:
                 # We must generate unique safe names for this node children too
                 child_unique_namer = UniqueNamer(child)
@@ -703,9 +711,9 @@ class DNodeInner(DNode):
                 res.append("        return res")
                 res.append("")
 
-        if len(self.children) > 0:
+        if len(attr_children) > 0:
             res.append("    def _get_attr(self, name: str) -> ?value:")
-            for child in self.children:
+            for child in attr_children:
                 res.append("        if name == '{usname(child)}':")
                 if isinstance(child, DList):
                     res.append("            return iter(self.{usname(child)})")
@@ -726,7 +734,7 @@ class DNodeInner(DNode):
         # .from_gdata()
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
-        for child in self.children:
+        for child in attr_children:
             if isinstance(child, DNodeLeaf):
                 from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
             else:
@@ -794,7 +802,7 @@ class DNodeInner(DNode):
             list_args_req = []
             list_args_opt = []
             list_key_types = {}
-            for child in self.children:
+            for child in attr_children:
                 if isinstance(child, DLeaf):
                     if usname(child) in list_key_args:
                         list_key_types[usname(child)] = child.type_
@@ -892,7 +900,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, breaker_idx=breaker_idx)
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, exclude_ext=exclude_ext, breaker_idx=breaker_idx)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -1681,7 +1689,7 @@ class DRoot(DNodeInner):
             ("module_metadata", self.module_metadata),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[]) -> str:
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[]) -> str:
         def build_spath(spath: list[DNode]):
             if len(root_path) == len(spath) - 1:
                 return spath
@@ -1698,7 +1706,7 @@ class DRoot(DNodeInner):
         # the SRC_DNODE constant to have the same view of the schema as the
         # adata code generator ...
         spath = build_spath([self])
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext)
 
         res = []
         res.append("import base64")
@@ -11098,3 +11106,4 @@ def escape_as_fstr(s: str) -> str:
     copy_until(b, s_len)
 
     return "".join(parts)
+


### PR DESCRIPTION
When generating adata for a transform, filter out attributes that are annotated with an extension statement. The adata types for the structures themselves are still printed.

This is used in StratoWeave for preventing the dynstate / memory containers from appearing as attributes in the transform input / output type.