### PR TITLE
Move module docstrings first

### DIFF
--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -1,13 +1,11 @@
+"""Base classes for YANG-modeled data classes (MData)
+"""
 
 import yang.schema
 import yang.gdata
 from yang.data import from_data, YangData, PathElement, YangValidationError
 from yang.data import coerce_integer_value, unwrap_key
 from yang.data import OP_CREATE, OP_DELETE, OP_REMOVE, OP_REPLACE, OP_MERGE
-
-
-"""Base classes for YANG-modeled data classes (MData)
-"""
 
 class MNode(object):
     _ns: str

--- a/src/yang/gdata.act
+++ b/src/yang/gdata.act
@@ -1,3 +1,9 @@
+"""YANG data
+
+This module defines classes for YANG data nodes. It can represent a YANG data
+tree, and can be used to serialize and deserialize YANG data.
+"""
+
 import base64
 import testing
 import json
@@ -5,12 +11,6 @@ import xml
 
 from yang.identityref import Identityref, PartialIdentityref
 from yang.type import Decimal
-
-"""YANG data
-
-This module defines classes for YANG data nodes. It can represent a YANG data
-tree, and can be used to serialize and deserialize YANG data.
-"""
 
 # kinds of things?
 # - container


### PR DESCRIPTION
The stricter module parser only treats a bare string as a module
 docstring when it is the first statement in the file.

adata.act, data.act, and gdata.act still carried valid module
 documentation, but two of them placed that text after imports and my
 earlier local fix dropped it entirely.

This restores the docstrings and places them before the imports so the
 documentation remains intact and the modules still satisfy the
 top-level constant-only rule.