### PR TITLE
Return None for missing adata attrs

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -723,7 +723,6 @@ class DNodeInner(DNode):
                     res.append("            return iter(self.{usname(child)})")
                 else:
                     res.append("            return self.{usname(child)}")
-            res.append("        raise ValueError('Attribute {{name}} not found in {pname()}')")
             res.append("")
 
         # .to_gdata()

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -111,7 +111,6 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
             return self.max_nodes
         if name == 'supported_excluded_change_type':
             return self.supported_excluded_change_type
-        raise ValueError('Attribute {name} not found in base__system_capabilities__subscription_capabilities')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:system-capabilities', 'augmenter:subscription-capabilities'])
@@ -142,7 +141,6 @@ class base__system_capabilities(yang.adata.MNode):
             return iter(self.per_node_capabilities)
         if name == 'subscription_capabilities':
             return self.subscription_capabilities
-        raise ValueError('Attribute {name} not found in base__system_capabilities')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:system-capabilities'])
@@ -169,7 +167,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'system_capabilities':
             return self.system_capabilities
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment
+++ b/snapshots/expected/test_yang/compile_augment
@@ -49,7 +49,6 @@ class foo__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -76,7 +75,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_augmented_node
+++ b/snapshots/expected/test_yang/compile_augment_augmented_node
@@ -59,7 +59,6 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
             return self.bind
         if name == 'port':
             return self.port
-        raise ValueError('Attribute {name} not found in base__native__voice__service__voip__sip')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice', 'service', 'voip', 'sip'])
@@ -90,7 +89,6 @@ class base__native__voice__service__voip(yang.adata.MNode):
             return self.enabled
         if name == 'sip':
             return self.sip
-        raise ValueError('Attribute {name} not found in base__native__voice__service__voip')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice', 'service', 'voip'])
@@ -117,7 +115,6 @@ class base__native__voice__service(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'voip':
             return self.voip
-        raise ValueError('Attribute {name} not found in base__native__voice__service')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice', 'service'])
@@ -144,7 +141,6 @@ class base__native__voice(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'service':
             return self.service
-        raise ValueError('Attribute {name} not found in base__native__voice')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice'])
@@ -171,7 +167,6 @@ class base__native(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'voice':
             return self.voice
-        raise ValueError('Attribute {name} not found in base__native')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native'])
@@ -198,7 +193,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'native':
             return self.native
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -80,7 +80,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)
@@ -107,7 +106,6 @@ class foo__r1__input__c3(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l3':
             return self.l3
-        raise ValueError('Attribute {name} not found in foo__r1__input__c3')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:r1', 'input', 'c3'])
@@ -134,7 +132,6 @@ class foo__r1__input(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c3':
             return self.c3
-        raise ValueError('Attribute {name} not found in foo__r1__input')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:r1', 'input'])
@@ -161,7 +158,6 @@ class foo__r1__output(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l4':
             return self.l4
-        raise ValueError('Attribute {name} not found in foo__r1__output')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:r1', 'output'])

--- a/snapshots/expected/test_yang/compile_augment_import
+++ b/snapshots/expected/test_yang/compile_augment_import
@@ -50,7 +50,6 @@ class foo__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -77,7 +76,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_on_augment
+++ b/snapshots/expected/test_yang/compile_augment_on_augment
@@ -52,7 +52,6 @@ class foo__c1__c2(yang.adata.MNode):
             return self.l2
         if name == 'l3':
             return self.l3
-        raise ValueError('Attribute {name} not found in foo__c1__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'c2'])
@@ -83,7 +82,6 @@ class foo__c1(yang.adata.MNode):
             return self.l1
         if name == 'c2':
             return self.c2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -110,7 +108,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
+++ b/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
@@ -54,7 +54,6 @@ class foo__c1__c2(yang.adata.MNode):
             return self.l2
         if name == 'l3':
             return self.l3
-        raise ValueError('Attribute {name} not found in foo__c1__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'bar:c2'])
@@ -85,7 +84,6 @@ class foo__c1(yang.adata.MNode):
             return self.l1
         if name == 'c2':
             return self.c2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -112,7 +110,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_uses
+++ b/snapshots/expected/test_yang/compile_augment_uses
@@ -49,7 +49,6 @@ class foo__c1__c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'c2'])
@@ -76,7 +75,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c2':
             return self.c2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -103,7 +101,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_bundle1
+++ b/snapshots/expected/test_yang/compile_bundle1
@@ -50,7 +50,6 @@ class foo__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -77,7 +76,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -56,7 +56,6 @@ class foo__c1__things_entry(yang.adata.MNode):
             return self.name
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in foo__c1__things')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'things'])
@@ -123,7 +122,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'things':
             return iter(self.things)
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -150,7 +148,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_import_hyphenated_prefix
+++ b/snapshots/expected/test_yang/compile_import_hyphenated_prefix
@@ -45,7 +45,6 @@ class acme_foo_bar__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in acme_foo_bar__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['acme_foo-bar:c1'])
@@ -72,7 +71,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -68,7 +68,6 @@ class bar__c1__li1_entry(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in bar__c1__li1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:c1', 'li1'])
@@ -135,7 +134,6 @@ class bar__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'li1':
             return iter(self.li1)
-        raise ValueError('Attribute {name} not found in bar__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:c1'])
@@ -162,7 +160,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_refine
+++ b/snapshots/expected/test_yang/compile_refine
@@ -50,7 +50,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -77,7 +76,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
@@ -56,7 +56,6 @@ class parent__parent_container(yang.adata.MNode):
             return self.parent_leaf
         if name == 'augmented_leaf':
             return self.augmented_leaf
-        raise ValueError('Attribute {name} not found in parent__parent_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:parent-container'])
@@ -87,7 +86,6 @@ class parent__sub_container(yang.adata.MNode):
             return self.sub_leaf
         if name == 'another_leaf':
             return self.another_leaf
-        raise ValueError('Attribute {name} not found in parent__sub_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:sub-container'])
@@ -118,7 +116,6 @@ class root(yang.adata.MNode):
             return self.parent_container
         if name == 'sub_container':
             return self.sub_container
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -61,7 +61,6 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'sub_group_leaf':
             return self.sub_group_leaf
-        raise ValueError('Attribute {name} not found in main_module__main_container__sub_group_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'sub-group-container'])
@@ -96,7 +95,6 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
             return self.sub_value
         if name == 'ref_to_main':
             return self.ref_to_main
-        raise ValueError('Attribute {name} not found in main_module__main_container__sub_list')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'sub-list'])
@@ -169,7 +167,6 @@ class main_module__main_container__group_container(yang.adata.MNode):
             return self.group_leaf
         if name == 'augmented_in_group':
             return self.augmented_in_group
-        raise ValueError('Attribute {name} not found in main_module__main_container__group_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'group-container'])
@@ -212,7 +209,6 @@ class main_module__main_container(yang.adata.MNode):
             return iter(self.sub_list)
         if name == 'group_container':
             return self.group_container
-        raise ValueError('Attribute {name} not found in main_module__main_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container'])
@@ -239,7 +235,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'main_container':
             return self.main_container
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
@@ -55,7 +55,6 @@ class parent__parent_container(yang.adata.MNode):
             return self.parent_leaf
         if name == 'augmented_leaf':
             return self.augmented_leaf
-        raise ValueError('Attribute {name} not found in parent__parent_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:parent-container'])
@@ -86,7 +85,6 @@ class parent__sub_container(yang.adata.MNode):
             return self.sub_leaf
         if name == 'shared_leaf':
             return self.shared_leaf
-        raise ValueError('Attribute {name} not found in parent__sub_container')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:sub-container'])
@@ -117,7 +115,6 @@ class root(yang.adata.MNode):
             return self.parent_container
         if name == 'sub_container':
             return self.sub_container
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodules1
+++ b/snapshots/expected/test_yang/compile_submodules1
@@ -48,7 +48,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -75,7 +74,6 @@ class foo__c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c2'])
@@ -106,7 +104,6 @@ class root(yang.adata.MNode):
             return self.c1
         if name == 'c2':
             return self.c2
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -46,7 +46,6 @@ class foo__c1__li1_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1__li1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li1'])
@@ -111,7 +110,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'li1':
             return iter(self.li1)
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -138,7 +136,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_uses_augment
+++ b/snapshots/expected/test_yang/compile_uses_augment
@@ -52,7 +52,6 @@ class foo__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -79,7 +78,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/identityref
+++ b/snapshots/expected/test_yang/identityref
@@ -83,7 +83,6 @@ class base__config(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'active_protocol':
             return self.active_protocol
-        raise ValueError('Attribute {name} not found in base__config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:config'])
@@ -110,7 +109,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'config':
             return self.config
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -51,7 +51,6 @@ class base_module__network_instances__network_instance__state(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in base_module__network_instances__network_instance__state')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance', 'state'])
@@ -86,7 +85,6 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
             return self.state
         if name == 'ref':
             return self.ref
-        raise ValueError('Attribute {name} not found in base_module__network_instances__network_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance'])
@@ -153,7 +151,6 @@ class base_module__network_instances(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'network_instance':
             return iter(self.network_instance)
-        raise ValueError('Attribute {name} not found in base_module__network_instances')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances'])
@@ -180,7 +177,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'network_instances':
             return self.network_instances
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -60,7 +60,6 @@ class other_module__other_network_instances__network_instance_entry(yang.adata.M
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in other_module__other_network_instances__network_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['other-module:network-instances', 'network-instance'])
@@ -125,7 +124,6 @@ class other_module__other_network_instances(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'network_instance':
             return iter(self.network_instance)
-        raise ValueError('Attribute {name} not found in other_module__other_network_instances')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['other-module:network-instances'])
@@ -152,7 +150,6 @@ class base_module__base_network_instances__network_instance__config(yang.adata.M
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in base_module__base_network_instances__network_instance__config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance', 'config'])
@@ -183,7 +180,6 @@ class base_module__base_network_instances__network_instance_entry(yang.adata.MNo
             return self.name
         if name == 'config':
             return self.config
-        raise ValueError('Attribute {name} not found in base_module__base_network_instances__network_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance'])
@@ -248,7 +244,6 @@ class base_module__base_network_instances(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'network_instance':
             return iter(self.network_instance)
-        raise ValueError('Attribute {name} not found in base_module__base_network_instances')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances'])
@@ -275,7 +270,6 @@ class base_module__uses_leafref(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'ni':
             return self.ni
-        raise ValueError('Attribute {name} not found in base_module__uses_leafref')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:uses-leafref'])
@@ -310,7 +304,6 @@ class root(yang.adata.MNode):
             return self.base_network_instances
         if name == 'uses_leafref':
             return self.uses_leafref
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -54,7 +54,6 @@ class base_module__network_instances__network_instance__config(yang.adata.MNode)
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in base_module__network_instances__network_instance__config')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance', 'config'])
@@ -85,7 +84,6 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
             return self.name
         if name == 'config':
             return self.config
-        raise ValueError('Attribute {name} not found in base_module__network_instances__network_instance')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance'])
@@ -150,7 +148,6 @@ class base_module__network_instances(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'network_instance':
             return iter(self.network_instance)
-        raise ValueError('Attribute {name} not found in base_module__network_instances')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances'])
@@ -177,7 +174,6 @@ class consumer_module__uses_typedef(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'ni':
             return self.ni
-        raise ValueError('Attribute {name} not found in consumer_module__uses_typedef')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['consumer-module:uses-typedef'])
@@ -208,7 +204,6 @@ class root(yang.adata.MNode):
             return self.network_instances
         if name == 'uses_typedef':
             return self.uses_typedef
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -50,7 +50,6 @@ class foo__c__li__bar(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'man':
             return self.man
-        raise ValueError('Attribute {name} not found in foo__c__li__bar')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c', 'li', 'bar'])
@@ -85,7 +84,6 @@ class foo__c__li_entry(yang.adata.MNode):
             return self.foo
         if name == 'bar':
             return self.bar
-        raise ValueError('Attribute {name} not found in foo__c__li')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c', 'li'])

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -55,7 +55,6 @@ class base__c1__base_l1_entry(yang.adata.MNode):
             return self.base_k1
         if name == 'foo_k1':
             return self.foo_k1
-        raise ValueError('Attribute {name} not found in base__c1__base_l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'l1'])
@@ -121,7 +120,6 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'k2':
             return self.k2
-        raise ValueError('Attribute {name} not found in base__c1__foo_l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'foo:l1'])
@@ -190,7 +188,6 @@ class base__c1(yang.adata.MNode):
             return iter(self.base_l1)
         if name == 'foo_l1':
             return iter(self.foo_l1)
-        raise ValueError('Attribute {name} not found in base__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1'])
@@ -217,7 +214,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
@@ -50,7 +50,6 @@ class base__c1__base_c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in base__c1__base_c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'c2'])
@@ -77,7 +76,6 @@ class base__c1__foo_c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in base__c1__foo_c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'foo:c2'])
@@ -108,7 +106,6 @@ class base__c1(yang.adata.MNode):
             return self.base_c2
         if name == 'foo_c2':
             return self.foo_c2
-        raise ValueError('Attribute {name} not found in base__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1'])
@@ -135,7 +132,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_augment_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_name_conflict
@@ -51,7 +51,6 @@ class base__c1(yang.adata.MNode):
             return self.bar_foo
         if name == 'foo_foo':
             return self.foo_foo
-        raise ValueError('Attribute {name} not found in base__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1'])

--- a/snapshots/expected/test_yang/prdaclass_dot
+++ b/snapshots/expected/test_yang/prdaclass_dot
@@ -44,7 +44,6 @@ class foo__ieee_802_3(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'ieee_802_3':
             return self.ieee_802_3
-        raise ValueError('Attribute {name} not found in foo__ieee_802_3')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:ieee-802.3'])
@@ -71,7 +70,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'ieee_802_3':
             return self.ieee_802_3
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_exclude_ext
+++ b/snapshots/expected/test_yang/prdaclass_exclude_ext
@@ -49,7 +49,6 @@ class foo__c1__dynstate(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'ds1':
             return self.ds1
-        raise ValueError('Attribute {name} not found in foo__c1__dynstate')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'dynstate'])
@@ -76,7 +75,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -103,7 +101,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -70,7 +70,6 @@ class foo__c1__l1_entry(yang.adata.MNode):
             return self.k1
         if name == 'k2':
             return self.k2
-        raise ValueError('Attribute {name} not found in foo__c1__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'l1'])
@@ -138,7 +137,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return iter(self.l1)
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -165,7 +163,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_keyword_name_import
+++ b/snapshots/expected/test_yang/prdaclass_keyword_name_import
@@ -64,7 +64,6 @@ class foo__c1(yang.adata.MNode):
             return self.in_
         if name == 'with_':
             return self.with_
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -44,7 +44,6 @@ class foo__l1_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in foo__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -49,7 +49,6 @@ class foo__l1_entry(yang.adata.MNode):
             return self.name
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in foo__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])

--- a/snapshots/expected/test_yang/prdaclass_loose_container_in_container
+++ b/snapshots/expected/test_yang/prdaclass_loose_container_in_container
@@ -46,7 +46,6 @@ class foo__foo__bar(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__foo__bar')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo', 'bar'])
@@ -73,7 +72,6 @@ class foo__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'bar':
             return self.bar
-        raise ValueError('Attribute {name} not found in foo__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo'])

--- a/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -46,7 +46,6 @@ class foo__foo__bar(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__foo__bar')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo', 'bar'])
@@ -86,7 +85,6 @@ class foo__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'bar':
             return self.bar
-        raise ValueError('Attribute {name} not found in foo__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo'])

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -46,7 +46,6 @@ class foo__li1_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__li1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li1'])
@@ -115,7 +114,6 @@ class root(yang.adata.MNode):
             return iter(self.li1)
         if name == 'll1':
             return self.ll1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -46,7 +46,6 @@ class foo__li1_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__li1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li1'])
@@ -115,7 +114,6 @@ class root(yang.adata.MNode):
             return iter(self.li1)
         if name == 'll1':
             return self.ll1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -48,7 +48,6 @@ class foo__l1__bar(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'hi':
             return self.hi
-        raise ValueError('Attribute {name} not found in foo__l1__bar')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:l1', 'bar'])
@@ -83,7 +82,6 @@ class foo__l1_entry(yang.adata.MNode):
             return self.id
         if name == 'bar':
             return self.bar
-        raise ValueError('Attribute {name} not found in foo__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:l1'])
@@ -150,7 +148,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return iter(self.l1)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -82,7 +82,6 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'woo_b':
             return self.woo_b
-        raise ValueError('Attribute {name} not found in yangrpc__foo__input__woo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
@@ -113,7 +112,6 @@ class yangrpc__foo__input(yang.adata.MNode):
             return self.a
         if name == 'woo':
             return self.woo
-        raise ValueError('Attribute {name} not found in yangrpc__foo__input')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input'])
@@ -140,7 +138,6 @@ class yangrpc__foo__output(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'outoo':
             return self.outoo
-        raise ValueError('Attribute {name} not found in yangrpc__foo__output')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'output'])

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -49,7 +49,6 @@ class foo__l1_entry(yang.adata.MNode):
             return self.name
         if name == 'id':
             return self.id
-        raise ValueError('Attribute {name} not found in foo__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -47,7 +47,6 @@ class foo__l1__bar(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'hi':
             return self.hi
-        raise ValueError('Attribute {name} not found in foo__l1__bar')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1', 'bar'])
@@ -90,7 +89,6 @@ class foo__l1_entry(yang.adata.MNode):
             return self.name
         if name == 'bar':
             return self.bar
-        raise ValueError('Attribute {name} not found in foo__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])

--- a/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -57,7 +57,6 @@ class foo__foo__bar(yang.adata.MNode):
             return self.bar_l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__foo__bar')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:foo', 'bar'])
@@ -98,7 +97,6 @@ class foo__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'bar':
             return self.bar
-        raise ValueError('Attribute {name} not found in foo__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:foo'])
@@ -136,7 +134,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_top_conflict
+++ b/snapshots/expected/test_yang/prdaclass_top_conflict
@@ -49,7 +49,6 @@ class bar__bar_c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in bar__bar_c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:c1'])
@@ -76,7 +75,6 @@ class foo__foo_c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__foo_c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -107,7 +105,6 @@ class root(yang.adata.MNode):
             return self.bar_c1
         if name == 'foo_c1':
             return self.foo_c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
+++ b/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
@@ -50,7 +50,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -77,7 +76,6 @@ class foo__pc1__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__pc1__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1', 'foo'])
@@ -104,7 +102,6 @@ class foo__pc1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__pc1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1'])
@@ -146,7 +143,6 @@ class root(yang.adata.MNode):
             return self.c1
         if name == 'pc1':
             return self.pc1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -59,7 +59,6 @@ class foo__c1__l1_entry(yang.adata.MNode):
             return self.k2
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c1__l1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'l1'])
@@ -135,7 +134,6 @@ class foo__c1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return iter(self.l1)
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -162,7 +160,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/resolve_type_union_of_intX
+++ b/snapshots/expected/test_yang/resolve_type_union_of_intX
@@ -60,7 +60,6 @@ class root(yang.adata.MNode):
             return self.l3
         if name == 'l4':
             return self.l4
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/resolve_type_union_of_string
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string
@@ -42,7 +42,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
@@ -42,7 +42,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -719,7 +719,6 @@ class DNodeInner(DNode):
                     res.append("            return iter(self.{usname(child)})")
                 else:
                     res.append("            return self.{usname(child)}")
-            res.append("        raise ValueError('Attribute {{name}} not found in {pname()}')")
             res.append("")
 
         # .to_gdata()

--- a/src/yang/test_data.act
+++ b/src/yang/test_data.act
@@ -252,7 +252,7 @@ class _test_leafref_c(yang.adata.MNode):
             return self.ref
         if name == "refs":
             return self.refs
-        raise ValueError("Attribute {name} not found in _test_leafref_c")
+        return None
 
     mut def to_gdata(self) -> yang.gdata.Node:
         raise NotImplementedError("to_gdata")
@@ -271,7 +271,7 @@ class _test_leafref_root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == "c":
             return self.c
-        raise ValueError("Attribute {name} not found in _test_leafref_root")
+        return None
 
     mut def to_gdata(self) -> yang.gdata.Node:
         raise NotImplementedError("to_gdata")

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -197,7 +197,6 @@ class basics__c(yang.adata.MNode):
             return self.l_binary_def
         if name == 'l_identityref_def':
             return self.l_identityref_def
-        raise ValueError('Attribute {name} not found in basics__c')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['basics:c'])
@@ -224,7 +223,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c':
             return self.c
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -506,7 +506,6 @@ class foo__c1__li__c4(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l5':
             return self.l5
-        raise ValueError('Attribute {name} not found in foo__c1__li__c4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li', 'c4'])
@@ -541,7 +540,6 @@ class foo__c1__li_entry(yang.adata.MNode):
             return self.val
         if name == 'c4':
             return self.c4
-        raise ValueError('Attribute {name} not found in foo__c1__li')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li'])
@@ -664,7 +662,6 @@ class foo__c1(yang.adata.MNode):
             return self.l2
         if name == 'l_leafref':
             return self.l_leafref
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -691,7 +688,6 @@ class foo__pc1__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__pc1__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1', 'foo'])
@@ -718,7 +714,6 @@ class foo__pc1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__pc1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1'])
@@ -748,7 +743,6 @@ class foo__pc2__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l_mandatory':
             return self.l_mandatory
-        raise ValueError('Attribute {name} not found in foo__pc2__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2', 'foo'])
@@ -775,7 +769,6 @@ class foo__pc2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__pc2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2'])
@@ -809,7 +802,6 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
             return self.l3
         if name == 'l3_optional':
             return self.l3_optional
-        raise ValueError('Attribute {name} not found in foo__pc3__level1__level2__level3')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
@@ -844,7 +836,6 @@ class foo__pc3__level1__level2(yang.adata.MNode):
             return self.l2_optional
         if name == 'level3':
             return self.level3
-        raise ValueError('Attribute {name} not found in foo__pc3__level1__level2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2'])
@@ -879,7 +870,6 @@ class foo__pc3__level1(yang.adata.MNode):
             return self.l1_optional
         if name == 'level2':
             return self.level2
-        raise ValueError('Attribute {name} not found in foo__pc3__level1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1'])
@@ -906,7 +896,6 @@ class foo__pc3(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'level1':
             return self.level1
-        raise ValueError('Attribute {name} not found in foo__pc3')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3'])
@@ -964,7 +953,6 @@ class foo__c_dot(yang.adata.MNode):
             return self.l_dot1
         if name == 'l_dot2':
             return self.l_dot2
-        raise ValueError('Attribute {name} not found in foo__c_dot')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c.dot'])
@@ -991,7 +979,6 @@ class foo__cc__death_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in foo__cc__death')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc', 'death'])
@@ -1060,7 +1047,6 @@ class foo__cc(yang.adata.MNode):
             return self.cake
         if name == 'death':
             return iter(self.death)
-        raise ValueError('Attribute {name} not found in foo__cc')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc'])
@@ -1163,7 +1149,6 @@ class foo__f_conflict(yang.adata.MNode):
             return self.bar_foo
         if name == 'bar_inner':
             return self.bar_inner
-        raise ValueError('Attribute {name} not found in foo__f_conflict')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict'])
@@ -1190,7 +1175,6 @@ class foo__special_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'yes':
             return self.yes
-        raise ValueError('Attribute {name} not found in foo__special')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:special'])
@@ -1263,7 +1247,6 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
             return self.key2
         if name == 'baz':
             return self.baz
-        raise ValueError('Attribute {name} not found in foo__nested__f_inner__li1__li2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1', 'li2'])
@@ -1345,7 +1328,6 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
             return iter(self.li2)
         if name == 'bar_bar':
             return self.bar_bar
-        raise ValueError('Attribute {name} not found in foo__nested__f_inner__li1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1'])
@@ -1418,7 +1400,6 @@ class foo__nested__f_inner(yang.adata.MNode):
             return self.foo
         if name == 'li1':
             return iter(self.li1)
-        raise ValueError('Attribute {name} not found in foo__nested__f_inner')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner'])
@@ -1445,7 +1426,6 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__nested__bar_inner')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'bar:inner'])
@@ -1476,7 +1456,6 @@ class foo__nested(yang.adata.MNode):
             return self.f_inner
         if name == 'bar_inner':
             return self.bar_inner
-        raise ValueError('Attribute {name} not found in foo__nested')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested'])
@@ -1515,7 +1494,6 @@ class foo__li_union_entry(yang.adata.MNode):
             return self.k3
         if name == 'checker':
             return self.checker
-        raise ValueError('Attribute {name} not found in foo__li_union')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union'])
@@ -1604,7 +1582,6 @@ class foo__state__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__state__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state', 'c1'])
@@ -1631,7 +1608,6 @@ class foo__state(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in foo__state')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state'])
@@ -1658,7 +1634,6 @@ class foo__c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c2'])
@@ -1685,7 +1660,6 @@ class bar__test_idref(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'idref':
             return self.idref
-        raise ValueError('Attribute {name} not found in bar__test_idref')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:test-idref'])
@@ -1712,7 +1686,6 @@ class bar__bar_conflict(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in bar__bar_conflict')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:conflict'])
@@ -1833,7 +1806,6 @@ class root(yang.adata.MNode):
             return self.test_idref
         if name == 'bar_conflict':
             return self.bar_conflict
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -506,7 +506,6 @@ class foo__c1__li__c4(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l5':
             return self.l5
-        raise ValueError('Attribute {name} not found in foo__c1__li__c4')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li', 'c4'])
@@ -541,7 +540,6 @@ class foo__c1__li_entry(yang.adata.MNode):
             return self.val
         if name == 'c4':
             return self.c4
-        raise ValueError('Attribute {name} not found in foo__c1__li')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li'])
@@ -664,7 +662,6 @@ class foo__c1(yang.adata.MNode):
             return self.l2
         if name == 'l_leafref':
             return self.l_leafref
-        raise ValueError('Attribute {name} not found in foo__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1'])
@@ -691,7 +688,6 @@ class foo__pc1__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__pc1__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1', 'foo'])
@@ -718,7 +714,6 @@ class foo__pc1(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__pc1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1'])
@@ -748,7 +743,6 @@ class foo__pc2__foo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l_mandatory':
             return self.l_mandatory
-        raise ValueError('Attribute {name} not found in foo__pc2__foo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2', 'foo'])
@@ -775,7 +769,6 @@ class foo__pc2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__pc2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2'])
@@ -809,7 +802,6 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
             return self.l3
         if name == 'l3_optional':
             return self.l3_optional
-        raise ValueError('Attribute {name} not found in foo__pc3__level1__level2__level3')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
@@ -844,7 +836,6 @@ class foo__pc3__level1__level2(yang.adata.MNode):
             return self.l2_optional
         if name == 'level3':
             return self.level3
-        raise ValueError('Attribute {name} not found in foo__pc3__level1__level2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2'])
@@ -879,7 +870,6 @@ class foo__pc3__level1(yang.adata.MNode):
             return self.l1_optional
         if name == 'level2':
             return self.level2
-        raise ValueError('Attribute {name} not found in foo__pc3__level1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1'])
@@ -906,7 +896,6 @@ class foo__pc3(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'level1':
             return self.level1
-        raise ValueError('Attribute {name} not found in foo__pc3')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3'])
@@ -964,7 +953,6 @@ class foo__c_dot(yang.adata.MNode):
             return self.l_dot1
         if name == 'l_dot2':
             return self.l_dot2
-        raise ValueError('Attribute {name} not found in foo__c_dot')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c.dot'])
@@ -991,7 +979,6 @@ class foo__cc__death_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
-        raise ValueError('Attribute {name} not found in foo__cc__death')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc', 'death'])
@@ -1060,7 +1047,6 @@ class foo__cc(yang.adata.MNode):
             return self.cake
         if name == 'death':
             return iter(self.death)
-        raise ValueError('Attribute {name} not found in foo__cc')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc'])
@@ -1163,7 +1149,6 @@ class foo__f_conflict(yang.adata.MNode):
             return self.bar_foo
         if name == 'bar_inner':
             return self.bar_inner
-        raise ValueError('Attribute {name} not found in foo__f_conflict')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict'])
@@ -1190,7 +1175,6 @@ class foo__special_entry(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'yes':
             return self.yes
-        raise ValueError('Attribute {name} not found in foo__special')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:special'])
@@ -1263,7 +1247,6 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
             return self.key2
         if name == 'baz':
             return self.baz
-        raise ValueError('Attribute {name} not found in foo__nested__f_inner__li1__li2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1', 'li2'])
@@ -1345,7 +1328,6 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
             return iter(self.li2)
         if name == 'bar_bar':
             return self.bar_bar
-        raise ValueError('Attribute {name} not found in foo__nested__f_inner__li1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1'])
@@ -1418,7 +1400,6 @@ class foo__nested__f_inner(yang.adata.MNode):
             return self.foo
         if name == 'li1':
             return iter(self.li1)
-        raise ValueError('Attribute {name} not found in foo__nested__f_inner')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner'])
@@ -1445,7 +1426,6 @@ class foo__nested__bar_inner(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in foo__nested__bar_inner')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'bar:inner'])
@@ -1476,7 +1456,6 @@ class foo__nested(yang.adata.MNode):
             return self.f_inner
         if name == 'bar_inner':
             return self.bar_inner
-        raise ValueError('Attribute {name} not found in foo__nested')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested'])
@@ -1515,7 +1494,6 @@ class foo__li_union_entry(yang.adata.MNode):
             return self.k3
         if name == 'checker':
             return self.checker
-        raise ValueError('Attribute {name} not found in foo__li_union')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union'])
@@ -1604,7 +1582,6 @@ class foo__state__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__state__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state', 'c1'])
@@ -1631,7 +1608,6 @@ class foo__state(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in foo__state')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state'])
@@ -1658,7 +1634,6 @@ class foo__c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in foo__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c2'])
@@ -1685,7 +1660,6 @@ class bar__test_idref(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'idref':
             return self.idref
-        raise ValueError('Attribute {name} not found in bar__test_idref')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:test-idref'])
@@ -1712,7 +1686,6 @@ class bar__bar_conflict(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'foo':
             return self.foo
-        raise ValueError('Attribute {name} not found in bar__bar_conflict')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:conflict'])
@@ -1831,7 +1804,6 @@ class root(yang.adata.MNode):
             return self.test_idref
         if name == 'bar_conflict':
             return self.bar_conflict
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -61,7 +61,6 @@ class loose_required__c2(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'l1':
             return self.l1
-        raise ValueError('Attribute {name} not found in loose_required__c2')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['loose-required:c2'])
@@ -88,7 +87,6 @@ class root(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'c2':
             return self.c2
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -140,7 +140,6 @@ class foo__tc1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__tc1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:tc1'])
@@ -171,7 +170,6 @@ class foo__li__c1(yang.adata.MNode):
             return self.l1
         if name == 'l2':
             return self.l2
-        raise ValueError('Attribute {name} not found in foo__li__c1')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li', 'c1'])
@@ -202,7 +200,6 @@ class foo__li_entry(yang.adata.MNode):
             return self.name
         if name == 'c1':
             return self.c1
-        raise ValueError('Attribute {name} not found in foo__li')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li'])
@@ -272,7 +269,6 @@ class root(yang.adata.MNode):
             return self.tc1
         if name == 'li':
             return iter(self.li)
-        raise ValueError('Attribute {name} not found in root')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -104,7 +104,6 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'woo_b':
             return self.woo_b
-        raise ValueError('Attribute {name} not found in yangrpc__foo__input__woo')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
@@ -135,7 +134,6 @@ class yangrpc__foo__input(yang.adata.MNode):
             return self.a
         if name == 'woo':
             return self.woo
-        raise ValueError('Attribute {name} not found in yangrpc__foo__input')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input'])
@@ -162,7 +160,6 @@ class yangrpc__foo__output(yang.adata.MNode):
     def _get_attr(self, name: str) -> ?value:
         if name == 'outoo':
             return self.outoo
-        raise ValueError('Attribute {name} not found in yangrpc__foo__output')
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'output'])


### PR DESCRIPTION
Generated adata types can now omit attributes that are filtered out during prdaclass generation, while the schema-driven parser may still walk the full unfiltered schema. Return None for unknown attrs instead so the parser treats them as absent. This is still correct as the exception served more as a guard during parser refactoring.