### PR TITLE
Generate adata leafref targets

### DIFF
--- a/docs/adata-leafref-targets.md
+++ b/docs/adata-leafref-targets.md
@@ -1,0 +1,255 @@
+# Adata Leafref Targets
+
+This document describes the current prototype for exposing YANG
+`leafref` values in generated adata as reference objects with a resolved
+`target`.
+
+## Goal
+
+The old adata model flattened a `leafref` to its raw scalar value during
+gdata to adata conversion. For transforms that meant:
+
+- only the key value was preserved
+- following the reference required manual lookup code
+- two references to the same target could materialize separate adata
+  objects instead of sharing one object instance
+
+The current model keeps the raw scalar value and also resolves the
+reference to a typed adata target object.
+
+## Supported subset
+
+This is intentionally not a general runtime XPath evaluator. Code
+generation only enables the ref-target behavior for a narrow subset of
+leafrefs:
+
+- the leafref path must resolve statically at code generation time
+- the path must contain only simple location steps
+- predicates are not supported
+- the target must be the single key leaf of a list
+- only containers may appear between the root and that target list
+
+If a leafref falls outside this subset, adata continues to treat it like
+an ordinary scalar leaf.
+
+## Generated shape
+
+For a supported leafref field, code generation emits a specialized ref
+class for that exact schema location. For example, a leafref from
+`/transforms/consumer/input` to `/inventory/producer/name` generates a
+class like:
+
+```acton
+class refs__transforms__consumer__input_ref(yang.adata.Ref):
+    target: ?refs__inventory__producer_entry
+
+    def __init__(self, value: str, target: ?refs__inventory__producer_entry=None):
+        self.value = value
+        self.target = target
+```
+
+The public API of the generated field is:
+
+- `value`: the raw leafref value, for example `"prod-a"`
+- `target`: the resolved owning adata object, for example a
+  `producer_entry`
+
+The shared runtime base `yang.adata.Ref` only stores `value`. The typed
+`target` attribute lives on each generated ref class.
+
+## Resolution model
+
+Resolution happens during generated `from_gdata()` conversion.
+
+The top-level caller does not normally construct or pass a cache object.
+What the caller provides is:
+
+- `n`: the gdata node being deserialized into adata
+- optionally `lookup_root`: a root-shaped gdata view used for ref lookup
+
+When a subtree is being materialized, `n` is the subtree at the
+transform point while `lookup_root` is expected to describe the same
+conceptual data tree from the absolute schema root. In the full-tree
+case, generated root `from_gdata()` simply defaults `lookup_root` to
+`n`.
+
+From those inputs, generated adata creates or reuses a
+`yang.adata.RefContext`. This context contains:
+
+- `lookup_root`: the gdata tree used for ref lookup
+- `target_cache`: a dictionary that canonicalizes resolved target objects
+
+`target_cache` is created internally on the first call to
+`yang.adata.init_ref_ctx(...)`. It is then passed around internally as
+`_ref_ctx` through all nested generated `from_gdata()` calls, so all
+refs built during one conversion share one cache.
+
+### Why `lookup_root` exists
+
+Transforms are often materialized from a subtree rather than the schema
+root. A transform point like `/transforms/consumer[name='c1']` does not
+contain the rest of the tree needed to follow a leafref into
+`/inventory/producer[...]`.
+
+To handle that, generated `from_gdata()` has this shape:
+
+```acton
+from_gdata(n, lookup_root=None, _ref_ctx=None)
+```
+
+- `n` is the subtree being materialized into adata
+- `lookup_root` is a larger root-shaped gdata view used only for ref
+  resolution
+
+If the generated root object is built from the full tree, `lookup_root`
+defaults to `n`. For subtree materialization, the caller can pass a
+separate root view that represents the same conceptual dataset from the
+absolute root.
+
+## How a lookup is made
+
+For each supported leafref field, code generation emits a resolver
+function specialized to that field. The generated resolver already knows:
+
+- the target list path
+- the target key leaf
+- the generated adata entry type of the target list
+
+So runtime lookup does not interpret XPath. It uses the compiled target
+metadata baked into the generated code.
+
+Given a raw ref value, the resolver:
+
+1. creates the specialized ref object with `value=<raw>`
+2. initializes or reuses the shared `RefContext`
+3. computes a cache key from the target list path and raw key value
+4. checks whether the target adata object is already cached
+5. if not cached, walks `lookup_root` to the target list
+6. scans the target list for an element whose key leaf matches the raw
+   ref value
+7. materializes that list entry as adata
+8. stores the resulting target object in the cache
+9. assigns `ref.target`
+
+The actual tree walk is done by
+`yang.adata.lookup_list_entry_by_key(...)`. It is deliberately small and
+only supports the same narrow subset as code generation:
+
+- walk container children down to the target list
+- iterate list elements
+- compare the target key leaf with the raw ref value
+
+## Cache behavior and shared identity
+
+The cache is per materialization, not global.
+
+The cache key is:
+
+```text
+<target-list-path>::<repr(key-value)>
+```
+
+For example:
+
+```text
+/inventory/producer::'prod-a'
+```
+
+This cache is reused in two directions:
+
+### Ref resolves to an already built target
+
+If the target list entry was already materialized earlier in the same
+conversion, the resolver finds it in `target_cache` and assigns it
+directly to `ref.target`.
+
+### Target list entry is first built through a ref
+
+If the resolver materializes the target first, it stores that target in
+the cache. Later, when generated list-entry `from_gdata()` encounters the
+same list element through normal tree traversal, it also checks the same
+cache key and reuses the existing object.
+
+This is what gives pointer identity across references. If two consumers
+both have `input = "prod-a"`, both refs will have the same
+`producer_entry` object in `target`.
+
+## What `.target` means
+
+The useful object for transforms is usually not the leaf instance itself,
+but the owning modeled node. In the current subset, the target is the
+owning list entry because the leafref is required to point to the single
+key leaf of a list.
+
+So for a leafref to `/inventory/producer/name`, `.target` is a
+`producer_entry`, not the raw `name` leaf.
+
+## Serialization and validation
+
+Ref objects still serialize as their raw leaf values.
+
+That is handled by `yang.adata.try_validate_mnode_value(...)`, which
+unwraps `Ref.value` before leaf validation. As a result:
+
+- `to_gdata()` emits the raw scalar leafref value
+- the resolved `target` is not serialized
+- ordinary leaf validation still works
+
+`pradata()` was also updated to emit ref-wrapper construction for
+supported leafrefs, so generated source roundtrips preserve the new adata
+shape.
+
+## Example flow
+
+Consider this YANG model:
+
+```yang
+container inventory {
+  list producer {
+    key "name";
+    leaf name { type string; }
+    container config {
+      leaf interval { type uint32; }
+    }
+  }
+}
+
+container transforms {
+  list consumer {
+    key "name";
+    leaf name { type string; }
+    leaf input {
+      type leafref {
+        path "/inventory/producer/name";
+      }
+    }
+  }
+}
+```
+
+If a transform is materialized from `/transforms` with a separate
+`lookup_root` that also contains `/inventory`, then:
+
+1. `consumer.input` is read as `"prod-a"`
+2. the generated resolver looks for `/inventory/producer[name='prod-a']`
+3. the matching `producer` entry is built as adata
+4. `consumer.input.target` points to that `producer_entry`
+5. another consumer with the same `input` value reuses the same cached
+   `producer_entry`
+
+That is why mutating the target through one ref is observed through the
+other in the current tests.
+
+## Current limitations
+
+This is still a phase-1 implementation. Notable limits are:
+
+- no predicate support in leafref paths
+- no support for targets that are not single-key list keys
+- no support for intermediate lists in the target path
+- no lazy resolution after materialization
+- no global cache across separate `from_gdata()` calls
+
+The design is still useful because it matches the common transform case:
+compile a small, predictable subset into generated code and avoid a large
+runtime resolver.

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -66,9 +66,24 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'sub-group-container'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> main_module__main_container__sub_group_container:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> main_module__main_container__sub_group_container:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return main_module__main_container__sub_group_container(sub_group_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-group-leaf')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_main_module, 'main-container')), yang.gdata.Id(NS_main_module, 'sub-group-container'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, main_module__main_container__sub_group_container):
+                    return _cached
+            res = main_module__main_container__sub_group_container(sub_group_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-group-leaf')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return main_module__main_container__sub_group_container()
 
     def copy(self):
@@ -77,12 +92,40 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
 
 
 _breaker2 = None
+class main_module__main_container__sub_list__ref_to_main_ref(yang.adata.Ref):
+    target: ?main_module__main_container
+    def __init__(self, value: str, target: ?main_module__main_container=None):
+        self.value = value
+        self.target = target
+
+def _resolve_main_module__main_container__sub_list__ref_to_main_ref(value: ?str, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?main_module__main_container__sub_list__ref_to_main_ref:
+    if value is None:
+        return None
+    ref_value: str = yang.adata.expect_ref_value(value, ctx='/main-container/sub-list/ref-to-main')
+    ref = main_module__main_container__sub_list__ref_to_main_ref(ref_value)
+    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+    if ctx is not None:
+        lookup_node = ctx.lookup_root
+        if lookup_node is not None:
+            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, yang.adata.RefLookupPlan([yang.adata.RefLookupStep(yang.gdata.Id(NS_main_module, 'main-container'), False)], yang.gdata.Id(NS_main_module, 'main-leaf')))
+            if lookup_res is not None:
+                cache_key = lookup_res.owner_instance_key
+                cached_target = ctx.get_target(cache_key)
+                if isinstance(cached_target, main_module__main_container):
+                    ref.target = cached_target
+                    return ref
+                target = main_module__main_container.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)
+                ref.target = target
+                ctx.set_target(cache_key, target)
+    return ref
+
+_breaker3 = None
 class main_module__main_container__sub_list_entry(yang.adata.MNode):
     name: str
     sub_value: ?str
-    ref_to_main: ?str
+    ref_to_main: ?main_module__main_container__sub_list__ref_to_main_ref
 
-    mut def __init__(self, name: str, sub_value: ?str, ref_to_main: ?str):
+    mut def __init__(self, name: str, sub_value: ?str, ref_to_main: ?main_module__main_container__sub_list__ref_to_main_ref):
         self._ns = 'http://example.com/main'
         self.name = name
         self.sub_value = sub_value
@@ -100,14 +143,32 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'sub-list'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> main_module__main_container__sub_list_entry:
-        return main_module__main_container__sub_list_entry(name=n.get_str(yang.gdata.Id(NS_main_module, 'name')), sub_value=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-value')), ref_to_main=n.get_opt_str(yang.gdata.Id(NS_main_module, 'ref-to-main')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> main_module__main_container__sub_list_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_main_module, 'name'), n.get_str(yang.gdata.Id(NS_main_module, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_main_module, 'main-container')), yang.gdata.Id(NS_main_module, 'sub-list'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_main_module, 'sub-list'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, main_module__main_container__sub_list_entry):
+                return _cached
+        res = main_module__main_container__sub_list_entry(name=n.get_str(yang.gdata.Id(NS_main_module, 'name')), sub_value=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-value')), ref_to_main=_resolve_main_module__main_container__sub_list__ref_to_main_ref(n.get_opt_str(yang.gdata.Id(NS_main_module, 'ref-to-main')), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf(yang.gdata.Id(NS_main_module, 'ref-to-main'))), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
 
-_breaker3 = None
+_breaker4 = None
 class main_module__main_container__sub_list(yang.adata.MNode):
     elements: list[main_module__main_container__sub_list_entry]
     mut def __init__(self, elements=[]):
@@ -133,9 +194,13 @@ class main_module__main_container__sub_list(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[main_module__main_container__sub_list_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[main_module__main_container__sub_list_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_main_module, 'main-container'))
         if n is not None:
-            return [main_module__main_container__sub_list_entry.from_gdata(e) for e in n.elements]
+            return [main_module__main_container__sub_list_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -152,7 +217,7 @@ extension main_module__main_container__sub_list(Iterable[main_module__main_conta
     def __iter__(self) -> Iterator[main_module__main_container__sub_list_entry]:
         return self.elements.__iter__()
 
-_breaker4 = None
+_breaker5 = None
 class main_module__main_container__group_container(yang.adata.MNode):
     group_leaf: str
     augmented_in_group: ?str
@@ -172,9 +237,24 @@ class main_module__main_container__group_container(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'group-container'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> main_module__main_container__group_container:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> main_module__main_container__group_container:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return main_module__main_container__group_container(group_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'group-leaf')), augmented_in_group=n.get_opt_str(yang.gdata.Id(NS_main_module, 'augmented-in-group')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_main_module, 'main-container')), yang.gdata.Id(NS_main_module, 'group-container'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, main_module__main_container__group_container):
+                    return _cached
+            res = main_module__main_container__group_container(group_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'group-leaf')), augmented_in_group=n.get_opt_str(yang.gdata.Id(NS_main_module, 'augmented-in-group')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return main_module__main_container__group_container()
 
     def copy(self):
@@ -182,7 +262,7 @@ class main_module__main_container__group_container(yang.adata.MNode):
         return main_module__main_container__group_container.from_gdata(self.to_gdata())
 
 
-_breaker5 = None
+_breaker6 = None
 class main_module__main_container(yang.adata.MNode):
     main_leaf: ?str
     sub_group_container: main_module__main_container__sub_group_container
@@ -214,9 +294,24 @@ class main_module__main_container(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> main_module__main_container:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> main_module__main_container:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return main_module__main_container(main_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'main-leaf')), sub_group_container=main_module__main_container__sub_group_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'sub-group-container'))), sub_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-leaf')), sub_list=main_module__main_container__sub_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_main_module, 'sub-list'))), group_container=main_module__main_container__group_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'group-container'))))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_main_module, 'main-container'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, main_module__main_container):
+                    return _cached
+            res = main_module__main_container(main_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'main-leaf')), sub_group_container=main_module__main_container__sub_group_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'sub-group-container')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_main_module, 'sub-group-container'))), sub_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-leaf')), sub_list=main_module__main_container__sub_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_main_module, 'sub-list')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), group_container=main_module__main_container__group_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'group-container')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_main_module, 'group-container'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return main_module__main_container()
 
     def copy(self):
@@ -224,7 +319,7 @@ class main_module__main_container(yang.adata.MNode):
         return main_module__main_container.from_gdata(self.to_gdata())
 
 
-_breaker6 = None
+_breaker7 = None
 class root(yang.adata.MNode):
     main_container: main_module__main_container
 
@@ -240,9 +335,26 @@ class root(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> root:
+        _actual_lookup_root = lookup_root
+        if _actual_lookup_root is None:
+            _actual_lookup_root = n
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return root(main_container=main_module__main_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'main-container'))))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.root_instance_key()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, root):
+                    return _cached
+            res = root(main_container=main_module__main_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'main-container')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_main_module, 'main-container'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return root()
 
     def copy(self):

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -28,6 +28,50 @@ class Ref(object):
         self.value = value
 
 
+class RefValueSource(object):
+    kind: str
+    up_levels: int
+    source_path: list[yang.gdata.Id]
+    literal_value: ?value
+
+    def __init__(self, kind: str, up_levels: int=0, source_path: list[yang.gdata.Id]=[], literal_value: ?value=None):
+        self.kind = kind
+        self.up_levels = up_levels
+        self.source_path = source_path
+        self.literal_value = literal_value
+
+
+class RefLookupStep(object):
+    step_id: yang.gdata.Id
+    is_list: bool
+    key_bindings: list[(yang.gdata.Id, RefValueSource)]
+
+    def __init__(self, step_id: yang.gdata.Id, is_list: bool, key_bindings: list[(yang.gdata.Id, RefValueSource)]=[]):
+        self.step_id = step_id
+        self.is_list = is_list
+        self.key_bindings = key_bindings
+
+
+class RefLookupPlan(object):
+    steps: list[RefLookupStep]
+    leaf_id: yang.gdata.Id
+
+    def __init__(self, steps: list[RefLookupStep], leaf_id: yang.gdata.Id):
+        self.steps = steps
+        self.leaf_id = leaf_id
+
+
+class RefLookupResult(object):
+    owner_node: yang.gdata.Container
+    owner_source_nodes: list[yang.gdata.Node]
+    owner_instance_key: str
+
+    def __init__(self, owner_node: yang.gdata.Container, owner_source_nodes: list[yang.gdata.Node], owner_instance_key: str):
+        self.owner_node = owner_node
+        self.owner_source_nodes = owner_source_nodes
+        self.owner_instance_key = owner_instance_key
+
+
 class RefContext(object):
     lookup_root: ?yang.gdata.Node
     target_cache: dict[str, MNode]
@@ -56,6 +100,38 @@ def expect_ref_value[T](value: ?T, ctx: ?str=None) -> T:
     raise ValueError("expected value (not None){"for: {{ctx}}" if ctx is not None else ""}")
 
 
+def root_instance_key() -> str:
+    return "/"
+
+
+def append_source_node(source_nodes: list[yang.gdata.Node], node: ?yang.gdata.Node) -> list[yang.gdata.Node]:
+    if node is not None:
+        return source_nodes + [node]
+    return source_nodes
+
+
+def append_container_instance_key(parent_instance_key: ?str, step_id: yang.gdata.Id) -> str:
+    if parent_instance_key is None or parent_instance_key == "":
+        return ""
+    parent = parent_instance_key
+    if parent == root_instance_key():
+        return "{parent}{step_id}"
+    return "{parent}/{step_id}"
+
+
+def append_list_instance_key(parent_instance_key: ?str, step_id: yang.gdata.Id, key_values: list[(yang.gdata.Id, ?value)]) -> str:
+    base = append_container_instance_key(parent_instance_key, step_id)
+    if base == "":
+        return ""
+    parts = [base]
+    for key_id, key_value in key_values:
+        if key_value is None:
+            return ""
+        bound_key_value = expect_ref_value(key_value)
+        parts.append("[{key_id}={repr(bound_key_value)}]")
+    return "".join(parts)
+
+
 def ref_cache_key(path: str, key_value: value) -> str:
     return "{path}::{repr(key_value)}"
 
@@ -81,6 +157,105 @@ def lookup_list_entry_by_key(root: ?yang.gdata.Node, list_path: list[yang.gdata.
                 key_leaf = element.get_opt_leaf(key_id)
                 if key_leaf is not None and yang.gdata.vals_equal(key_leaf.val, key_value):
                     return element
+
+
+def lookup_list_entry_by_keys(target_list: ?yang.gdata.List, key_values: list[(yang.gdata.Id, ?value)]) -> ?yang.gdata.Node:
+    if isinstance(target_list, yang.gdata.List):
+        for element in target_list.elements:
+            match = True
+            for key_id, key_value in key_values:
+                if key_value is None:
+                    return None
+                bound_key_value = expect_ref_value(key_value)
+                maybe_key_leaf = element.get_opt_leaf(key_id)
+                if isinstance(maybe_key_leaf, yang.gdata.Leaf):
+                    if not yang.gdata.vals_equal(maybe_key_leaf.val, bound_key_value):
+                        match = False
+                        break
+                else:
+                    match = False
+                    break
+            if match:
+                return element
+
+
+def resolve_ref_source_value(source_nodes: list[yang.gdata.Node], ref_value: value, source: RefValueSource) -> ?value:
+    if source.kind == "ref_value":
+        return ref_value
+    if source.kind == "literal":
+        return source.literal_value
+    if source.kind == "source_path":
+        source_index = len(source_nodes) - 1 - source.up_levels
+        if source_index < 0:
+            return None
+
+        current = source_nodes[source_index]
+        source_path = source.source_path
+        if len(source_path) == 0:
+            if isinstance(current, yang.gdata.Leaf):
+                return current.val
+            return None
+
+        for step in source_path[:-1]:
+            if isinstance(current, yang.gdata.Container):
+                next_container = current.get_opt_cnt(step)
+                if next_container is not None:
+                    current = next_container
+                    continue
+            return None
+
+        final_step = source_path[-1]
+        if isinstance(current, yang.gdata.Container):
+            final_leaf = current.get_opt_leaf(final_step)
+            if final_leaf is not None:
+                return final_leaf.val
+    return None
+
+
+def lookup_ref_target(root: ?yang.gdata.Node, source_nodes: list[yang.gdata.Node], ref_value: value, plan: RefLookupPlan) -> ?RefLookupResult:
+    if isinstance(root, yang.gdata.Node):
+        current = root
+    else:
+        return None
+    current_source_nodes = [current]
+    current_instance_key = root_instance_key()
+    for step in plan.steps:
+        if step.is_list:
+            if isinstance(current, yang.gdata.Container):
+                target_list = current.get_opt_list(step.step_id)
+                if target_list is None:
+                    return None
+
+                key_values = []
+                for key_id, binding in step.key_bindings:
+                    key_value = resolve_ref_source_value(source_nodes, ref_value, binding)
+                    if key_value is None:
+                        return None
+                    key_values.append((key_id, key_value))
+
+                target_entry = lookup_list_entry_by_keys(target_list, key_values)
+                if isinstance(target_entry, yang.gdata.Container):
+                    current = target_entry
+                    current_source_nodes.append(current)
+                    current_instance_key = append_list_instance_key(current_instance_key, step.step_id, key_values)
+                    continue
+                return None
+            return None
+
+        if isinstance(current, yang.gdata.Container):
+            next_container = current.get_opt_cnt(step.step_id)
+            if next_container is not None:
+                current = next_container
+                current_source_nodes.append(current)
+                current_instance_key = append_container_instance_key(current_instance_key, step.step_id)
+                continue
+        return None
+
+    if isinstance(current, yang.gdata.Container):
+        target_leaf = current.get_opt_leaf(plan.leaf_id)
+        if isinstance(target_leaf, yang.gdata.Leaf):
+            if yang.gdata.vals_equal(target_leaf.val, ref_value):
+                return RefLookupResult(current, current_source_nodes, current_instance_key)
 
 
 extension MNode (YangData):

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -21,6 +21,68 @@ class MNode(object):
         raise NotImplementedError("_get_attrs")
 
 
+class Ref(object):
+    value: value
+
+    def __init__(self, value: value):
+        self.value = value
+
+
+class RefContext(object):
+    lookup_root: ?yang.gdata.Node
+    target_cache: dict[str, MNode]
+
+    def __init__(self, lookup_root: ?yang.gdata.Node=None, target_cache: ?dict[str, MNode]=None):
+        self.lookup_root = lookup_root
+        self.target_cache = target_cache if target_cache is not None else {}
+
+    def get_target(self, key: str) -> ?MNode:
+        return self.target_cache.get(key)
+
+    mut def set_target(self, key: str, target: MNode):
+        self.target_cache[key] = target
+
+
+def init_ref_ctx(lookup_root: ?yang.gdata.Node, ctx: ?RefContext=None) -> ?RefContext:
+    if ctx is not None:
+        return ctx
+    if lookup_root is not None:
+        return RefContext(lookup_root=lookup_root)
+
+
+def expect_ref_value[T](value: ?T, ctx: ?str=None) -> T:
+    if value is not None:
+        return value
+    raise ValueError("expected value (not None){"for: {{ctx}}" if ctx is not None else ""}")
+
+
+def ref_cache_key(path: str, key_value: value) -> str:
+    return "{path}::{repr(key_value)}"
+
+
+def lookup_list_entry_by_key(root: ?yang.gdata.Node, list_path: list[yang.gdata.Id], key_id: yang.gdata.Id, key_value: value) -> ?yang.gdata.Node:
+    if root is None or len(list_path) == 0:
+        return None
+
+    current = root
+    # Phase 1 only supports container ancestors on the way to the target list.
+    for step in list_path[:-1]:
+        if isinstance(current, yang.gdata.Container):
+            next_container = current.get_opt_cnt(step)
+            if next_container is not None:
+                current = next_container
+                continue
+        return None
+
+    if isinstance(current, yang.gdata.Container):
+        target_list = current.get_opt_list(list_path[-1])
+        if target_list is not None:
+            for element in target_list.elements:
+                key_leaf = element.get_opt_leaf(key_id)
+                if key_leaf is not None and yang.gdata.vals_equal(key_leaf.val, key_value):
+                    return element
+
+
 extension MNode (YangData):
     def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
         usname = yang.schema.safe_name(name if is_unique else "{schema.prefix}_{name}")
@@ -67,6 +129,8 @@ extension MNode (YangData):
 
 
 def try_validate_mnode_value(val: value, schema_type: yang.schema.DType, path: list[PathElement]) -> ?(t: str, val: value):
+    if isinstance(val, Ref):
+        return try_validate_mnode_value(val.value, schema_type, path)
     if isinstance(schema_type, yang.schema.DTypeUnion):
         for alt_type in schema_type.types:
             tv = try_validate_mnode_value(val, alt_type, path)

--- a/src/yang/data.act
+++ b/src/yang/data.act
@@ -377,6 +377,14 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
     def pname(pe: list[PathElement]):
         return yang.schema.get_path_name([e.node for e in pe])
 
+    root_node = spath[0].node
+
+    def leaf_value_expr(leaf: yang.schema.DLeaf, leaf_path: list[PathElement], raw_expr: str) -> str:
+        if isinstance(root_node, yang.schema.DRoot):
+            if yang.schema.supported_leafref_target_info(root_node, leaf) is not None:
+                return "{pname(leaf_path)}_ref({raw_expr})"
+        return raw_expr
+
     def _find_non_optional_subtree(container: yang.schema.DNodeInner, spath: list[PathElement], node: yang.gdata.Node, path: list[str], local_prefix="_") -> (list[str], list[str]):
         r"""Discover the non-optional descendants of a container
 
@@ -421,7 +429,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                 # come first in the correct order.
                 if not yang.schema.is_optional_arg_yang_leaf(cchild, yang.schema.list_keys(container), loose):
                     leaf = node.get_leaf(fqname(cchild))
-                    non_optional_args.append("{repr_adata(leaf.val)}")
+                    non_optional_args.append(leaf_value_expr(cchild, path_with_child(), "{repr_adata(leaf.val)}"))
             elif isinstance(cchild, yang.schema.DContainer):
                 if not (cchild.presence or loose or yang.schema.optional_subtree(cchild)):
                     cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
@@ -445,7 +453,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
 
         return non_optional_args, non_optional_containers
 
-    def _find_direct_optional_leaf_create_args(container: yang.schema.DNodeInner, node: yang.gdata.Node) -> (list[str], set[str]):
+    def _find_direct_optional_leaf_create_args(container: yang.schema.DNodeInner, container_path: list[PathElement], node: yang.gdata.Node) -> (list[str], set[str]):
         """Collect direct optional DLeaf kwargs accepted by create*()
 
         Unlike _find_non_optional_subtree(), this only inspects direct DLeaf
@@ -463,7 +471,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                 cchild_arg = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
                 leaf = node.get_opt_leaf_or_absent(fqname(cchild))
                 if isinstance(leaf, yang.gdata.Leaf):
-                    optional_leaf_args.append("{cchild_arg}={repr_adata(leaf.val)}")
+                    optional_leaf_args.append("{cchild_arg}={leaf_value_expr(cchild, container_path + [PathElement(cchild)], repr_adata(leaf.val))}")
                     create_consumed_leaf_args.add(cchild_arg)
                 elif isinstance(leaf, yang.gdata.Absent):
                     optional_leaf_args.append("{cchild_arg}=False")
@@ -508,7 +516,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
             leaf = node.get_opt_leaf_or_absent(fqname(child))
             if isinstance(leaf, yang.gdata.Leaf):
                 # DLeaf values are copied verbatim
-                leaves.append("{self_name}.{usname(child)} = {repr_adata(leaf.val)}")
+                leaves.append("{self_name}.{usname(child)} = {leaf_value_expr(child, path_with_child(), repr_adata(leaf.val))}")
             elif isinstance(leaf, yang.gdata.Absent):
                 # "leaf": Absent() is a remove op on an empty leaf
                 leaves.append("{self_name}.{usname(child)} = False")
@@ -526,7 +534,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
                     res.append("# P-container: {format_schema_path(path_with_child())}")
                     # Build .pradata() code for this P-container
                     pc_args, pc_var_declarations = _find_non_optional_subtree(child, path_with_child(), container, [usname(child)])
-                    pc_opt_leaf_args, pc_consumed_leaf_args = _find_direct_optional_leaf_create_args(child, container)
+                    pc_opt_leaf_args, pc_consumed_leaf_args = _find_direct_optional_leaf_create_args(child, path_with_child(), container)
 
                     # Add variable declarations in reverse order to ensure the prerequisites are met
                     res.extend(list(reversed(pc_var_declarations)))
@@ -549,7 +557,7 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
 
                     # Build the list of arguments for create() method
                     non_optional_args, non_optional_containers = _find_non_optional_subtree(child, path_with_child(), element, ["element"])
-                    list_opt_leaf_args, list_consumed_leaf_args = _find_direct_optional_leaf_create_args(child, element)
+                    list_opt_leaf_args, list_consumed_leaf_args = _find_direct_optional_leaf_create_args(child, path_with_child(), element)
 
                     res.extend(list(reversed(non_optional_containers)))
 

--- a/src/yang/data.act
+++ b/src/yang/data.act
@@ -377,11 +377,17 @@ def _pradata_recursive(s: yang.schema.DNodeInner, node: yang.gdata.Node, self_na
     def pname(pe: list[PathElement]):
         return yang.schema.get_path_name([e.node for e in pe])
 
+    def pnodes(pe: list[PathElement]) -> list[yang.schema.DNode]:
+        nodes = []
+        for elem in pe:
+            nodes.append(elem.node)
+        return nodes
+
     root_node = spath[0].node
 
     def leaf_value_expr(leaf: yang.schema.DLeaf, leaf_path: list[PathElement], raw_expr: str) -> str:
         if isinstance(root_node, yang.schema.DRoot):
-            if yang.schema.supported_leafref_target_info(root_node, leaf) is not None:
+            if yang.schema.supported_leafref_target_info(root_node, pnodes(leaf_path), leaf) is not None:
                 return "{pname(leaf_path)}_ref({raw_expr})"
         return raw_expr
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -384,7 +384,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, ref_support=False) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -507,7 +507,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, ref_support=False) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -563,10 +563,31 @@ class DNodeInner(DNode):
         def maybe_user_order_ll(n: DLeafList):
             return ", user_order=True" if n.ordered_by == "user" else ""
 
+        root_node = spath[0]
+
+        def supported_leafref_info(leaf):
+            if not ref_support:
+                return None
+            if isinstance(root_node, DRoot):
+                return supported_leafref_target_info(root_node, leaf)
+            return None
+
+        def leaf_ref_class_name(leaf) -> str:
+            return "{get_path_name(spath + [leaf])}_ref"
+
+        def leaf_ref_resolver_name(leaf) -> str:
+            return "_resolve_{leaf_ref_class_name(leaf)}"
+
+        def gdata_id_expr(node) -> str:
+            return "yang.gdata.Id(NS_{safe_name(node.module)}, '{node.name}')"
+
+        def gdata_path_expr(nodes) -> str:
+            return "[{', '.join([gdata_id_expr(node) for node in nodes[1:]])}]"
+
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, exclude_ext=exclude_ext, breaker_idx=breaker_idx)
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, exclude_ext=exclude_ext, breaker_idx=breaker_idx, ref_support=ref_support)
             res.extend(child_res)
 
         def excluded(n):
@@ -576,6 +597,53 @@ class DNodeInner(DNode):
                         return True
             return False
         attr_children = [c for c in self.children if not excluded(c)]
+
+        for child in attr_children:
+            if isinstance(child, DLeaf):
+                if supported_leafref_info(child) is None:
+                    continue
+                ref_class_name = leaf_ref_class_name(child)
+                target_list_path = _expect(supported_leafref_info(child), ctx=get_path(spath + [child])).0
+                key_leaf = _expect(supported_leafref_info(child), ctx=get_path(spath + [child])).2
+                target_entry_name = "{get_path_name(target_list_path)}_entry"
+                child_optional = False if isinstance(self, DList) and child.is_key(self) else not (child.mandatory and not loose)
+                child_arg_optional = True if child.default is not None else child_optional
+                raw_value_type = yang_type_to_acton_type(child.type_)
+                raw_arg_type = ("?" if child_arg_optional else "") + raw_value_type
+                ref_arg_type = ("?" if child_arg_optional else "") + ref_class_name
+
+                breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                res.append("{breaker_name} = None")
+                res.append("class {ref_class_name}(yang.adata.Ref):")
+                res.append("    target: ?{target_entry_name}")
+                res.append("    def __init__(self, value: {raw_value_type}, target: ?{target_entry_name}=None):")
+                res.append("        self.value = value")
+                res.append("        self.target = target")
+                res.append("")
+                res.append("def {leaf_ref_resolver_name(child)}(value: {raw_arg_type}, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {ref_arg_type}:")
+                if child_arg_optional:
+                    res.append("    if value is None:")
+                    res.append("        return None")
+                    res.append("    ref_value: {raw_value_type} = yang.adata.expect_ref_value(value, ctx={repr(get_path(spath + [child]))})")
+                else:
+                    res.append("    ref_value = value")
+                res.append("    ref = {ref_class_name}(ref_value)")
+                res.append("    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)")
+                res.append("    if ctx is not None:")
+                res.append("        cache_key = yang.adata.ref_cache_key({repr(get_path(target_list_path))}, ref_value)")
+                res.append("        cached_target = ctx.get_target(cache_key)")
+                res.append("        if isinstance(cached_target, {target_entry_name}):")
+                res.append("            ref.target = cached_target")
+                res.append("            return ref")
+                res.append("        lookup_node = ctx.lookup_root")
+                res.append("        if lookup_node is not None:")
+                res.append("            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, {gdata_path_expr(target_list_path)}, {gdata_id_expr(key_leaf)}, ref_value)")
+                res.append("            if target_node is not None:")
+                res.append("                target = {target_entry_name}.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)")
+                res.append("                ref.target = target")
+                res.append("                ctx.set_target(cache_key, target)")
+                res.append("    return ref")
+                res.append("")
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -592,7 +660,11 @@ class DNodeInner(DNode):
 
         for child in attr_children:
             if isinstance(child, DLeaf):
-                res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, list_keys(self), loose)}")
+                if supported_leafref_info(child) is not None:
+                    child_optional = False if isinstance(self, DList) and child.is_key(self) else not (child.mandatory and not loose)
+                    res.append("    {usname(child)}: {'?' if child_optional else ''}{leaf_ref_class_name(child)}")
+                else:
+                    res.append("    {usname(child)}: {yang_leaf_to_acton_type(child, list_keys(self), loose)}")
             elif isinstance(child, DLeafList):
                 res.append("    {usname(child)}: {yang_leaflist_to_acton_type(child)}")
             elif isinstance(child, DContainer):
@@ -630,7 +702,12 @@ class DNodeInner(DNode):
                 child_default = child.default
                 if not loose and child_default is not None:
                     defval = "=None"
-                child_arg = "{usname(child)}: {yang_leaf_to_acton_arg_type(child, list_keys(self), loose)}{defval}"
+                if supported_leafref_info(child) is not None:
+                    child_optional = False if isinstance(self, DList) and child.is_key(self) else not (child.mandatory and not loose)
+                    child_arg_optional = True if child.default is not None else child_optional
+                    child_arg = "{usname(child)}: {'?' if child_arg_optional else ''}{leaf_ref_class_name(child)}{defval}"
+                else:
+                    child_arg = "{usname(child)}: {yang_leaf_to_acton_arg_type(child, list_keys(self), loose)}{defval}"
                 if is_optional_arg_yang_leaf(child, list_keys(self), loose):
                     opt_args.append(child_arg)
                 else:
@@ -663,6 +740,8 @@ class DNodeInner(DNode):
                         res.append("            self.{usname(child)} = {usname(child)} if {usname(child)} is not None else _default_{usname(child)}")
                         res.append("        else:")
                         res.append("            raise ValueError('Invalid default value for identityref leaf {self.name}: {{error}}')")
+                    elif supported_leafref_info(child) is not None:
+                        res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {leaf_ref_class_name(child)}({prsrc_literal(child_type.builtin_type, child_default)})")
                     else:
                         res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {prsrc_literal(child_type.builtin_type, child_default)}")
                 else:
@@ -734,18 +813,54 @@ class DNodeInner(DNode):
         # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
         from_gdata_args_list = []
         for child in attr_children:
-            if isinstance(child, DNodeLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
+            child_id = "yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}')"
+            if isinstance(child, DLeaf):
+                if supported_leafref_info(child) is not None:
+                    from_gdata_args_list.append("{usname(child)}={leaf_ref_resolver_name(child)}(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx)")
+                else:
+                    from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}({child_id})")
+            elif isinstance(child, DLeafList):
+                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}({child_id})")
             else:
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}')))")
+                if ref_support:
+                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx)")
+                else:
+                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}))")
         from_gdata_args = ", ".join(from_gdata_args_list)
+        list_key_leaf = get_single_key_leaf(self) if ref_support and isinstance(self, DList) else None
         res.append("    @staticmethod")
         if isinstance(self, DList):
-            res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname()}_entry:")
-            res.append("        return {pname()}_entry({from_gdata_args})")
+            if ref_support:
+                res.append("    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {pname()}_entry:")
+                res.append("        _actual_lookup_root = lookup_root")
+                res.append("        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)")
+                if list_key_leaf is not None:
+                    res.append("        _cache_key = ''")
+                    res.append("        if _ref_ctx is not None:")
+                    res.append("            _key_value = n.{taker_name(list_key_leaf, list_keys(self), loose=loose)}({gdata_id_expr(list_key_leaf)})")
+                    res.append("            _cache_key = yang.adata.ref_cache_key({repr(get_path(spath))}, _key_value)")
+                    res.append("            _cached = _ref_ctx.get_target(_cache_key)")
+                    res.append("            if isinstance(_cached, {pname()}_entry):")
+                    res.append("                return _cached")
+                res.append("        res = {pname()}_entry({from_gdata_args})")
+                if list_key_leaf is not None:
+                    res.append("        if _ref_ctx is not None and _cache_key != '':")
+                    res.append("            _ref_ctx.set_target(_cache_key, res)")
+                res.append("        return res")
+            else:
+                res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname()}_entry:")
+                res.append("        return {pname()}_entry({from_gdata_args})")
         else:
             opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
+            if ref_support:
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {'?' if opt_cnt else ''}{pname()}:")
+                res.append("        _actual_lookup_root = lookup_root")
+                if isinstance(self, DRoot):
+                    res.append("        if _actual_lookup_root is None:")
+                    res.append("            _actual_lookup_root = n")
+                res.append("        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)")
+            else:
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
             res.append("        if n is not None:")
             res.append("            return {pname()}({from_gdata_args})")
             if opt_cnt:
@@ -862,9 +977,15 @@ class DNodeInner(DNode):
 #            # .from_gdata()
 #            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
             res.append("    @staticmethod")
-            res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname()}_entry]:")
-            res.append("        if n is not None:")
-            res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
+            if ref_support:
+                res.append("    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[{pname()}_entry]:")
+                res.append("        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)")
+                res.append("        if n is not None:")
+                res.append("            return [{pname()}_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]")
+            else:
+                res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname()}_entry]:")
+                res.append("        if n is not None:")
+                res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
             res.append("        return []")
             #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
             # TODO: trying to use list(map(lambda)) here results in an error,
@@ -898,7 +1019,7 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, exclude_ext=exclude_ext, breaker_idx=breaker_idx)
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, exclude_ext=exclude_ext, breaker_idx=breaker_idx, ref_support=ref_support)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -1704,7 +1825,8 @@ class DRoot(DNodeInner):
         # the SRC_DNODE constant to have the same view of the schema as the
         # adata code generator ...
         spath = build_spath([self])
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext)
+        ref_support = top and len(root_path) == 0 and contains_supported_leafref(self, self)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext, ref_support=ref_support)
 
         res = []
         res.append("import base64")
@@ -3880,6 +4002,72 @@ def taker_name(n: DNode, key_names: ?list[str], loose: bool=False) -> str:
 def yang_leaflist_to_acton_type(leaf: DLeafList) -> str:
     t = yang_type_to_acton_type(leaf.type_)
     return "list[{t}]"
+
+
+def get_single_key_leaf(node: DList) -> ?DLeaf:
+    if len(node.key) != 1:
+        return None
+    key_name = node.key[0]
+    for child in node.children:
+        if isinstance(child, DLeaf) and child.name == key_name:
+            return child
+
+
+def resolve_dnode_path(root: DRoot, path: xpath.AbsoluteLocationPath, current_module: str) -> ?list[DNode]:
+    nodes = [root]
+    current = root
+    for step in path.steps:
+        if isinstance(step, xpath.NodeTestStep):
+            if len(step.predicates) > 0:
+                return None
+            try:
+                if step.prefix is not None:
+                    current = current.get(step.name, prefix=step.prefix)
+                else:
+                    current = current.get(step.name, module=current_module)
+            except ValueError:
+                return None
+            nodes.append(current)
+        else:
+            return None
+    return nodes
+
+
+def supported_leafref_target_info(root: DRoot, leaf: DLeaf):
+    leaf_type = leaf.type_
+    if isinstance(leaf_type, DTypeLeafref):
+        maybe_target_nodes = resolve_dnode_path(root, leaf_type.path, leaf.module)
+        if maybe_target_nodes is None:
+            return None
+        target_nodes: list[DNode] = _expect(maybe_target_nodes, ctx=get_path([root, leaf]))
+        if len(target_nodes) < 3:
+            return None
+
+        maybe_target_leaf = target_nodes[-1]
+        maybe_target_list = target_nodes[-2]
+        if isinstance(maybe_target_leaf, DLeaf):
+            if isinstance(maybe_target_list, DList):
+                maybe_key_leaf = get_single_key_leaf(maybe_target_list)
+                if isinstance(maybe_key_leaf, DLeaf):
+                    if maybe_key_leaf.name != maybe_target_leaf.name:
+                        return None
+
+                    for node in target_nodes[1:-2]:
+                        if isinstance(node, DList):
+                            return None
+
+                    return (target_nodes[:-1], maybe_target_list, maybe_key_leaf)
+    return None
+
+
+def contains_supported_leafref(node: DNode, root: DRoot) -> bool:
+    if isinstance(node, DLeaf):
+        return supported_leafref_target_info(root, node) is not None
+    if isinstance(node, DNodeInner):
+        for child in node.children:
+            if contains_supported_leafref(child, root):
+                return True
+    return False
 
 
 def yang_typename_to_acton_type(type_name: str) -> str:
@@ -11104,4 +11292,3 @@ def escape_as_fstr(s: str) -> str:
     copy_until(b, s_len)
 
     return "".join(parts)
-

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -569,7 +569,7 @@ class DNodeInner(DNode):
             if not ref_support:
                 return None
             if isinstance(root_node, DRoot):
-                return supported_leafref_target_info(root_node, leaf)
+                return supported_leafref_target_info(root_node, spath + [leaf], leaf)
             return None
 
         def leaf_ref_class_name(leaf) -> str:
@@ -583,6 +583,39 @@ class DNodeInner(DNode):
 
         def gdata_path_expr(nodes) -> str:
             return "[{', '.join([gdata_id_expr(node) for node in nodes[1:]])}]"
+
+        def static_instance_key_expr(nodes: list[DNode]) -> ?str:
+            key_expr = "yang.adata.root_instance_key()"
+            for node in nodes[1:]:
+                if isinstance(node, DList):
+                    return None
+                key_expr = "yang.adata.append_container_instance_key({key_expr}, {gdata_id_expr(node)})"
+            return key_expr
+
+        def target_class_name(info: SupportedLeafrefTargetInfo) -> str:
+            if isinstance(info.owner_node, DList):
+                return "{get_path_name(info.owner_nodes)}_entry"
+            return get_path_name(info.owner_nodes)
+
+        def leafref_binding_expr(binding: SupportedLeafrefBinding) -> str:
+            if binding.kind == "ref_value":
+                return "yang.adata.RefValueSource('ref_value')"
+            if binding.kind == "source_path":
+                source_path_expr = "[{', '.join([gdata_id_expr(node) for node in binding.source_nodes])}]"
+                return "yang.adata.RefValueSource('source_path', up_levels={binding.up_levels}, source_path={source_path_expr})"
+            if binding.kind == "literal":
+                return "yang.adata.RefValueSource('literal', literal_value={repr(binding.literal_value)})"
+            raise ValueError("Unknown SupportedLeafrefBinding kind {binding.kind}")
+
+        def leafref_lookup_step_expr(step: SupportedLeafrefStep) -> str:
+            if isinstance(step.node, DList):
+                bindings_expr = "[{', '.join(['({gdata_id_expr(key_leaf)}, {leafref_binding_expr(binding)})' for key_leaf, binding in step.key_bindings])}]"
+                return "yang.adata.RefLookupStep({gdata_id_expr(step.node)}, True, key_bindings={bindings_expr})"
+            return "yang.adata.RefLookupStep({gdata_id_expr(step.node)}, False)"
+
+        def leafref_lookup_plan_expr(info: SupportedLeafrefTargetInfo) -> str:
+            steps_expr = "[{', '.join([leafref_lookup_step_expr(step) for step in info.lookup_steps])}]"
+            return "yang.adata.RefLookupPlan({steps_expr}, {gdata_id_expr(info.target_leaf)})"
 
         for child in self.children:
             if isinstance(child, DNodeLeaf):
@@ -600,12 +633,12 @@ class DNodeInner(DNode):
 
         for child in attr_children:
             if isinstance(child, DLeaf):
-                if supported_leafref_info(child) is None:
+                maybe_ref_info = supported_leafref_info(child)
+                if maybe_ref_info is None:
                     continue
                 ref_class_name = leaf_ref_class_name(child)
-                target_list_path = _expect(supported_leafref_info(child), ctx=get_path(spath + [child])).0
-                key_leaf = _expect(supported_leafref_info(child), ctx=get_path(spath + [child])).2
-                target_entry_name = "{get_path_name(target_list_path)}_entry"
+                ref_info = _expect(maybe_ref_info, ctx=get_path(spath + [child]))
+                target_entry_name = target_class_name(ref_info)
                 child_optional = False if isinstance(self, DList) and child.is_key(self) else not (child.mandatory and not loose)
                 child_arg_optional = True if child.default is not None else child_optional
                 raw_value_type = yang_type_to_acton_type(child.type_)
@@ -620,7 +653,7 @@ class DNodeInner(DNode):
                 res.append("        self.value = value")
                 res.append("        self.target = target")
                 res.append("")
-                res.append("def {leaf_ref_resolver_name(child)}(value: {raw_arg_type}, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {ref_arg_type}:")
+                res.append("def {leaf_ref_resolver_name(child)}(value: {raw_arg_type}, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {ref_arg_type}:")
                 if child_arg_optional:
                     res.append("    if value is None:")
                     res.append("        return None")
@@ -630,16 +663,16 @@ class DNodeInner(DNode):
                 res.append("    ref = {ref_class_name}(ref_value)")
                 res.append("    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)")
                 res.append("    if ctx is not None:")
-                res.append("        cache_key = yang.adata.ref_cache_key({repr(get_path(target_list_path))}, ref_value)")
-                res.append("        cached_target = ctx.get_target(cache_key)")
-                res.append("        if isinstance(cached_target, {target_entry_name}):")
-                res.append("            ref.target = cached_target")
-                res.append("            return ref")
                 res.append("        lookup_node = ctx.lookup_root")
                 res.append("        if lookup_node is not None:")
-                res.append("            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, {gdata_path_expr(target_list_path)}, {gdata_id_expr(key_leaf)}, ref_value)")
-                res.append("            if target_node is not None:")
-                res.append("                target = {target_entry_name}.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)")
+                res.append("            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, {leafref_lookup_plan_expr(ref_info)})")
+                res.append("            if lookup_res is not None:")
+                res.append("                cache_key = lookup_res.owner_instance_key")
+                res.append("                cached_target = ctx.get_target(cache_key)")
+                res.append("                if isinstance(cached_target, {target_entry_name}):")
+                res.append("                    ref.target = cached_target")
+                res.append("                    return ref")
+                res.append("                target = {target_entry_name}.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)")
                 res.append("                ref.target = target")
                 res.append("                ctx.set_target(cache_key, target)")
                 res.append("    return ref")
@@ -816,36 +849,52 @@ class DNodeInner(DNode):
             child_id = "yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}')"
             if isinstance(child, DLeaf):
                 if supported_leafref_info(child) is not None:
-                    from_gdata_args_list.append("{usname(child)}={leaf_ref_resolver_name(child)}(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx)")
+                    from_gdata_args_list.append("{usname(child)}={leaf_ref_resolver_name(child)}(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf({child_id})), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx)")
                 else:
                     from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}({child_id})")
             elif isinstance(child, DLeafList):
                 from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}({child_id})")
             else:
                 if ref_support:
-                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx)")
+                    if isinstance(child, DList):
+                        from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key)")
+                    else:
+                        from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, {child_id}))")
                 else:
                     from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}({child_id}))")
         from_gdata_args = ", ".join(from_gdata_args_list)
-        list_key_leaf = get_single_key_leaf(self) if ref_support and isinstance(self, DList) else None
+        list_key_leaves = [_expect(get_key_leaf(self, key_name), ctx=get_path(spath)) for key_name in self.key] if isinstance(self, DList) else []
+        default_self_instance_key = static_instance_key_expr(spath)
+        default_parent_instance_key = static_instance_key_expr(spath[:-1]) if len(spath) > 1 else "yang.adata.root_instance_key()"
         res.append("    @staticmethod")
         if isinstance(self, DList):
             if ref_support:
-                res.append("    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {pname()}_entry:")
+                res.append("    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> {pname()}_entry:")
                 res.append("        _actual_lookup_root = lookup_root")
                 res.append("        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)")
-                if list_key_leaf is not None:
-                    res.append("        _cache_key = ''")
-                    res.append("        if _ref_ctx is not None:")
-                    res.append("            _key_value = n.{taker_name(list_key_leaf, list_keys(self), loose=loose)}({gdata_id_expr(list_key_leaf)})")
-                    res.append("            _cache_key = yang.adata.ref_cache_key({repr(get_path(spath))}, _key_value)")
-                    res.append("            _cached = _ref_ctx.get_target(_cache_key)")
-                    res.append("            if isinstance(_cached, {pname()}_entry):")
-                    res.append("                return _cached")
+                res.append("        _self_source_nodes = _source_nodes + [n]")
+                res.append("        _self_instance_key = ''")
+                if len(list_key_leaves) > 0:
+                    key_values_expr = "[{', '.join(['({gdata_id_expr(key_leaf)}, n.{taker_name(key_leaf, list_keys(self), loose=loose)}({gdata_id_expr(key_leaf)}))' for key_leaf in list_key_leaves])}]"
+                    res.append("        _key_values = {key_values_expr}")
+                res.append("        if _instance_key is not None:")
+                res.append("            _self_instance_key = _instance_key")
+                if len(list_key_leaves) > 0:
+                    if default_parent_instance_key is not None:
+                        res.append("        elif _parent_instance_key is None:")
+                        res.append("            _self_instance_key = yang.adata.append_list_instance_key({default_parent_instance_key}, {gdata_id_expr(self)}, _key_values)")
+                        res.append("        else:")
+                        res.append("            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, {gdata_id_expr(self)}, _key_values)")
+                    else:
+                        res.append("        elif _parent_instance_key is not None:")
+                        res.append("            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, {gdata_id_expr(self)}, _key_values)")
+                res.append("        if _ref_ctx is not None and _self_instance_key != '':")
+                res.append("            _cached = _ref_ctx.get_target(_self_instance_key)")
+                res.append("            if isinstance(_cached, {pname()}_entry):")
+                res.append("                return _cached")
                 res.append("        res = {pname()}_entry({from_gdata_args})")
-                if list_key_leaf is not None:
-                    res.append("        if _ref_ctx is not None and _cache_key != '':")
-                    res.append("            _ref_ctx.set_target(_cache_key, res)")
+                res.append("        if _ref_ctx is not None and _self_instance_key != '':")
+                res.append("            _ref_ctx.set_target(_self_instance_key, res)")
                 res.append("        return res")
             else:
                 res.append("    mut def from_gdata(n: yang.gdata.Node) -> {pname()}_entry:")
@@ -853,7 +902,7 @@ class DNodeInner(DNode):
         else:
             opt_cnt = True if isinstance(self, DContainer) and self.presence else False
             if ref_support:
-                res.append("    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> {'?' if opt_cnt else ''}{pname()}:")
+                res.append("    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> {'?' if opt_cnt else ''}{pname()}:")
                 res.append("        _actual_lookup_root = lookup_root")
                 if isinstance(self, DRoot):
                     res.append("        if _actual_lookup_root is None:")
@@ -862,7 +911,24 @@ class DNodeInner(DNode):
             else:
                 res.append("    mut def from_gdata(n: ?yang.gdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
             res.append("        if n is not None:")
-            res.append("            return {pname()}({from_gdata_args})")
+            if ref_support:
+                res.append("            _self_source_nodes = _source_nodes + [n]")
+                res.append("            _self_instance_key = ''")
+                res.append("            if _instance_key is not None:")
+                res.append("                _self_instance_key = _instance_key")
+                if default_self_instance_key is not None:
+                    res.append("            else:")
+                    res.append("                _self_instance_key = {default_self_instance_key}")
+                res.append("            if _ref_ctx is not None and _self_instance_key != '':")
+                res.append("                _cached = _ref_ctx.get_target(_self_instance_key)")
+                res.append("                if isinstance(_cached, {pname()}):")
+                res.append("                    return _cached")
+                res.append("            res = {pname()}({from_gdata_args})")
+                res.append("            if _ref_ctx is not None and _self_instance_key != '':")
+                res.append("                _ref_ctx.set_target(_self_instance_key, res)")
+                res.append("            return res")
+            else:
+                res.append("            return {pname()}({from_gdata_args})")
             if opt_cnt:
                 res.append("        return None")
             elif loose or optional_subtree(self):
@@ -978,10 +1044,14 @@ class DNodeInner(DNode):
 #            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of yang.gdata.Node?
             res.append("    @staticmethod")
             if ref_support:
-                res.append("    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[{pname()}_entry]:")
+                res.append("    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[{pname()}_entry]:")
                 res.append("        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)")
+                res.append("        _actual_parent_instance_key = _parent_instance_key")
+                if default_parent_instance_key is not None:
+                    res.append("        if _actual_parent_instance_key is None:")
+                    res.append("            _actual_parent_instance_key = {default_parent_instance_key}")
                 res.append("        if n is not None:")
-                res.append("            return [{pname()}_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]")
+                res.append("            return [{pname()}_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]")
             else:
                 res.append("    mut def from_gdata(n: ?yang.gdata.List) -> list[{pname()}_entry]:")
                 res.append("        if n is not None:")
@@ -1825,7 +1895,7 @@ class DRoot(DNodeInner):
         # the SRC_DNODE constant to have the same view of the schema as the
         # adata code generator ...
         spath = build_spath([self])
-        ref_support = top and len(root_path) == 0 and contains_supported_leafref(self, self)
+        ref_support = top and len(root_path) == 0 and contains_supported_leafref(self, self, [self])
         inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext, ref_support=ref_support)
 
         res = []
@@ -4004,13 +4074,51 @@ def yang_leaflist_to_acton_type(leaf: DLeafList) -> str:
     return "list[{t}]"
 
 
-def get_single_key_leaf(node: DList) -> ?DLeaf:
-    if len(node.key) != 1:
-        return None
-    key_name = node.key[0]
+class SupportedLeafrefBinding(object):
+    kind: str
+    up_levels: int
+    source_nodes: list[DNode]
+    literal_value: ?value
+
+    def __init__(self, kind: str, up_levels: int=0, source_nodes: list[DNode]=[], literal_value: ?value=None):
+        self.kind = kind
+        self.up_levels = up_levels
+        self.source_nodes = source_nodes
+        self.literal_value = literal_value
+
+
+class SupportedLeafrefStep(object):
+    node: DNodeInner
+    key_bindings: list[(DLeaf, SupportedLeafrefBinding)]
+
+    def __init__(self, node: DNodeInner, key_bindings: list[(DLeaf, SupportedLeafrefBinding)]=[]):
+        self.node = node
+        self.key_bindings = key_bindings
+
+
+class SupportedLeafrefTargetInfo(object):
+    owner_nodes: list[DNode]
+    owner_node: DNodeInner
+    target_leaf: DLeaf
+    lookup_steps: list[SupportedLeafrefStep]
+
+    def __init__(self, owner_nodes: list[DNode], owner_node: DNodeInner, target_leaf: DLeaf, lookup_steps: list[SupportedLeafrefStep]):
+        self.owner_nodes = owner_nodes
+        self.owner_node = owner_node
+        self.target_leaf = target_leaf
+        self.lookup_steps = lookup_steps
+
+
+def get_key_leaf(node: DList, key_name: str) -> ?DLeaf:
     for child in node.children:
         if isinstance(child, DLeaf) and child.name == key_name:
             return child
+
+
+def get_single_key_leaf(node: DList) -> ?DLeaf:
+    if len(node.key) != 1:
+        return None
+    return get_key_leaf(node, node.key[0])
 
 
 def resolve_dnode_path(root: DRoot, path: xpath.AbsoluteLocationPath, current_module: str) -> ?list[DNode]:
@@ -4018,8 +4126,6 @@ def resolve_dnode_path(root: DRoot, path: xpath.AbsoluteLocationPath, current_mo
     current = root
     for step in path.steps:
         if isinstance(step, xpath.NodeTestStep):
-            if len(step.predicates) > 0:
-                return None
             try:
                 if step.prefix is not None:
                     current = current.get(step.name, prefix=step.prefix)
@@ -4033,39 +4139,199 @@ def resolve_dnode_path(root: DRoot, path: xpath.AbsoluteLocationPath, current_mo
     return nodes
 
 
-def supported_leafref_target_info(root: DRoot, leaf: DLeaf):
+def parse_prefixed_name_ref(name_ref: str) -> ?(?str, str):
+    raw = name_ref.strip()
+    if raw == "":
+        return None
+    parts = raw.split(":", 1)
+    if len(parts) == 2:
+        if parts[0] == "" or parts[1] == "":
+            return None
+        return (parts[0], parts[1])
+    return (None, raw)
+
+
+def split_supported_predicate(predicate: str) -> ?(str, str):
+    quote = None
+    for i, ch in enumerate(predicate):
+        if quote is not None:
+            if ch == quote:
+                quote = None
+        elif ch == "'" or ch == '"':
+            quote = ch
+        elif ch == "=":
+            lhs = predicate[:i].strip()
+            rhs = predicate[i + 1:].strip()
+            if lhs != "" and rhs != "":
+                return (lhs, rhs)
+            return None
+
+
+def parse_current_source_binding(expr: str, source_spath: list[DNode], current_module: str) -> ?(int, list[DNode]):
+    current_expr = expr.strip()
+    if not current_expr.startswith("current()"):
+        return None
+
+    remainder = current_expr[len("current()"):]
+    up_levels = 0
+    source_idx = len(source_spath) - 1
+    while remainder.startswith("/.."):
+        up_levels += 1
+        source_idx -= 1
+        remainder = remainder[3:]
+        if source_idx < 0:
+            return None
+
+    if remainder.startswith("/"):
+        remainder = remainder[1:]
+    elif remainder != "":
+        return None
+
+    current_node = source_spath[source_idx]
+    if remainder == "":
+        if isinstance(current_node, DLeaf):
+            return (up_levels, [])
+        return None
+
+    resolved_nodes: list[DNode] = []
+    for segment in remainder.split("/"):
+        if segment == "" or segment == "." or segment == "..":
+            return None
+        maybe_ref = parse_prefixed_name_ref(segment)
+        if maybe_ref is None:
+            return None
+        prefix, name = _expect(maybe_ref, ctx=expr)
+        if not isinstance(current_node, DNodeInner):
+            return None
+        try:
+            if prefix is not None:
+                current_node = current_node.get(name, prefix=prefix)
+            else:
+                current_node = current_node.get(name, module=current_module)
+        except ValueError:
+            return None
+        resolved_nodes.append(current_node)
+
+    if len(resolved_nodes) == 0 or not isinstance(resolved_nodes[-1], DLeaf):
+        return None
+    return (up_levels, resolved_nodes)
+
+
+def parse_supported_key_binding(list_node: DList, predicate: xpath.Predicate, source_spath: list[DNode], current_module: str) -> ?(DLeaf, SupportedLeafrefBinding):
+    maybe_eq = split_supported_predicate(predicate.predicate)
+    if maybe_eq is None:
+        return None
+    lhs, rhs = _expect(maybe_eq, ctx=predicate.predicate)
+
+    maybe_key_ref = parse_prefixed_name_ref(lhs)
+    if maybe_key_ref is None:
+        return None
+    key_prefix, key_name = _expect(maybe_key_ref, ctx=lhs)
+    try:
+        if key_prefix is not None:
+            maybe_key_leaf = list_node.get(key_name, prefix=key_prefix)
+        else:
+            maybe_key_leaf = list_node.get(key_name, module=current_module)
+    except ValueError:
+        return None
+
+    if isinstance(maybe_key_leaf, DLeaf):
+        key_leaf = maybe_key_leaf
+    else:
+        return None
+    if key_leaf.name not in list_node.key:
+        return None
+
+    maybe_source_binding = parse_current_source_binding(rhs, source_spath, current_module)
+    if maybe_source_binding is None:
+        return None
+    up_levels, source_nodes = _expect(maybe_source_binding, ctx=rhs)
+    return (key_leaf, SupportedLeafrefBinding("source_path", up_levels=up_levels, source_nodes=source_nodes))
+
+
+def supported_leafref_target_info(root: DRoot, source_spath: list[DNode], leaf: DLeaf) -> ?SupportedLeafrefTargetInfo:
     leaf_type = leaf.type_
     if isinstance(leaf_type, DTypeLeafref):
         maybe_target_nodes = resolve_dnode_path(root, leaf_type.path, leaf.module)
         if maybe_target_nodes is None:
             return None
-        target_nodes: list[DNode] = _expect(maybe_target_nodes, ctx=get_path([root, leaf]))
-        if len(target_nodes) < 3:
+        target_nodes: list[DNode] = _expect(maybe_target_nodes, ctx=get_path(source_spath))
+        if len(target_nodes) < 2:
             return None
 
         maybe_target_leaf = target_nodes[-1]
-        maybe_target_list = target_nodes[-2]
+        maybe_owner_node = target_nodes[-2]
         if isinstance(maybe_target_leaf, DLeaf):
-            if isinstance(maybe_target_list, DList):
-                maybe_key_leaf = get_single_key_leaf(maybe_target_list)
-                if isinstance(maybe_key_leaf, DLeaf):
-                    if maybe_key_leaf.name != maybe_target_leaf.name:
-                        return None
+            if isinstance(maybe_owner_node, DNodeInner):
+                owner_nodes = target_nodes[:-1]
+                leaf_path_steps = leaf_type.path.steps
+                if len(leaf_path_steps) != len(target_nodes) - 1:
+                    return None
+                if len(leaf_path_steps) == 0:
+                    return None
+                final_raw_step = leaf_path_steps[-1]
+                if isinstance(final_raw_step, xpath.NodeTestStep):
+                    final_predicates = final_raw_step.predicates
+                else:
+                    return None
+                if len(final_predicates) > 0:
+                    return None
 
-                    for node in target_nodes[1:-2]:
-                        if isinstance(node, DList):
+                lookup_steps: list[SupportedLeafrefStep] = []
+                owner_lookup_nodes = owner_nodes[1:]
+                owner_lookup_last_idx = len(owner_lookup_nodes) - 1
+                for idx, pair in enumerate(zip(leaf_path_steps[:-1], owner_lookup_nodes)):
+                    raw_step, node = pair
+                    if isinstance(raw_step, xpath.NodeTestStep):
+                        step_predicates = raw_step.predicates
+                    else:
+                        return None
+                    if isinstance(node, DContainer):
+                        if len(step_predicates) > 0:
+                            return None
+                        lookup_steps.append(SupportedLeafrefStep(node))
+                        continue
+                    if isinstance(node, DList):
+                        binding_by_key = {}
+                        for predicate in step_predicates:
+                            maybe_binding = parse_supported_key_binding(node, predicate, source_spath, leaf.module)
+                            if maybe_binding is None:
+                                return None
+                            key_leaf, binding = _expect(maybe_binding, ctx=predicate.predicate)
+                            if key_leaf.name in binding_by_key:
+                                return None
+                            binding_by_key[key_leaf.name] = (key_leaf, binding)
+
+                        ordered_bindings = []
+                        for key_name in node.key:
+                            maybe_key_leaf = get_key_leaf(node, key_name)
+                            if isinstance(maybe_key_leaf, DLeaf):
+                                key_leaf = maybe_key_leaf
+                            else:
+                                return None
+                            bound = binding_by_key.get(key_name)
+                            if bound is not None:
+                                ordered_bindings.append(bound)
+                                continue
+                            if idx == owner_lookup_last_idx and isinstance(maybe_owner_node, DList) and maybe_target_leaf.name == key_name:
+                                ordered_bindings.append((key_leaf, SupportedLeafrefBinding("ref_value")))
+                                continue
                             return None
 
-                    return (target_nodes[:-1], maybe_target_list, maybe_key_leaf)
+                        lookup_steps.append(SupportedLeafrefStep(node, key_bindings=ordered_bindings))
+                        continue
+                    return None
+
+                return SupportedLeafrefTargetInfo(owner_nodes, maybe_owner_node, maybe_target_leaf, lookup_steps)
     return None
 
 
-def contains_supported_leafref(node: DNode, root: DRoot) -> bool:
+def contains_supported_leafref(node: DNode, root: DRoot, spath: list[DNode]) -> bool:
     if isinstance(node, DLeaf):
-        return supported_leafref_target_info(root, node) is not None
+        return supported_leafref_target_info(root, spath, node) is not None
     if isinstance(node, DNodeInner):
         for child in node.children:
-            if contains_supported_leafref(child, root):
+            if contains_supported_leafref(child, root, spath + [child]):
                 return True
     return False
 

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -216,17 +216,48 @@ def _refs_gdata():
                         refs_id("interval"): yang.gdata.Leaf(u64(60))
                     })
                 })
+            ]),
+            refs_id("device"): yang.gdata.List([refs_id("name")], elements=[
+                yang.gdata.Container({
+                    refs_id("name"): yang.gdata.Leaf("r1"),
+                    refs_id("interface"): yang.gdata.List([refs_id("name"), refs_id("subif")], elements=[
+                        yang.gdata.Container({
+                            refs_id("name"): yang.gdata.Leaf("eth0"),
+                            refs_id("subif"): yang.gdata.Leaf(u64(0)),
+                            refs_id("config"): yang.gdata.Container({
+                                refs_id("enabled"): yang.gdata.Leaf(True)
+                            })
+                        }),
+                        yang.gdata.Container({
+                            refs_id("name"): yang.gdata.Leaf("eth0"),
+                            refs_id("subif"): yang.gdata.Leaf(u64(1)),
+                            refs_id("config"): yang.gdata.Container({
+                                refs_id("enabled"): yang.gdata.Leaf(False)
+                            })
+                        })
+                    ])
+                })
             ])
         }),
         refs_id("transforms"): yang.gdata.Container({
             refs_id("consumer"): yang.gdata.List([refs_id("name")], elements=[
                 yang.gdata.Container({
                     refs_id("name"): yang.gdata.Leaf("c1"),
-                    refs_id("input"): yang.gdata.Leaf("prod-a")
+                    refs_id("input"): yang.gdata.Leaf("prod-a"),
+                    refs_id("device"): yang.gdata.Leaf("r1"),
+                    refs_id("if-name"): yang.gdata.Leaf("eth0"),
+                    refs_id("if-subif"): yang.gdata.Leaf(u64(0)),
+                    refs_id("nested-input"): yang.gdata.Leaf("eth0"),
+                    refs_id("nested-enabled"): yang.gdata.Leaf(True)
                 }),
                 yang.gdata.Container({
                     refs_id("name"): yang.gdata.Leaf("c2"),
-                    refs_id("input"): yang.gdata.Leaf("prod-a")
+                    refs_id("input"): yang.gdata.Leaf("prod-a"),
+                    refs_id("device"): yang.gdata.Leaf("r1"),
+                    refs_id("if-name"): yang.gdata.Leaf("eth0"),
+                    refs_id("if-subif"): yang.gdata.Leaf(u64(0)),
+                    refs_id("nested-input"): yang.gdata.Leaf("eth0"),
+                    refs_id("nested-enabled"): yang.gdata.Leaf(True)
                 })
             ])
         })
@@ -259,6 +290,36 @@ def _test_leafref_lookup_root_shared_target():
                     p1.config.interval = u64(99)
                     testing.assertEqual(p2.config.interval, u64(99))
 
+            testing.assertNotNone(c1.nested_input)
+            testing.assertNotNone(c2.nested_input)
+            nested_input1 = c1.nested_input
+            nested_input2 = c2.nested_input
+            if nested_input1 is not None:
+                if nested_input2 is not None:
+                    iface1 = nested_input1.target
+                    iface2 = nested_input2.target
+                    testing.assertNotNone(iface1)
+                    testing.assertNotNone(iface2)
+                    if iface1 is not None:
+                        if iface2 is not None:
+                            iface1.config.enabled = False
+                            testing.assertEqual(iface2.config.enabled, False)
+
+            testing.assertNotNone(c1.nested_enabled)
+            testing.assertNotNone(c2.nested_enabled)
+            nested_enabled1 = c1.nested_enabled
+            nested_enabled2 = c2.nested_enabled
+            if nested_enabled1 is not None:
+                if nested_enabled2 is not None:
+                    cfg1 = nested_enabled1.target
+                    cfg2 = nested_enabled2.target
+                    testing.assertNotNone(cfg1)
+                    testing.assertNotNone(cfg2)
+                    if cfg1 is not None:
+                        if cfg2 is not None:
+                            cfg1.enabled = True
+                            testing.assertEqual(cfg2.enabled, True)
+
 
 def _test_leafref_full_tree_canonical_target():
     gd = _refs_gdata()
@@ -266,6 +327,7 @@ def _test_leafref_full_tree_canonical_target():
 
     producer = ad.inventory.producer.elements[0]
     consumer = ad.transforms.consumer.elements[0]
+    interface = ad.inventory.device.elements[0].interface.elements[0]
 
     testing.assertNotNone(consumer.input)
     input_ref = consumer.input
@@ -275,6 +337,24 @@ def _test_leafref_full_tree_canonical_target():
         if target is not None:
             producer.config.interval = u64(41)
             testing.assertEqual(target.config.interval, u64(41))
+
+    testing.assertNotNone(consumer.nested_input)
+    nested_input_ref = consumer.nested_input
+    if nested_input_ref is not None:
+        iface_target = nested_input_ref.target
+        testing.assertNotNone(iface_target)
+        if iface_target is not None:
+            interface.config.enabled = False
+            testing.assertEqual(iface_target.config.enabled, False)
+
+    testing.assertNotNone(consumer.nested_enabled)
+    nested_enabled_ref = consumer.nested_enabled
+    if nested_enabled_ref is not None:
+        cfg_target = nested_enabled_ref.target
+        testing.assertNotNone(cfg_target)
+        if cfg_target is not None:
+            interface.config.enabled = True
+            testing.assertEqual(cfg_target.enabled, True)
 
 actor _test_gdata_source_roundtrip_xml_full(t: testing.EnvT):
     wfcap = file.WriteFileCap(file.FileCap(t.env.cap))

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -20,6 +20,7 @@ import yang_foo_loose
 import yang_loose_required
 from yang_foo import root as yang_foo_root
 import yang_basics
+import yang_refs
 
 def _test_mandatory1():
     xml_text = """<data><tc1 xmlns="http://example.com/foo"><l1>foo</l1></tc1></data>"""
@@ -195,6 +196,85 @@ def _test_foo_from_xml_full():
     testing.assertEqual(xml_in.encode(), xml_out.encode())
     # Return golden gdata
     return gd2.prsrc()
+
+def _refs_gdata():
+    refs_ns = "http://example.com/refs"
+    refs_id = lambda name: yang.gdata.Id(refs_ns, name)
+
+    return yang.gdata.Container({
+        refs_id("inventory"): yang.gdata.Container({
+            refs_id("producer"): yang.gdata.List([refs_id("name")], elements=[
+                yang.gdata.Container({
+                    refs_id("name"): yang.gdata.Leaf("prod-a"),
+                    refs_id("config"): yang.gdata.Container({
+                        refs_id("interval"): yang.gdata.Leaf(u64(30))
+                    })
+                }),
+                yang.gdata.Container({
+                    refs_id("name"): yang.gdata.Leaf("prod-b"),
+                    refs_id("config"): yang.gdata.Container({
+                        refs_id("interval"): yang.gdata.Leaf(u64(60))
+                    })
+                })
+            ])
+        }),
+        refs_id("transforms"): yang.gdata.Container({
+            refs_id("consumer"): yang.gdata.List([refs_id("name")], elements=[
+                yang.gdata.Container({
+                    refs_id("name"): yang.gdata.Leaf("c1"),
+                    refs_id("input"): yang.gdata.Leaf("prod-a")
+                }),
+                yang.gdata.Container({
+                    refs_id("name"): yang.gdata.Leaf("c2"),
+                    refs_id("input"): yang.gdata.Leaf("prod-a")
+                })
+            ])
+        })
+    })
+
+
+def _test_leafref_lookup_root_shared_target():
+    gd = _refs_gdata()
+    transforms = gd.get_cnt(yang.gdata.Id("http://example.com/refs", "transforms"))
+    ad = yang_refs.refs__transforms.from_gdata(transforms, lookup_root=gd)
+
+    c1 = ad.consumer.elements[0]
+    c2 = ad.consumer.elements[1]
+
+    testing.assertNotNone(c1.input)
+    testing.assertNotNone(c2.input)
+    input1 = c1.input
+    input2 = c2.input
+    if input1 is not None:
+        if input2 is not None:
+            raw_value = input1.value
+            if isinstance(raw_value, str):
+                testing.assertEqual(raw_value, "prod-a")
+            p1 = input1.target
+            p2 = input2.target
+            testing.assertNotNone(p1)
+            testing.assertNotNone(p2)
+            if p1 is not None:
+                if p2 is not None:
+                    p1.config.interval = u64(99)
+                    testing.assertEqual(p2.config.interval, u64(99))
+
+
+def _test_leafref_full_tree_canonical_target():
+    gd = _refs_gdata()
+    ad = yang_refs.root.from_gdata(gd)
+
+    producer = ad.inventory.producer.elements[0]
+    consumer = ad.transforms.consumer.elements[0]
+
+    testing.assertNotNone(consumer.input)
+    input_ref = consumer.input
+    if input_ref is not None:
+        target = input_ref.target
+        testing.assertNotNone(target)
+        if target is not None:
+            producer.config.interval = u64(41)
+            testing.assertEqual(target.config.interval, u64(41))
 
 actor _test_gdata_source_roundtrip_xml_full(t: testing.EnvT):
     wfcap = file.WriteFileCap(file.FileCap(t.env.cap))

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -527,11 +527,22 @@ class foo__c1__li__c4(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li', 'c4'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li__c4:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c1__li__c4:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c1__li__c4):
+                    return _cached
+            res = foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c1__li__c4()
 
     def copy(self):
@@ -563,19 +574,25 @@ class foo__c1__li_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__c1__li_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/c1/li', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'name'), n.get_str(yang.gdata.Id(NS_foo, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c1')), yang.gdata.Id(NS_foo, 'li'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__c1__li_entry):
                 return _cached
-        res = foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        res = foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c4'))))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -606,10 +623,13 @@ class foo__c1__li(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__c1__li_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__c1__li_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c1'))
         if n is not None:
-            return [foo__c1__li_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__c1__li_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -633,23 +653,23 @@ class foo__c1__l_leafref_ref(yang.adata.Ref):
         self.value = value
         self.target = target
 
-def _resolve_foo__c1__l_leafref_ref(value: ?str, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__c1__l_leafref_ref:
+def _resolve_foo__c1__l_leafref_ref(value: ?str, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__c1__l_leafref_ref:
     if value is None:
         return None
     ref_value: str = yang.adata.expect_ref_value(value, ctx='/c1/l_leafref')
     ref = foo__c1__l_leafref_ref(ref_value)
     ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
     if ctx is not None:
-        cache_key = yang.adata.ref_cache_key('/c1/li', ref_value)
-        cached_target = ctx.get_target(cache_key)
-        if isinstance(cached_target, foo__c1__li_entry):
-            ref.target = cached_target
-            return ref
         lookup_node = ctx.lookup_root
         if lookup_node is not None:
-            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, [yang.gdata.Id(NS_foo, 'c1'), yang.gdata.Id(NS_foo, 'li')], yang.gdata.Id(NS_foo, 'name'), ref_value)
-            if target_node is not None:
-                target = foo__c1__li_entry.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)
+            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, yang.adata.RefLookupPlan([yang.adata.RefLookupStep(yang.gdata.Id(NS_foo, 'c1'), False), yang.adata.RefLookupStep(yang.gdata.Id(NS_foo, 'li'), True, key_bindings=[(yang.gdata.Id(NS_foo, 'name'), yang.adata.RefValueSource('ref_value'))])], yang.gdata.Id(NS_foo, 'name')))
+            if lookup_res is not None:
+                cache_key = lookup_res.owner_instance_key
+                cached_target = ctx.get_target(cache_key)
+                if isinstance(cached_target, foo__c1__li_entry):
+                    ref.target = cached_target
+                    return ref
+                target = foo__c1__li_entry.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)
                 ref.target = target
                 ctx.set_target(cache_key, target)
     return ref
@@ -726,11 +746,24 @@ class foo__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=_resolve_foo__c1__l_leafref_ref(n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c1):
+                    return _cached
+            res = foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=_resolve_foo__c1__l_leafref_ref(n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf(yang.gdata.Id(NS_bar, 'l_leafref'))), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c1()
 
     def copy(self):
@@ -754,11 +787,24 @@ class foo__pc1__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc1__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc1__foo:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc1')), yang.gdata.Id(NS_foo, 'foo'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc1__foo):
+                    return _cached
+            res = foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__pc1__foo()
 
     def copy(self):
@@ -782,11 +828,24 @@ class foo__pc1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__pc1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc1):
+                    return _cached
+            res = foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'foo'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -813,11 +872,24 @@ class foo__pc2__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc2__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc2__foo:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc2__foo(l_mandatory=n.get_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc2')), yang.gdata.Id(NS_foo, 'foo'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc2__foo):
+                    return _cached
+            res = foo__pc2__foo(l_mandatory=n.get_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         raise ValueError('Missing required subtree foo__pc2__foo')
 
     def copy(self):
@@ -841,11 +913,24 @@ class foo__pc2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__pc2:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc2'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc2):
+                    return _cached
+            res = foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'foo'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -876,11 +961,24 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2__level3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc3__level1__level2__level3:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1__level2__level3(l3=n.get_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3')), yang.gdata.Id(NS_foo, 'level1')), yang.gdata.Id(NS_foo, 'level2')), yang.gdata.Id(NS_foo, 'level3'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3__level1__level2__level3):
+                    return _cached
+            res = foo__pc3__level1__level2__level3(l3=n.get_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         raise ValueError('Missing required subtree foo__pc3__level1__level2__level3')
 
     def copy(self):
@@ -912,11 +1010,24 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc3__level1__level2:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1__level2(l2=n.get_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3')), yang.gdata.Id(NS_foo, 'level1')), yang.gdata.Id(NS_foo, 'level2'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3__level1__level2):
+                    return _cached
+            res = foo__pc3__level1__level2(l2=n.get_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'level3'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
 
     def copy(self):
@@ -948,11 +1059,24 @@ class foo__pc3__level1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc3__level1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3')), yang.gdata.Id(NS_foo, 'level1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3__level1):
+                    return _cached
+            res = foo__pc3__level1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'level2'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         raise ValueError('Missing required subtree foo__pc3__level1')
 
     def copy(self):
@@ -976,11 +1100,24 @@ class foo__pc3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__pc3:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3):
+                    return _cached
+            res = foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'level1'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1002,11 +1139,24 @@ class foo__empty_presence(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:empty-presence'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__empty_presence:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__empty_presence:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__empty_presence()
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'empty-presence'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__empty_presence):
+                    return _cached
+            res = foo__empty_presence()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1037,11 +1187,24 @@ class foo__c_dot(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c.dot'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c_dot:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c_dot:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c.dot'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c_dot):
+                    return _cached
+            res = foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c_dot()
 
     def copy(self):
@@ -1065,19 +1228,25 @@ class foo__cc__death_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc', 'death'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc__death_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__cc__death_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/cc/death', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'name'), n.get_str(yang.gdata.Id(NS_foo, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'cc')), yang.gdata.Id(NS_foo, 'death'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'death'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__cc__death_entry):
                 return _cached
         res = foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1106,10 +1275,13 @@ class foo__cc__death(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__cc__death_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__cc__death_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'cc'))
         if n is not None:
-            return [foo__cc__death_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__cc__death_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1146,11 +1318,24 @@ class foo__cc(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__cc:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'cc'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__cc):
+                    return _cached
+            res = foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__cc()
 
     def copy(self):
@@ -1169,11 +1354,24 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__f_conflict__f_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict__f_inner()
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'conflict')), yang.gdata.Id(NS_foo, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__f_conflict__f_inner):
+                    return _cached
+            res = foo__f_conflict__f_inner()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1195,11 +1393,24 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__f_conflict__bar_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict__bar_inner()
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'conflict')), yang.gdata.Id(NS_bar, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__f_conflict__bar_inner):
+                    return _cached
+            res = foo__f_conflict__bar_inner()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1254,11 +1465,24 @@ class foo__f_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__f_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__f_conflict:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'conflict'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__f_conflict):
+                    return _cached
+            res = foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'inner'))), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'inner'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__f_conflict()
 
     def copy(self):
@@ -1282,19 +1506,25 @@ class foo__special_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:special'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__special_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__special_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_bool(yang.gdata.Id(NS_foo, 'yes'))
-            _cache_key = yang.adata.ref_cache_key('/special', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'yes'), n.get_bool(yang.gdata.Id(NS_foo, 'yes')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'special'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'special'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__special_entry):
                 return _cached
         res = foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1323,10 +1553,13 @@ class foo__special(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__special_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__special_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.root_instance_key()
         if n is not None:
-            return [foo__special_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__special_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1367,10 +1600,23 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1__li2_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'key1'), n.get_str(yang.gdata.Id(NS_foo, 'key1'))), (yang.gdata.Id(NS_foo, 'key2'), n.get_str(yang.gdata.Id(NS_foo, 'key2')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is not None:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li2'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, foo__nested__f_inner__li1__li2_entry):
+                return _cached
         res = foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1404,10 +1650,11 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1__li2_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__nested__f_inner__li1__li2_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
         if n is not None:
-            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1452,19 +1699,25 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__nested__f_inner__li1_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/nested/f:inner/li1', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'name'), n.get_str(yang.gdata.Id(NS_foo, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_foo, 'inner')), yang.gdata.Id(NS_foo, 'li1'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li1'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__nested__f_inner__li1_entry):
                 return _cached
-        res = foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        res = foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1497,10 +1750,13 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__nested__f_inner__li1_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_foo, 'inner'))
         if n is not None:
-            return [foo__nested__f_inner__li1_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__nested__f_inner__li1_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1537,11 +1793,24 @@ class foo__nested__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__nested__f_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_foo, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__nested__f_inner):
+                    return _cached
+            res = foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__nested__f_inner()
 
     def copy(self):
@@ -1565,11 +1834,24 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__nested__bar_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_bar, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__nested__bar_inner):
+                    return _cached
+            res = foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__nested__bar_inner()
 
     def copy(self):
@@ -1597,11 +1879,24 @@ class foo__nested(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__nested:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__nested):
+                    return _cached
+            res = foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'inner'))), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'inner'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__nested()
 
     def copy(self):
@@ -1637,10 +1932,25 @@ class foo__li_union_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__li_union_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'k1'), n.get_str(yang.gdata.Id(NS_foo, 'k1'))), (yang.gdata.Id(NS_foo, 'k2'), n.get_value(yang.gdata.Id(NS_foo, 'k2'))), (yang.gdata.Id(NS_foo, 'k3'), n.get_bytes(yang.gdata.Id(NS_foo, 'k3')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'li-union'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li-union'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, foo__li_union_entry):
+                return _cached
         res = foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1689,10 +1999,13 @@ class foo__li_union(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__li_union_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.root_instance_key()
         if n is not None:
-            return [foo__li_union_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__li_union_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1725,19 +2038,25 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union-one-base'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_one_base_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__li_union_one_base_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_value(yang.gdata.Id(NS_foo, 'k1'))
-            _cache_key = yang.adata.ref_cache_key('/li-union-one-base', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'k1'), n.get_value(yang.gdata.Id(NS_foo, 'k1')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'li-union-one-base'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li-union-one-base'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__li_union_one_base_entry):
                 return _cached
         res = foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1768,10 +2087,13 @@ class foo__li_union_one_base(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_one_base_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__li_union_one_base_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.root_instance_key()
         if n is not None:
-            return [foo__li_union_one_base_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__li_union_one_base_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1808,11 +2130,24 @@ class foo__state__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state', 'c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__state__c1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'state')), yang.gdata.Id(NS_foo, 'c1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__state__c1):
+                    return _cached
+            res = foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__state__c1()
 
     def copy(self):
@@ -1836,11 +2171,24 @@ class foo__state(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__state:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'state'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__state):
+                    return _cached
+            res = foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c1'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__state()
 
     def copy(self):
@@ -1864,11 +2212,24 @@ class foo__c2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c2:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c2'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c2):
+                    return _cached
+            res = foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c2()
 
     def copy(self):
@@ -1892,11 +2253,24 @@ class bar__test_idref(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:test-idref'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__test_idref:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> bar__test_idref:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_bar, 'test-idref'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, bar__test_idref):
+                    return _cached
+            res = bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return bar__test_idref()
 
     def copy(self):
@@ -1920,11 +2294,24 @@ class bar__bar_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__bar_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> bar__bar_conflict:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_bar, 'conflict'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, bar__bar_conflict):
+                    return _cached
+            res = bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return bar__bar_conflict()
 
     def copy(self):
@@ -2046,13 +2433,26 @@ class root(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> root:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> root:
         _actual_lookup_root = lookup_root
         if _actual_lookup_root is None:
             _actual_lookup_root = n
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.root_instance_key()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, root):
+                    return _cached
+            res = root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'pc1'))), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'pc2'))), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'pc3'))), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'empty-presence'))), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c.dot'))), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'cc'))), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'conflict'))), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'nested'))), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'state'))), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c2'))), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'test-idref'))), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'conflict'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return root()
 
     def copy(self):

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -527,7 +527,9 @@ class foo__c1__li__c4(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li', 'c4'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__li__c4:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li__c4:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
         return foo__c1__li__c4()
@@ -561,8 +563,20 @@ class foo__c1__li_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4'))))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/c1/li', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__c1__li_entry):
+                return _cached
+        res = foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -592,9 +606,10 @@ class foo__c1__li(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__c1__li_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__c1__li_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__c1__li_entry.from_gdata(e) for e in n.elements]
+            return [foo__c1__li_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -612,6 +627,34 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
         return self.elements.__iter__()
 
 _breaker4 = None
+class foo__c1__l_leafref_ref(yang.adata.Ref):
+    target: ?foo__c1__li_entry
+    def __init__(self, value: str, target: ?foo__c1__li_entry=None):
+        self.value = value
+        self.target = target
+
+def _resolve_foo__c1__l_leafref_ref(value: ?str, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__c1__l_leafref_ref:
+    if value is None:
+        return None
+    ref_value: str = yang.adata.expect_ref_value(value, ctx='/c1/l_leafref')
+    ref = foo__c1__l_leafref_ref(ref_value)
+    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+    if ctx is not None:
+        cache_key = yang.adata.ref_cache_key('/c1/li', ref_value)
+        cached_target = ctx.get_target(cache_key)
+        if isinstance(cached_target, foo__c1__li_entry):
+            ref.target = cached_target
+            return ref
+        lookup_node = ctx.lookup_root
+        if lookup_node is not None:
+            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, [yang.gdata.Id(NS_foo, 'c1'), yang.gdata.Id(NS_foo, 'li')], yang.gdata.Id(NS_foo, 'name'), ref_value)
+            if target_node is not None:
+                target = foo__c1__li_entry.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)
+                ref.target = target
+                ctx.set_target(cache_key, target)
+    return ref
+
+_breaker5 = None
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
     l3: ?u64
@@ -627,9 +670,9 @@ class foo__c1(yang.adata.MNode):
     l4: ?str
     bar_l1: ?str
     l2: ?str
-    l_leafref: ?str
+    l_leafref: ?foo__c1__l_leafref_ref
 
-    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?foo__c1__l_leafref_ref):
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -683,9 +726,11 @@ class foo__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
+            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=_resolve_foo__c1__l_leafref_ref(n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__c1()
 
     def copy(self):
@@ -693,7 +738,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker5 = None
+_breaker6 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
@@ -709,7 +754,9 @@ class foo__pc1__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc1__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc1__foo:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
         return foo__pc1__foo()
@@ -719,7 +766,7 @@ class foo__pc1__foo(yang.adata.MNode):
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
 
-_breaker6 = None
+_breaker7 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
@@ -735,9 +782,11 @@ class foo__pc1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
+            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return None
 
     def copy(self):
@@ -748,7 +797,7 @@ class foo__pc1(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc1.copy()')
 
 
-_breaker7 = None
+_breaker8 = None
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: str
 
@@ -764,7 +813,9 @@ class foo__pc2__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc2__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc2__foo:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__pc2__foo(l_mandatory=n.get_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
         raise ValueError('Missing required subtree foo__pc2__foo')
@@ -774,7 +825,7 @@ class foo__pc2__foo(yang.adata.MNode):
         return foo__pc2__foo.from_gdata(self.to_gdata())
 
 
-_breaker8 = None
+_breaker9 = None
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
@@ -790,9 +841,11 @@ class foo__pc2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc2:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'foo'))))
+            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return None
 
     def copy(self):
@@ -803,7 +856,7 @@ class foo__pc2(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc2.copy()')
 
 
-_breaker9 = None
+_breaker10 = None
 class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: str
     l3_optional: ?str
@@ -823,7 +876,9 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1__level2__level3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2__level3:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__pc3__level1__level2__level3(l3=n.get_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
         raise ValueError('Missing required subtree foo__pc3__level1__level2__level3')
@@ -833,7 +888,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
 
 
-_breaker10 = None
+_breaker11 = None
 class foo__pc3__level1__level2(yang.adata.MNode):
     l2: str
     l2_optional: ?str
@@ -857,9 +912,11 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1__level2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1__level2(l2=n.get_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level3'))))
+            return foo__pc3__level1__level2(l2=n.get_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
 
     def copy(self):
@@ -867,7 +924,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
 
-_breaker11 = None
+_breaker12 = None
 class foo__pc3__level1(yang.adata.MNode):
     l1: str
     l1_optional: ?str
@@ -891,9 +948,11 @@ class foo__pc3__level1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level2'))))
+            return foo__pc3__level1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         raise ValueError('Missing required subtree foo__pc3__level1')
 
     def copy(self):
@@ -901,7 +960,7 @@ class foo__pc3__level1(yang.adata.MNode):
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
 
-_breaker12 = None
+_breaker13 = None
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
 
@@ -917,9 +976,11 @@ class foo__pc3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc3:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level1'))))
+            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return None
 
     def copy(self):
@@ -930,7 +991,7 @@ class foo__pc3(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc3.copy()')
 
 
-_breaker13 = None
+_breaker14 = None
 class foo__empty_presence(yang.adata.MNode):
 
     mut def __init__(self):
@@ -941,7 +1002,9 @@ class foo__empty_presence(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:empty-presence'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__empty_presence:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__empty_presence:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__empty_presence()
         return None
@@ -954,7 +1017,7 @@ class foo__empty_presence(yang.adata.MNode):
         raise Exception('Unreachable in foo__empty_presence.copy()')
 
 
-_breaker14 = None
+_breaker15 = None
 class foo__c_dot(yang.adata.MNode):
     l_dot1: ?str
     l_dot2: ?str
@@ -974,7 +1037,9 @@ class foo__c_dot(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c.dot'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c_dot:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c_dot:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
         return foo__c_dot()
@@ -984,7 +1049,7 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot.from_gdata(self.to_gdata())
 
 
-_breaker15 = None
+_breaker16 = None
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
 
@@ -1000,14 +1065,26 @@ class foo__cc__death_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc', 'death'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
-        return foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc__death_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/cc/death', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__cc__death_entry):
+                return _cached
+        res = foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
-_breaker16 = None
+_breaker17 = None
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
     mut def __init__(self, elements=[]):
@@ -1029,9 +1106,10 @@ class foo__cc__death(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__cc__death_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__cc__death_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__cc__death_entry.from_gdata(e) for e in n.elements]
+            return [foo__cc__death_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1048,7 +1126,7 @@ extension foo__cc__death(Iterable[foo__cc__death_entry]):
     def __iter__(self) -> Iterator[foo__cc__death_entry]:
         return self.elements.__iter__()
 
-_breaker17 = None
+_breaker18 = None
 class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
@@ -1068,9 +1146,11 @@ class foo__cc(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__cc:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death'))))
+            return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__cc()
 
     def copy(self):
@@ -1078,7 +1158,7 @@ class foo__cc(yang.adata.MNode):
         return foo__cc.from_gdata(self.to_gdata())
 
 
-_breaker18 = None
+_breaker19 = None
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1089,7 +1169,9 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__f_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__f_conflict__f_inner()
         return None
@@ -1102,7 +1184,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
 
-_breaker19 = None
+_breaker20 = None
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1113,7 +1195,9 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__bar_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__f_conflict__bar_inner()
         return None
@@ -1126,7 +1210,7 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
 
 
-_breaker20 = None
+_breaker21 = None
 class foo__f_conflict(yang.adata.MNode):
     f_foo: ?str
     f_inner: ?foo__f_conflict__f_inner
@@ -1170,9 +1254,11 @@ class foo__f_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__f_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__f_conflict:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
+            return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__f_conflict()
 
     def copy(self):
@@ -1180,7 +1266,7 @@ class foo__f_conflict(yang.adata.MNode):
         return foo__f_conflict.from_gdata(self.to_gdata())
 
 
-_breaker21 = None
+_breaker22 = None
 class foo__special_entry(yang.adata.MNode):
     yes: bool
 
@@ -1196,14 +1282,26 @@ class foo__special_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:special'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
-        return foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__special_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_bool(yang.gdata.Id(NS_foo, 'yes'))
+            _cache_key = yang.adata.ref_cache_key('/special', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__special_entry):
+                return _cached
+        res = foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
 
-_breaker22 = None
+_breaker23 = None
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
     mut def __init__(self, elements=[]):
@@ -1225,9 +1323,10 @@ class foo__special(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__special_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__special_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__special_entry.from_gdata(e) for e in n.elements]
+            return [foo__special_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1244,7 +1343,7 @@ extension foo__special(Iterable[foo__special_entry]):
     def __iter__(self) -> Iterator[foo__special_entry]:
         return self.elements.__iter__()
 
-_breaker23 = None
+_breaker24 = None
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key1: str
     key2: str
@@ -1268,14 +1367,17 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
-        return foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1__li2_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        res = foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
-_breaker24 = None
+_breaker25 = None
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -1302,9 +1404,10 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__nested__f_inner__li1__li2_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1__li2_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e) for e in n.elements]
+            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1321,7 +1424,7 @@ extension foo__nested__f_inner__li1__li2(Iterable[foo__nested__f_inner__li1__li2
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1__li2_entry]:
         return self.elements.__iter__()
 
-_breaker25 = None
+_breaker26 = None
 class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     name: str
     f_bar: ?str
@@ -1349,14 +1452,26 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
-        return foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2'))), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/nested/f:inner/li1', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__nested__f_inner__li1_entry):
+                return _cached
+        res = foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
-_breaker26 = None
+_breaker27 = None
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1382,9 +1497,10 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__nested__f_inner__li1_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__nested__f_inner__li1_entry.from_gdata(e) for e in n.elements]
+            return [foo__nested__f_inner__li1_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1401,7 +1517,7 @@ extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
         return self.elements.__iter__()
 
-_breaker27 = None
+_breaker28 = None
 class foo__nested__f_inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__f_inner__li1
@@ -1421,9 +1537,11 @@ class foo__nested__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1'))))
+            return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__nested__f_inner()
 
     def copy(self):
@@ -1431,7 +1549,7 @@ class foo__nested__f_inner(yang.adata.MNode):
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
 
-_breaker28 = None
+_breaker29 = None
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
@@ -1447,7 +1565,9 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__bar_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return foo__nested__bar_inner()
@@ -1457,7 +1577,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
 
 
-_breaker29 = None
+_breaker30 = None
 class foo__nested(yang.adata.MNode):
     f_inner: foo__nested__f_inner
     bar_inner: foo__nested__bar_inner
@@ -1477,9 +1597,11 @@ class foo__nested(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
+            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__nested()
 
     def copy(self):
@@ -1487,7 +1609,7 @@ class foo__nested(yang.adata.MNode):
         return foo__nested.from_gdata(self.to_gdata())
 
 
-_breaker30 = None
+_breaker31 = None
 class foo__li_union_entry(yang.adata.MNode):
     k1: str
     k2: value
@@ -1515,14 +1637,17 @@ class foo__li_union_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
-        return foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        res = foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
-_breaker31 = None
+_breaker32 = None
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
     mut def __init__(self, elements=[]):
@@ -1564,9 +1689,10 @@ class foo__li_union(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__li_union_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__li_union_entry.from_gdata(e) for e in n.elements]
+            return [foo__li_union_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1583,7 +1709,7 @@ extension foo__li_union(Iterable[foo__li_union_entry]):
     def __iter__(self) -> Iterator[foo__li_union_entry]:
         return self.elements.__iter__()
 
-_breaker32 = None
+_breaker33 = None
 class foo__li_union_one_base_entry(yang.adata.MNode):
     k1: value
 
@@ -1599,14 +1725,26 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union-one-base'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_one_base_entry:
-        return foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_one_base_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_value(yang.gdata.Id(NS_foo, 'k1'))
+            _cache_key = yang.adata.ref_cache_key('/li-union-one-base', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__li_union_one_base_entry):
+                return _cached
+        res = foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_union_one_base_entry.from_gdata(self.to_gdata())
 
-_breaker33 = None
+_breaker34 = None
 class foo__li_union_one_base(yang.adata.MNode):
     elements: list[foo__li_union_one_base_entry]
     mut def __init__(self, elements=[]):
@@ -1630,9 +1768,10 @@ class foo__li_union_one_base(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__li_union_one_base_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_one_base_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__li_union_one_base_entry.from_gdata(e) for e in n.elements]
+            return [foo__li_union_one_base_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1649,7 +1788,7 @@ extension foo__li_union_one_base(Iterable[foo__li_union_one_base_entry]):
     def __iter__(self) -> Iterator[foo__li_union_one_base_entry]:
         return self.elements.__iter__()
 
-_breaker34 = None
+_breaker35 = None
 class foo__state__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -1669,7 +1808,9 @@ class foo__state__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state', 'c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state__c1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__state__c1()
@@ -1679,7 +1820,7 @@ class foo__state__c1(yang.adata.MNode):
         return foo__state__c1.from_gdata(self.to_gdata())
 
 
-_breaker35 = None
+_breaker36 = None
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
@@ -1695,9 +1836,11 @@ class foo__state(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
+            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__state()
 
     def copy(self):
@@ -1705,7 +1848,7 @@ class foo__state(yang.adata.MNode):
         return foo__state.from_gdata(self.to_gdata())
 
 
-_breaker36 = None
+_breaker37 = None
 class foo__c2(yang.adata.MNode):
     l1: ?str
 
@@ -1721,7 +1864,9 @@ class foo__c2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c2:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c2()
@@ -1731,7 +1876,7 @@ class foo__c2(yang.adata.MNode):
         return foo__c2.from_gdata(self.to_gdata())
 
 
-_breaker37 = None
+_breaker38 = None
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
 
@@ -1747,7 +1892,9 @@ class bar__test_idref(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:test-idref'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__test_idref:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__test_idref:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
         return bar__test_idref()
@@ -1757,7 +1904,7 @@ class bar__test_idref(yang.adata.MNode):
         return bar__test_idref.from_gdata(self.to_gdata())
 
 
-_breaker38 = None
+_breaker39 = None
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
@@ -1773,7 +1920,9 @@ class bar__bar_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__bar_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__bar_conflict:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return bar__bar_conflict()
@@ -1783,7 +1932,7 @@ class bar__bar_conflict(yang.adata.MNode):
         return bar__bar_conflict.from_gdata(self.to_gdata())
 
 
-_breaker39 = None
+_breaker40 = None
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1
@@ -1897,9 +2046,13 @@ class root(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> root:
+        _actual_lookup_root = lookup_root
+        if _actual_lookup_root is None:
+            _actual_lookup_root = n
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1'))), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2'))), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3'))), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence'))), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot'))), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc'))), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict'))), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special'))), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested'))), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union'))), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base'))), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state'))), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref'))), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict'))))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return root()
 
     def copy(self):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -527,7 +527,9 @@ class foo__c1__li__c4(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li', 'c4'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1__li__c4:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li__c4:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
         return foo__c1__li__c4()
@@ -561,8 +563,20 @@ class foo__c1__li_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
-        return foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4'))))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/c1/li', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__c1__li_entry):
+                return _cached
+        res = foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
@@ -592,9 +606,10 @@ class foo__c1__li(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__c1__li_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__c1__li_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__c1__li_entry.from_gdata(e) for e in n.elements]
+            return [foo__c1__li_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -612,6 +627,34 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
         return self.elements.__iter__()
 
 _breaker4 = None
+class foo__c1__l_leafref_ref(yang.adata.Ref):
+    target: ?foo__c1__li_entry
+    def __init__(self, value: str, target: ?foo__c1__li_entry=None):
+        self.value = value
+        self.target = target
+
+def _resolve_foo__c1__l_leafref_ref(value: ?str, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__c1__l_leafref_ref:
+    if value is None:
+        return None
+    ref_value: str = yang.adata.expect_ref_value(value, ctx='/c1/l_leafref')
+    ref = foo__c1__l_leafref_ref(ref_value)
+    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+    if ctx is not None:
+        cache_key = yang.adata.ref_cache_key('/c1/li', ref_value)
+        cached_target = ctx.get_target(cache_key)
+        if isinstance(cached_target, foo__c1__li_entry):
+            ref.target = cached_target
+            return ref
+        lookup_node = ctx.lookup_root
+        if lookup_node is not None:
+            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, [yang.gdata.Id(NS_foo, 'c1'), yang.gdata.Id(NS_foo, 'li')], yang.gdata.Id(NS_foo, 'name'), ref_value)
+            if target_node is not None:
+                target = foo__c1__li_entry.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)
+                ref.target = target
+                ctx.set_target(cache_key, target)
+    return ref
+
+_breaker5 = None
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
     l3: ?u64
@@ -627,9 +670,9 @@ class foo__c1(yang.adata.MNode):
     l4: ?str
     bar_l1: ?str
     l2: ?str
-    l_leafref: ?str
+    l_leafref: ?foo__c1__l_leafref_ref
 
-    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?foo__c1__l_leafref_ref):
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -683,9 +726,11 @@ class foo__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
+            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=_resolve_foo__c1__l_leafref_ref(n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__c1()
 
     def copy(self):
@@ -693,7 +738,7 @@ class foo__c1(yang.adata.MNode):
         return foo__c1.from_gdata(self.to_gdata())
 
 
-_breaker5 = None
+_breaker6 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
@@ -709,7 +754,9 @@ class foo__pc1__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc1__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc1__foo:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
         return foo__pc1__foo()
@@ -719,7 +766,7 @@ class foo__pc1__foo(yang.adata.MNode):
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
 
-_breaker6 = None
+_breaker7 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
@@ -735,9 +782,11 @@ class foo__pc1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
+            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return None
 
     def copy(self):
@@ -748,7 +797,7 @@ class foo__pc1(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc1.copy()')
 
 
-_breaker7 = None
+_breaker8 = None
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: ?str
 
@@ -764,7 +813,9 @@ class foo__pc2__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc2__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc2__foo:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__pc2__foo(l_mandatory=n.get_opt_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
         return foo__pc2__foo()
@@ -774,7 +825,7 @@ class foo__pc2__foo(yang.adata.MNode):
         return foo__pc2__foo.from_gdata(self.to_gdata())
 
 
-_breaker8 = None
+_breaker9 = None
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
@@ -790,9 +841,11 @@ class foo__pc2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc2:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
+            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return None
 
     def copy(self):
@@ -803,7 +856,7 @@ class foo__pc2(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc2.copy()')
 
 
-_breaker9 = None
+_breaker10 = None
 class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: ?str
     l3_optional: ?str
@@ -823,7 +876,9 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1__level2__level3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2__level3:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__pc3__level1__level2__level3(l3=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
         return foo__pc3__level1__level2__level3()
@@ -833,7 +888,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
 
 
-_breaker10 = None
+_breaker11 = None
 class foo__pc3__level1__level2(yang.adata.MNode):
     l2: ?str
     l2_optional: ?str
@@ -857,9 +912,11 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1__level2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1__level2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level3'))))
+            return foo__pc3__level1__level2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__pc3__level1__level2()
 
     def copy(self):
@@ -867,7 +924,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
 
-_breaker11 = None
+_breaker12 = None
 class foo__pc3__level1(yang.adata.MNode):
     l1: ?str
     l1_optional: ?str
@@ -891,9 +948,11 @@ class foo__pc3__level1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__pc3__level1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level2'))))
+            return foo__pc3__level1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__pc3__level1()
 
     def copy(self):
@@ -901,7 +960,7 @@ class foo__pc3__level1(yang.adata.MNode):
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
 
-_breaker12 = None
+_breaker13 = None
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
 
@@ -917,9 +976,11 @@ class foo__pc3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__pc3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc3:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level1'))))
+            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return None
 
     def copy(self):
@@ -930,7 +991,7 @@ class foo__pc3(yang.adata.MNode):
         raise Exception('Unreachable in foo__pc3.copy()')
 
 
-_breaker13 = None
+_breaker14 = None
 class foo__empty_presence(yang.adata.MNode):
 
     mut def __init__(self):
@@ -941,7 +1002,9 @@ class foo__empty_presence(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:empty-presence'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__empty_presence:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__empty_presence:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__empty_presence()
         return None
@@ -954,7 +1017,7 @@ class foo__empty_presence(yang.adata.MNode):
         raise Exception('Unreachable in foo__empty_presence.copy()')
 
 
-_breaker14 = None
+_breaker15 = None
 class foo__c_dot(yang.adata.MNode):
     l_dot1: ?str
     l_dot2: ?str
@@ -974,7 +1037,9 @@ class foo__c_dot(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c.dot'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c_dot:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c_dot:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
         return foo__c_dot()
@@ -984,7 +1049,7 @@ class foo__c_dot(yang.adata.MNode):
         return foo__c_dot.from_gdata(self.to_gdata())
 
 
-_breaker15 = None
+_breaker16 = None
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
 
@@ -1000,14 +1065,26 @@ class foo__cc__death_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc', 'death'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
-        return foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc__death_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/cc/death', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__cc__death_entry):
+                return _cached
+        res = foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
-_breaker16 = None
+_breaker17 = None
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
     mut def __init__(self, elements=[]):
@@ -1029,9 +1106,10 @@ class foo__cc__death(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__cc__death_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__cc__death_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__cc__death_entry.from_gdata(e) for e in n.elements]
+            return [foo__cc__death_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1048,7 +1126,7 @@ extension foo__cc__death(Iterable[foo__cc__death_entry]):
     def __iter__(self) -> Iterator[foo__cc__death_entry]:
         return self.elements.__iter__()
 
-_breaker17 = None
+_breaker18 = None
 class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
@@ -1068,9 +1146,11 @@ class foo__cc(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__cc:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death'))))
+            return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__cc()
 
     def copy(self):
@@ -1078,7 +1158,7 @@ class foo__cc(yang.adata.MNode):
         return foo__cc.from_gdata(self.to_gdata())
 
 
-_breaker18 = None
+_breaker19 = None
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1089,7 +1169,9 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__f_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__f_conflict__f_inner()
         return None
@@ -1102,7 +1184,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__f_inner.copy()')
 
 
-_breaker19 = None
+_breaker20 = None
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
     mut def __init__(self):
@@ -1113,7 +1195,9 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> ?foo__f_conflict__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__bar_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__f_conflict__bar_inner()
         return None
@@ -1126,7 +1210,7 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         raise Exception('Unreachable in foo__f_conflict__bar_inner.copy()')
 
 
-_breaker20 = None
+_breaker21 = None
 class foo__f_conflict(yang.adata.MNode):
     f_foo: ?str
     f_inner: ?foo__f_conflict__f_inner
@@ -1170,9 +1254,11 @@ class foo__f_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__f_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__f_conflict:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
+            return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__f_conflict()
 
     def copy(self):
@@ -1180,7 +1266,7 @@ class foo__f_conflict(yang.adata.MNode):
         return foo__f_conflict.from_gdata(self.to_gdata())
 
 
-_breaker21 = None
+_breaker22 = None
 class foo__special_entry(yang.adata.MNode):
     yes: bool
 
@@ -1196,14 +1282,26 @@ class foo__special_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:special'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
-        return foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__special_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_bool(yang.gdata.Id(NS_foo, 'yes'))
+            _cache_key = yang.adata.ref_cache_key('/special', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__special_entry):
+                return _cached
+        res = foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
 
-_breaker22 = None
+_breaker23 = None
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
     mut def __init__(self, elements=[]):
@@ -1225,9 +1323,10 @@ class foo__special(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__special_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__special_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__special_entry.from_gdata(e) for e in n.elements]
+            return [foo__special_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1244,7 +1343,7 @@ extension foo__special(Iterable[foo__special_entry]):
     def __iter__(self) -> Iterator[foo__special_entry]:
         return self.elements.__iter__()
 
-_breaker23 = None
+_breaker24 = None
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key1: str
     key2: str
@@ -1268,14 +1367,17 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
-        return foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1__li2_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        res = foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
-_breaker24 = None
+_breaker25 = None
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
     mut def __init__(self, elements=[]):
@@ -1302,9 +1404,10 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__nested__f_inner__li1__li2_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1__li2_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e) for e in n.elements]
+            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1321,7 +1424,7 @@ extension foo__nested__f_inner__li1__li2(Iterable[foo__nested__f_inner__li1__li2
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1__li2_entry]:
         return self.elements.__iter__()
 
-_breaker25 = None
+_breaker26 = None
 class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     name: str
     f_bar: ?str
@@ -1349,14 +1452,26 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
-        return foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2'))), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/nested/f:inner/li1', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__nested__f_inner__li1_entry):
+                return _cached
+        res = foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
-_breaker26 = None
+_breaker27 = None
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
     mut def __init__(self, elements=[]):
@@ -1382,9 +1497,10 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__nested__f_inner__li1_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__nested__f_inner__li1_entry.from_gdata(e) for e in n.elements]
+            return [foo__nested__f_inner__li1_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1401,7 +1517,7 @@ extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
         return self.elements.__iter__()
 
-_breaker27 = None
+_breaker28 = None
 class foo__nested__f_inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__f_inner__li1
@@ -1421,9 +1537,11 @@ class foo__nested__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1'))))
+            return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__nested__f_inner()
 
     def copy(self):
@@ -1431,7 +1549,7 @@ class foo__nested__f_inner(yang.adata.MNode):
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
 
-_breaker28 = None
+_breaker29 = None
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
@@ -1447,7 +1565,9 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__bar_inner:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return foo__nested__bar_inner()
@@ -1457,7 +1577,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
 
 
-_breaker29 = None
+_breaker30 = None
 class foo__nested(yang.adata.MNode):
     f_inner: foo__nested__f_inner
     bar_inner: foo__nested__bar_inner
@@ -1477,9 +1597,11 @@ class foo__nested(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__nested:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
+            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__nested()
 
     def copy(self):
@@ -1487,7 +1609,7 @@ class foo__nested(yang.adata.MNode):
         return foo__nested.from_gdata(self.to_gdata())
 
 
-_breaker30 = None
+_breaker31 = None
 class foo__li_union_entry(yang.adata.MNode):
     k1: str
     k2: value
@@ -1515,14 +1637,17 @@ class foo__li_union_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
-        return foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        res = foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
-_breaker31 = None
+_breaker32 = None
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
     mut def __init__(self, elements=[]):
@@ -1564,9 +1689,10 @@ class foo__li_union(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__li_union_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__li_union_entry.from_gdata(e) for e in n.elements]
+            return [foo__li_union_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1583,7 +1709,7 @@ extension foo__li_union(Iterable[foo__li_union_entry]):
     def __iter__(self) -> Iterator[foo__li_union_entry]:
         return self.elements.__iter__()
 
-_breaker32 = None
+_breaker33 = None
 class foo__li_union_one_base_entry(yang.adata.MNode):
     k1: value
 
@@ -1599,14 +1725,26 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union-one-base'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_one_base_entry:
-        return foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_one_base_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_value(yang.gdata.Id(NS_foo, 'k1'))
+            _cache_key = yang.adata.ref_cache_key('/li-union-one-base', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, foo__li_union_one_base_entry):
+                return _cached
+        res = foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return foo__li_union_one_base_entry.from_gdata(self.to_gdata())
 
-_breaker33 = None
+_breaker34 = None
 class foo__li_union_one_base(yang.adata.MNode):
     elements: list[foo__li_union_one_base_entry]
     mut def __init__(self, elements=[]):
@@ -1630,9 +1768,10 @@ class foo__li_union_one_base(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__li_union_one_base_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_one_base_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
         if n is not None:
-            return [foo__li_union_one_base_entry.from_gdata(e) for e in n.elements]
+            return [foo__li_union_one_base_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
         return []
 
     def copy(self):
@@ -1649,7 +1788,7 @@ extension foo__li_union_one_base(Iterable[foo__li_union_one_base_entry]):
     def __iter__(self) -> Iterator[foo__li_union_one_base_entry]:
         return self.elements.__iter__()
 
-_breaker34 = None
+_breaker35 = None
 class foo__state__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
@@ -1669,7 +1808,9 @@ class foo__state__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state', 'c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state__c1:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__state__c1()
@@ -1679,7 +1820,7 @@ class foo__state__c1(yang.adata.MNode):
         return foo__state__c1.from_gdata(self.to_gdata())
 
 
-_breaker35 = None
+_breaker36 = None
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
@@ -1695,9 +1836,11 @@ class foo__state(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__state:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
+            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return foo__state()
 
     def copy(self):
@@ -1705,7 +1848,7 @@ class foo__state(yang.adata.MNode):
         return foo__state.from_gdata(self.to_gdata())
 
 
-_breaker36 = None
+_breaker37 = None
 class foo__c2(yang.adata.MNode):
     l1: ?str
 
@@ -1721,7 +1864,9 @@ class foo__c2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> foo__c2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c2:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c2()
@@ -1731,7 +1876,7 @@ class foo__c2(yang.adata.MNode):
         return foo__c2.from_gdata(self.to_gdata())
 
 
-_breaker37 = None
+_breaker38 = None
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
 
@@ -1747,7 +1892,9 @@ class bar__test_idref(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:test-idref'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__test_idref:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__test_idref:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
         return bar__test_idref()
@@ -1757,7 +1904,7 @@ class bar__test_idref(yang.adata.MNode):
         return bar__test_idref.from_gdata(self.to_gdata())
 
 
-_breaker38 = None
+_breaker39 = None
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
@@ -1773,7 +1920,9 @@ class bar__bar_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> bar__bar_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__bar_conflict:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
             return bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return bar__bar_conflict()
@@ -1783,7 +1932,7 @@ class bar__bar_conflict(yang.adata.MNode):
         return bar__bar_conflict.from_gdata(self.to_gdata())
 
 
-_breaker39 = None
+_breaker40 = None
 class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1
@@ -1895,9 +2044,13 @@ class root(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node) -> root:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> root:
+        _actual_lookup_root = lookup_root
+        if _actual_lookup_root is None:
+            _actual_lookup_root = n
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1'))), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2'))), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3'))), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence'))), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot'))), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc'))), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict'))), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special'))), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested'))), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union'))), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base'))), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state'))), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref'))), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict'))))
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
         return root()
 
     def copy(self):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -527,11 +527,22 @@ class foo__c1__li__c4(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li', 'c4'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li__c4:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c1__li__c4:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c1__li__c4):
+                    return _cached
+            res = foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c1__li__c4()
 
     def copy(self):
@@ -563,19 +574,25 @@ class foo__c1__li_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1__li_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__c1__li_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/c1/li', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'name'), n.get_str(yang.gdata.Id(NS_foo, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c1')), yang.gdata.Id(NS_foo, 'li'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__c1__li_entry):
                 return _cached
-        res = foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        res = foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c4'))))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -606,10 +623,13 @@ class foo__c1__li(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__c1__li_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__c1__li_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c1'))
         if n is not None:
-            return [foo__c1__li_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__c1__li_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -633,23 +653,23 @@ class foo__c1__l_leafref_ref(yang.adata.Ref):
         self.value = value
         self.target = target
 
-def _resolve_foo__c1__l_leafref_ref(value: ?str, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__c1__l_leafref_ref:
+def _resolve_foo__c1__l_leafref_ref(value: ?str, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__c1__l_leafref_ref:
     if value is None:
         return None
     ref_value: str = yang.adata.expect_ref_value(value, ctx='/c1/l_leafref')
     ref = foo__c1__l_leafref_ref(ref_value)
     ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
     if ctx is not None:
-        cache_key = yang.adata.ref_cache_key('/c1/li', ref_value)
-        cached_target = ctx.get_target(cache_key)
-        if isinstance(cached_target, foo__c1__li_entry):
-            ref.target = cached_target
-            return ref
         lookup_node = ctx.lookup_root
         if lookup_node is not None:
-            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, [yang.gdata.Id(NS_foo, 'c1'), yang.gdata.Id(NS_foo, 'li')], yang.gdata.Id(NS_foo, 'name'), ref_value)
-            if target_node is not None:
-                target = foo__c1__li_entry.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)
+            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, yang.adata.RefLookupPlan([yang.adata.RefLookupStep(yang.gdata.Id(NS_foo, 'c1'), False), yang.adata.RefLookupStep(yang.gdata.Id(NS_foo, 'li'), True, key_bindings=[(yang.gdata.Id(NS_foo, 'name'), yang.adata.RefValueSource('ref_value'))])], yang.gdata.Id(NS_foo, 'name')))
+            if lookup_res is not None:
+                cache_key = lookup_res.owner_instance_key
+                cached_target = ctx.get_target(cache_key)
+                if isinstance(cached_target, foo__c1__li_entry):
+                    ref.target = cached_target
+                    return ref
+                target = foo__c1__li_entry.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)
                 ref.target = target
                 ctx.set_target(cache_key, target)
     return ref
@@ -726,11 +746,24 @@ class foo__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=_resolve_foo__c1__l_leafref_ref(n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c1):
+                    return _cached
+            res = foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=_resolve_foo__c1__l_leafref_ref(n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf(yang.gdata.Id(NS_bar, 'l_leafref'))), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c1()
 
     def copy(self):
@@ -754,11 +787,24 @@ class foo__pc1__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc1__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc1__foo:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc1')), yang.gdata.Id(NS_foo, 'foo'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc1__foo):
+                    return _cached
+            res = foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__pc1__foo()
 
     def copy(self):
@@ -782,11 +828,24 @@ class foo__pc1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__pc1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc1):
+                    return _cached
+            res = foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'foo'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -813,11 +872,24 @@ class foo__pc2__foo(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2', 'foo'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc2__foo:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc2__foo:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc2__foo(l_mandatory=n.get_opt_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc2')), yang.gdata.Id(NS_foo, 'foo'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc2__foo):
+                    return _cached
+            res = foo__pc2__foo(l_mandatory=n.get_opt_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__pc2__foo()
 
     def copy(self):
@@ -841,11 +913,24 @@ class foo__pc2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__pc2:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc2'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc2):
+                    return _cached
+            res = foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'foo'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -876,11 +961,24 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2__level3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc3__level1__level2__level3:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1__level2__level3(l3=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3')), yang.gdata.Id(NS_foo, 'level1')), yang.gdata.Id(NS_foo, 'level2')), yang.gdata.Id(NS_foo, 'level3'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3__level1__level2__level3):
+                    return _cached
+            res = foo__pc3__level1__level2__level3(l3=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__pc3__level1__level2__level3()
 
     def copy(self):
@@ -912,11 +1010,24 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1__level2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc3__level1__level2:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1__level2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3')), yang.gdata.Id(NS_foo, 'level1')), yang.gdata.Id(NS_foo, 'level2'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3__level1__level2):
+                    return _cached
+            res = foo__pc3__level1__level2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'level3'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__pc3__level1__level2()
 
     def copy(self):
@@ -948,11 +1059,24 @@ class foo__pc3__level1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__pc3__level1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__pc3__level1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3__level1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3')), yang.gdata.Id(NS_foo, 'level1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3__level1):
+                    return _cached
+            res = foo__pc3__level1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'level2'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__pc3__level1()
 
     def copy(self):
@@ -976,11 +1100,24 @@ class foo__pc3(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__pc3:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__pc3:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'pc3'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__pc3):
+                    return _cached
+            res = foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'level1'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1002,11 +1139,24 @@ class foo__empty_presence(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:empty-presence'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__empty_presence:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__empty_presence:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__empty_presence()
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'empty-presence'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__empty_presence):
+                    return _cached
+            res = foo__empty_presence()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1037,11 +1187,24 @@ class foo__c_dot(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c.dot'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c_dot:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c_dot:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c.dot'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c_dot):
+                    return _cached
+            res = foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c_dot()
 
     def copy(self):
@@ -1065,19 +1228,25 @@ class foo__cc__death_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc', 'death'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc__death_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__cc__death_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/cc/death', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'name'), n.get_str(yang.gdata.Id(NS_foo, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'cc')), yang.gdata.Id(NS_foo, 'death'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'death'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__cc__death_entry):
                 return _cached
         res = foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1106,10 +1275,13 @@ class foo__cc__death(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__cc__death_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__cc__death_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'cc'))
         if n is not None:
-            return [foo__cc__death_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__cc__death_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1146,11 +1318,24 @@ class foo__cc(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__cc:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__cc:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'cc'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__cc):
+                    return _cached
+            res = foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__cc()
 
     def copy(self):
@@ -1169,11 +1354,24 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__f_conflict__f_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict__f_inner()
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'conflict')), yang.gdata.Id(NS_foo, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__f_conflict__f_inner):
+                    return _cached
+            res = foo__f_conflict__f_inner()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1195,11 +1393,24 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?foo__f_conflict__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> ?foo__f_conflict__bar_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict__bar_inner()
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'conflict')), yang.gdata.Id(NS_bar, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__f_conflict__bar_inner):
+                    return _cached
+            res = foo__f_conflict__bar_inner()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return None
 
     def copy(self):
@@ -1254,11 +1465,24 @@ class foo__f_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__f_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__f_conflict:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'conflict'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__f_conflict):
+                    return _cached
+            res = foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'inner'))), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'inner'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__f_conflict()
 
     def copy(self):
@@ -1282,19 +1506,25 @@ class foo__special_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:special'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__special_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__special_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_bool(yang.gdata.Id(NS_foo, 'yes'))
-            _cache_key = yang.adata.ref_cache_key('/special', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'yes'), n.get_bool(yang.gdata.Id(NS_foo, 'yes')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'special'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'special'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__special_entry):
                 return _cached
         res = foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1323,10 +1553,13 @@ class foo__special(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__special_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__special_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.root_instance_key()
         if n is not None:
-            return [foo__special_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__special_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1367,10 +1600,23 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1__li2_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'key1'), n.get_str(yang.gdata.Id(NS_foo, 'key1'))), (yang.gdata.Id(NS_foo, 'key2'), n.get_str(yang.gdata.Id(NS_foo, 'key2')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is not None:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li2'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, foo__nested__f_inner__li1__li2_entry):
+                return _cached
         res = foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1404,10 +1650,11 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1__li2_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__nested__f_inner__li1__li2_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
         if n is not None:
-            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__nested__f_inner__li1__li2_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1452,19 +1699,25 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner__li1_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__nested__f_inner__li1_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_foo, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/nested/f:inner/li1', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'name'), n.get_str(yang.gdata.Id(NS_foo, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_foo, 'inner')), yang.gdata.Id(NS_foo, 'li1'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li1'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__nested__f_inner__li1_entry):
                 return _cached
-        res = foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        res = foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1497,10 +1750,13 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__nested__f_inner__li1_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__nested__f_inner__li1_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_foo, 'inner'))
         if n is not None:
-            return [foo__nested__f_inner__li1_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__nested__f_inner__li1_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1537,11 +1793,24 @@ class foo__nested__f_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__f_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__nested__f_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_foo, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__nested__f_inner):
+                    return _cached
+            res = foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__nested__f_inner()
 
     def copy(self):
@@ -1565,11 +1834,24 @@ class foo__nested__bar_inner(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'bar:inner'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested__bar_inner:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__nested__bar_inner:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested')), yang.gdata.Id(NS_bar, 'inner'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__nested__bar_inner):
+                    return _cached
+            res = foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__nested__bar_inner()
 
     def copy(self):
@@ -1597,11 +1879,24 @@ class foo__nested(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__nested:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__nested:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'nested'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__nested):
+                    return _cached
+            res = foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'inner'))), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'inner'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__nested()
 
     def copy(self):
@@ -1637,10 +1932,25 @@ class foo__li_union_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__li_union_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'k1'), n.get_str(yang.gdata.Id(NS_foo, 'k1'))), (yang.gdata.Id(NS_foo, 'k2'), n.get_value(yang.gdata.Id(NS_foo, 'k2'))), (yang.gdata.Id(NS_foo, 'k3'), n.get_bytes(yang.gdata.Id(NS_foo, 'k3')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'li-union'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li-union'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, foo__li_union_entry):
+                return _cached
         res = foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1689,10 +1999,13 @@ class foo__li_union(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__li_union_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.root_instance_key()
         if n is not None:
-            return [foo__li_union_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__li_union_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1725,19 +2038,25 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union-one-base'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__li_union_one_base_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> foo__li_union_one_base_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_value(yang.gdata.Id(NS_foo, 'k1'))
-            _cache_key = yang.adata.ref_cache_key('/li-union-one-base', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_foo, 'k1'), n.get_value(yang.gdata.Id(NS_foo, 'k1')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'li-union-one-base'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_foo, 'li-union-one-base'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, foo__li_union_one_base_entry):
                 return _cached
         res = foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -1768,10 +2087,13 @@ class foo__li_union_one_base(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[foo__li_union_one_base_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[foo__li_union_one_base_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.root_instance_key()
         if n is not None:
-            return [foo__li_union_one_base_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [foo__li_union_one_base_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -1808,11 +2130,24 @@ class foo__state__c1(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state', 'c1'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state__c1:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__state__c1:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'state')), yang.gdata.Id(NS_foo, 'c1'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__state__c1):
+                    return _cached
+            res = foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__state__c1()
 
     def copy(self):
@@ -1836,11 +2171,24 @@ class foo__state(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__state:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__state:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'state'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__state):
+                    return _cached
+            res = foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c1'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__state()
 
     def copy(self):
@@ -1864,11 +2212,24 @@ class foo__c2(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c2'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> foo__c2:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> foo__c2:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_foo, 'c2'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, foo__c2):
+                    return _cached
+            res = foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return foo__c2()
 
     def copy(self):
@@ -1892,11 +2253,24 @@ class bar__test_idref(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:test-idref'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__test_idref:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> bar__test_idref:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_bar, 'test-idref'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, bar__test_idref):
+                    return _cached
+            res = bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return bar__test_idref()
 
     def copy(self):
@@ -1920,11 +2294,24 @@ class bar__bar_conflict(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:conflict'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> bar__bar_conflict:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> bar__bar_conflict:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_bar, 'conflict'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, bar__bar_conflict):
+                    return _cached
+            res = bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return bar__bar_conflict()
 
     def copy(self):
@@ -2044,13 +2431,26 @@ class root(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=True)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> root:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> root:
         _actual_lookup_root = lookup_root
         if _actual_lookup_root is None:
             _actual_lookup_root = n
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.root_instance_key()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, root):
+                    return _cached
+            res = root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'pc1'))), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'pc2'))), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'pc3'))), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'empty-presence'))), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c.dot'))), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'cc'))), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'conflict'))), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'nested'))), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'state'))), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_foo, 'c2'))), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'test-idref'))), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_bar, 'conflict'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return root()
 
     def copy(self):

--- a/test/test_data_classes/src/yang_refs.act
+++ b/test/test_data_classes/src/yang_refs.act
@@ -25,13 +25,31 @@ SRC_DNODE_CHILD_0 = DContainer(module='refs', namespace='http://example.com/refs
         DContainer(module='refs', namespace='http://example.com/refs', prefix='refs', name='config', config=True, presence=False, children=[
             DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='interval', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
         ])
+    ]),
+    DList(module='refs', namespace='http://example.com/refs', prefix='refs', name='device', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DList(module='refs', namespace='http://example.com/refs', prefix='refs', name='interface', key=[
+'name',
+'subif'
+            ], config=True, min_elements=0, ordered_by='system', children=[
+            DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+            DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='subif', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+            DContainer(module='refs', namespace='http://example.com/refs', prefix='refs', name='config', config=True, presence=False, children=[
+                DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='enabled', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
+            ])
+        ])
     ])
 ])
 
 SRC_DNODE_CHILD_1 = DContainer(module='refs', namespace='http://example.com/refs', prefix='refs', name='transforms', config=True, presence=False, children=[
     DList(module='refs', namespace='http://example.com/refs', prefix='refs', name='consumer', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='input', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('refs', 'inventory', []), yang.xpath.NodeTestStep('refs', 'producer', []), yang.xpath.NodeTestStep('refs', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='input', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('refs', 'inventory', []), yang.xpath.NodeTestStep('refs', 'producer', []), yang.xpath.NodeTestStep('refs', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))),
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='device', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='if-name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='if-subif', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)]))),
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='nested-input', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('refs', 'inventory', []), yang.xpath.NodeTestStep('refs', 'device', [yang.xpath.Predicate('refs:name=current()/../refs:device')]), yang.xpath.NodeTestStep('refs', 'interface', [yang.xpath.Predicate('refs:name=current()/../refs:if-name'), yang.xpath.Predicate('refs:subif=current()/../refs:if-subif')]), yang.xpath.NodeTestStep('refs', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))),
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='nested-enabled', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('refs', 'inventory', []), yang.xpath.NodeTestStep('refs', 'device', [yang.xpath.Predicate('refs:name=current()/../refs:device')]), yang.xpath.NodeTestStep('refs', 'interface', [yang.xpath.Predicate('refs:name=current()/../refs:if-name'), yang.xpath.Predicate('refs:subif=current()/../refs:if-subif')]), yang.xpath.NodeTestStep('refs', 'config', []), yang.xpath.NodeTestStep('refs', 'enabled', [])]), require_instance=False, target_type=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)))
     ])
 ])
 
@@ -63,6 +81,32 @@ def src_yang():
         }
       }
     }
+
+    list device {
+      key "name";
+
+      leaf name {
+        type string;
+      }
+
+      list interface {
+        key "name subif";
+
+        leaf name {
+          type string;
+        }
+
+        leaf subif {
+          type uint32;
+        }
+
+        container config {
+          leaf enabled {
+            type boolean;
+          }
+        }
+      }
+    }
   }
 
   container transforms {
@@ -76,6 +120,34 @@ def src_yang():
       leaf input {
         type leafref {
           path "/refs:inventory/refs:producer/refs:name";
+        }
+      }
+
+      leaf device {
+        type string;
+      }
+
+      leaf if-name {
+        type string;
+      }
+
+      leaf if-subif {
+        type uint32;
+      }
+
+      leaf nested-input {
+        type leafref {
+          path "/refs:inventory/refs:device[refs:name=current()/../refs:device]/" +
+               "refs:interface[refs:name=current()/../refs:if-name][refs:subif=current()/../refs:if-subif]/" +
+               "refs:name";
+        }
+      }
+
+      leaf nested-enabled {
+        type leafref {
+          path "/refs:inventory/refs:device[refs:name=current()/../refs:device]/" +
+               "refs:interface[refs:name=current()/../refs:if-name][refs:subif=current()/../refs:if-subif]/" +
+               "refs:config/refs:enabled";
         }
       }
     }
@@ -103,11 +175,22 @@ class refs__inventory__producer__config(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'producer', 'config'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__inventory__producer__config:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> refs__inventory__producer__config:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return refs__inventory__producer__config(interval=n.get_opt_u64(yang.gdata.Id(NS_refs, 'interval')))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, refs__inventory__producer__config):
+                    return _cached
+            res = refs__inventory__producer__config(interval=n.get_opt_u64(yang.gdata.Id(NS_refs, 'interval')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return refs__inventory__producer__config()
 
     def copy(self):
@@ -135,19 +218,25 @@ class refs__inventory__producer_entry(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'producer'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__inventory__producer_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> refs__inventory__producer_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_refs, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/inventory/producer', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_refs, 'name'), n.get_str(yang.gdata.Id(NS_refs, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'inventory')), yang.gdata.Id(NS_refs, 'producer'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_refs, 'producer'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, refs__inventory__producer_entry):
                 return _cached
-        res = refs__inventory__producer_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), config=refs__inventory__producer__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'config')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        res = refs__inventory__producer_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), config=refs__inventory__producer__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'config')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_refs, 'config'))))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
@@ -176,10 +265,13 @@ class refs__inventory__producer(yang.adata.MNode):
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[refs__inventory__producer_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[refs__inventory__producer_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'inventory'))
         if n is not None:
-            return [refs__inventory__producer_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [refs__inventory__producer_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -197,26 +289,265 @@ extension refs__inventory__producer(Iterable[refs__inventory__producer_entry]):
         return self.elements.__iter__()
 
 _breaker4 = None
+class refs__inventory__device__interface__config(yang.adata.MNode):
+    enabled: ?bool
+
+    mut def __init__(self, enabled: ?bool):
+        self._ns = 'http://example.com/refs'
+        self.enabled = enabled
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'enabled':
+            return self.enabled
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'device', 'interface', 'config'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> refs__inventory__device__interface__config:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        if n is not None:
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, refs__inventory__device__interface__config):
+                    return _cached
+            res = refs__inventory__device__interface__config(enabled=n.get_opt_bool(yang.gdata.Id(NS_refs, 'enabled')))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
+        return refs__inventory__device__interface__config()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__inventory__device__interface__config.from_gdata(self.to_gdata())
+
+
+_breaker5 = None
+class refs__inventory__device__interface_entry(yang.adata.MNode):
+    name: str
+    subif: u64
+    config: refs__inventory__device__interface__config
+
+    mut def __init__(self, name: str, subif: u64, config: ?refs__inventory__device__interface__config=None):
+        self._ns = 'http://example.com/refs'
+        self.name = name
+        self.subif = subif
+        self.config = config if config is not None else refs__inventory__device__interface__config()
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'name':
+            return self.name
+        if name == 'subif':
+            return self.subif
+        if name == 'config':
+            return self.config
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'device', 'interface'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> refs__inventory__device__interface_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_refs, 'name'), n.get_str(yang.gdata.Id(NS_refs, 'name'))), (yang.gdata.Id(NS_refs, 'subif'), n.get_u64(yang.gdata.Id(NS_refs, 'subif')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is not None:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_refs, 'interface'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, refs__inventory__device__interface_entry):
+                return _cached
+        res = refs__inventory__device__interface_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), subif=n.get_u64(yang.gdata.Id(NS_refs, 'subif')), config=refs__inventory__device__interface__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'config')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_refs, 'config'))))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
+        return res
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__inventory__device__interface_entry.from_gdata(self.to_gdata())
+
+_breaker6 = None
+class refs__inventory__device__interface(yang.adata.MNode):
+    elements: list[refs__inventory__device__interface_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'http://example.com/refs'
+        self._name = 'interface'
+        self.elements = elements
+
+    mut def create(self, name, subif):
+        for e in self:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if e.subif != subif:
+                match = False
+                continue
+            if match:
+                return e
+
+        res = refs__inventory__device__interface_entry(name=name, subif=subif)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[refs__inventory__device__interface_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if n is not None:
+            return [refs__inventory__device__interface_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return refs__inventory__device__interface(elements=copied_elements)
+
+extension refs__inventory__device__interface(Iterable[refs__inventory__device__interface_entry]):
+    def __iter__(self) -> Iterator[refs__inventory__device__interface_entry]:
+        return self.elements.__iter__()
+
+_breaker7 = None
+class refs__inventory__device_entry(yang.adata.MNode):
+    name: str
+    interface: refs__inventory__device__interface
+
+    mut def __init__(self, name: str, interface: list[refs__inventory__device__interface_entry]=[]):
+        self._ns = 'http://example.com/refs'
+        self.name = name
+        self.interface = refs__inventory__device__interface(elements=interface)
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'name':
+            return self.name
+        if name == 'interface':
+            return iter(self.interface)
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'device'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> refs__inventory__device_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_refs, 'name'), n.get_str(yang.gdata.Id(NS_refs, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'inventory')), yang.gdata.Id(NS_refs, 'device'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_refs, 'device'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
+            if isinstance(_cached, refs__inventory__device_entry):
+                return _cached
+        res = refs__inventory__device_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), interface=refs__inventory__device__interface.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'interface')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
+        return res
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__inventory__device_entry.from_gdata(self.to_gdata())
+
+_breaker8 = None
+class refs__inventory__device(yang.adata.MNode):
+    elements: list[refs__inventory__device_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'http://example.com/refs'
+        self._name = 'device'
+        self.elements = elements
+
+    mut def create(self, name):
+        for e in self:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if match:
+                return e
+
+        res = refs__inventory__device_entry(name=name)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[refs__inventory__device_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'inventory'))
+        if n is not None:
+            return [refs__inventory__device_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return refs__inventory__device(elements=copied_elements)
+
+extension refs__inventory__device(Iterable[refs__inventory__device_entry]):
+    def __iter__(self) -> Iterator[refs__inventory__device_entry]:
+        return self.elements.__iter__()
+
+_breaker9 = None
 class refs__inventory(yang.adata.MNode):
     producer: refs__inventory__producer
+    device: refs__inventory__device
 
-    mut def __init__(self, producer: list[refs__inventory__producer_entry]=[]):
+    mut def __init__(self, producer: list[refs__inventory__producer_entry]=[], device: list[refs__inventory__device_entry]=[]):
         self._ns = 'http://example.com/refs'
         self.producer = refs__inventory__producer(elements=producer)
+        self.device = refs__inventory__device(elements=device)
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'producer':
             return iter(self.producer)
+        if name == 'device':
+            return iter(self.device)
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__inventory:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> refs__inventory:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return refs__inventory(producer=refs__inventory__producer.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'producer')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'inventory'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, refs__inventory):
+                    return _cached
+            res = refs__inventory(producer=refs__inventory__producer.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'producer')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key), device=refs__inventory__device.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'device')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return refs__inventory()
 
     def copy(self):
@@ -224,74 +555,156 @@ class refs__inventory(yang.adata.MNode):
         return refs__inventory.from_gdata(self.to_gdata())
 
 
-_breaker5 = None
+_breaker10 = None
 class refs__transforms__consumer__input_ref(yang.adata.Ref):
     target: ?refs__inventory__producer_entry
     def __init__(self, value: str, target: ?refs__inventory__producer_entry=None):
         self.value = value
         self.target = target
 
-def _resolve_refs__transforms__consumer__input_ref(value: ?str, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?refs__transforms__consumer__input_ref:
+def _resolve_refs__transforms__consumer__input_ref(value: ?str, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?refs__transforms__consumer__input_ref:
     if value is None:
         return None
     ref_value: str = yang.adata.expect_ref_value(value, ctx='/transforms/consumer/input')
     ref = refs__transforms__consumer__input_ref(ref_value)
     ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
     if ctx is not None:
-        cache_key = yang.adata.ref_cache_key('/inventory/producer', ref_value)
-        cached_target = ctx.get_target(cache_key)
-        if isinstance(cached_target, refs__inventory__producer_entry):
-            ref.target = cached_target
-            return ref
         lookup_node = ctx.lookup_root
         if lookup_node is not None:
-            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, [yang.gdata.Id(NS_refs, 'inventory'), yang.gdata.Id(NS_refs, 'producer')], yang.gdata.Id(NS_refs, 'name'), ref_value)
-            if target_node is not None:
-                target = refs__inventory__producer_entry.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)
+            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, yang.adata.RefLookupPlan([yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'inventory'), False), yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'producer'), True, key_bindings=[(yang.gdata.Id(NS_refs, 'name'), yang.adata.RefValueSource('ref_value'))])], yang.gdata.Id(NS_refs, 'name')))
+            if lookup_res is not None:
+                cache_key = lookup_res.owner_instance_key
+                cached_target = ctx.get_target(cache_key)
+                if isinstance(cached_target, refs__inventory__producer_entry):
+                    ref.target = cached_target
+                    return ref
+                target = refs__inventory__producer_entry.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)
                 ref.target = target
                 ctx.set_target(cache_key, target)
     return ref
 
-_breaker6 = None
+_breaker11 = None
+class refs__transforms__consumer__nested_input_ref(yang.adata.Ref):
+    target: ?refs__inventory__device__interface_entry
+    def __init__(self, value: str, target: ?refs__inventory__device__interface_entry=None):
+        self.value = value
+        self.target = target
+
+def _resolve_refs__transforms__consumer__nested_input_ref(value: ?str, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?refs__transforms__consumer__nested_input_ref:
+    if value is None:
+        return None
+    ref_value: str = yang.adata.expect_ref_value(value, ctx='/transforms/consumer/nested-input')
+    ref = refs__transforms__consumer__nested_input_ref(ref_value)
+    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+    if ctx is not None:
+        lookup_node = ctx.lookup_root
+        if lookup_node is not None:
+            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, yang.adata.RefLookupPlan([yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'inventory'), False), yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'device'), True, key_bindings=[(yang.gdata.Id(NS_refs, 'name'), yang.adata.RefValueSource('source_path', up_levels=1, source_path=[yang.gdata.Id(NS_refs, 'device')]))]), yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'interface'), True, key_bindings=[(yang.gdata.Id(NS_refs, 'name'), yang.adata.RefValueSource('source_path', up_levels=1, source_path=[yang.gdata.Id(NS_refs, 'if-name')])), (yang.gdata.Id(NS_refs, 'subif'), yang.adata.RefValueSource('source_path', up_levels=1, source_path=[yang.gdata.Id(NS_refs, 'if-subif')]))])], yang.gdata.Id(NS_refs, 'name')))
+            if lookup_res is not None:
+                cache_key = lookup_res.owner_instance_key
+                cached_target = ctx.get_target(cache_key)
+                if isinstance(cached_target, refs__inventory__device__interface_entry):
+                    ref.target = cached_target
+                    return ref
+                target = refs__inventory__device__interface_entry.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)
+                ref.target = target
+                ctx.set_target(cache_key, target)
+    return ref
+
+_breaker12 = None
+class refs__transforms__consumer__nested_enabled_ref(yang.adata.Ref):
+    target: ?refs__inventory__device__interface__config
+    def __init__(self, value: bool, target: ?refs__inventory__device__interface__config=None):
+        self.value = value
+        self.target = target
+
+def _resolve_refs__transforms__consumer__nested_enabled_ref(value: ?bool, source_nodes: list[yang.gdata.Node]=[], lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?refs__transforms__consumer__nested_enabled_ref:
+    if value is None:
+        return None
+    ref_value: bool = yang.adata.expect_ref_value(value, ctx='/transforms/consumer/nested-enabled')
+    ref = refs__transforms__consumer__nested_enabled_ref(ref_value)
+    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+    if ctx is not None:
+        lookup_node = ctx.lookup_root
+        if lookup_node is not None:
+            lookup_res = yang.adata.lookup_ref_target(lookup_node, source_nodes, ref_value, yang.adata.RefLookupPlan([yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'inventory'), False), yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'device'), True, key_bindings=[(yang.gdata.Id(NS_refs, 'name'), yang.adata.RefValueSource('source_path', up_levels=1, source_path=[yang.gdata.Id(NS_refs, 'device')]))]), yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'interface'), True, key_bindings=[(yang.gdata.Id(NS_refs, 'name'), yang.adata.RefValueSource('source_path', up_levels=1, source_path=[yang.gdata.Id(NS_refs, 'if-name')])), (yang.gdata.Id(NS_refs, 'subif'), yang.adata.RefValueSource('source_path', up_levels=1, source_path=[yang.gdata.Id(NS_refs, 'if-subif')]))]), yang.adata.RefLookupStep(yang.gdata.Id(NS_refs, 'config'), False)], yang.gdata.Id(NS_refs, 'enabled')))
+            if lookup_res is not None:
+                cache_key = lookup_res.owner_instance_key
+                cached_target = ctx.get_target(cache_key)
+                if isinstance(cached_target, refs__inventory__device__interface__config):
+                    ref.target = cached_target
+                    return ref
+                target = refs__inventory__device__interface__config.from_gdata(lookup_res.owner_node, lookup_root=lookup_node, _ref_ctx=ctx, _source_nodes=lookup_res.owner_source_nodes[:-1], _instance_key=cache_key)
+                ref.target = target
+                ctx.set_target(cache_key, target)
+    return ref
+
+_breaker13 = None
 class refs__transforms__consumer_entry(yang.adata.MNode):
     name: str
     input: ?refs__transforms__consumer__input_ref
+    device: ?str
+    if_name: ?str
+    if_subif: ?u64
+    nested_input: ?refs__transforms__consumer__nested_input_ref
+    nested_enabled: ?refs__transforms__consumer__nested_enabled_ref
 
-    mut def __init__(self, name: str, input: ?refs__transforms__consumer__input_ref):
+    mut def __init__(self, name: str, input: ?refs__transforms__consumer__input_ref, device: ?str, if_name: ?str, if_subif: ?u64, nested_input: ?refs__transforms__consumer__nested_input_ref, nested_enabled: ?refs__transforms__consumer__nested_enabled_ref):
         self._ns = 'http://example.com/refs'
         self.name = name
         self.input = input
+        self.device = device
+        self.if_name = if_name
+        self.if_subif = if_subif
+        self.nested_input = nested_input
+        self.nested_enabled = nested_enabled
 
     def _get_attr(self, name: str) -> ?value:
         if name == 'name':
             return self.name
         if name == 'input':
             return self.input
+        if name == 'device':
+            return self.device
+        if name == 'if_name':
+            return self.if_name
+        if name == 'if_subif':
+            return self.if_subif
+        if name == 'nested_input':
+            return self.nested_input
+        if name == 'nested_enabled':
+            return self.nested_enabled
 
     mut def to_gdata(self) -> yang.gdata.Node:
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:transforms', 'consumer'])
 
     @staticmethod
-    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__transforms__consumer_entry:
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None, _instance_key: ?str=None) -> refs__transforms__consumer_entry:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
-        _cache_key = ''
-        if _ref_ctx is not None:
-            _key_value = n.get_str(yang.gdata.Id(NS_refs, 'name'))
-            _cache_key = yang.adata.ref_cache_key('/transforms/consumer', _key_value)
-            _cached = _ref_ctx.get_target(_cache_key)
+        _self_source_nodes = _source_nodes + [n]
+        _self_instance_key = ''
+        _key_values = [(yang.gdata.Id(NS_refs, 'name'), n.get_str(yang.gdata.Id(NS_refs, 'name')))]
+        if _instance_key is not None:
+            _self_instance_key = _instance_key
+        elif _parent_instance_key is None:
+            _self_instance_key = yang.adata.append_list_instance_key(yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'transforms')), yang.gdata.Id(NS_refs, 'consumer'), _key_values)
+        else:
+            _self_instance_key = yang.adata.append_list_instance_key(_parent_instance_key, yang.gdata.Id(NS_refs, 'consumer'), _key_values)
+        if _ref_ctx is not None and _self_instance_key != '':
+            _cached = _ref_ctx.get_target(_self_instance_key)
             if isinstance(_cached, refs__transforms__consumer_entry):
                 return _cached
-        res = refs__transforms__consumer_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), input=_resolve_refs__transforms__consumer__input_ref(n.get_opt_str(yang.gdata.Id(NS_refs, 'input')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
-        if _ref_ctx is not None and _cache_key != '':
-            _ref_ctx.set_target(_cache_key, res)
+        res = refs__transforms__consumer_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), input=_resolve_refs__transforms__consumer__input_ref(n.get_opt_str(yang.gdata.Id(NS_refs, 'input')), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf(yang.gdata.Id(NS_refs, 'input'))), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), device=n.get_opt_str(yang.gdata.Id(NS_refs, 'device')), if_name=n.get_opt_str(yang.gdata.Id(NS_refs, 'if-name')), if_subif=n.get_opt_u64(yang.gdata.Id(NS_refs, 'if-subif')), nested_input=_resolve_refs__transforms__consumer__nested_input_ref(n.get_opt_str(yang.gdata.Id(NS_refs, 'nested-input')), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf(yang.gdata.Id(NS_refs, 'nested-input'))), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), nested_enabled=_resolve_refs__transforms__consumer__nested_enabled_ref(n.get_opt_bool(yang.gdata.Id(NS_refs, 'nested-enabled')), source_nodes=yang.adata.append_source_node(_self_source_nodes, n.get_opt_leaf(yang.gdata.Id(NS_refs, 'nested-enabled'))), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        if _ref_ctx is not None and _self_instance_key != '':
+            _ref_ctx.set_target(_self_instance_key, res)
         return res
 
     def copy(self):
         """Create a deep copy of this adata object"""
         return refs__transforms__consumer_entry.from_gdata(self.to_gdata())
 
-_breaker7 = None
+_breaker14 = None
 class refs__transforms__consumer(yang.adata.MNode):
     elements: list[refs__transforms__consumer_entry]
     mut def __init__(self, elements=[]):
@@ -299,7 +712,7 @@ class refs__transforms__consumer(yang.adata.MNode):
         self._name = 'consumer'
         self.elements = elements
 
-    mut def create(self, name, input=None):
+    mut def create(self, name, input=None, device=None, if_name=None, if_subif=None, nested_input=None, nested_enabled=None):
         for e in self:
             match = True
             if e.name != name:
@@ -308,17 +721,30 @@ class refs__transforms__consumer(yang.adata.MNode):
             if match:
                 if input is not None:
                     e.input = input
+                if device is not None:
+                    e.device = device
+                if if_name is not None:
+                    e.if_name = if_name
+                if if_subif is not None:
+                    e.if_subif = if_subif
+                if nested_input is not None:
+                    e.nested_input = nested_input
+                if nested_enabled is not None:
+                    e.nested_enabled = nested_enabled
                 return e
 
-        res = refs__transforms__consumer_entry(name=name, input=input)
+        res = refs__transforms__consumer_entry(name=name, input=input, device=device, if_name=if_name, if_subif=if_subif, nested_input=nested_input, nested_enabled=nested_enabled)
         self.elements.append(res)
         return res
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[refs__transforms__consumer_entry]:
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _parent_instance_key: ?str=None) -> list[refs__transforms__consumer_entry]:
         _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        _actual_parent_instance_key = _parent_instance_key
+        if _actual_parent_instance_key is None:
+            _actual_parent_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'transforms'))
         if n is not None:
-            return [refs__transforms__consumer_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+            return [refs__transforms__consumer_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_source_nodes, _parent_instance_key=_actual_parent_instance_key) for e in n.elements]
         return []
 
     def copy(self):
@@ -335,7 +761,7 @@ extension refs__transforms__consumer(Iterable[refs__transforms__consumer_entry])
     def __iter__(self) -> Iterator[refs__transforms__consumer_entry]:
         return self.elements.__iter__()
 
-_breaker8 = None
+_breaker15 = None
 class refs__transforms(yang.adata.MNode):
     consumer: refs__transforms__consumer
 
@@ -351,11 +777,24 @@ class refs__transforms(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:transforms'])
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__transforms:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> refs__transforms:
         _actual_lookup_root = lookup_root
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return refs__transforms(consumer=refs__transforms__consumer.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'consumer')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.append_container_instance_key(yang.adata.root_instance_key(), yang.gdata.Id(NS_refs, 'transforms'))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, refs__transforms):
+                    return _cached
+            res = refs__transforms(consumer=refs__transforms__consumer.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'consumer')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _parent_instance_key=_self_instance_key))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return refs__transforms()
 
     def copy(self):
@@ -363,7 +802,7 @@ class refs__transforms(yang.adata.MNode):
         return refs__transforms.from_gdata(self.to_gdata())
 
 
-_breaker9 = None
+_breaker16 = None
 class root(yang.adata.MNode):
     inventory: refs__inventory
     transforms: refs__transforms
@@ -383,13 +822,26 @@ class root(yang.adata.MNode):
         return yang.adata.from_adata(SRC_DNODE, self, loose=False)
 
     @staticmethod
-    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> root:
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None, _source_nodes: list[yang.gdata.Node]=[], _instance_key: ?str=None) -> root:
         _actual_lookup_root = lookup_root
         if _actual_lookup_root is None:
             _actual_lookup_root = n
         _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
         if n is not None:
-            return root(inventory=refs__inventory.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'inventory')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), transforms=refs__transforms.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'transforms')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+            _self_source_nodes = _source_nodes + [n]
+            _self_instance_key = ''
+            if _instance_key is not None:
+                _self_instance_key = _instance_key
+            else:
+                _self_instance_key = yang.adata.root_instance_key()
+            if _ref_ctx is not None and _self_instance_key != '':
+                _cached = _ref_ctx.get_target(_self_instance_key)
+                if isinstance(_cached, root):
+                    return _cached
+            res = root(inventory=refs__inventory.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'inventory')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_refs, 'inventory'))), transforms=refs__transforms.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'transforms')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx, _source_nodes=_self_source_nodes, _instance_key=yang.adata.append_container_instance_key(_self_instance_key, yang.gdata.Id(NS_refs, 'transforms'))))
+            if _ref_ctx is not None and _self_instance_key != '':
+                _ref_ctx.set_target(_self_instance_key, res)
+            return res
         return root()
 
     def copy(self):
@@ -409,12 +861,27 @@ def src_schema():
             Container('config', children=[
                 Leaf('interval', type_=Type('uint32'))
             ])
+        ]),
+        List('device', key='name', children=[
+            Leaf('name', type_=Type('string')),
+            List('interface', key='name subif', children=[
+                Leaf('name', type_=Type('string')),
+                Leaf('subif', type_=Type('uint32')),
+                Container('config', children=[
+                    Leaf('enabled', type_=Type('boolean'))
+                ])
+            ])
         ])
     ]),
     Container('transforms', children=[
         List('consumer', key='name', children=[
             Leaf('name', type_=Type('string')),
-            Leaf('input', type_=Type('leafref', path='/refs:inventory/refs:producer/refs:name'))
+            Leaf('input', type_=Type('leafref', path='/refs:inventory/refs:producer/refs:name')),
+            Leaf('device', type_=Type('string')),
+            Leaf('if-name', type_=Type('string')),
+            Leaf('if-subif', type_=Type('uint32')),
+            Leaf('nested-input', type_=Type('leafref', path='/refs:inventory/refs:device[refs:name=current()/../refs:device]/refs:interface[refs:name=current()/../refs:if-name][refs:subif=current()/../refs:if-subif]/refs:name')),
+            Leaf('nested-enabled', type_=Type('leafref', path='/refs:inventory/refs:device[refs:name=current()/../refs:device]/refs:interface[refs:name=current()/../refs:if-name][refs:subif=current()/../refs:if-subif]/refs:config/refs:enabled'))
         ])
     ])
 ])

--- a/test/test_data_classes/src/yang_refs.act
+++ b/test/test_data_classes/src/yang_refs.act
@@ -1,0 +1,422 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.xml
+import yang.xpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+
+
+_identities: list[DIdentity] = []
+
+
+SRC_DNODE_CHILD_0 = DContainer(module='refs', namespace='http://example.com/refs', prefix='refs', name='inventory', config=True, presence=False, children=[
+    DList(module='refs', namespace='http://example.com/refs', prefix='refs', name='producer', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DContainer(module='refs', namespace='http://example.com/refs', prefix='refs', name='config', config=True, presence=False, children=[
+            DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='interval', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+        ])
+    ])
+])
+
+SRC_DNODE_CHILD_1 = DContainer(module='refs', namespace='http://example.com/refs', prefix='refs', name='transforms', config=True, presence=False, children=[
+    DList(module='refs', namespace='http://example.com/refs', prefix='refs', name='consumer', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='refs', namespace='http://example.com/refs', prefix='refs', name='input', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yang.xpath.AbsoluteLocationPath([yang.xpath.NodeTestStep('refs', 'inventory', []), yang.xpath.NodeTestStep('refs', 'producer', []), yang.xpath.NodeTestStep('refs', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+    ])
+])
+
+SRC_DNODE = DRoot(
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_1],
+    identities=[],
+    rpcs=[],
+    module_metadata={'http://example.com/refs':('refs', None)},
+)
+
+def src_yang():
+    res = []
+    res.append(r"""module refs {
+  yang-version "1.1";
+  namespace "http://example.com/refs";
+  prefix "refs";
+
+  container inventory {
+    list producer {
+      key "name";
+
+      leaf name {
+        type string;
+      }
+
+      container config {
+        leaf interval {
+          type uint32;
+        }
+      }
+    }
+  }
+
+  container transforms {
+    list consumer {
+      key "name";
+
+      leaf name {
+        type string;
+      }
+
+      leaf input {
+        type leafref {
+          path "/refs:inventory/refs:producer/refs:name";
+        }
+      }
+    }
+  }
+}""")
+    return res
+
+
+NS_refs = 'http://example.com/refs'
+
+
+_breaker1 = None
+class refs__inventory__producer__config(yang.adata.MNode):
+    interval: ?u64
+
+    mut def __init__(self, interval: ?u64):
+        self._ns = 'http://example.com/refs'
+        self.interval = interval
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'interval':
+            return self.interval
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'producer', 'config'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__inventory__producer__config:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        if n is not None:
+            return refs__inventory__producer__config(interval=n.get_opt_u64(yang.gdata.Id(NS_refs, 'interval')))
+        return refs__inventory__producer__config()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__inventory__producer__config.from_gdata(self.to_gdata())
+
+
+_breaker2 = None
+class refs__inventory__producer_entry(yang.adata.MNode):
+    name: str
+    config: refs__inventory__producer__config
+
+    mut def __init__(self, name: str, config: ?refs__inventory__producer__config=None):
+        self._ns = 'http://example.com/refs'
+        self.name = name
+        self.config = config if config is not None else refs__inventory__producer__config()
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'name':
+            return self.name
+        if name == 'config':
+            return self.config
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory', 'producer'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__inventory__producer_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_refs, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/inventory/producer', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, refs__inventory__producer_entry):
+                return _cached
+        res = refs__inventory__producer_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), config=refs__inventory__producer__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'config')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__inventory__producer_entry.from_gdata(self.to_gdata())
+
+_breaker3 = None
+class refs__inventory__producer(yang.adata.MNode):
+    elements: list[refs__inventory__producer_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'http://example.com/refs'
+        self._name = 'producer'
+        self.elements = elements
+
+    mut def create(self, name):
+        for e in self:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if match:
+                return e
+
+        res = refs__inventory__producer_entry(name=name)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[refs__inventory__producer_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        if n is not None:
+            return [refs__inventory__producer_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return refs__inventory__producer(elements=copied_elements)
+
+extension refs__inventory__producer(Iterable[refs__inventory__producer_entry]):
+    def __iter__(self) -> Iterator[refs__inventory__producer_entry]:
+        return self.elements.__iter__()
+
+_breaker4 = None
+class refs__inventory(yang.adata.MNode):
+    producer: refs__inventory__producer
+
+    mut def __init__(self, producer: list[refs__inventory__producer_entry]=[]):
+        self._ns = 'http://example.com/refs'
+        self.producer = refs__inventory__producer(elements=producer)
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'producer':
+            return iter(self.producer)
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:inventory'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__inventory:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        if n is not None:
+            return refs__inventory(producer=refs__inventory__producer.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'producer')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        return refs__inventory()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__inventory.from_gdata(self.to_gdata())
+
+
+_breaker5 = None
+class refs__transforms__consumer__input_ref(yang.adata.Ref):
+    target: ?refs__inventory__producer_entry
+    def __init__(self, value: str, target: ?refs__inventory__producer_entry=None):
+        self.value = value
+        self.target = target
+
+def _resolve_refs__transforms__consumer__input_ref(value: ?str, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> ?refs__transforms__consumer__input_ref:
+    if value is None:
+        return None
+    ref_value: str = yang.adata.expect_ref_value(value, ctx='/transforms/consumer/input')
+    ref = refs__transforms__consumer__input_ref(ref_value)
+    ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+    if ctx is not None:
+        cache_key = yang.adata.ref_cache_key('/inventory/producer', ref_value)
+        cached_target = ctx.get_target(cache_key)
+        if isinstance(cached_target, refs__inventory__producer_entry):
+            ref.target = cached_target
+            return ref
+        lookup_node = ctx.lookup_root
+        if lookup_node is not None:
+            target_node = yang.adata.lookup_list_entry_by_key(lookup_node, [yang.gdata.Id(NS_refs, 'inventory'), yang.gdata.Id(NS_refs, 'producer')], yang.gdata.Id(NS_refs, 'name'), ref_value)
+            if target_node is not None:
+                target = refs__inventory__producer_entry.from_gdata(target_node, lookup_root=lookup_node, _ref_ctx=ctx)
+                ref.target = target
+                ctx.set_target(cache_key, target)
+    return ref
+
+_breaker6 = None
+class refs__transforms__consumer_entry(yang.adata.MNode):
+    name: str
+    input: ?refs__transforms__consumer__input_ref
+
+    mut def __init__(self, name: str, input: ?refs__transforms__consumer__input_ref):
+        self._ns = 'http://example.com/refs'
+        self.name = name
+        self.input = input
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'name':
+            return self.name
+        if name == 'input':
+            return self.input
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:transforms', 'consumer'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__transforms__consumer_entry:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        _cache_key = ''
+        if _ref_ctx is not None:
+            _key_value = n.get_str(yang.gdata.Id(NS_refs, 'name'))
+            _cache_key = yang.adata.ref_cache_key('/transforms/consumer', _key_value)
+            _cached = _ref_ctx.get_target(_cache_key)
+            if isinstance(_cached, refs__transforms__consumer_entry):
+                return _cached
+        res = refs__transforms__consumer_entry(name=n.get_str(yang.gdata.Id(NS_refs, 'name')), input=_resolve_refs__transforms__consumer__input_ref(n.get_opt_str(yang.gdata.Id(NS_refs, 'input')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        if _ref_ctx is not None and _cache_key != '':
+            _ref_ctx.set_target(_cache_key, res)
+        return res
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__transforms__consumer_entry.from_gdata(self.to_gdata())
+
+_breaker7 = None
+class refs__transforms__consumer(yang.adata.MNode):
+    elements: list[refs__transforms__consumer_entry]
+    mut def __init__(self, elements=[]):
+        self._ns = 'http://example.com/refs'
+        self._name = 'consumer'
+        self.elements = elements
+
+    mut def create(self, name, input=None):
+        for e in self:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if match:
+                if input is not None:
+                    e.input = input
+                return e
+
+        res = refs__transforms__consumer_entry(name=name, input=input)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> list[refs__transforms__consumer_entry]:
+        _ref_ctx = yang.adata.init_ref_ctx(lookup_root, _ref_ctx)
+        if n is not None:
+            return [refs__transforms__consumer_entry.from_gdata(e, lookup_root=lookup_root, _ref_ctx=_ref_ctx) for e in n.elements]
+        return []
+
+    def copy(self):
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return refs__transforms__consumer(elements=copied_elements)
+
+extension refs__transforms__consumer(Iterable[refs__transforms__consumer_entry]):
+    def __iter__(self) -> Iterator[refs__transforms__consumer_entry]:
+        return self.elements.__iter__()
+
+_breaker8 = None
+class refs__transforms(yang.adata.MNode):
+    consumer: refs__transforms__consumer
+
+    mut def __init__(self, consumer: list[refs__transforms__consumer_entry]=[]):
+        self._ns = 'http://example.com/refs'
+        self.consumer = refs__transforms__consumer(elements=consumer)
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'consumer':
+            return iter(self.consumer)
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['refs:transforms'])
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> refs__transforms:
+        _actual_lookup_root = lookup_root
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        if n is not None:
+            return refs__transforms(consumer=refs__transforms__consumer.from_gdata(n.get_opt_list(yang.gdata.Id(NS_refs, 'consumer')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        return refs__transforms()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return refs__transforms.from_gdata(self.to_gdata())
+
+
+_breaker9 = None
+class root(yang.adata.MNode):
+    inventory: refs__inventory
+    transforms: refs__transforms
+
+    mut def __init__(self, inventory: ?refs__inventory=None, transforms: ?refs__transforms=None):
+        self._ns = ''
+        self.inventory = inventory if inventory is not None else refs__inventory()
+        self.transforms = transforms if transforms is not None else refs__transforms()
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'inventory':
+            return self.inventory
+        if name == 'transforms':
+            return self.transforms
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False)
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.Node, lookup_root: ?yang.gdata.Node=None, _ref_ctx: ?yang.adata.RefContext=None) -> root:
+        _actual_lookup_root = lookup_root
+        if _actual_lookup_root is None:
+            _actual_lookup_root = n
+        _ref_ctx = yang.adata.init_ref_ctx(_actual_lookup_root, _ref_ctx)
+        if n is not None:
+            return root(inventory=refs__inventory.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'inventory')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx), transforms=refs__transforms.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_refs, 'transforms')), lookup_root=_actual_lookup_root, _ref_ctx=_ref_ctx))
+        return root()
+
+    def copy(self):
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+
+actor rpc_root(tp: yang.gdata.TreeProvider):
+    pass
+
+def src_schema():
+    res = {}
+    res["refs"] = Module('refs', yang_version=1.1, namespace='http://example.com/refs', prefix='refs', children=[
+    Container('inventory', children=[
+        List('producer', key='name', children=[
+            Leaf('name', type_=Type('string')),
+            Container('config', children=[
+                Leaf('interval', type_=Type('uint32'))
+            ])
+        ])
+    ]),
+    Container('transforms', children=[
+        List('consumer', key='name', children=[
+            Leaf('name', type_=Type('string')),
+            Leaf('input', type_=Type('leafref', path='/refs:inventory/refs:producer/refs:name'))
+        ])
+    ])
+])
+    return res
+

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -504,6 +504,44 @@ ys_yangrpc = r"""module yangrpc {
   rpc silent;
 }"""
 
+ys_refs = r"""module refs {
+  yang-version "1.1";
+  namespace "http://example.com/refs";
+  prefix "refs";
+
+  container inventory {
+    list producer {
+      key "name";
+
+      leaf name {
+        type string;
+      }
+
+      container config {
+        leaf interval {
+          type uint32;
+        }
+      }
+    }
+  }
+
+  container transforms {
+    list consumer {
+      key "name";
+
+      leaf name {
+        type string;
+      }
+
+      leaf input {
+        type leafref {
+          path "/refs:inventory/refs:producer/refs:name";
+        }
+      }
+    }
+  }
+}"""
+
 
 actor main(env: Env):
     wfcap = file.WriteFileCap(file.FileCap(env.cap))
@@ -512,5 +550,6 @@ actor main(env: Env):
     yang_to_act(wfcap, yangs=[ys_foo, ys_qux, ys_bar], filename="../test_data_classes/src/yang_foo_loose.act", loose=True)
     yang_to_act(wfcap, yangs=[ys_loose_required], filename="../test_data_classes/src/yang_loose_required.act", loose=True)
     yang_to_act(wfcap, yangs=[ys_basics], filename="../test_data_classes/src/yang_basics.act")
+    yang_to_act(wfcap, yangs=[ys_refs], filename="../test_data_classes/src/yang_refs.act")
     yang_to_act(wfcap, yangs=[ys_yangrpc], filename="../test_data_classes/src/yangrpc.act")
     env.exit(0)

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -523,6 +523,32 @@ ys_refs = r"""module refs {
         }
       }
     }
+
+    list device {
+      key "name";
+
+      leaf name {
+        type string;
+      }
+
+      list interface {
+        key "name subif";
+
+        leaf name {
+          type string;
+        }
+
+        leaf subif {
+          type uint32;
+        }
+
+        container config {
+          leaf enabled {
+            type boolean;
+          }
+        }
+      }
+    }
   }
 
   container transforms {
@@ -536,6 +562,34 @@ ys_refs = r"""module refs {
       leaf input {
         type leafref {
           path "/refs:inventory/refs:producer/refs:name";
+        }
+      }
+
+      leaf device {
+        type string;
+      }
+
+      leaf if-name {
+        type string;
+      }
+
+      leaf if-subif {
+        type uint32;
+      }
+
+      leaf nested-input {
+        type leafref {
+          path "/refs:inventory/refs:device[refs:name=current()/../refs:device]/" +
+               "refs:interface[refs:name=current()/../refs:if-name][refs:subif=current()/../refs:if-subif]/" +
+               "refs:name";
+        }
+      }
+
+      leaf nested-enabled {
+        type leafref {
+          path "/refs:inventory/refs:device[refs:name=current()/../refs:device]/" +
+               "refs:interface[refs:name=current()/../refs:if-name][refs:subif=current()/../refs:if-subif]/" +
+               "refs:config/refs:enabled";
         }
       }
     }

--- a/test/test_data_source_roundtrip/src/xml_full_adata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata.act
@@ -20,7 +20,7 @@ def adata():
     ad.c1.l4 = 'foo-qux'
     ad.c1.bar_l1 = 'foo-bar'
     ad.c1.l2 = 'bar'
-    ad.c1.l_leafref = 'tuta'
+    ad.c1.l_leafref = foo__c1__l_leafref_ref('tuta')
     
     # List /c1/li element: tuta
     li_element = ad.c1.li.create('tuta', val='baba')

--- a/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
@@ -20,7 +20,7 @@ def adata():
     ad.c1.l4 = 'foo-qux'
     ad.c1.bar_l1 = 'foo-bar'
     ad.c1.l2 = 'bar'
-    ad.c1.l_leafref = 'tuta'
+    ad.c1.l_leafref = foo__c1__l_leafref_ref('tuta')
     
     # List /c1/li element: tuta
     li_element = ad.c1.li.create('tuta', val='baba')


### PR DESCRIPTION
Generated adata leafrefs were flattened to their raw scalar values during gdata to adata conversion. That left transform code with only the key value, made refs awkward to use from subtree transform points, and lost object identity when multiple refs pointed at the same list entry.

This change teaches adata code generation to emit a specialized ref class for each supported leafref location and to resolve those refs against an explicit lookup root while building adata. The generated from_gdata() methods thread a small ref context through subtree construction, cache single-key list entries by instance key, and reuse the same entry object when later refs resolve to that target. The ref wrappers keep the raw leaf value for serialization and expose the resolved entry directly through a typed target attribute.

Keeping the lookup root separate from the materialized subtree matches how transform points are built in practice while still allowing leafrefs to resolve outside the immediate input subtree. Reusing cached targets preserves shared graph semantics in adata instead of copying the same referenced subtree for each leafref. A design note was added to document the supported leafref subset, lookup_root handling, and target cache behaviour.