### PR TITLE
Emit complete adata method signatures

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -645,7 +645,7 @@ class DNodeInner(DNode):
                 opt_args.append("{usname(child)}: list[{pname(child)}_entry]=[]")
 
         init_args_str = ", ".join(["self"] + req_args + opt_args)
-        res.append("    mut def __init__({init_args_str}):")
+        res.append("    mut def __init__({init_args_str}) -> None:")
         # Set namespace from us
         res.append("        self._ns = '{self.namespace}'")
 
@@ -689,19 +689,28 @@ class DNodeInner(DNode):
                 child_unique_namer = UniqueNamer(child)
 
                 pc_args_req = []
+                pc_args_req_sig = []
                 pc_args_opt = []
+                pc_args_opt_sig = []
                 for cchild in child.children:
                     if isinstance(cchild, DLeaf):
+                        carg = child_unique_namer.unique_safe_name(cchild.name, cchild.prefix)
+                        ctype = yang_leaf_to_acton_arg_type(cchild, list_keys(self), loose)
                         if is_optional_arg_yang_leaf(cchild, list_keys(self), loose):
-                            pc_args_opt.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
+                            pc_args_opt.append(carg)
+                            pc_args_opt_sig.append("{carg}: {ctype}=None")
                         else:
-                            pc_args_req.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
+                            pc_args_req.append(carg)
+                            pc_args_req_sig.append("{carg}: {ctype}")
                     elif isinstance(cchild, DContainer):
                         if not (loose or optional_subtree(cchild) or cchild.presence):
-                            pc_args_req.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
-                pc_args_str = ", ".join(["self"] + pc_args_req + ["{arg}=None" for arg in pc_args_opt])
+                            carg = child_unique_namer.unique_safe_name(cchild.name, cchild.prefix)
+                            ctype = get_path_name(spath + [child, cchild])
+                            pc_args_req.append(carg)
+                            pc_args_req_sig.append("{carg}: {ctype}")
+                pc_args_str = ", ".join(["self"] + pc_args_req_sig + pc_args_opt_sig)
                 pc_params_str= ", ".join(["{arg}={arg}" for arg in pc_args_req + pc_args_opt])
-                res.append("    mut def create_{usname(child)}({pc_args_str}):")
+                res.append("    mut def create_{usname(child)}({pc_args_str}) -> {pname(child)}:")
                 res.append("        existing = self.{usname(child)}")
                 res.append("        if existing is not None:")
                 for req_arg in pc_args_req:
@@ -761,7 +770,10 @@ class DNodeInner(DNode):
         res.append("")
 
         # .copy() method
-        res.append("    def copy(self):")
+        if isinstance(self, DList):
+            res.append("    def copy(self) -> {pname()}_entry:")
+        else:
+            res.append("    def copy(self) -> {pname()}:")
         res.append('        """Create a deep copy of this adata object"""')
         if isinstance(self, DList):
             res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
@@ -789,9 +801,9 @@ class DNodeInner(DNode):
             res.append("    elements: list[{pname()}_entry]")
 
             init_args = ["self"]
-            init_args.append("elements=[]")
+            init_args.append("elements: list[{pname()}_entry]=[]")
             init_args_str: str = ", ".join(init_args)
-            res.append("    mut def __init__({init_args_str}):")
+            res.append("    mut def __init__({init_args_str}) -> None:")
             # Set namespace from us
             res.append("        self._ns = '{self.namespace}'")
             res.append("        self._name = {repr(self.name)}")
@@ -803,23 +815,32 @@ class DNodeInner(DNode):
 
             list_key_args = us_list_key()
             list_args_req = []
+            list_args_req_sig = []
             list_args_opt = []
+            list_args_opt_sig = []
             list_key_types = {}
             for child in attr_children:
                 if isinstance(child, DLeaf):
-                    if usname(child) in list_key_args:
-                        list_key_types[usname(child)] = child.type_
-                        list_args_req.append(usname(child))
+                    arg = usname(child)
+                    arg_type = yang_leaf_to_acton_arg_type(child, list_keys(self), loose)
+                    if arg in list_key_args:
+                        list_key_types[arg] = child.type_
+                        list_args_req.append(arg)
+                        list_args_req_sig.append("{arg}: {arg_type}")
                         continue
                     if is_optional_arg_yang_leaf(child, list_keys(self), loose):
-                        list_args_opt.append(usname(child))
+                        list_args_opt.append(arg)
+                        list_args_opt_sig.append("{arg}: {arg_type}=None")
                     else:
-                        list_args_req.append(usname(child))
+                        list_args_req.append(arg)
+                        list_args_req_sig.append("{arg}: {arg_type}")
                 elif isinstance(child, DContainer):
                     if not (loose or optional_subtree(child) or child.presence):
-                        list_args_req.append(usname(child))
-            list_args_str = ", ".join(["self"] + list_args_req + ["{arg}=None" for arg in list_args_opt])
-            res.append("    mut def create({list_args_str}):")
+                        arg = usname(child)
+                        list_args_req.append(arg)
+                        list_args_req_sig.append("{arg}: {pname(child)}")
+            list_args_str = ", ".join(["self"] + list_args_req_sig + list_args_opt_sig)
+            res.append("    mut def create({list_args_str}) -> {pname()}_entry:")
             res.append("        for e in self:")
             res.append("            match = True")
             for us_key in list_key_args:
@@ -878,7 +899,7 @@ class DNodeInner(DNode):
             res.append("")
 
             # .copy() method for list wrapper
-            res.append("    def copy(self):")
+            res.append("    def copy(self) -> {pname()}:")
             res.append('        """Create a deep copy of this list object"""')
             res.append("        # Copy each element in the list")
             res.append("        copied_elements = []")
@@ -1955,7 +1976,7 @@ class DRoot(DNodeInner):
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
                     res.append("    {usname(child)}: {child_type}")
                 res.append("")
-                res.append("    def __init__(self, path: ?SubscriptionPath=None):")
+                res.append("    def __init__(self, path: ?SubscriptionPath=None) -> None:")
                 res.append("        SubscriptionNode.__init__(self, path)")
                 for child in selectables:
                     child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -1975,7 +1996,7 @@ class DRoot(DNodeInner):
                 for child in selectables:
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
                     res.append("    {usname(child)}: {child_type}")
-                res.append("    def __init__(self, path: ?SubscriptionPath=None):")
+                res.append("    def __init__(self, path: ?SubscriptionPath=None) -> None:")
                 res.append("        SubscriptionNode.__init__(self, path)")
                 for child in selectables:
                     child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -2009,7 +2030,7 @@ class DRoot(DNodeInner):
                         child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
                         res.append("    {usname(child)}: {child_type}")
                     res.append("")
-                    res.append("    def __init__(self, path: ?SubscriptionPath=None):")
+                    res.append("    def __init__(self, path: ?SubscriptionPath=None) -> None:")
                     res.append("        SubscriptionNode.__init__(self, path)")
                     for child in selectables:
                         child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -43,7 +43,7 @@ NS_base = 'http://example.com/base'
 _breaker1 = None
 class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/base'
         pass
 
@@ -54,19 +54,19 @@ class base__system_capabilities__per_node_capabilities_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__system_capabilities__per_node_capabilities_entry:
         return base__system_capabilities__per_node_capabilities_entry()
 
-    def copy(self):
+    def copy(self) -> base__system_capabilities__per_node_capabilities_entry:
         """Create a deep copy of this adata object"""
         return base__system_capabilities__per_node_capabilities_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class base__system_capabilities__per_node_capabilities(yang.adata.MNode):
     elements: list[base__system_capabilities__per_node_capabilities_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[base__system_capabilities__per_node_capabilities_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self._name = 'per-node-capabilities'
         self.elements = elements
 
-    mut def create(self):
+    mut def create(self) -> base__system_capabilities__per_node_capabilities_entry:
         for e in self:
             match = True
             if match:
@@ -82,7 +82,7 @@ class base__system_capabilities__per_node_capabilities(yang.adata.MNode):
             return [base__system_capabilities__per_node_capabilities_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> base__system_capabilities__per_node_capabilities:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -101,7 +101,7 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
     max_nodes: u64
     supported_excluded_change_type: list[str]
 
-    mut def __init__(self, max_nodes: ?u64=None, supported_excluded_change_type: ?list[str]=None):
+    mut def __init__(self, max_nodes: ?u64=None, supported_excluded_change_type: ?list[str]=None) -> None:
         self._ns = 'http://example.com/augmenter'
         self.max_nodes = max_nodes if max_nodes is not None else u64(42)
         self.supported_excluded_change_type = supported_excluded_change_type if supported_excluded_change_type is not None else []
@@ -121,7 +121,7 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
             return base__system_capabilities__subscription_capabilities(max_nodes=n.get_opt_u64(yang.gdata.Id(NS_augmenter, 'max-nodes')), supported_excluded_change_type=n.get_opt_strs(yang.gdata.Id(NS_augmenter, 'supported-excluded-change-type')))
         return base__system_capabilities__subscription_capabilities()
 
-    def copy(self):
+    def copy(self) -> base__system_capabilities__subscription_capabilities:
         """Create a deep copy of this adata object"""
         return base__system_capabilities__subscription_capabilities.from_gdata(self.to_gdata())
 
@@ -131,7 +131,7 @@ class base__system_capabilities(yang.adata.MNode):
     per_node_capabilities: base__system_capabilities__per_node_capabilities
     subscription_capabilities: base__system_capabilities__subscription_capabilities
 
-    mut def __init__(self, per_node_capabilities: list[base__system_capabilities__per_node_capabilities_entry]=[], subscription_capabilities: ?base__system_capabilities__subscription_capabilities=None):
+    mut def __init__(self, per_node_capabilities: list[base__system_capabilities__per_node_capabilities_entry]=[], subscription_capabilities: ?base__system_capabilities__subscription_capabilities=None) -> None:
         self._ns = 'http://example.com/base'
         self.per_node_capabilities = base__system_capabilities__per_node_capabilities(elements=per_node_capabilities)
         self.subscription_capabilities = subscription_capabilities if subscription_capabilities is not None else base__system_capabilities__subscription_capabilities()
@@ -151,7 +151,7 @@ class base__system_capabilities(yang.adata.MNode):
             return base__system_capabilities(per_node_capabilities=base__system_capabilities__per_node_capabilities.from_gdata(n.get_opt_list(yang.gdata.Id(NS_base, 'per-node-capabilities'))), subscription_capabilities=base__system_capabilities__subscription_capabilities.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_augmenter, 'subscription-capabilities'))))
         return base__system_capabilities()
 
-    def copy(self):
+    def copy(self) -> base__system_capabilities:
         """Create a deep copy of this adata object"""
         return base__system_capabilities.from_gdata(self.to_gdata())
 
@@ -160,7 +160,7 @@ _breaker5 = None
 class root(yang.adata.MNode):
     system_capabilities: base__system_capabilities
 
-    mut def __init__(self, system_capabilities: ?base__system_capabilities=None):
+    mut def __init__(self, system_capabilities: ?base__system_capabilities=None) -> None:
         self._ns = ''
         self.system_capabilities = system_capabilities if system_capabilities is not None else base__system_capabilities()
 
@@ -177,7 +177,7 @@ class root(yang.adata.MNode):
             return root(system_capabilities=base__system_capabilities.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base, 'system-capabilities'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment
+++ b/snapshots/expected/test_yang/compile_augment
@@ -39,7 +39,7 @@ class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
 
-    mut def __init__(self, l1: ?str, l2: ?str):
+    mut def __init__(self, l1: ?str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -59,7 +59,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -68,7 +68,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -85,7 +85,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment_augmented_node
+++ b/snapshots/expected/test_yang/compile_augment_augmented_node
@@ -49,7 +49,7 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
     bind: ?str
     port: u64
 
-    mut def __init__(self, bind: ?str, port: ?u64=None):
+    mut def __init__(self, bind: ?str, port: ?u64=None) -> None:
         self._ns = 'http://example.com/voice'
         self.bind = bind
         self.port = port if port is not None else u64(5060)
@@ -69,7 +69,7 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
             return base__native__voice__service__voip__sip(bind=n.get_opt_str(yang.gdata.Id(NS_voice, 'bind')), port=n.get_opt_u64(yang.gdata.Id(NS_voice, 'port')))
         return base__native__voice__service__voip__sip()
 
-    def copy(self):
+    def copy(self) -> base__native__voice__service__voip__sip:
         """Create a deep copy of this adata object"""
         return base__native__voice__service__voip__sip.from_gdata(self.to_gdata())
 
@@ -79,7 +79,7 @@ class base__native__voice__service__voip(yang.adata.MNode):
     enabled: bool
     sip: base__native__voice__service__voip__sip
 
-    mut def __init__(self, enabled: ?bool=None, sip: ?base__native__voice__service__voip__sip=None):
+    mut def __init__(self, enabled: ?bool=None, sip: ?base__native__voice__service__voip__sip=None) -> None:
         self._ns = 'http://example.com/voice'
         self.enabled = enabled if enabled is not None else False
         self.sip = sip if sip is not None else base__native__voice__service__voip__sip()
@@ -99,7 +99,7 @@ class base__native__voice__service__voip(yang.adata.MNode):
             return base__native__voice__service__voip(enabled=n.get_opt_bool(yang.gdata.Id(NS_voice, 'enabled')), sip=base__native__voice__service__voip__sip.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_voice, 'sip'))))
         return base__native__voice__service__voip()
 
-    def copy(self):
+    def copy(self) -> base__native__voice__service__voip:
         """Create a deep copy of this adata object"""
         return base__native__voice__service__voip.from_gdata(self.to_gdata())
 
@@ -108,7 +108,7 @@ _breaker3 = None
 class base__native__voice__service(yang.adata.MNode):
     voip: base__native__voice__service__voip
 
-    mut def __init__(self, voip: ?base__native__voice__service__voip=None):
+    mut def __init__(self, voip: ?base__native__voice__service__voip=None) -> None:
         self._ns = 'http://example.com/voice'
         self.voip = voip if voip is not None else base__native__voice__service__voip()
 
@@ -125,7 +125,7 @@ class base__native__voice__service(yang.adata.MNode):
             return base__native__voice__service(voip=base__native__voice__service__voip.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_voice, 'voip'))))
         return base__native__voice__service()
 
-    def copy(self):
+    def copy(self) -> base__native__voice__service:
         """Create a deep copy of this adata object"""
         return base__native__voice__service.from_gdata(self.to_gdata())
 
@@ -134,7 +134,7 @@ _breaker4 = None
 class base__native__voice(yang.adata.MNode):
     service: base__native__voice__service
 
-    mut def __init__(self, service: ?base__native__voice__service=None):
+    mut def __init__(self, service: ?base__native__voice__service=None) -> None:
         self._ns = 'http://example.com/voice'
         self.service = service if service is not None else base__native__voice__service()
 
@@ -151,7 +151,7 @@ class base__native__voice(yang.adata.MNode):
             return base__native__voice(service=base__native__voice__service.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_voice, 'service'))))
         return base__native__voice()
 
-    def copy(self):
+    def copy(self) -> base__native__voice:
         """Create a deep copy of this adata object"""
         return base__native__voice.from_gdata(self.to_gdata())
 
@@ -160,7 +160,7 @@ _breaker5 = None
 class base__native(yang.adata.MNode):
     voice: base__native__voice
 
-    mut def __init__(self, voice: ?base__native__voice=None):
+    mut def __init__(self, voice: ?base__native__voice=None) -> None:
         self._ns = 'http://example.com/base'
         self.voice = voice if voice is not None else base__native__voice()
 
@@ -177,7 +177,7 @@ class base__native(yang.adata.MNode):
             return base__native(voice=base__native__voice.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_voice, 'voice'))))
         return base__native()
 
-    def copy(self):
+    def copy(self) -> base__native:
         """Create a deep copy of this adata object"""
         return base__native.from_gdata(self.to_gdata())
 
@@ -186,7 +186,7 @@ _breaker6 = None
 class root(yang.adata.MNode):
     native: base__native
 
-    mut def __init__(self, native: ?base__native=None):
+    mut def __init__(self, native: ?base__native=None) -> None:
         self._ns = ''
         self.native = native if native is not None else base__native()
 
@@ -203,7 +203,7 @@ class root(yang.adata.MNode):
             return root(native=base__native.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base, 'native'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -51,7 +51,7 @@ NS_foo = 'http://example.com/foo'
 _breaker1 = None
 class foo__c1(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/foo'
         pass
 
@@ -64,7 +64,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1()
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -73,7 +73,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -90,7 +90,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
@@ -99,7 +99,7 @@ _breaker3 = None
 class foo__r1__input__c3(yang.adata.MNode):
     l3: ?str
 
-    mut def __init__(self, l3: ?str):
+    mut def __init__(self, l3: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l3 = l3
 
@@ -116,7 +116,7 @@ class foo__r1__input__c3(yang.adata.MNode):
             return foo__r1__input__c3(l3=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3')))
         return foo__r1__input__c3()
 
-    def copy(self):
+    def copy(self) -> foo__r1__input__c3:
         """Create a deep copy of this adata object"""
         return foo__r1__input__c3.from_gdata(self.to_gdata())
 
@@ -125,7 +125,7 @@ _breaker4 = None
 class foo__r1__input(yang.adata.MNode):
     c3: foo__r1__input__c3
 
-    mut def __init__(self, c3: ?foo__r1__input__c3=None):
+    mut def __init__(self, c3: ?foo__r1__input__c3=None) -> None:
         self._ns = 'http://example.com/foo'
         self.c3 = c3 if c3 is not None else foo__r1__input__c3()
 
@@ -142,7 +142,7 @@ class foo__r1__input(yang.adata.MNode):
             return foo__r1__input(c3=foo__r1__input__c3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c3'))))
         return foo__r1__input()
 
-    def copy(self):
+    def copy(self) -> foo__r1__input:
         """Create a deep copy of this adata object"""
         return foo__r1__input.from_gdata(self.to_gdata())
 
@@ -151,7 +151,7 @@ _breaker5 = None
 class foo__r1__output(yang.adata.MNode):
     l4: ?str
 
-    mut def __init__(self, l4: ?str):
+    mut def __init__(self, l4: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l4 = l4
 
@@ -168,7 +168,7 @@ class foo__r1__output(yang.adata.MNode):
             return foo__r1__output(l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')))
         return foo__r1__output()
 
-    def copy(self):
+    def copy(self) -> foo__r1__output:
         """Create a deep copy of this adata object"""
         return foo__r1__output.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment_import
+++ b/snapshots/expected/test_yang/compile_augment_import
@@ -40,7 +40,7 @@ class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
 
-    mut def __init__(self, l1: ?str, l2: ?str):
+    mut def __init__(self, l1: ?str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -60,7 +60,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -69,7 +69,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -86,7 +86,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment_on_augment
+++ b/snapshots/expected/test_yang/compile_augment_on_augment
@@ -42,7 +42,7 @@ class foo__c1__c2(yang.adata.MNode):
     l2: ?str
     l3: ?str
 
-    mut def __init__(self, l2: ?str, l3: ?str):
+    mut def __init__(self, l2: ?str, l3: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l2 = l2
         self.l3 = l3
@@ -62,7 +62,7 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')), l3=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3')))
         return foo__c1__c2()
 
-    def copy(self):
+    def copy(self) -> foo__c1__c2:
         """Create a deep copy of this adata object"""
         return foo__c1__c2.from_gdata(self.to_gdata())
 
@@ -72,7 +72,7 @@ class foo__c1(yang.adata.MNode):
     l1: ?str
     c2: foo__c1__c2
 
-    mut def __init__(self, l1: ?str, c2: ?foo__c1__c2=None):
+    mut def __init__(self, l1: ?str, c2: ?foo__c1__c2=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.c2 = c2 if c2 is not None else foo__c1__c2()
@@ -92,7 +92,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), c2=foo__c1__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -101,7 +101,7 @@ _breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -118,7 +118,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
+++ b/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
@@ -44,7 +44,7 @@ class foo__c1__c2(yang.adata.MNode):
     l2: ?str
     l3: ?str
 
-    mut def __init__(self, l2: ?str, l3: ?str):
+    mut def __init__(self, l2: ?str, l3: ?str) -> None:
         self._ns = 'http://example.com/bar'
         self.l2 = l2
         self.l3 = l3
@@ -64,7 +64,7 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l3=n.get_opt_str(yang.gdata.Id(NS_baz, 'l3')))
         return foo__c1__c2()
 
-    def copy(self):
+    def copy(self) -> foo__c1__c2:
         """Create a deep copy of this adata object"""
         return foo__c1__c2.from_gdata(self.to_gdata())
 
@@ -74,7 +74,7 @@ class foo__c1(yang.adata.MNode):
     l1: ?str
     c2: foo__c1__c2
 
-    mut def __init__(self, l1: ?str, c2: ?foo__c1__c2=None):
+    mut def __init__(self, l1: ?str, c2: ?foo__c1__c2=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.c2 = c2 if c2 is not None else foo__c1__c2()
@@ -94,7 +94,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), c2=foo__c1__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'c2'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -103,7 +103,7 @@ _breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -120,7 +120,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_augment_uses
+++ b/snapshots/expected/test_yang/compile_augment_uses
@@ -42,7 +42,7 @@ _breaker1 = None
 class foo__c1__c2(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -59,7 +59,7 @@ class foo__c1__c2(yang.adata.MNode):
             return foo__c1__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c1__c2()
 
-    def copy(self):
+    def copy(self) -> foo__c1__c2:
         """Create a deep copy of this adata object"""
         return foo__c1__c2.from_gdata(self.to_gdata())
 
@@ -68,7 +68,7 @@ _breaker2 = None
 class foo__c1(yang.adata.MNode):
     c2: foo__c1__c2
 
-    mut def __init__(self, c2: ?foo__c1__c2=None):
+    mut def __init__(self, c2: ?foo__c1__c2=None) -> None:
         self._ns = 'http://example.com/foo'
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
@@ -85,7 +85,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(c2=foo__c1__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -94,7 +94,7 @@ _breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -111,7 +111,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_bundle1
+++ b/snapshots/expected/test_yang/compile_bundle1
@@ -40,7 +40,7 @@ class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
 
-    mut def __init__(self, l1: ?str, l2: ?str):
+    mut def __init__(self, l1: ?str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -60,7 +60,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -69,7 +69,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -86,7 +86,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -46,7 +46,7 @@ class foo__c1__things_entry(yang.adata.MNode):
     name: str
     id: ?str
 
-    mut def __init__(self, name: str, id: ?str):
+    mut def __init__(self, name: str, id: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.id = id
@@ -64,19 +64,19 @@ class foo__c1__things_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__things_entry:
         return foo__c1__things_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), id=n.get_opt_str(yang.gdata.Id(NS_foo, 'id')))
 
-    def copy(self):
+    def copy(self) -> foo__c1__things_entry:
         """Create a deep copy of this adata object"""
         return foo__c1__things_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__c1__things(yang.adata.MNode):
     elements: list[foo__c1__things_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c1__things_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'things'
         self.elements = elements
 
-    mut def create(self, name, id=None):
+    mut def create(self, name: str, id: ?str=None) -> foo__c1__things_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -97,7 +97,7 @@ class foo__c1__things(yang.adata.MNode):
             return [foo__c1__things_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c1__things:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -115,7 +115,7 @@ _breaker3 = None
 class foo__c1(yang.adata.MNode):
     things: foo__c1__things
 
-    mut def __init__(self, things: list[foo__c1__things_entry]=[]):
+    mut def __init__(self, things: list[foo__c1__things_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.things = foo__c1__things(elements=things)
 
@@ -132,7 +132,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(things=foo__c1__things.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'things'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -141,7 +141,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -158,7 +158,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_import_hyphenated_prefix
+++ b/snapshots/expected/test_yang/compile_import_hyphenated_prefix
@@ -38,7 +38,7 @@ _breaker1 = None
 class acme_foo_bar__c1(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -55,7 +55,7 @@ class acme_foo_bar__c1(yang.adata.MNode):
             return acme_foo_bar__c1(l1=n.get_opt_str(yang.gdata.Id(NS_acme_foo_bar, 'l1')))
         return acme_foo_bar__c1()
 
-    def copy(self):
+    def copy(self) -> acme_foo_bar__c1:
         """Create a deep copy of this adata object"""
         return acme_foo_bar__c1.from_gdata(self.to_gdata())
 
@@ -64,7 +64,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: acme_foo_bar__c1
 
-    mut def __init__(self, c1: ?acme_foo_bar__c1=None):
+    mut def __init__(self, c1: ?acme_foo_bar__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else acme_foo_bar__c1()
 
@@ -81,7 +81,7 @@ class root(yang.adata.MNode):
             return root(c1=acme_foo_bar__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_acme_foo_bar, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -58,7 +58,7 @@ class bar__c1__li1_entry(yang.adata.MNode):
     l1: str
     l2: ?Identityref
 
-    mut def __init__(self, l1: str, l2: ?Identityref):
+    mut def __init__(self, l1: str, l2: ?Identityref) -> None:
         self._ns = 'http://example.com/bar'
         self.l1 = l1
         self.l2 = l2
@@ -76,19 +76,19 @@ class bar__c1__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> bar__c1__li1_entry:
         return bar__c1__li1_entry(l1=n.get_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_Identityref(yang.gdata.Id(NS_bar, 'l2')))
 
-    def copy(self):
+    def copy(self) -> bar__c1__li1_entry:
         """Create a deep copy of this adata object"""
         return bar__c1__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class bar__c1__li1(yang.adata.MNode):
     elements: list[bar__c1__li1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[bar__c1__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/bar'
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1, l2=None):
+    mut def create(self, l1: str, l2: ?Identityref=None) -> bar__c1__li1_entry:
         for e in self:
             match = True
             if e.l1 != l1:
@@ -109,7 +109,7 @@ class bar__c1__li1(yang.adata.MNode):
             return [bar__c1__li1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> bar__c1__li1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -127,7 +127,7 @@ _breaker3 = None
 class bar__c1(yang.adata.MNode):
     li1: bar__c1__li1
 
-    mut def __init__(self, li1: list[bar__c1__li1_entry]=[]):
+    mut def __init__(self, li1: list[bar__c1__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/bar'
         self.li1 = bar__c1__li1(elements=li1)
 
@@ -144,7 +144,7 @@ class bar__c1(yang.adata.MNode):
             return bar__c1(li1=bar__c1__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_bar, 'li1'))))
         return bar__c1()
 
-    def copy(self):
+    def copy(self) -> bar__c1:
         """Create a deep copy of this adata object"""
         return bar__c1.from_gdata(self.to_gdata())
 
@@ -153,7 +153,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     c1: bar__c1
 
-    mut def __init__(self, c1: ?bar__c1=None):
+    mut def __init__(self, c1: ?bar__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else bar__c1()
 
@@ -170,7 +170,7 @@ class root(yang.adata.MNode):
             return root(c1=bar__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_refine
+++ b/snapshots/expected/test_yang/compile_refine
@@ -43,7 +43,7 @@ _breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: list[str]
 
-    mut def __init__(self, l1: ?list[str]=None):
+    mut def __init__(self, l1: ?list[str]=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1 if l1 is not None else []
 
@@ -60,7 +60,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_strs(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -69,7 +69,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -86,7 +86,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
@@ -46,7 +46,7 @@ class parent__parent_container(yang.adata.MNode):
     parent_leaf: ?str
     augmented_leaf: ?str
 
-    mut def __init__(self, parent_leaf: ?str, augmented_leaf: ?str):
+    mut def __init__(self, parent_leaf: ?str, augmented_leaf: ?str) -> None:
         self._ns = 'http://example.com/parent'
         self.parent_leaf = parent_leaf
         self.augmented_leaf = augmented_leaf
@@ -66,7 +66,7 @@ class parent__parent_container(yang.adata.MNode):
             return parent__parent_container(parent_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'parent-leaf')), augmented_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'augmented-leaf')))
         return parent__parent_container()
 
-    def copy(self):
+    def copy(self) -> parent__parent_container:
         """Create a deep copy of this adata object"""
         return parent__parent_container.from_gdata(self.to_gdata())
 
@@ -76,7 +76,7 @@ class parent__sub_container(yang.adata.MNode):
     sub_leaf: ?str
     another_leaf: ?str
 
-    mut def __init__(self, sub_leaf: ?str, another_leaf: ?str):
+    mut def __init__(self, sub_leaf: ?str, another_leaf: ?str) -> None:
         self._ns = 'http://example.com/parent'
         self.sub_leaf = sub_leaf
         self.another_leaf = another_leaf
@@ -96,7 +96,7 @@ class parent__sub_container(yang.adata.MNode):
             return parent__sub_container(sub_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'sub-leaf')), another_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'another-leaf')))
         return parent__sub_container()
 
-    def copy(self):
+    def copy(self) -> parent__sub_container:
         """Create a deep copy of this adata object"""
         return parent__sub_container.from_gdata(self.to_gdata())
 
@@ -106,7 +106,7 @@ class root(yang.adata.MNode):
     parent_container: parent__parent_container
     sub_container: parent__sub_container
 
-    mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None):
+    mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None) -> None:
         self._ns = ''
         self.parent_container = parent_container if parent_container is not None else parent__parent_container()
         self.sub_container = sub_container if sub_container is not None else parent__sub_container()
@@ -126,7 +126,7 @@ class root(yang.adata.MNode):
             return root(parent_container=parent__parent_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_parent, 'parent-container'))), sub_container=parent__sub_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_parent, 'sub-container'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -54,7 +54,7 @@ _breaker1 = None
 class main_module__main_container__sub_group_container(yang.adata.MNode):
     sub_group_leaf: str
 
-    mut def __init__(self, sub_group_leaf: ?str=None):
+    mut def __init__(self, sub_group_leaf: ?str=None) -> None:
         self._ns = 'http://example.com/main'
         self.sub_group_leaf = sub_group_leaf if sub_group_leaf is not None else "from-submodule"
 
@@ -71,7 +71,7 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
             return main_module__main_container__sub_group_container(sub_group_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-group-leaf')))
         return main_module__main_container__sub_group_container()
 
-    def copy(self):
+    def copy(self) -> main_module__main_container__sub_group_container:
         """Create a deep copy of this adata object"""
         return main_module__main_container__sub_group_container.from_gdata(self.to_gdata())
 
@@ -82,7 +82,7 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
     sub_value: ?str
     ref_to_main: ?str
 
-    mut def __init__(self, name: str, sub_value: ?str, ref_to_main: ?str):
+    mut def __init__(self, name: str, sub_value: ?str, ref_to_main: ?str) -> None:
         self._ns = 'http://example.com/main'
         self.name = name
         self.sub_value = sub_value
@@ -103,19 +103,19 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> main_module__main_container__sub_list_entry:
         return main_module__main_container__sub_list_entry(name=n.get_str(yang.gdata.Id(NS_main_module, 'name')), sub_value=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-value')), ref_to_main=n.get_opt_str(yang.gdata.Id(NS_main_module, 'ref-to-main')))
 
-    def copy(self):
+    def copy(self) -> main_module__main_container__sub_list_entry:
         """Create a deep copy of this adata object"""
         return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class main_module__main_container__sub_list(yang.adata.MNode):
     elements: list[main_module__main_container__sub_list_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[main_module__main_container__sub_list_entry]=[]) -> None:
         self._ns = 'http://example.com/main'
         self._name = 'sub-list'
         self.elements = elements
 
-    mut def create(self, name, sub_value=None, ref_to_main=None):
+    mut def create(self, name: str, sub_value: ?str=None, ref_to_main: ?str=None) -> main_module__main_container__sub_list_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -138,7 +138,7 @@ class main_module__main_container__sub_list(yang.adata.MNode):
             return [main_module__main_container__sub_list_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> main_module__main_container__sub_list:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -157,7 +157,7 @@ class main_module__main_container__group_container(yang.adata.MNode):
     group_leaf: str
     augmented_in_group: ?str
 
-    mut def __init__(self, group_leaf: ?str=None, augmented_in_group: ?str):
+    mut def __init__(self, group_leaf: ?str=None, augmented_in_group: ?str) -> None:
         self._ns = 'http://example.com/main'
         self.group_leaf = group_leaf if group_leaf is not None else "refined-default"
         self.augmented_in_group = augmented_in_group
@@ -177,7 +177,7 @@ class main_module__main_container__group_container(yang.adata.MNode):
             return main_module__main_container__group_container(group_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'group-leaf')), augmented_in_group=n.get_opt_str(yang.gdata.Id(NS_main_module, 'augmented-in-group')))
         return main_module__main_container__group_container()
 
-    def copy(self):
+    def copy(self) -> main_module__main_container__group_container:
         """Create a deep copy of this adata object"""
         return main_module__main_container__group_container.from_gdata(self.to_gdata())
 
@@ -190,7 +190,7 @@ class main_module__main_container(yang.adata.MNode):
     sub_list: main_module__main_container__sub_list
     group_container: main_module__main_container__group_container
 
-    mut def __init__(self, main_leaf: ?str, sub_group_container: ?main_module__main_container__sub_group_container=None, sub_leaf: ?str, sub_list: list[main_module__main_container__sub_list_entry]=[], group_container: ?main_module__main_container__group_container=None):
+    mut def __init__(self, main_leaf: ?str, sub_group_container: ?main_module__main_container__sub_group_container=None, sub_leaf: ?str, sub_list: list[main_module__main_container__sub_list_entry]=[], group_container: ?main_module__main_container__group_container=None) -> None:
         self._ns = 'http://example.com/main'
         self.main_leaf = main_leaf
         self.sub_group_container = sub_group_container if sub_group_container is not None else main_module__main_container__sub_group_container()
@@ -219,7 +219,7 @@ class main_module__main_container(yang.adata.MNode):
             return main_module__main_container(main_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'main-leaf')), sub_group_container=main_module__main_container__sub_group_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'sub-group-container'))), sub_leaf=n.get_opt_str(yang.gdata.Id(NS_main_module, 'sub-leaf')), sub_list=main_module__main_container__sub_list.from_gdata(n.get_opt_list(yang.gdata.Id(NS_main_module, 'sub-list'))), group_container=main_module__main_container__group_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'group-container'))))
         return main_module__main_container()
 
-    def copy(self):
+    def copy(self) -> main_module__main_container:
         """Create a deep copy of this adata object"""
         return main_module__main_container.from_gdata(self.to_gdata())
 
@@ -228,7 +228,7 @@ _breaker6 = None
 class root(yang.adata.MNode):
     main_container: main_module__main_container
 
-    mut def __init__(self, main_container: ?main_module__main_container=None):
+    mut def __init__(self, main_container: ?main_module__main_container=None) -> None:
         self._ns = ''
         self.main_container = main_container if main_container is not None else main_module__main_container()
 
@@ -245,7 +245,7 @@ class root(yang.adata.MNode):
             return root(main_container=main_module__main_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_main_module, 'main-container'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
@@ -45,7 +45,7 @@ class parent__parent_container(yang.adata.MNode):
     parent_leaf: ?str
     augmented_leaf: ?str
 
-    mut def __init__(self, parent_leaf: ?str, augmented_leaf: ?str):
+    mut def __init__(self, parent_leaf: ?str, augmented_leaf: ?str) -> None:
         self._ns = 'http://example.com/parent'
         self.parent_leaf = parent_leaf
         self.augmented_leaf = augmented_leaf
@@ -65,7 +65,7 @@ class parent__parent_container(yang.adata.MNode):
             return parent__parent_container(parent_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'parent-leaf')), augmented_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'augmented-leaf')))
         return parent__parent_container()
 
-    def copy(self):
+    def copy(self) -> parent__parent_container:
         """Create a deep copy of this adata object"""
         return parent__parent_container.from_gdata(self.to_gdata())
 
@@ -75,7 +75,7 @@ class parent__sub_container(yang.adata.MNode):
     sub_leaf: ?str
     shared_leaf: str
 
-    mut def __init__(self, sub_leaf: ?str, shared_leaf: ?str=None):
+    mut def __init__(self, sub_leaf: ?str, shared_leaf: ?str=None) -> None:
         self._ns = 'http://example.com/parent'
         self.sub_leaf = sub_leaf
         self.shared_leaf = shared_leaf if shared_leaf is not None else "from-shared"
@@ -95,7 +95,7 @@ class parent__sub_container(yang.adata.MNode):
             return parent__sub_container(sub_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'sub-leaf')), shared_leaf=n.get_opt_str(yang.gdata.Id(NS_parent, 'shared-leaf')))
         return parent__sub_container()
 
-    def copy(self):
+    def copy(self) -> parent__sub_container:
         """Create a deep copy of this adata object"""
         return parent__sub_container.from_gdata(self.to_gdata())
 
@@ -105,7 +105,7 @@ class root(yang.adata.MNode):
     parent_container: parent__parent_container
     sub_container: parent__sub_container
 
-    mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None):
+    mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None) -> None:
         self._ns = ''
         self.parent_container = parent_container if parent_container is not None else parent__parent_container()
         self.sub_container = sub_container if sub_container is not None else parent__sub_container()
@@ -125,7 +125,7 @@ class root(yang.adata.MNode):
             return root(parent_container=parent__parent_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_parent, 'parent-container'))), sub_container=parent__sub_container.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_parent, 'sub-container'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_submodules1
+++ b/snapshots/expected/test_yang/compile_submodules1
@@ -41,7 +41,7 @@ _breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -58,7 +58,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -67,7 +67,7 @@ _breaker2 = None
 class foo__c2(yang.adata.MNode):
     l2: ?str
 
-    mut def __init__(self, l2: ?str):
+    mut def __init__(self, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l2 = l2
 
@@ -84,7 +84,7 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__c2()
 
-    def copy(self):
+    def copy(self) -> foo__c2:
         """Create a deep copy of this adata object"""
         return foo__c2.from_gdata(self.to_gdata())
 
@@ -94,7 +94,7 @@ class root(yang.adata.MNode):
     c1: foo__c1
     c2: foo__c2
 
-    mut def __init__(self, c1: ?foo__c1=None, c2: ?foo__c2=None):
+    mut def __init__(self, c1: ?foo__c1=None, c2: ?foo__c2=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.c2 = c2 if c2 is not None else foo__c2()
@@ -114,7 +114,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -39,7 +39,7 @@ _breaker1 = None
 class foo__c1__li1_entry(yang.adata.MNode):
     l1: str
 
-    mut def __init__(self, l1: str):
+    mut def __init__(self, l1: str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -54,19 +54,19 @@ class foo__c1__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li1_entry:
         return foo__c1__li1_entry(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')))
 
-    def copy(self):
+    def copy(self) -> foo__c1__li1_entry:
         """Create a deep copy of this adata object"""
         return foo__c1__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__c1__li1(yang.adata.MNode):
     elements: list[foo__c1__li1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c1__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1):
+    mut def create(self, l1: str) -> foo__c1__li1_entry:
         for e in self:
             match = True
             if e.l1 != l1:
@@ -85,7 +85,7 @@ class foo__c1__li1(yang.adata.MNode):
             return [foo__c1__li1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c1__li1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -103,7 +103,7 @@ _breaker3 = None
 class foo__c1(yang.adata.MNode):
     li1: foo__c1__li1
 
-    mut def __init__(self, li1: list[foo__c1__li1_entry]=[]):
+    mut def __init__(self, li1: list[foo__c1__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.li1 = foo__c1__li1(elements=li1)
 
@@ -120,7 +120,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(li1=foo__c1__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -129,7 +129,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -146,7 +146,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/compile_uses_augment
+++ b/snapshots/expected/test_yang/compile_uses_augment
@@ -42,7 +42,7 @@ class foo__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
 
-    mut def __init__(self, l1: ?str, l2: ?str):
+    mut def __init__(self, l1: ?str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -62,7 +62,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -71,7 +71,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -88,7 +88,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/identity_base_resolution_import_prefix
+++ b/snapshots/expected/test_yang/identity_base_resolution_import_prefix
@@ -69,7 +69,7 @@ NS_derived_module = 'http://example.com/derived'
 _breaker1 = None
 class root(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = ''
         pass
 
@@ -82,7 +82,7 @@ class root(yang.adata.MNode):
             return root()
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/identityref
+++ b/snapshots/expected/test_yang/identityref
@@ -76,7 +76,7 @@ _breaker1 = None
 class base__config(yang.adata.MNode):
     active_protocol: ?Identityref
 
-    mut def __init__(self, active_protocol: ?Identityref):
+    mut def __init__(self, active_protocol: ?Identityref) -> None:
         self._ns = 'http://example.com/base'
         self.active_protocol = active_protocol
 
@@ -93,7 +93,7 @@ class base__config(yang.adata.MNode):
             return base__config(active_protocol=n.get_opt_Identityref(yang.gdata.Id(NS_base, 'active-protocol')))
         return base__config()
 
-    def copy(self):
+    def copy(self) -> base__config:
         """Create a deep copy of this adata object"""
         return base__config.from_gdata(self.to_gdata())
 
@@ -102,7 +102,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     config: base__config
 
-    mut def __init__(self, config: ?base__config=None):
+    mut def __init__(self, config: ?base__config=None) -> None:
         self._ns = ''
         self.config = config if config is not None else base__config()
 
@@ -119,7 +119,7 @@ class root(yang.adata.MNode):
             return root(config=base__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base, 'config'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -44,7 +44,7 @@ _breaker1 = None
 class base_module__network_instances__network_instance__state(yang.adata.MNode):
     id: ?str
 
-    mut def __init__(self, id: ?str):
+    mut def __init__(self, id: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.id = id
 
@@ -61,7 +61,7 @@ class base_module__network_instances__network_instance__state(yang.adata.MNode):
             return base_module__network_instances__network_instance__state(id=n.get_opt_str(yang.gdata.Id(NS_base_module, 'id')))
         return base_module__network_instances__network_instance__state()
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances__network_instance__state:
         """Create a deep copy of this adata object"""
         return base_module__network_instances__network_instance__state.from_gdata(self.to_gdata())
 
@@ -72,7 +72,7 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
     state: base_module__network_instances__network_instance__state
     ref: ?str
 
-    mut def __init__(self, name: str, state: ?base_module__network_instances__network_instance__state=None, ref: ?str):
+    mut def __init__(self, name: str, state: ?base_module__network_instances__network_instance__state=None, ref: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.name = name
         self.state = state if state is not None else base_module__network_instances__network_instance__state()
@@ -93,19 +93,19 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base_module__network_instances__network_instance_entry:
         return base_module__network_instances__network_instance_entry(name=n.get_str(yang.gdata.Id(NS_base_module, 'name')), state=base_module__network_instances__network_instance__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'state'))), ref=n.get_opt_str(yang.gdata.Id(NS_augment_module, 'ref')))
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances__network_instance_entry:
         """Create a deep copy of this adata object"""
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class base_module__network_instances__network_instance(yang.adata.MNode):
     elements: list[base_module__network_instances__network_instance_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name, ref=None):
+    mut def create(self, name: str, ref: ?str=None) -> base_module__network_instances__network_instance_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -126,7 +126,7 @@ class base_module__network_instances__network_instance(yang.adata.MNode):
             return [base_module__network_instances__network_instance_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances__network_instance:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -144,7 +144,7 @@ _breaker4 = None
 class base_module__network_instances(yang.adata.MNode):
     network_instance: base_module__network_instances__network_instance
 
-    mut def __init__(self, network_instance: list[base_module__network_instances__network_instance_entry]=[]):
+    mut def __init__(self, network_instance: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self.network_instance = base_module__network_instances__network_instance(elements=network_instance)
 
@@ -161,7 +161,7 @@ class base_module__network_instances(yang.adata.MNode):
             return base_module__network_instances(network_instance=base_module__network_instances__network_instance.from_gdata(n.get_opt_list(yang.gdata.Id(NS_base_module, 'network-instance'))))
         return base_module__network_instances()
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances:
         """Create a deep copy of this adata object"""
         return base_module__network_instances.from_gdata(self.to_gdata())
 
@@ -170,7 +170,7 @@ _breaker5 = None
 class root(yang.adata.MNode):
     network_instances: base_module__network_instances
 
-    mut def __init__(self, network_instances: ?base_module__network_instances=None):
+    mut def __init__(self, network_instances: ?base_module__network_instances=None) -> None:
         self._ns = ''
         self.network_instances = network_instances if network_instances is not None else base_module__network_instances()
 
@@ -187,7 +187,7 @@ class root(yang.adata.MNode):
             return root(network_instances=base_module__network_instances.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'network-instances'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -53,7 +53,7 @@ _breaker1 = None
 class other_module__other_network_instances__network_instance_entry(yang.adata.MNode):
     name: str
 
-    mut def __init__(self, name: str):
+    mut def __init__(self, name: str) -> None:
         self._ns = 'http://example.com/other'
         self.name = name
 
@@ -68,19 +68,19 @@ class other_module__other_network_instances__network_instance_entry(yang.adata.M
     mut def from_gdata(n: yang.gdata.Node) -> other_module__other_network_instances__network_instance_entry:
         return other_module__other_network_instances__network_instance_entry(name=n.get_str(yang.gdata.Id(NS_other_module, 'name')))
 
-    def copy(self):
+    def copy(self) -> other_module__other_network_instances__network_instance_entry:
         """Create a deep copy of this adata object"""
         return other_module__other_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class other_module__other_network_instances__network_instance(yang.adata.MNode):
     elements: list[other_module__other_network_instances__network_instance_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[other_module__other_network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/other'
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> other_module__other_network_instances__network_instance_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -99,7 +99,7 @@ class other_module__other_network_instances__network_instance(yang.adata.MNode):
             return [other_module__other_network_instances__network_instance_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> other_module__other_network_instances__network_instance:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -117,7 +117,7 @@ _breaker3 = None
 class other_module__other_network_instances(yang.adata.MNode):
     network_instance: other_module__other_network_instances__network_instance
 
-    mut def __init__(self, network_instance: list[other_module__other_network_instances__network_instance_entry]=[]):
+    mut def __init__(self, network_instance: list[other_module__other_network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/other'
         self.network_instance = other_module__other_network_instances__network_instance(elements=network_instance)
 
@@ -134,7 +134,7 @@ class other_module__other_network_instances(yang.adata.MNode):
             return other_module__other_network_instances(network_instance=other_module__other_network_instances__network_instance.from_gdata(n.get_opt_list(yang.gdata.Id(NS_other_module, 'network-instance'))))
         return other_module__other_network_instances()
 
-    def copy(self):
+    def copy(self) -> other_module__other_network_instances:
         """Create a deep copy of this adata object"""
         return other_module__other_network_instances.from_gdata(self.to_gdata())
 
@@ -143,7 +143,7 @@ _breaker4 = None
 class base_module__base_network_instances__network_instance__config(yang.adata.MNode):
     name: ?str
 
-    mut def __init__(self, name: ?str):
+    mut def __init__(self, name: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.name = name
 
@@ -160,7 +160,7 @@ class base_module__base_network_instances__network_instance__config(yang.adata.M
             return base_module__base_network_instances__network_instance__config(name=n.get_opt_str(yang.gdata.Id(NS_base_module, 'name')))
         return base_module__base_network_instances__network_instance__config()
 
-    def copy(self):
+    def copy(self) -> base_module__base_network_instances__network_instance__config:
         """Create a deep copy of this adata object"""
         return base_module__base_network_instances__network_instance__config.from_gdata(self.to_gdata())
 
@@ -170,7 +170,7 @@ class base_module__base_network_instances__network_instance_entry(yang.adata.MNo
     name: str
     config: base_module__base_network_instances__network_instance__config
 
-    mut def __init__(self, name: str, config: ?base_module__base_network_instances__network_instance__config=None):
+    mut def __init__(self, name: str, config: ?base_module__base_network_instances__network_instance__config=None) -> None:
         self._ns = 'http://example.com/base'
         self.name = name
         self.config = config if config is not None else base_module__base_network_instances__network_instance__config()
@@ -188,19 +188,19 @@ class base_module__base_network_instances__network_instance_entry(yang.adata.MNo
     mut def from_gdata(n: yang.gdata.Node) -> base_module__base_network_instances__network_instance_entry:
         return base_module__base_network_instances__network_instance_entry(name=n.get_str(yang.gdata.Id(NS_base_module, 'name')), config=base_module__base_network_instances__network_instance__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'config'))))
 
-    def copy(self):
+    def copy(self) -> base_module__base_network_instances__network_instance_entry:
         """Create a deep copy of this adata object"""
         return base_module__base_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker6 = None
 class base_module__base_network_instances__network_instance(yang.adata.MNode):
     elements: list[base_module__base_network_instances__network_instance_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[base_module__base_network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> base_module__base_network_instances__network_instance_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -219,7 +219,7 @@ class base_module__base_network_instances__network_instance(yang.adata.MNode):
             return [base_module__base_network_instances__network_instance_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> base_module__base_network_instances__network_instance:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -237,7 +237,7 @@ _breaker7 = None
 class base_module__base_network_instances(yang.adata.MNode):
     network_instance: base_module__base_network_instances__network_instance
 
-    mut def __init__(self, network_instance: list[base_module__base_network_instances__network_instance_entry]=[]):
+    mut def __init__(self, network_instance: list[base_module__base_network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self.network_instance = base_module__base_network_instances__network_instance(elements=network_instance)
 
@@ -254,7 +254,7 @@ class base_module__base_network_instances(yang.adata.MNode):
             return base_module__base_network_instances(network_instance=base_module__base_network_instances__network_instance.from_gdata(n.get_opt_list(yang.gdata.Id(NS_base_module, 'network-instance'))))
         return base_module__base_network_instances()
 
-    def copy(self):
+    def copy(self) -> base_module__base_network_instances:
         """Create a deep copy of this adata object"""
         return base_module__base_network_instances.from_gdata(self.to_gdata())
 
@@ -263,7 +263,7 @@ _breaker8 = None
 class base_module__uses_leafref(yang.adata.MNode):
     ni: ?str
 
-    mut def __init__(self, ni: ?str):
+    mut def __init__(self, ni: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.ni = ni
 
@@ -280,7 +280,7 @@ class base_module__uses_leafref(yang.adata.MNode):
             return base_module__uses_leafref(ni=n.get_opt_str(yang.gdata.Id(NS_base_module, 'ni')))
         return base_module__uses_leafref()
 
-    def copy(self):
+    def copy(self) -> base_module__uses_leafref:
         """Create a deep copy of this adata object"""
         return base_module__uses_leafref.from_gdata(self.to_gdata())
 
@@ -291,7 +291,7 @@ class root(yang.adata.MNode):
     base_network_instances: base_module__base_network_instances
     uses_leafref: base_module__uses_leafref
 
-    mut def __init__(self, other_network_instances: ?other_module__other_network_instances=None, base_network_instances: ?base_module__base_network_instances=None, uses_leafref: ?base_module__uses_leafref=None):
+    mut def __init__(self, other_network_instances: ?other_module__other_network_instances=None, base_network_instances: ?base_module__base_network_instances=None, uses_leafref: ?base_module__uses_leafref=None) -> None:
         self._ns = ''
         self.other_network_instances = other_network_instances if other_network_instances is not None else other_module__other_network_instances()
         self.base_network_instances = base_network_instances if base_network_instances is not None else base_module__base_network_instances()
@@ -314,7 +314,7 @@ class root(yang.adata.MNode):
             return root(other_network_instances=other_module__other_network_instances.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_other_module, 'network-instances'))), base_network_instances=base_module__base_network_instances.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'network-instances'))), uses_leafref=base_module__uses_leafref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'uses-leafref'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -47,7 +47,7 @@ _breaker1 = None
 class base_module__network_instances__network_instance__config(yang.adata.MNode):
     name: ?str
 
-    mut def __init__(self, name: ?str):
+    mut def __init__(self, name: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.name = name
 
@@ -64,7 +64,7 @@ class base_module__network_instances__network_instance__config(yang.adata.MNode)
             return base_module__network_instances__network_instance__config(name=n.get_opt_str(yang.gdata.Id(NS_base_module, 'name')))
         return base_module__network_instances__network_instance__config()
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances__network_instance__config:
         """Create a deep copy of this adata object"""
         return base_module__network_instances__network_instance__config.from_gdata(self.to_gdata())
 
@@ -74,7 +74,7 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
     name: str
     config: base_module__network_instances__network_instance__config
 
-    mut def __init__(self, name: str, config: ?base_module__network_instances__network_instance__config=None):
+    mut def __init__(self, name: str, config: ?base_module__network_instances__network_instance__config=None) -> None:
         self._ns = 'http://example.com/base'
         self.name = name
         self.config = config if config is not None else base_module__network_instances__network_instance__config()
@@ -92,19 +92,19 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base_module__network_instances__network_instance_entry:
         return base_module__network_instances__network_instance_entry(name=n.get_str(yang.gdata.Id(NS_base_module, 'name')), config=base_module__network_instances__network_instance__config.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'config'))))
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances__network_instance_entry:
         """Create a deep copy of this adata object"""
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class base_module__network_instances__network_instance(yang.adata.MNode):
     elements: list[base_module__network_instances__network_instance_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> base_module__network_instances__network_instance_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -123,7 +123,7 @@ class base_module__network_instances__network_instance(yang.adata.MNode):
             return [base_module__network_instances__network_instance_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances__network_instance:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -141,7 +141,7 @@ _breaker4 = None
 class base_module__network_instances(yang.adata.MNode):
     network_instance: base_module__network_instances__network_instance
 
-    mut def __init__(self, network_instance: list[base_module__network_instances__network_instance_entry]=[]):
+    mut def __init__(self, network_instance: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self.network_instance = base_module__network_instances__network_instance(elements=network_instance)
 
@@ -158,7 +158,7 @@ class base_module__network_instances(yang.adata.MNode):
             return base_module__network_instances(network_instance=base_module__network_instances__network_instance.from_gdata(n.get_opt_list(yang.gdata.Id(NS_base_module, 'network-instance'))))
         return base_module__network_instances()
 
-    def copy(self):
+    def copy(self) -> base_module__network_instances:
         """Create a deep copy of this adata object"""
         return base_module__network_instances.from_gdata(self.to_gdata())
 
@@ -167,7 +167,7 @@ _breaker5 = None
 class consumer_module__uses_typedef(yang.adata.MNode):
     ni: ?str
 
-    mut def __init__(self, ni: ?str):
+    mut def __init__(self, ni: ?str) -> None:
         self._ns = 'http://example.com/consumer'
         self.ni = ni
 
@@ -184,7 +184,7 @@ class consumer_module__uses_typedef(yang.adata.MNode):
             return consumer_module__uses_typedef(ni=n.get_opt_str(yang.gdata.Id(NS_consumer_module, 'ni')))
         return consumer_module__uses_typedef()
 
-    def copy(self):
+    def copy(self) -> consumer_module__uses_typedef:
         """Create a deep copy of this adata object"""
         return consumer_module__uses_typedef.from_gdata(self.to_gdata())
 
@@ -194,7 +194,7 @@ class root(yang.adata.MNode):
     network_instances: base_module__network_instances
     uses_typedef: consumer_module__uses_typedef
 
-    mut def __init__(self, network_instances: ?base_module__network_instances=None, uses_typedef: ?consumer_module__uses_typedef=None):
+    mut def __init__(self, network_instances: ?base_module__network_instances=None, uses_typedef: ?consumer_module__uses_typedef=None) -> None:
         self._ns = ''
         self.network_instances = network_instances if network_instances is not None else base_module__network_instances()
         self.uses_typedef = uses_typedef if uses_typedef is not None else consumer_module__uses_typedef()
@@ -214,7 +214,7 @@ class root(yang.adata.MNode):
             return root(network_instances=base_module__network_instances.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base_module, 'network-instances'))), uses_typedef=consumer_module__uses_typedef.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_consumer_module, 'uses-typedef'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -43,7 +43,7 @@ _breaker1 = None
 class foo__c__li__bar(yang.adata.MNode):
     man: str
 
-    mut def __init__(self, man: str):
+    mut def __init__(self, man: str) -> None:
         self._ns = 'http://example.com/foo'
         self.man = man
 
@@ -60,7 +60,7 @@ class foo__c__li__bar(yang.adata.MNode):
             return foo__c__li__bar(man=n.get_str(yang.gdata.Id(NS_foo, 'man')))
         raise ValueError('Missing required subtree foo__c__li__bar')
 
-    def copy(self):
+    def copy(self) -> foo__c__li__bar:
         """Create a deep copy of this adata object"""
         return foo__c__li__bar.from_gdata(self.to_gdata())
 
@@ -71,7 +71,7 @@ class foo__c__li_entry(yang.adata.MNode):
     foo: str
     bar: foo__c__li__bar
 
-    mut def __init__(self, name: str, bar: foo__c__li__bar, foo: ?str=None):
+    mut def __init__(self, name: str, bar: foo__c__li__bar, foo: ?str=None) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.foo = foo if foo is not None else "banana"
@@ -92,19 +92,19 @@ class foo__c__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c__li_entry:
         return foo__c__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), bar=foo__c__li__bar.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'bar'))))
 
-    def copy(self):
+    def copy(self) -> foo__c__li_entry:
         """Create a deep copy of this adata object"""
         return foo__c__li_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class foo__c__li(yang.adata.MNode):
     elements: list[foo__c__li_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c__li_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name, bar, foo=None):
+    mut def create(self, name: str, bar: foo__c__li__bar, foo: ?str=None) -> foo__c__li_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -126,7 +126,7 @@ class foo__c__li(yang.adata.MNode):
             return [foo__c__li_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c__li:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -45,7 +45,7 @@ class base__c1__base_l1_entry(yang.adata.MNode):
     base_k1: str
     foo_k1: str
 
-    mut def __init__(self, base_k1: str, foo_k1: str):
+    mut def __init__(self, base_k1: str, foo_k1: str) -> None:
         self._ns = 'http://example.com/base'
         self.base_k1 = base_k1
         self.foo_k1 = foo_k1
@@ -63,19 +63,19 @@ class base__c1__base_l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__base_l1_entry:
         return base__c1__base_l1_entry(base_k1=n.get_str(yang.gdata.Id(NS_base, 'k1')), foo_k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')))
 
-    def copy(self):
+    def copy(self) -> base__c1__base_l1_entry:
         """Create a deep copy of this adata object"""
         return base__c1__base_l1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class base__c1__base_l1(yang.adata.MNode):
     elements: list[base__c1__base_l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[base__c1__base_l1_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, base_k1, foo_k1):
+    mut def create(self, base_k1: str, foo_k1: str) -> base__c1__base_l1_entry:
         for e in self:
             match = True
             if e.base_k1 != base_k1:
@@ -95,7 +95,7 @@ class base__c1__base_l1(yang.adata.MNode):
             return [base__c1__base_l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> base__c1__base_l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -113,7 +113,7 @@ _breaker3 = None
 class base__c1__foo_l1_entry(yang.adata.MNode):
     k2: str
 
-    mut def __init__(self, k2: str):
+    mut def __init__(self, k2: str) -> None:
         self._ns = 'http://example.com/foo'
         self.k2 = k2
 
@@ -128,19 +128,19 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> base__c1__foo_l1_entry:
         return base__c1__foo_l1_entry(k2=n.get_str(yang.gdata.Id(NS_foo, 'k2')))
 
-    def copy(self):
+    def copy(self) -> base__c1__foo_l1_entry:
         """Create a deep copy of this adata object"""
         return base__c1__foo_l1_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class base__c1__foo_l1(yang.adata.MNode):
     elements: list[base__c1__foo_l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[base__c1__foo_l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k2):
+    mut def create(self, k2: str) -> base__c1__foo_l1_entry:
         for e in self:
             match = True
             if e.k2 != k2:
@@ -159,7 +159,7 @@ class base__c1__foo_l1(yang.adata.MNode):
             return [base__c1__foo_l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> base__c1__foo_l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -178,7 +178,7 @@ class base__c1(yang.adata.MNode):
     base_l1: base__c1__base_l1
     foo_l1: base__c1__foo_l1
 
-    mut def __init__(self, base_l1: list[base__c1__base_l1_entry]=[], foo_l1: list[base__c1__foo_l1_entry]=[]):
+    mut def __init__(self, base_l1: list[base__c1__base_l1_entry]=[], foo_l1: list[base__c1__foo_l1_entry]=[]) -> None:
         self._ns = 'http://example.com/base'
         self.base_l1 = base__c1__base_l1(elements=base_l1)
         self.foo_l1 = base__c1__foo_l1(elements=foo_l1)
@@ -198,7 +198,7 @@ class base__c1(yang.adata.MNode):
             return base__c1(base_l1=base__c1__base_l1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_base, 'l1'))), foo_l1=base__c1__foo_l1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'l1'))))
         return base__c1()
 
-    def copy(self):
+    def copy(self) -> base__c1:
         """Create a deep copy of this adata object"""
         return base__c1.from_gdata(self.to_gdata())
 
@@ -207,7 +207,7 @@ _breaker6 = None
 class root(yang.adata.MNode):
     c1: base__c1
 
-    mut def __init__(self, c1: ?base__c1=None):
+    mut def __init__(self, c1: ?base__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else base__c1()
 
@@ -224,7 +224,7 @@ class root(yang.adata.MNode):
             return root(c1=base__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
@@ -43,7 +43,7 @@ _breaker1 = None
 class base__c1__base_c2(yang.adata.MNode):
     foo: ?str
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self, foo: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.foo = foo
 
@@ -60,7 +60,7 @@ class base__c1__base_c2(yang.adata.MNode):
             return base__c1__base_c2(foo=n.get_opt_str(yang.gdata.Id(NS_base, 'foo')))
         return base__c1__base_c2()
 
-    def copy(self):
+    def copy(self) -> base__c1__base_c2:
         """Create a deep copy of this adata object"""
         return base__c1__base_c2.from_gdata(self.to_gdata())
 
@@ -69,7 +69,7 @@ _breaker2 = None
 class base__c1__foo_c2(yang.adata.MNode):
     foo: ?str
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self, foo: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo
 
@@ -86,7 +86,7 @@ class base__c1__foo_c2(yang.adata.MNode):
             return base__c1__foo_c2(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')))
         return base__c1__foo_c2()
 
-    def copy(self):
+    def copy(self) -> base__c1__foo_c2:
         """Create a deep copy of this adata object"""
         return base__c1__foo_c2.from_gdata(self.to_gdata())
 
@@ -96,7 +96,7 @@ class base__c1(yang.adata.MNode):
     base_c2: base__c1__base_c2
     foo_c2: base__c1__foo_c2
 
-    mut def __init__(self, base_c2: ?base__c1__base_c2=None, foo_c2: ?base__c1__foo_c2=None):
+    mut def __init__(self, base_c2: ?base__c1__base_c2=None, foo_c2: ?base__c1__foo_c2=None) -> None:
         self._ns = 'http://example.com/base'
         self.base_c2 = base_c2 if base_c2 is not None else base__c1__base_c2()
         self.foo_c2 = foo_c2 if foo_c2 is not None else base__c1__foo_c2()
@@ -116,7 +116,7 @@ class base__c1(yang.adata.MNode):
             return base__c1(base_c2=base__c1__base_c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base, 'c2'))), foo_c2=base__c1__foo_c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))))
         return base__c1()
 
-    def copy(self):
+    def copy(self) -> base__c1:
         """Create a deep copy of this adata object"""
         return base__c1.from_gdata(self.to_gdata())
 
@@ -125,7 +125,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     c1: base__c1
 
-    mut def __init__(self, c1: ?base__c1=None):
+    mut def __init__(self, c1: ?base__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else base__c1()
 
@@ -142,7 +142,7 @@ class root(yang.adata.MNode):
             return root(c1=base__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_base, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_augment_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_name_conflict
@@ -41,7 +41,7 @@ class base__c1(yang.adata.MNode):
     bar_foo: ?str
     foo_foo: ?str
 
-    mut def __init__(self, bar_foo: ?str, foo_foo: ?str):
+    mut def __init__(self, bar_foo: ?str, foo_foo: ?str) -> None:
         self._ns = 'http://example.com/base'
         self.bar_foo = bar_foo
         self.foo_foo = foo_foo
@@ -61,7 +61,7 @@ class base__c1(yang.adata.MNode):
             return base__c1(bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), foo_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')))
         return base__c1()
 
-    def copy(self):
+    def copy(self) -> base__c1:
         """Create a deep copy of this adata object"""
         return base__c1.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_dot
+++ b/snapshots/expected/test_yang/prdaclass_dot
@@ -37,7 +37,7 @@ _breaker1 = None
 class foo__ieee_802_3(yang.adata.MNode):
     ieee_802_3: ?str
 
-    mut def __init__(self, ieee_802_3: ?str):
+    mut def __init__(self, ieee_802_3: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.ieee_802_3 = ieee_802_3
 
@@ -54,7 +54,7 @@ class foo__ieee_802_3(yang.adata.MNode):
             return foo__ieee_802_3(ieee_802_3=n.get_opt_str(yang.gdata.Id(NS_foo, 'ieee-802.3')))
         return foo__ieee_802_3()
 
-    def copy(self):
+    def copy(self) -> foo__ieee_802_3:
         """Create a deep copy of this adata object"""
         return foo__ieee_802_3.from_gdata(self.to_gdata())
 
@@ -63,7 +63,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     ieee_802_3: foo__ieee_802_3
 
-    mut def __init__(self, ieee_802_3: ?foo__ieee_802_3=None):
+    mut def __init__(self, ieee_802_3: ?foo__ieee_802_3=None) -> None:
         self._ns = ''
         self.ieee_802_3 = ieee_802_3 if ieee_802_3 is not None else foo__ieee_802_3()
 
@@ -80,7 +80,7 @@ class root(yang.adata.MNode):
             return root(ieee_802_3=foo__ieee_802_3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'ieee-802.3'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_exclude_ext
+++ b/snapshots/expected/test_yang/prdaclass_exclude_ext
@@ -42,7 +42,7 @@ _breaker1 = None
 class foo__c1__dynstate(yang.adata.MNode):
     ds1: ?str
 
-    mut def __init__(self, ds1: ?str):
+    mut def __init__(self, ds1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.ds1 = ds1
 
@@ -59,7 +59,7 @@ class foo__c1__dynstate(yang.adata.MNode):
             return foo__c1__dynstate(ds1=n.get_opt_str(yang.gdata.Id(NS_foo, 'ds1')))
         return foo__c1__dynstate()
 
-    def copy(self):
+    def copy(self) -> foo__c1__dynstate:
         """Create a deep copy of this adata object"""
         return foo__c1__dynstate.from_gdata(self.to_gdata())
 
@@ -68,7 +68,7 @@ _breaker2 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -85,7 +85,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -94,7 +94,7 @@ _breaker3 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -111,7 +111,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -60,7 +60,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
     k1: str
     k2: Identityref
 
-    mut def __init__(self, k1: str, k2: Identityref):
+    mut def __init__(self, k1: str, k2: Identityref) -> None:
         self._ns = 'http://example.com/foo'
         self.k1 = k1
         self.k2 = k2
@@ -78,19 +78,19 @@ class foo__c1__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
         return foo__c1__l1_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_Identityref(yang.gdata.Id(NS_foo, 'k2')))
 
-    def copy(self):
+    def copy(self) -> foo__c1__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k1, k2):
+    mut def create(self, k1: str, k2: Identityref) -> foo__c1__l1_entry:
         for e in self:
             match = True
             if e.k1 != k1:
@@ -112,7 +112,7 @@ class foo__c1__l1(yang.adata.MNode):
             return [foo__c1__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c1__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -130,7 +130,7 @@ _breaker3 = None
 class foo__c1(yang.adata.MNode):
     l1: foo__c1__l1
 
-    mut def __init__(self, l1: list[foo__c1__l1_entry]=[]):
+    mut def __init__(self, l1: list[foo__c1__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = foo__c1__l1(elements=l1)
 
@@ -147,7 +147,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=foo__c1__l1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'l1'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -156,7 +156,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -173,7 +173,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_keyword_name_import
+++ b/snapshots/expected/test_yang/prdaclass_keyword_name_import
@@ -45,7 +45,7 @@ class foo__c1(yang.adata.MNode):
     in_: ?str
     with_: ?str
 
-    mut def __init__(self, as_: ?str, for_: ?str, import_: ?str, in_: ?str, with_: ?str):
+    mut def __init__(self, as_: ?str, for_: ?str, import_: ?str, in_: ?str, with_: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.as_ = as_
         self.for_ = for_
@@ -74,7 +74,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(as_=n.get_opt_str(yang.gdata.Id(NS_foo, 'as')), for_=n.get_opt_str(yang.gdata.Id(NS_foo, 'for')), import_=n.get_opt_str(yang.gdata.Id(NS_foo, 'import')), in_=n.get_opt_str(yang.gdata.Id(NS_foo, 'in')), with_=n.get_opt_str(yang.gdata.Id(NS_foo, 'with')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -37,7 +37,7 @@ _breaker1 = None
 class foo__l1_entry(yang.adata.MNode):
     name: str
 
-    mut def __init__(self, name: str):
+    mut def __init__(self, name: str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
 
@@ -52,19 +52,19 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
 
-    def copy(self):
+    def copy(self) -> foo__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> foo__l1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -83,7 +83,7 @@ class foo__l1(yang.adata.MNode):
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -39,7 +39,7 @@ class foo__l1_entry(yang.adata.MNode):
     name: str
     id: ?str
 
-    mut def __init__(self, name: str, id: ?str):
+    mut def __init__(self, name: str, id: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.id = id
@@ -57,19 +57,19 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), id=n.get_opt_str(yang.gdata.Id(NS_foo, 'id')))
 
-    def copy(self):
+    def copy(self) -> foo__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name, id=None):
+    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -90,7 +90,7 @@ class foo__l1(yang.adata.MNode):
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []

--- a/snapshots/expected/test_yang/prdaclass_loose_container_in_container
+++ b/snapshots/expected/test_yang/prdaclass_loose_container_in_container
@@ -39,7 +39,7 @@ _breaker1 = None
 class foo__foo__bar(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -56,7 +56,7 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__foo__bar()
 
-    def copy(self):
+    def copy(self) -> foo__foo__bar:
         """Create a deep copy of this adata object"""
         return foo__foo__bar.from_gdata(self.to_gdata())
 
@@ -65,7 +65,7 @@ _breaker2 = None
 class foo__foo(yang.adata.MNode):
     bar: foo__foo__bar
 
-    mut def __init__(self, bar: ?foo__foo__bar=None):
+    mut def __init__(self, bar: ?foo__foo__bar=None) -> None:
         self._ns = 'http://example.com/foo'
         self.bar = bar if bar is not None else foo__foo__bar()
 
@@ -82,7 +82,7 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'bar'))))
         return foo__foo()
 
-    def copy(self):
+    def copy(self) -> foo__foo:
         """Create a deep copy of this adata object"""
         return foo__foo.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -39,7 +39,7 @@ _breaker1 = None
 class foo__foo__bar(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -56,7 +56,7 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__foo__bar:
         """Create a deep copy of this adata object"""
         ad = foo__foo__bar.from_gdata(self.to_gdata())
         if ad is not None:
@@ -68,11 +68,11 @@ _breaker2 = None
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
 
-    mut def __init__(self, bar: ?foo__foo__bar=None):
+    mut def __init__(self, bar: ?foo__foo__bar=None) -> None:
         self._ns = 'http://example.com/foo'
         self.bar = bar
 
-    mut def create_bar(self, l1=None):
+    mut def create_bar(self, l1: ?str=None) -> foo__foo__bar:
         existing = self.bar
         if existing is not None:
             if l1 is not None:
@@ -95,7 +95,7 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'bar'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__foo:
         """Create a deep copy of this adata object"""
         ad = foo__foo.from_gdata(self.to_gdata())
         if ad is not None:

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -39,7 +39,7 @@ _breaker1 = None
 class foo__li1_entry(yang.adata.MNode):
     l1: str
 
-    mut def __init__(self, l1: str):
+    mut def __init__(self, l1: str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -54,19 +54,19 @@ class foo__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
         return foo__li1_entry(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')))
 
-    def copy(self):
+    def copy(self) -> foo__li1_entry:
         """Create a deep copy of this adata object"""
         return foo__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1):
+    mut def create(self, l1: str) -> foo__li1_entry:
         for e in self:
             match = True
             if e.l1 != l1:
@@ -85,7 +85,7 @@ class foo__li1(yang.adata.MNode):
             return [foo__li1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -104,7 +104,7 @@ class root(yang.adata.MNode):
     li1: foo__li1
     ll1: list[str]
 
-    mut def __init__(self, li1: list[foo__li1_entry]=[], ll1: ?list[str]=None):
+    mut def __init__(self, li1: list[foo__li1_entry]=[], ll1: ?list[str]=None) -> None:
         self._ns = ''
         self.li1 = foo__li1(elements=li1)
         self.ll1 = ll1 if ll1 is not None else []
@@ -124,7 +124,7 @@ class root(yang.adata.MNode):
             return root(li1=foo__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1'))), ll1=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll1')))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -39,7 +39,7 @@ _breaker1 = None
 class foo__li1_entry(yang.adata.MNode):
     l1: str
 
-    mut def __init__(self, l1: str):
+    mut def __init__(self, l1: str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -54,19 +54,19 @@ class foo__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li1_entry:
         return foo__li1_entry(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')))
 
-    def copy(self):
+    def copy(self) -> foo__li1_entry:
         """Create a deep copy of this adata object"""
         return foo__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__li1(yang.adata.MNode):
     elements: list[foo__li1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1):
+    mut def create(self, l1: str) -> foo__li1_entry:
         for e in self:
             match = True
             if e.l1 != l1:
@@ -85,7 +85,7 @@ class foo__li1(yang.adata.MNode):
             return [foo__li1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -104,7 +104,7 @@ class root(yang.adata.MNode):
     li1: foo__li1
     ll1: list[str]
 
-    mut def __init__(self, li1: list[foo__li1_entry]=[], ll1: ?list[str]=None):
+    mut def __init__(self, li1: list[foo__li1_entry]=[], ll1: ?list[str]=None) -> None:
         self._ns = ''
         self.li1 = foo__li1(elements=li1)
         self.ll1 = ll1 if ll1 is not None else []
@@ -124,7 +124,7 @@ class root(yang.adata.MNode):
             return root(li1=foo__li1.from_gdata(n.get_list(yang.gdata.Id(NS_foo, 'li1'))), ll1=n.get_strs(yang.gdata.Id(NS_foo, 'll1')))
         raise ValueError('Missing required subtree root')
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -41,7 +41,7 @@ _breaker1 = None
 class foo__l1__bar(yang.adata.MNode):
     hi: ?str
 
-    mut def __init__(self, hi: ?str):
+    mut def __init__(self, hi: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.hi = hi
 
@@ -58,7 +58,7 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=n.get_opt_str(yang.gdata.Id(NS_foo, 'hi')))
         return foo__l1__bar()
 
-    def copy(self):
+    def copy(self) -> foo__l1__bar:
         """Create a deep copy of this adata object"""
         return foo__l1__bar.from_gdata(self.to_gdata())
 
@@ -69,7 +69,7 @@ class foo__l1_entry(yang.adata.MNode):
     id: ?str
     bar: foo__l1__bar
 
-    mut def __init__(self, name: str, id: ?str, bar: ?foo__l1__bar=None):
+    mut def __init__(self, name: str, id: ?str, bar: ?foo__l1__bar=None) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.id = id
@@ -90,19 +90,19 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), id=n.get_opt_str(yang.gdata.Id(NS_foo, 'id')), bar=foo__l1__bar.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'bar'))))
 
-    def copy(self):
+    def copy(self) -> foo__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name, id=None):
+    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -123,7 +123,7 @@ class foo__l1(yang.adata.MNode):
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -141,7 +141,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     l1: foo__l1
 
-    mut def __init__(self, l1: list[foo__l1_entry]=[]):
+    mut def __init__(self, l1: list[foo__l1_entry]=[]) -> None:
         self._ns = ''
         self.l1 = foo__l1(elements=l1)
 
@@ -158,7 +158,7 @@ class root(yang.adata.MNode):
             return root(l1=foo__l1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'l1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -53,7 +53,7 @@ NS_yangrpc = 'http://example.com/yangrpc'
 _breaker1 = None
 class root(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = ''
         pass
 
@@ -66,7 +66,7 @@ class root(yang.adata.MNode):
             return root()
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
@@ -75,7 +75,7 @@ _breaker2 = None
 class yangrpc__foo__input__woo(yang.adata.MNode):
     woo_b: ?int
 
-    mut def __init__(self, woo_b: ?int):
+    mut def __init__(self, woo_b: ?int) -> None:
         self._ns = 'http://example.com/yangrpc'
         self.woo_b = woo_b
 
@@ -92,7 +92,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
             return yangrpc__foo__input__woo(woo_b=n.get_opt_int(yang.gdata.Id(NS_yangrpc, 'woo_b')))
         return yangrpc__foo__input__woo()
 
-    def copy(self):
+    def copy(self) -> yangrpc__foo__input__woo:
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
 
@@ -102,7 +102,7 @@ class yangrpc__foo__input(yang.adata.MNode):
     a: ?str
     woo: yangrpc__foo__input__woo
 
-    mut def __init__(self, a: ?str, woo: ?yangrpc__foo__input__woo=None):
+    mut def __init__(self, a: ?str, woo: ?yangrpc__foo__input__woo=None) -> None:
         self._ns = 'http://example.com/yangrpc'
         self.a = a
         self.woo = woo if woo is not None else yangrpc__foo__input__woo()
@@ -122,7 +122,7 @@ class yangrpc__foo__input(yang.adata.MNode):
             return yangrpc__foo__input(a=n.get_opt_str(yang.gdata.Id(NS_yangrpc, 'a')), woo=yangrpc__foo__input__woo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_yangrpc, 'woo'))))
         return yangrpc__foo__input()
 
-    def copy(self):
+    def copy(self) -> yangrpc__foo__input:
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input.from_gdata(self.to_gdata())
 
@@ -131,7 +131,7 @@ _breaker4 = None
 class yangrpc__foo__output(yang.adata.MNode):
     outoo: ?str
 
-    mut def __init__(self, outoo: ?str):
+    mut def __init__(self, outoo: ?str) -> None:
         self._ns = 'http://example.com/yangrpc'
         self.outoo = outoo
 
@@ -148,7 +148,7 @@ class yangrpc__foo__output(yang.adata.MNode):
             return yangrpc__foo__output(outoo=n.get_opt_str(yang.gdata.Id(NS_yangrpc, 'outoo')))
         return yangrpc__foo__output()
 
-    def copy(self):
+    def copy(self) -> yangrpc__foo__output:
         """Create a deep copy of this adata object"""
         return yangrpc__foo__output.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -39,7 +39,7 @@ class foo__l1_entry(yang.adata.MNode):
     name: str
     id: str
 
-    mut def __init__(self, name: str, id: str):
+    mut def __init__(self, name: str, id: str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.id = id
@@ -57,19 +57,19 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), id=n.get_str(yang.gdata.Id(NS_foo, 'id')))
 
-    def copy(self):
+    def copy(self) -> foo__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name, id):
+    mut def create(self, name: str, id: str) -> foo__l1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -89,7 +89,7 @@ class foo__l1(yang.adata.MNode):
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -40,7 +40,7 @@ _breaker1 = None
 class foo__l1__bar(yang.adata.MNode):
     hi: str
 
-    mut def __init__(self, hi: str):
+    mut def __init__(self, hi: str) -> None:
         self._ns = 'http://example.com/foo'
         self.hi = hi
 
@@ -57,7 +57,7 @@ class foo__l1__bar(yang.adata.MNode):
             return foo__l1__bar(hi=n.get_str(yang.gdata.Id(NS_foo, 'hi')))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__l1__bar:
         """Create a deep copy of this adata object"""
         ad = foo__l1__bar.from_gdata(self.to_gdata())
         if ad is not None:
@@ -70,12 +70,12 @@ class foo__l1_entry(yang.adata.MNode):
     name: str
     bar: ?foo__l1__bar
 
-    mut def __init__(self, name: str, bar: ?foo__l1__bar=None):
+    mut def __init__(self, name: str, bar: ?foo__l1__bar=None) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.bar = bar
 
-    mut def create_bar(self, hi):
+    mut def create_bar(self, hi: str) -> foo__l1__bar:
         existing = self.bar
         if existing is not None:
             existing.hi = hi
@@ -97,19 +97,19 @@ class foo__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
         return foo__l1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), bar=foo__l1__bar.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'bar'))))
 
-    def copy(self):
+    def copy(self) -> foo__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class foo__l1(yang.adata.MNode):
     elements: list[foo__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> foo__l1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -128,7 +128,7 @@ class foo__l1(yang.adata.MNode):
             return [foo__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []

--- a/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -44,7 +44,7 @@ class foo__foo__bar(yang.adata.MNode):
     bar_l1: str
     l2: str
 
-    mut def __init__(self, foo_l1: str, bar_l1: str, l2: str):
+    mut def __init__(self, foo_l1: str, bar_l1: str, l2: str) -> None:
         self._ns = 'http://example.com/foo'
         self.foo_l1 = foo_l1
         self.bar_l1 = bar_l1
@@ -67,7 +67,7 @@ class foo__foo__bar(yang.adata.MNode):
             return foo__foo__bar(foo_l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), bar_l1=n.get_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_str(yang.gdata.Id(NS_bar, 'l2')))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__foo__bar:
         """Create a deep copy of this adata object"""
         ad = foo__foo__bar.from_gdata(self.to_gdata())
         if ad is not None:
@@ -79,11 +79,11 @@ _breaker2 = None
 class foo__foo(yang.adata.MNode):
     bar: ?foo__foo__bar
 
-    mut def __init__(self, bar: ?foo__foo__bar=None):
+    mut def __init__(self, bar: ?foo__foo__bar=None) -> None:
         self._ns = 'http://example.com/foo'
         self.bar = bar
 
-    mut def create_bar(self, foo_l1, bar_l1, l2):
+    mut def create_bar(self, foo_l1: str, bar_l1: str, l2: str) -> foo__foo__bar:
         existing = self.bar
         if existing is not None:
             existing.foo_l1 = foo_l1
@@ -107,7 +107,7 @@ class foo__foo(yang.adata.MNode):
             return foo__foo(bar=foo__foo__bar.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'bar'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__foo:
         """Create a deep copy of this adata object"""
         ad = foo__foo.from_gdata(self.to_gdata())
         if ad is not None:
@@ -119,11 +119,11 @@ _breaker3 = None
 class root(yang.adata.MNode):
     foo: ?foo__foo
 
-    mut def __init__(self, foo: ?foo__foo=None):
+    mut def __init__(self, foo: ?foo__foo=None) -> None:
         self._ns = ''
         self.foo = foo
 
-    mut def create_foo(self):
+    mut def create_foo(self) -> foo__foo:
         existing = self.foo
         if existing is not None:
             return existing
@@ -144,7 +144,7 @@ class root(yang.adata.MNode):
             return root(foo=foo__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_top_conflict
+++ b/snapshots/expected/test_yang/prdaclass_top_conflict
@@ -42,7 +42,7 @@ _breaker1 = None
 class bar__bar_c1(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/bar'
         self.l1 = l1
 
@@ -59,7 +59,7 @@ class bar__bar_c1(yang.adata.MNode):
             return bar__bar_c1(l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')))
         return bar__bar_c1()
 
-    def copy(self):
+    def copy(self) -> bar__bar_c1:
         """Create a deep copy of this adata object"""
         return bar__bar_c1.from_gdata(self.to_gdata())
 
@@ -68,7 +68,7 @@ _breaker2 = None
 class foo__foo_c1(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -85,7 +85,7 @@ class foo__foo_c1(yang.adata.MNode):
             return foo__foo_c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__foo_c1()
 
-    def copy(self):
+    def copy(self) -> foo__foo_c1:
         """Create a deep copy of this adata object"""
         return foo__foo_c1.from_gdata(self.to_gdata())
 
@@ -95,7 +95,7 @@ class root(yang.adata.MNode):
     bar_c1: bar__bar_c1
     foo_c1: foo__foo_c1
 
-    mut def __init__(self, bar_c1: ?bar__bar_c1=None, foo_c1: ?foo__foo_c1=None):
+    mut def __init__(self, bar_c1: ?bar__bar_c1=None, foo_c1: ?foo__foo_c1=None) -> None:
         self._ns = ''
         self.bar_c1 = bar_c1 if bar_c1 is not None else bar__bar_c1()
         self.foo_c1 = foo_c1 if foo_c1 is not None else foo__foo_c1()
@@ -115,7 +115,7 @@ class root(yang.adata.MNode):
             return root(bar_c1=bar__bar_c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'c1'))), foo_c1=foo__foo_c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
+++ b/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
@@ -43,7 +43,7 @@ _breaker1 = None
 class foo__c1(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -60,7 +60,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -69,7 +69,7 @@ _breaker2 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -86,7 +86,7 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__pc1__foo()
 
-    def copy(self):
+    def copy(self) -> foo__pc1__foo:
         """Create a deep copy of this adata object"""
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
@@ -95,7 +95,7 @@ _breaker3 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
-    mut def __init__(self, foo: ?foo__pc1__foo=None):
+    mut def __init__(self, foo: ?foo__pc1__foo=None) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo if foo is not None else foo__pc1__foo()
 
@@ -112,7 +112,7 @@ class foo__pc1(yang.adata.MNode):
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc1:
         """Create a deep copy of this adata object"""
         ad = foo__pc1.from_gdata(self.to_gdata())
         if ad is not None:
@@ -125,12 +125,12 @@ class root(yang.adata.MNode):
     c1: foo__c1
     pc1: ?foo__pc1
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
 
-    mut def create_pc1(self):
+    mut def create_pc1(self) -> foo__pc1:
         existing = self.pc1
         if existing is not None:
             return existing
@@ -153,7 +153,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -46,7 +46,7 @@ class foo__c1__l1_entry(yang.adata.MNode):
     k2: value
     l1: str
 
-    mut def __init__(self, k1: str, k2: value, l1: str):
+    mut def __init__(self, k1: str, k2: value, l1: str) -> None:
         self._ns = 'http://example.com/foo'
         self.k1 = k1
         self.k2 = k2
@@ -67,19 +67,19 @@ class foo__c1__l1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__l1_entry:
         return foo__c1__l1_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')))
 
-    def copy(self):
+    def copy(self) -> foo__c1__l1_entry:
         """Create a deep copy of this adata object"""
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2 = None
 class foo__c1__l1(yang.adata.MNode):
     elements: list[foo__c1__l1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k1, k2, l1):
+    mut def create(self, k1: str, k2: value, l1: str) -> foo__c1__l1_entry:
         for e in self:
             match = True
             if e.k1 != k1:
@@ -109,7 +109,7 @@ class foo__c1__l1(yang.adata.MNode):
             return [foo__c1__l1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c1__l1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -127,7 +127,7 @@ _breaker3 = None
 class foo__c1(yang.adata.MNode):
     l1: foo__c1__l1
 
-    mut def __init__(self, l1: list[foo__c1__l1_entry]=[]):
+    mut def __init__(self, l1: list[foo__c1__l1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = foo__c1__l1(elements=l1)
 
@@ -144,7 +144,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(l1=foo__c1__l1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'l1'))))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -153,7 +153,7 @@ _breaker4 = None
 class root(yang.adata.MNode):
     c1: foo__c1
 
-    mut def __init__(self, c1: ?foo__c1=None):
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
 
@@ -170,7 +170,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_intX
+++ b/snapshots/expected/test_yang/resolve_type_union_of_intX
@@ -44,7 +44,7 @@ class root(yang.adata.MNode):
     l3: ?value
     l4: ?value
 
-    mut def __init__(self, l1: ?int, l2: ?u64, l3: ?value, l4: ?value):
+    mut def __init__(self, l1: ?int, l2: ?u64, l3: ?value, l4: ?value) -> None:
         self._ns = ''
         self.l1 = l1
         self.l2 = l2
@@ -70,7 +70,7 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_int(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l2')), l3=n.get_opt_value(yang.gdata.Id(NS_foo, 'l3')), l4=n.get_opt_value(yang.gdata.Id(NS_foo, 'l4')))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_string
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string
@@ -35,7 +35,7 @@ _breaker1 = None
 class root(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = ''
         self.l1 = l1
 
@@ -52,7 +52,7 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
@@ -35,7 +35,7 @@ _breaker1 = None
 class root(yang.adata.MNode):
     l1: value
 
-    mut def __init__(self, l1: ?value=None):
+    mut def __init__(self, l1: ?value=None) -> None:
         self._ns = ''
         self.l1 = l1 if l1 is not None else 42
 
@@ -52,7 +52,7 @@ class root(yang.adata.MNode):
             return root(l1=n.get_opt_value(yang.gdata.Id(NS_foo, 'l1')))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -641,7 +641,7 @@ class DNodeInner(DNode):
                 opt_args.append("{usname(child)}: list[{pname(child)}_entry]=[]")
 
         init_args_str = ", ".join(["self"] + req_args + opt_args)
-        res.append("    mut def __init__({init_args_str}):")
+        res.append("    mut def __init__({init_args_str}) -> None:")
         # Set namespace from us
         res.append("        self._ns = '{self.namespace}'")
 
@@ -685,19 +685,28 @@ class DNodeInner(DNode):
                 child_unique_namer = UniqueNamer(child)
 
                 pc_args_req = []
+                pc_args_req_sig = []
                 pc_args_opt = []
+                pc_args_opt_sig = []
                 for cchild in child.children:
                     if isinstance(cchild, DLeaf):
+                        carg = child_unique_namer.unique_safe_name(cchild.name, cchild.prefix)
+                        ctype = yang_leaf_to_acton_arg_type(cchild, list_keys(self), loose)
                         if is_optional_arg_yang_leaf(cchild, list_keys(self), loose):
-                            pc_args_opt.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
+                            pc_args_opt.append(carg)
+                            pc_args_opt_sig.append("{carg}: {ctype}=None")
                         else:
-                            pc_args_req.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
+                            pc_args_req.append(carg)
+                            pc_args_req_sig.append("{carg}: {ctype}")
                     elif isinstance(cchild, DContainer):
                         if not (loose or optional_subtree(cchild) or cchild.presence):
-                            pc_args_req.append(child_unique_namer.unique_safe_name(cchild.name, cchild.prefix))
-                pc_args_str = ", ".join(["self"] + pc_args_req + ["{arg}=None" for arg in pc_args_opt])
+                            carg = child_unique_namer.unique_safe_name(cchild.name, cchild.prefix)
+                            ctype = get_path_name(spath + [child, cchild])
+                            pc_args_req.append(carg)
+                            pc_args_req_sig.append("{carg}: {ctype}")
+                pc_args_str = ", ".join(["self"] + pc_args_req_sig + pc_args_opt_sig)
                 pc_params_str= ", ".join(["{arg}={arg}" for arg in pc_args_req + pc_args_opt])
-                res.append("    mut def create_{usname(child)}({pc_args_str}):")
+                res.append("    mut def create_{usname(child)}({pc_args_str}) -> {pname(child)}:")
                 res.append("        existing = self.{usname(child)}")
                 res.append("        if existing is not None:")
                 for req_arg in pc_args_req:
@@ -757,7 +766,10 @@ class DNodeInner(DNode):
         res.append("")
 
         # .copy() method
-        res.append("    def copy(self):")
+        if isinstance(self, DList):
+            res.append("    def copy(self) -> {pname()}_entry:")
+        else:
+            res.append("    def copy(self) -> {pname()}:")
         res.append('        """Create a deep copy of this adata object"""')
         if isinstance(self, DList):
             res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
@@ -785,9 +797,9 @@ class DNodeInner(DNode):
             res.append("    elements: list[{pname()}_entry]")
 
             init_args = ["self"]
-            init_args.append("elements=[]")
+            init_args.append("elements: list[{pname()}_entry]=[]")
             init_args_str: str = ", ".join(init_args)
-            res.append("    mut def __init__({init_args_str}):")
+            res.append("    mut def __init__({init_args_str}) -> None:")
             # Set namespace from us
             res.append("        self._ns = '{self.namespace}'")
             res.append("        self._name = {repr(self.name)}")
@@ -799,23 +811,32 @@ class DNodeInner(DNode):
 
             list_key_args = us_list_key()
             list_args_req = []
+            list_args_req_sig = []
             list_args_opt = []
+            list_args_opt_sig = []
             list_key_types = {}
             for child in attr_children:
                 if isinstance(child, DLeaf):
-                    if usname(child) in list_key_args:
-                        list_key_types[usname(child)] = child.type_
-                        list_args_req.append(usname(child))
+                    arg = usname(child)
+                    arg_type = yang_leaf_to_acton_arg_type(child, list_keys(self), loose)
+                    if arg in list_key_args:
+                        list_key_types[arg] = child.type_
+                        list_args_req.append(arg)
+                        list_args_req_sig.append("{arg}: {arg_type}")
                         continue
                     if is_optional_arg_yang_leaf(child, list_keys(self), loose):
-                        list_args_opt.append(usname(child))
+                        list_args_opt.append(arg)
+                        list_args_opt_sig.append("{arg}: {arg_type}=None")
                     else:
-                        list_args_req.append(usname(child))
+                        list_args_req.append(arg)
+                        list_args_req_sig.append("{arg}: {arg_type}")
                 elif isinstance(child, DContainer):
                     if not (loose or optional_subtree(child) or child.presence):
-                        list_args_req.append(usname(child))
-            list_args_str = ", ".join(["self"] + list_args_req + ["{arg}=None" for arg in list_args_opt])
-            res.append("    mut def create({list_args_str}):")
+                        arg = usname(child)
+                        list_args_req.append(arg)
+                        list_args_req_sig.append("{arg}: {pname(child)}")
+            list_args_str = ", ".join(["self"] + list_args_req_sig + list_args_opt_sig)
+            res.append("    mut def create({list_args_str}) -> {pname()}_entry:")
             res.append("        for e in self:")
             res.append("            match = True")
             for us_key in list_key_args:
@@ -874,7 +895,7 @@ class DNodeInner(DNode):
             res.append("")
 
             # .copy() method for list wrapper
-            res.append("    def copy(self):")
+            res.append("    def copy(self) -> {pname()}:")
             res.append('        """Create a deep copy of this list object"""')
             res.append("        # Copy each element in the list")
             res.append("        copied_elements = []")
@@ -1951,7 +1972,7 @@ class DRoot(DNodeInner):
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
                     res.append("    {usname(child)}: {child_type}")
                 res.append("")
-                res.append("    def __init__(self, path: ?SubscriptionPath=None):")
+                res.append("    def __init__(self, path: ?SubscriptionPath=None) -> None:")
                 res.append("        SubscriptionNode.__init__(self, path)")
                 for child in selectables:
                     child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -1971,7 +1992,7 @@ class DRoot(DNodeInner):
                 for child in selectables:
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
                     res.append("    {usname(child)}: {child_type}")
-                res.append("    def __init__(self, path: ?SubscriptionPath=None):")
+                res.append("    def __init__(self, path: ?SubscriptionPath=None) -> None:")
                 res.append("        SubscriptionNode.__init__(self, path)")
                 for child in selectables:
                     child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -2005,7 +2026,7 @@ class DRoot(DNodeInner):
                         child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
                         res.append("    {usname(child)}: {child_type}")
                     res.append("")
-                    res.append("    def __init__(self, path: ?SubscriptionPath=None):")
+                    res.append("    def __init__(self, path: ?SubscriptionPath=None) -> None:")
                     res.append("        SubscriptionNode.__init__(self, path)")
                     for child in selectables:
                         child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -156,7 +156,7 @@ class basics__c(yang.adata.MNode):
     l_binary_def: bytes
     l_identityref_def: Identityref
 
-    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?u64=None, l_decimal64_def: ?Decimal=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None):
+    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?u64=None, l_decimal64_def: ?Decimal=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None) -> None:
         self._ns = 'http://example.com/basics'
         self.l_str_def = l_str_def if l_str_def is not None else "foo"
         self.l_str_def_quoted = l_str_def_quoted if l_str_def_quoted is not None else "\"foo\""
@@ -207,7 +207,7 @@ class basics__c(yang.adata.MNode):
             return basics__c(l_str_def=n.get_opt_str(yang.gdata.Id(NS_basics, 'l_str_def')), l_str_def_quoted=n.get_opt_str(yang.gdata.Id(NS_basics, 'l_str_def_quoted')), l_uint64_def=n.get_opt_u64(yang.gdata.Id(NS_basics, 'l_uint64_def')), l_decimal64_def=n.get_opt_Decimal(yang.gdata.Id(NS_basics, 'l_decimal64_def')), l_union_def_str=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_str')), l_union_def_int=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_int')), l_union_def_float=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_float')), l_union_def_bool=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_bool')), l_union_def_enumeration=n.get_opt_value(yang.gdata.Id(NS_basics, 'l_union_def_enumeration')), l_binary_def=n.get_opt_bytes(yang.gdata.Id(NS_basics, 'l_binary_def')), l_identityref_def=n.get_opt_Identityref(yang.gdata.Id(NS_basics, 'l_identityref_def')))
         return basics__c()
 
-    def copy(self):
+    def copy(self) -> basics__c:
         """Create a deep copy of this adata object"""
         return basics__c.from_gdata(self.to_gdata())
 
@@ -216,7 +216,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c: basics__c
 
-    mut def __init__(self, c: ?basics__c=None):
+    mut def __init__(self, c: ?basics__c=None) -> None:
         self._ns = ''
         self.c = c if c is not None else basics__c()
 
@@ -233,7 +233,7 @@ class root(yang.adata.MNode):
             return root(c=basics__c.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_basics, 'c'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -135,7 +135,7 @@ class filter_test__system_state__clock(yang.adata.MNode):
     current_datetime: ?str
     boot_datetime: ?str
 
-    mut def __init__(self, current_datetime: ?str, boot_datetime: ?str):
+    mut def __init__(self, current_datetime: ?str, boot_datetime: ?str) -> None:
         self._ns = 'http://example.com/filter-test'
         self.current_datetime = current_datetime
         self.boot_datetime = boot_datetime
@@ -155,7 +155,7 @@ class filter_test__system_state__clock(yang.adata.MNode):
             return filter_test__system_state__clock(current_datetime=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'current-datetime')), boot_datetime=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'boot-datetime')))
         return filter_test__system_state__clock()
 
-    def copy(self):
+    def copy(self) -> filter_test__system_state__clock:
         """Create a deep copy of this adata object"""
         return filter_test__system_state__clock.from_gdata(self.to_gdata())
 
@@ -164,7 +164,7 @@ _breaker2 = None
 class filter_test__system_state(yang.adata.MNode):
     clock: filter_test__system_state__clock
 
-    mut def __init__(self, clock: ?filter_test__system_state__clock=None):
+    mut def __init__(self, clock: ?filter_test__system_state__clock=None) -> None:
         self._ns = 'http://example.com/filter-test'
         self.clock = clock if clock is not None else filter_test__system_state__clock()
 
@@ -181,7 +181,7 @@ class filter_test__system_state(yang.adata.MNode):
             return filter_test__system_state(clock=filter_test__system_state__clock.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_filter_test, 'clock'))))
         return filter_test__system_state()
 
-    def copy(self):
+    def copy(self) -> filter_test__system_state:
         """Create a deep copy of this adata object"""
         return filter_test__system_state.from_gdata(self.to_gdata())
 
@@ -191,7 +191,7 @@ class filter_test__interfaces__interface__statistics(yang.adata.MNode):
     in_octets: ?u64
     out_octets: ?u64
 
-    mut def __init__(self, in_octets: ?u64, out_octets: ?u64):
+    mut def __init__(self, in_octets: ?u64, out_octets: ?u64) -> None:
         self._ns = 'http://example.com/filter-test'
         self.in_octets = in_octets
         self.out_octets = out_octets
@@ -211,7 +211,7 @@ class filter_test__interfaces__interface__statistics(yang.adata.MNode):
             return filter_test__interfaces__interface__statistics(in_octets=n.get_opt_u64(yang.gdata.Id(NS_filter_test, 'in-octets')), out_octets=n.get_opt_u64(yang.gdata.Id(NS_filter_test, 'out-octets')))
         return filter_test__interfaces__interface__statistics()
 
-    def copy(self):
+    def copy(self) -> filter_test__interfaces__interface__statistics:
         """Create a deep copy of this adata object"""
         return filter_test__interfaces__interface__statistics.from_gdata(self.to_gdata())
 
@@ -220,7 +220,7 @@ _breaker4 = None
 class filter_test__interfaces__interface__ipv4(yang.adata.MNode):
     mtu: ?u64
 
-    mut def __init__(self, mtu: ?u64):
+    mut def __init__(self, mtu: ?u64) -> None:
         self._ns = 'http://example.com/filter-test'
         self.mtu = mtu
 
@@ -237,7 +237,7 @@ class filter_test__interfaces__interface__ipv4(yang.adata.MNode):
             return filter_test__interfaces__interface__ipv4(mtu=n.get_opt_u64(yang.gdata.Id(NS_filter_test, 'mtu')))
         return filter_test__interfaces__interface__ipv4()
 
-    def copy(self):
+    def copy(self) -> filter_test__interfaces__interface__ipv4:
         """Create a deep copy of this adata object"""
         return filter_test__interfaces__interface__ipv4.from_gdata(self.to_gdata())
 
@@ -246,7 +246,7 @@ _breaker5 = None
 class filter_test__interfaces__interface__ipv6(yang.adata.MNode):
     mtu: ?u64
 
-    mut def __init__(self, mtu: ?u64):
+    mut def __init__(self, mtu: ?u64) -> None:
         self._ns = 'http://example.com/filter-test'
         self.mtu = mtu
 
@@ -263,7 +263,7 @@ class filter_test__interfaces__interface__ipv6(yang.adata.MNode):
             return filter_test__interfaces__interface__ipv6(mtu=n.get_opt_u64(yang.gdata.Id(NS_filter_test, 'mtu')))
         return filter_test__interfaces__interface__ipv6()
 
-    def copy(self):
+    def copy(self) -> filter_test__interfaces__interface__ipv6:
         """Create a deep copy of this adata object"""
         return filter_test__interfaces__interface__ipv6.from_gdata(self.to_gdata())
 
@@ -281,7 +281,7 @@ class filter_test__interfaces__interface_entry(yang.adata.MNode):
     ipv4: filter_test__interfaces__interface__ipv4
     ipv6: filter_test__interfaces__interface__ipv6
 
-    mut def __init__(self, name: str, description: ?str, type: ?str, enabled: ?bool, admin_status: ?str, oper_status: ?str, last_change: ?str, statistics: ?filter_test__interfaces__interface__statistics=None, ipv4: ?filter_test__interfaces__interface__ipv4=None, ipv6: ?filter_test__interfaces__interface__ipv6=None):
+    mut def __init__(self, name: str, description: ?str, type: ?str, enabled: ?bool, admin_status: ?str, oper_status: ?str, last_change: ?str, statistics: ?filter_test__interfaces__interface__statistics=None, ipv4: ?filter_test__interfaces__interface__ipv4=None, ipv6: ?filter_test__interfaces__interface__ipv6=None) -> None:
         self._ns = 'http://example.com/filter-test'
         self.name = name
         self.description = description
@@ -323,19 +323,19 @@ class filter_test__interfaces__interface_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> filter_test__interfaces__interface_entry:
         return filter_test__interfaces__interface_entry(name=n.get_str(yang.gdata.Id(NS_filter_test, 'name')), description=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'description')), type=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'type')), enabled=n.get_opt_bool(yang.gdata.Id(NS_filter_test, 'enabled')), admin_status=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'admin-status')), oper_status=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'oper-status')), last_change=n.get_opt_str(yang.gdata.Id(NS_filter_test, 'last-change')), statistics=filter_test__interfaces__interface__statistics.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_filter_test, 'statistics'))), ipv4=filter_test__interfaces__interface__ipv4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_filter_test, 'ipv4'))), ipv6=filter_test__interfaces__interface__ipv6.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_filter_test, 'ipv6'))))
 
-    def copy(self):
+    def copy(self) -> filter_test__interfaces__interface_entry:
         """Create a deep copy of this adata object"""
         return filter_test__interfaces__interface_entry.from_gdata(self.to_gdata())
 
 _breaker7 = None
 class filter_test__interfaces__interface(yang.adata.MNode):
     elements: list[filter_test__interfaces__interface_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[filter_test__interfaces__interface_entry]=[]) -> None:
         self._ns = 'http://example.com/filter-test'
         self._name = 'interface'
         self.elements = elements
 
-    mut def create(self, name, description=None, type=None, enabled=None, admin_status=None, oper_status=None, last_change=None):
+    mut def create(self, name: str, description: ?str=None, type: ?str=None, enabled: ?bool=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None) -> filter_test__interfaces__interface_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -366,7 +366,7 @@ class filter_test__interfaces__interface(yang.adata.MNode):
             return [filter_test__interfaces__interface_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> filter_test__interfaces__interface:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -384,7 +384,7 @@ _breaker8 = None
 class filter_test__interfaces(yang.adata.MNode):
     interface: filter_test__interfaces__interface
 
-    mut def __init__(self, interface: list[filter_test__interfaces__interface_entry]=[]):
+    mut def __init__(self, interface: list[filter_test__interfaces__interface_entry]=[]) -> None:
         self._ns = 'http://example.com/filter-test'
         self.interface = filter_test__interfaces__interface(elements=interface)
 
@@ -401,7 +401,7 @@ class filter_test__interfaces(yang.adata.MNode):
             return filter_test__interfaces(interface=filter_test__interfaces__interface.from_gdata(n.get_opt_list(yang.gdata.Id(NS_filter_test, 'interface'))))
         return filter_test__interfaces()
 
-    def copy(self):
+    def copy(self) -> filter_test__interfaces:
         """Create a deep copy of this adata object"""
         return filter_test__interfaces.from_gdata(self.to_gdata())
 
@@ -411,7 +411,7 @@ class root(yang.adata.MNode):
     system_state: filter_test__system_state
     interfaces: filter_test__interfaces
 
-    mut def __init__(self, system_state: ?filter_test__system_state=None, interfaces: ?filter_test__interfaces=None):
+    mut def __init__(self, system_state: ?filter_test__system_state=None, interfaces: ?filter_test__interfaces=None) -> None:
         self._ns = ''
         self.system_state = system_state if system_state is not None else filter_test__system_state()
         self.interfaces = interfaces if interfaces is not None else filter_test__interfaces()
@@ -431,7 +431,7 @@ class root(yang.adata.MNode):
             return root(system_state=filter_test__system_state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_filter_test, 'system-state'))), interfaces=filter_test__interfaces.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_filter_test, 'interfaces'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
@@ -445,7 +445,7 @@ class filter_test__system_state__clock_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
     boot_datetime: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.current_datetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'current-datetime'), parent=path))
         self.boot_datetime = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'boot-datetime'), parent=path))
@@ -457,7 +457,7 @@ class filter_test__system_state__clock_subs(SubscriptionNode):
 class filter_test__system_state_subs(SubscriptionNode):
     clock: filter_test__system_state__clock_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.clock = filter_test__system_state__clock_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'clock'), parent=path))
 
@@ -469,7 +469,7 @@ class filter_test__interfaces__interface__statistics_subs(SubscriptionNode):
     in_octets: SubscriptionNode
     out_octets: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.in_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'in-octets'), parent=path))
         self.out_octets = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'out-octets'), parent=path))
@@ -481,7 +481,7 @@ class filter_test__interfaces__interface__statistics_subs(SubscriptionNode):
 class filter_test__interfaces__interface__ipv4_subs(SubscriptionNode):
     mtu: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'mtu'), parent=path))
 
@@ -492,7 +492,7 @@ class filter_test__interfaces__interface__ipv4_subs(SubscriptionNode):
 class filter_test__interfaces__interface__ipv6_subs(SubscriptionNode):
     mtu: SubscriptionNode
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.mtu = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'mtu'), parent=path))
 
@@ -511,7 +511,7 @@ class filter_test__interfaces__interface_subs(SubscriptionNode):
     statistics: filter_test__interfaces__interface__statistics_subs
     ipv4: filter_test__interfaces__interface__ipv4_subs
     ipv6: filter_test__interfaces__interface__ipv6_subs
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'name'), parent=path))
         self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'description'), parent=path))
@@ -547,7 +547,7 @@ class filter_test__interfaces__interface_entry_subs(SubscriptionNode):
     ipv4: filter_test__interfaces__interface__ipv4_subs
     ipv6: filter_test__interfaces__interface__ipv6_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'name'), parent=path))
         self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'description'), parent=path))
@@ -567,7 +567,7 @@ class filter_test__interfaces__interface_entry_subs(SubscriptionNode):
 class filter_test__interfaces_subs(SubscriptionNode):
     interface: filter_test__interfaces__interface_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.interface = filter_test__interfaces__interface_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'interface'), parent=path))
 
@@ -579,7 +579,7 @@ class root_subs(SubscriptionNode):
     system_state: filter_test__system_state_subs
     interfaces: filter_test__interfaces_subs
 
-    def __init__(self, path: ?SubscriptionPath=None):
+    def __init__(self, path: ?SubscriptionPath=None) -> None:
         SubscriptionNode.__init__(self, path)
         self.system_state = filter_test__system_state_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'system-state'), parent=path))
         self.interfaces = filter_test__interfaces_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'interfaces'), parent=path))

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -515,7 +515,7 @@ _breaker1 = None
 class foo__c1__li__c4(yang.adata.MNode):
     l5: ?str
 
-    mut def __init__(self, l5: ?str):
+    mut def __init__(self, l5: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l5 = l5
 
@@ -532,7 +532,7 @@ class foo__c1__li__c4(yang.adata.MNode):
             return foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
         return foo__c1__li__c4()
 
-    def copy(self):
+    def copy(self) -> foo__c1__li__c4:
         """Create a deep copy of this adata object"""
         return foo__c1__li__c4.from_gdata(self.to_gdata())
 
@@ -543,7 +543,7 @@ class foo__c1__li_entry(yang.adata.MNode):
     val: ?str
     c4: foo__c1__li__c4
 
-    mut def __init__(self, name: str, val: ?str, c4: ?foo__c1__li__c4=None):
+    mut def __init__(self, name: str, val: ?str, c4: ?foo__c1__li__c4=None) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.val = val
@@ -564,19 +564,19 @@ class foo__c1__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
         return foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4'))))
 
-    def copy(self):
+    def copy(self) -> foo__c1__li_entry:
         """Create a deep copy of this adata object"""
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name, val=None):
+    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -597,7 +597,7 @@ class foo__c1__li(yang.adata.MNode):
             return [foo__c1__li_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c1__li:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -629,7 +629,7 @@ class foo__c1(yang.adata.MNode):
     l2: ?str
     l_leafref: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -688,7 +688,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -697,7 +697,7 @@ _breaker5 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
-    mut def __init__(self, l1: ?list[bytes]=None):
+    mut def __init__(self, l1: ?list[bytes]=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1 if l1 is not None else []
 
@@ -714,7 +714,7 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
         return foo__pc1__foo()
 
-    def copy(self):
+    def copy(self) -> foo__pc1__foo:
         """Create a deep copy of this adata object"""
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
@@ -723,7 +723,7 @@ _breaker6 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
-    mut def __init__(self, foo: ?foo__pc1__foo=None):
+    mut def __init__(self, foo: ?foo__pc1__foo=None) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo if foo is not None else foo__pc1__foo()
 
@@ -740,7 +740,7 @@ class foo__pc1(yang.adata.MNode):
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc1:
         """Create a deep copy of this adata object"""
         ad = foo__pc1.from_gdata(self.to_gdata())
         if ad is not None:
@@ -752,7 +752,7 @@ _breaker7 = None
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: str
 
-    mut def __init__(self, l_mandatory: str):
+    mut def __init__(self, l_mandatory: str) -> None:
         self._ns = 'http://example.com/foo'
         self.l_mandatory = l_mandatory
 
@@ -769,7 +769,7 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=n.get_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
         raise ValueError('Missing required subtree foo__pc2__foo')
 
-    def copy(self):
+    def copy(self) -> foo__pc2__foo:
         """Create a deep copy of this adata object"""
         return foo__pc2__foo.from_gdata(self.to_gdata())
 
@@ -778,7 +778,7 @@ _breaker8 = None
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
-    mut def __init__(self, foo: foo__pc2__foo):
+    mut def __init__(self, foo: foo__pc2__foo) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo
 
@@ -795,7 +795,7 @@ class foo__pc2(yang.adata.MNode):
             return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'foo'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc2:
         """Create a deep copy of this adata object"""
         ad = foo__pc2.from_gdata(self.to_gdata())
         if ad is not None:
@@ -808,7 +808,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: str
     l3_optional: ?str
 
-    mut def __init__(self, l3: str, l3_optional: ?str):
+    mut def __init__(self, l3: str, l3_optional: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l3 = l3
         self.l3_optional = l3_optional
@@ -828,7 +828,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
             return foo__pc3__level1__level2__level3(l3=n.get_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
         raise ValueError('Missing required subtree foo__pc3__level1__level2__level3')
 
-    def copy(self):
+    def copy(self) -> foo__pc3__level1__level2__level3:
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
 
@@ -839,7 +839,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     l2_optional: ?str
     level3: foo__pc3__level1__level2__level3
 
-    mut def __init__(self, l2: str, level3: foo__pc3__level1__level2__level3, l2_optional: ?str):
+    mut def __init__(self, l2: str, level3: foo__pc3__level1__level2__level3, l2_optional: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l2 = l2
         self.l2_optional = l2_optional
@@ -862,7 +862,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
             return foo__pc3__level1__level2(l2=n.get_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level3'))))
         raise ValueError('Missing required subtree foo__pc3__level1__level2')
 
-    def copy(self):
+    def copy(self) -> foo__pc3__level1__level2:
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
@@ -873,7 +873,7 @@ class foo__pc3__level1(yang.adata.MNode):
     l1_optional: ?str
     level2: foo__pc3__level1__level2
 
-    mut def __init__(self, l1: str, level2: foo__pc3__level1__level2, l1_optional: ?str):
+    mut def __init__(self, l1: str, level2: foo__pc3__level1__level2, l1_optional: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l1_optional = l1_optional
@@ -896,7 +896,7 @@ class foo__pc3__level1(yang.adata.MNode):
             return foo__pc3__level1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level2'))))
         raise ValueError('Missing required subtree foo__pc3__level1')
 
-    def copy(self):
+    def copy(self) -> foo__pc3__level1:
         """Create a deep copy of this adata object"""
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
@@ -905,7 +905,7 @@ _breaker12 = None
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
 
-    mut def __init__(self, level1: foo__pc3__level1):
+    mut def __init__(self, level1: foo__pc3__level1) -> None:
         self._ns = 'http://example.com/foo'
         self.level1 = level1
 
@@ -922,7 +922,7 @@ class foo__pc3(yang.adata.MNode):
             return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'level1'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc3:
         """Create a deep copy of this adata object"""
         ad = foo__pc3.from_gdata(self.to_gdata())
         if ad is not None:
@@ -933,7 +933,7 @@ class foo__pc3(yang.adata.MNode):
 _breaker13 = None
 class foo__empty_presence(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/foo'
         pass
 
@@ -946,7 +946,7 @@ class foo__empty_presence(yang.adata.MNode):
             return foo__empty_presence()
         return None
 
-    def copy(self):
+    def copy(self) -> foo__empty_presence:
         """Create a deep copy of this adata object"""
         ad = foo__empty_presence.from_gdata(self.to_gdata())
         if ad is not None:
@@ -959,7 +959,7 @@ class foo__c_dot(yang.adata.MNode):
     l_dot1: ?str
     l_dot2: ?str
 
-    mut def __init__(self, l_dot1: ?str, l_dot2: ?str):
+    mut def __init__(self, l_dot1: ?str, l_dot2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l_dot1 = l_dot1
         self.l_dot2 = l_dot2
@@ -979,7 +979,7 @@ class foo__c_dot(yang.adata.MNode):
             return foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
         return foo__c_dot()
 
-    def copy(self):
+    def copy(self) -> foo__c_dot:
         """Create a deep copy of this adata object"""
         return foo__c_dot.from_gdata(self.to_gdata())
 
@@ -988,7 +988,7 @@ _breaker15 = None
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
 
-    mut def __init__(self, name: str):
+    mut def __init__(self, name: str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
 
@@ -1003,19 +1003,19 @@ class foo__cc__death_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
         return foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
 
-    def copy(self):
+    def copy(self) -> foo__cc__death_entry:
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'death'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> foo__cc__death_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1034,7 +1034,7 @@ class foo__cc__death(yang.adata.MNode):
             return [foo__cc__death_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__cc__death:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1053,7 +1053,7 @@ class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
 
-    mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]):
+    mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.cake = cake
         self.death = foo__cc__death(elements=death)
@@ -1073,7 +1073,7 @@ class foo__cc(yang.adata.MNode):
             return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death'))))
         return foo__cc()
 
-    def copy(self):
+    def copy(self) -> foo__cc:
         """Create a deep copy of this adata object"""
         return foo__cc.from_gdata(self.to_gdata())
 
@@ -1081,7 +1081,7 @@ class foo__cc(yang.adata.MNode):
 _breaker18 = None
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/foo'
         pass
 
@@ -1094,7 +1094,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
             return foo__f_conflict__f_inner()
         return None
 
-    def copy(self):
+    def copy(self) -> foo__f_conflict__f_inner:
         """Create a deep copy of this adata object"""
         ad = foo__f_conflict__f_inner.from_gdata(self.to_gdata())
         if ad is not None:
@@ -1105,7 +1105,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
 _breaker19 = None
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/bar'
         pass
 
@@ -1118,7 +1118,7 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
             return foo__f_conflict__bar_inner()
         return None
 
-    def copy(self):
+    def copy(self) -> foo__f_conflict__bar_inner:
         """Create a deep copy of this adata object"""
         ad = foo__f_conflict__bar_inner.from_gdata(self.to_gdata())
         if ad is not None:
@@ -1133,14 +1133,14 @@ class foo__f_conflict(yang.adata.MNode):
     bar_foo: ?str
     bar_inner: ?foo__f_conflict__bar_inner
 
-    mut def __init__(self, f_foo: ?str, f_inner: ?foo__f_conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__f_conflict__bar_inner=None):
+    mut def __init__(self, f_foo: ?str, f_inner: ?foo__f_conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__f_conflict__bar_inner=None) -> None:
         self._ns = 'http://example.com/foo'
         self.f_foo = f_foo
         self.f_inner = f_inner
         self.bar_foo = bar_foo
         self.bar_inner = bar_inner
 
-    mut def create_f_inner(self):
+    mut def create_f_inner(self) -> foo__f_conflict__f_inner:
         existing = self.f_inner
         if existing is not None:
             return existing
@@ -1148,7 +1148,7 @@ class foo__f_conflict(yang.adata.MNode):
         self.f_inner = res
         return res
 
-    mut def create_bar_inner(self):
+    mut def create_bar_inner(self) -> foo__f_conflict__bar_inner:
         existing = self.bar_inner
         if existing is not None:
             return existing
@@ -1175,7 +1175,7 @@ class foo__f_conflict(yang.adata.MNode):
             return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
         return foo__f_conflict()
 
-    def copy(self):
+    def copy(self) -> foo__f_conflict:
         """Create a deep copy of this adata object"""
         return foo__f_conflict.from_gdata(self.to_gdata())
 
@@ -1184,7 +1184,7 @@ _breaker21 = None
 class foo__special_entry(yang.adata.MNode):
     yes: bool
 
-    mut def __init__(self, yes: bool):
+    mut def __init__(self, yes: bool) -> None:
         self._ns = 'http://example.com/foo'
         self.yes = yes
 
@@ -1199,19 +1199,19 @@ class foo__special_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
         return foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
 
-    def copy(self):
+    def copy(self) -> foo__special_entry:
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
 
 _breaker22 = None
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'special'
         self.elements = elements
 
-    mut def create(self, yes):
+    mut def create(self, yes: bool) -> foo__special_entry:
         for e in self:
             match = True
             if e.yes != yes:
@@ -1230,7 +1230,7 @@ class foo__special(yang.adata.MNode):
             return [foo__special_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__special:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1250,7 +1250,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key2: str
     baz: ?str
 
-    mut def __init__(self, key1: str, key2: str, baz: ?str):
+    mut def __init__(self, key1: str, key2: str, baz: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.key1 = key1
         self.key2 = key2
@@ -1271,19 +1271,19 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
         return foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1__li2_entry:
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
 _breaker24 = None
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li2'
         self.elements = elements
 
-    mut def create(self, key1, key2, baz=None):
+    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
         for e in self:
             match = True
             if e.key1 != key1:
@@ -1307,7 +1307,7 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
             return [foo__nested__f_inner__li1__li2_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1__li2:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1328,7 +1328,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     li2: foo__nested__f_inner__li1__li2
     bar_bar: ?str
 
-    mut def __init__(self, name: str, f_bar: ?str, li2: list[foo__nested__f_inner__li1__li2_entry]=[], bar_bar: ?str):
+    mut def __init__(self, name: str, f_bar: ?str, li2: list[foo__nested__f_inner__li1__li2_entry]=[], bar_bar: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.f_bar = f_bar
@@ -1352,19 +1352,19 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
         return foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2'))), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1_entry:
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
 _breaker26 = None
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, name, f_bar=None, bar_bar=None):
+    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1387,7 +1387,7 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
             return [foo__nested__f_inner__li1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1406,7 +1406,7 @@ class foo__nested__f_inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__f_inner__li1
 
-    mut def __init__(self, foo: ?str, li1: list[foo__nested__f_inner__li1_entry]=[]):
+    mut def __init__(self, foo: ?str, li1: list[foo__nested__f_inner__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo
         self.li1 = foo__nested__f_inner__li1(elements=li1)
@@ -1426,7 +1426,7 @@ class foo__nested__f_inner(yang.adata.MNode):
             return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1'))))
         return foo__nested__f_inner()
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner:
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
@@ -1435,7 +1435,7 @@ _breaker28 = None
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self, foo: ?str) -> None:
         self._ns = 'http://example.com/bar'
         self.foo = foo
 
@@ -1452,7 +1452,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return foo__nested__bar_inner()
 
-    def copy(self):
+    def copy(self) -> foo__nested__bar_inner:
         """Create a deep copy of this adata object"""
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
 
@@ -1462,7 +1462,7 @@ class foo__nested(yang.adata.MNode):
     f_inner: foo__nested__f_inner
     bar_inner: foo__nested__bar_inner
 
-    mut def __init__(self, f_inner: ?foo__nested__f_inner=None, bar_inner: ?foo__nested__bar_inner=None):
+    mut def __init__(self, f_inner: ?foo__nested__f_inner=None, bar_inner: ?foo__nested__bar_inner=None) -> None:
         self._ns = 'http://example.com/foo'
         self.f_inner = f_inner if f_inner is not None else foo__nested__f_inner()
         self.bar_inner = bar_inner if bar_inner is not None else foo__nested__bar_inner()
@@ -1482,7 +1482,7 @@ class foo__nested(yang.adata.MNode):
             return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
         return foo__nested()
 
-    def copy(self):
+    def copy(self) -> foo__nested:
         """Create a deep copy of this adata object"""
         return foo__nested.from_gdata(self.to_gdata())
 
@@ -1494,7 +1494,7 @@ class foo__li_union_entry(yang.adata.MNode):
     k3: bytes
     checker: ?value
 
-    mut def __init__(self, k1: str, k2: value, k3: bytes, checker: ?value):
+    mut def __init__(self, k1: str, k2: value, k3: bytes, checker: ?value) -> None:
         self._ns = 'http://example.com/foo'
         self.k1 = k1
         self.k2 = k2
@@ -1518,19 +1518,19 @@ class foo__li_union_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
         return foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
 
-    def copy(self):
+    def copy(self) -> foo__li_union_entry:
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
 _breaker31 = None
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li_union_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li-union'
         self.elements = elements
 
-    mut def create(self, k1, k2, k3, checker=None):
+    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
         for e in self:
             match = True
             if e.k1 != k1:
@@ -1569,7 +1569,7 @@ class foo__li_union(yang.adata.MNode):
             return [foo__li_union_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li_union:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1587,7 +1587,7 @@ _breaker32 = None
 class foo__li_union_one_base_entry(yang.adata.MNode):
     k1: value
 
-    mut def __init__(self, k1: value):
+    mut def __init__(self, k1: value) -> None:
         self._ns = 'http://example.com/foo'
         self.k1 = k1
 
@@ -1602,19 +1602,19 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_one_base_entry:
         return foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
 
-    def copy(self):
+    def copy(self) -> foo__li_union_one_base_entry:
         """Create a deep copy of this adata object"""
         return foo__li_union_one_base_entry.from_gdata(self.to_gdata())
 
 _breaker33 = None
 class foo__li_union_one_base(yang.adata.MNode):
     elements: list[foo__li_union_one_base_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li_union_one_base_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li-union-one-base'
         self.elements = elements
 
-    mut def create(self, k1):
+    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
         for e in self:
             match = True
             e_k1 = e.k1
@@ -1635,7 +1635,7 @@ class foo__li_union_one_base(yang.adata.MNode):
             return [foo__li_union_one_base_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li_union_one_base:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1654,7 +1654,7 @@ class foo__state__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
 
-    mut def __init__(self, l1: ?str, l2: ?str):
+    mut def __init__(self, l1: ?str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -1674,7 +1674,7 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__state__c1()
 
-    def copy(self):
+    def copy(self) -> foo__state__c1:
         """Create a deep copy of this adata object"""
         return foo__state__c1.from_gdata(self.to_gdata())
 
@@ -1683,7 +1683,7 @@ _breaker35 = None
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
-    mut def __init__(self, c1: ?foo__state__c1=None):
+    mut def __init__(self, c1: ?foo__state__c1=None) -> None:
         self._ns = 'http://example.com/foo'
         self.c1 = c1 if c1 is not None else foo__state__c1()
 
@@ -1700,7 +1700,7 @@ class foo__state(yang.adata.MNode):
             return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return foo__state()
 
-    def copy(self):
+    def copy(self) -> foo__state:
         """Create a deep copy of this adata object"""
         return foo__state.from_gdata(self.to_gdata())
 
@@ -1709,7 +1709,7 @@ _breaker36 = None
 class foo__c2(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -1726,7 +1726,7 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c2()
 
-    def copy(self):
+    def copy(self) -> foo__c2:
         """Create a deep copy of this adata object"""
         return foo__c2.from_gdata(self.to_gdata())
 
@@ -1735,7 +1735,7 @@ _breaker37 = None
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
 
-    mut def __init__(self, idref: ?list[Identityref]=None):
+    mut def __init__(self, idref: ?list[Identityref]=None) -> None:
         self._ns = 'http://example.com/bar'
         self.idref = idref if idref is not None else []
 
@@ -1752,7 +1752,7 @@ class bar__test_idref(yang.adata.MNode):
             return bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
         return bar__test_idref()
 
-    def copy(self):
+    def copy(self) -> bar__test_idref:
         """Create a deep copy of this adata object"""
         return bar__test_idref.from_gdata(self.to_gdata())
 
@@ -1761,7 +1761,7 @@ _breaker38 = None
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self, foo: ?str) -> None:
         self._ns = 'http://example.com/bar'
         self.foo = foo
 
@@ -1778,7 +1778,7 @@ class bar__bar_conflict(yang.adata.MNode):
             return bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return bar__bar_conflict()
 
-    def copy(self):
+    def copy(self) -> bar__bar_conflict:
         """Create a deep copy of this adata object"""
         return bar__bar_conflict.from_gdata(self.to_gdata())
 
@@ -1803,7 +1803,7 @@ class root(yang.adata.MNode):
     test_idref: bar__test_idref
     bar_conflict: bar__bar_conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__f_conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], li_union_one_base: list[foo__li_union_one_base_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__bar_conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__f_conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], li_union_one_base: list[foo__li_union_one_base_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__bar_conflict=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -1823,7 +1823,7 @@ class root(yang.adata.MNode):
         self.test_idref = test_idref if test_idref is not None else bar__test_idref()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__bar_conflict()
 
-    mut def create_pc1(self):
+    mut def create_pc1(self) -> foo__pc1:
         existing = self.pc1
         if existing is not None:
             return existing
@@ -1831,7 +1831,7 @@ class root(yang.adata.MNode):
         self.pc1 = res
         return res
 
-    mut def create_pc2(self, foo):
+    mut def create_pc2(self, foo: foo__pc2__foo) -> foo__pc2:
         existing = self.pc2
         if existing is not None:
             existing.foo = foo
@@ -1840,7 +1840,7 @@ class root(yang.adata.MNode):
         self.pc2 = res
         return res
 
-    mut def create_pc3(self, level1):
+    mut def create_pc3(self, level1: foo__pc3__level1) -> foo__pc3:
         existing = self.pc3
         if existing is not None:
             existing.level1 = level1
@@ -1849,7 +1849,7 @@ class root(yang.adata.MNode):
         self.pc3 = res
         return res
 
-    mut def create_empty_presence(self):
+    mut def create_empty_presence(self) -> foo__empty_presence:
         existing = self.empty_presence
         if existing is not None:
             return existing
@@ -1902,7 +1902,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1'))), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2'))), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3'))), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence'))), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot'))), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc'))), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict'))), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special'))), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested'))), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union'))), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base'))), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state'))), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref'))), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -515,7 +515,7 @@ _breaker1 = None
 class foo__c1__li__c4(yang.adata.MNode):
     l5: ?str
 
-    mut def __init__(self, l5: ?str):
+    mut def __init__(self, l5: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l5 = l5
 
@@ -532,7 +532,7 @@ class foo__c1__li__c4(yang.adata.MNode):
             return foo__c1__li__c4(l5=n.get_opt_str(yang.gdata.Id(NS_foo, 'l5')))
         return foo__c1__li__c4()
 
-    def copy(self):
+    def copy(self) -> foo__c1__li__c4:
         """Create a deep copy of this adata object"""
         return foo__c1__li__c4.from_gdata(self.to_gdata())
 
@@ -543,7 +543,7 @@ class foo__c1__li_entry(yang.adata.MNode):
     val: ?str
     c4: foo__c1__li__c4
 
-    mut def __init__(self, name: str, val: ?str, c4: ?foo__c1__li__c4=None):
+    mut def __init__(self, name: str, val: ?str, c4: ?foo__c1__li__c4=None) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.val = val
@@ -564,19 +564,19 @@ class foo__c1__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__c1__li_entry:
         return foo__c1__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), val=n.get_opt_str(yang.gdata.Id(NS_foo, 'val')), c4=foo__c1__li__c4.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c4'))))
 
-    def copy(self):
+    def copy(self) -> foo__c1__li_entry:
         """Create a deep copy of this adata object"""
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
 _breaker3 = None
 class foo__c1__li(yang.adata.MNode):
     elements: list[foo__c1__li_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name, val=None):
+    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -597,7 +597,7 @@ class foo__c1__li(yang.adata.MNode):
             return [foo__c1__li_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__c1__li:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -629,7 +629,7 @@ class foo__c1(yang.adata.MNode):
     l2: ?str
     l_leafref: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str):
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.f_l1 = f_l1
         self.l3 = l3
@@ -688,7 +688,7 @@ class foo__c1(yang.adata.MNode):
             return foo__c1(f_l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(yang.gdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(yang.gdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(yang.gdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(yang.gdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(yang.gdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(yang.gdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(yang.gdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(yang.gdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(yang.gdata.Id(NS_bar, 'l_leafref')))
         return foo__c1()
 
-    def copy(self):
+    def copy(self) -> foo__c1:
         """Create a deep copy of this adata object"""
         return foo__c1.from_gdata(self.to_gdata())
 
@@ -697,7 +697,7 @@ _breaker5 = None
 class foo__pc1__foo(yang.adata.MNode):
     l1: list[bytes]
 
-    mut def __init__(self, l1: ?list[bytes]=None):
+    mut def __init__(self, l1: ?list[bytes]=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1 if l1 is not None else []
 
@@ -714,7 +714,7 @@ class foo__pc1__foo(yang.adata.MNode):
             return foo__pc1__foo(l1=n.get_opt_bytess(yang.gdata.Id(NS_foo, 'l1')))
         return foo__pc1__foo()
 
-    def copy(self):
+    def copy(self) -> foo__pc1__foo:
         """Create a deep copy of this adata object"""
         return foo__pc1__foo.from_gdata(self.to_gdata())
 
@@ -723,7 +723,7 @@ _breaker6 = None
 class foo__pc1(yang.adata.MNode):
     foo: foo__pc1__foo
 
-    mut def __init__(self, foo: ?foo__pc1__foo=None):
+    mut def __init__(self, foo: ?foo__pc1__foo=None) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo if foo is not None else foo__pc1__foo()
 
@@ -740,7 +740,7 @@ class foo__pc1(yang.adata.MNode):
             return foo__pc1(foo=foo__pc1__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc1:
         """Create a deep copy of this adata object"""
         ad = foo__pc1.from_gdata(self.to_gdata())
         if ad is not None:
@@ -752,7 +752,7 @@ _breaker7 = None
 class foo__pc2__foo(yang.adata.MNode):
     l_mandatory: ?str
 
-    mut def __init__(self, l_mandatory: ?str):
+    mut def __init__(self, l_mandatory: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l_mandatory = l_mandatory
 
@@ -769,7 +769,7 @@ class foo__pc2__foo(yang.adata.MNode):
             return foo__pc2__foo(l_mandatory=n.get_opt_str(yang.gdata.Id(NS_foo, 'l_mandatory')))
         return foo__pc2__foo()
 
-    def copy(self):
+    def copy(self) -> foo__pc2__foo:
         """Create a deep copy of this adata object"""
         return foo__pc2__foo.from_gdata(self.to_gdata())
 
@@ -778,7 +778,7 @@ _breaker8 = None
 class foo__pc2(yang.adata.MNode):
     foo: foo__pc2__foo
 
-    mut def __init__(self, foo: ?foo__pc2__foo=None):
+    mut def __init__(self, foo: ?foo__pc2__foo=None) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo if foo is not None else foo__pc2__foo()
 
@@ -795,7 +795,7 @@ class foo__pc2(yang.adata.MNode):
             return foo__pc2(foo=foo__pc2__foo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'foo'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc2:
         """Create a deep copy of this adata object"""
         ad = foo__pc2.from_gdata(self.to_gdata())
         if ad is not None:
@@ -808,7 +808,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
     l3: ?str
     l3_optional: ?str
 
-    mut def __init__(self, l3: ?str, l3_optional: ?str):
+    mut def __init__(self, l3: ?str, l3_optional: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l3 = l3
         self.l3_optional = l3_optional
@@ -828,7 +828,7 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
             return foo__pc3__level1__level2__level3(l3=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3')), l3_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l3-optional')))
         return foo__pc3__level1__level2__level3()
 
-    def copy(self):
+    def copy(self) -> foo__pc3__level1__level2__level3:
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2__level3.from_gdata(self.to_gdata())
 
@@ -839,7 +839,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
     l2_optional: ?str
     level3: foo__pc3__level1__level2__level3
 
-    mut def __init__(self, l2: ?str, l2_optional: ?str, level3: ?foo__pc3__level1__level2__level3=None):
+    mut def __init__(self, l2: ?str, l2_optional: ?str, level3: ?foo__pc3__level1__level2__level3=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l2 = l2
         self.l2_optional = l2_optional
@@ -862,7 +862,7 @@ class foo__pc3__level1__level2(yang.adata.MNode):
             return foo__pc3__level1__level2(l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')), l2_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2-optional')), level3=foo__pc3__level1__level2__level3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level3'))))
         return foo__pc3__level1__level2()
 
-    def copy(self):
+    def copy(self) -> foo__pc3__level1__level2:
         """Create a deep copy of this adata object"""
         return foo__pc3__level1__level2.from_gdata(self.to_gdata())
 
@@ -873,7 +873,7 @@ class foo__pc3__level1(yang.adata.MNode):
     l1_optional: ?str
     level2: foo__pc3__level1__level2
 
-    mut def __init__(self, l1: ?str, l1_optional: ?str, level2: ?foo__pc3__level1__level2=None):
+    mut def __init__(self, l1: ?str, l1_optional: ?str, level2: ?foo__pc3__level1__level2=None) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l1_optional = l1_optional
@@ -896,7 +896,7 @@ class foo__pc3__level1(yang.adata.MNode):
             return foo__pc3__level1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l1_optional=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1-optional')), level2=foo__pc3__level1__level2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level2'))))
         return foo__pc3__level1()
 
-    def copy(self):
+    def copy(self) -> foo__pc3__level1:
         """Create a deep copy of this adata object"""
         return foo__pc3__level1.from_gdata(self.to_gdata())
 
@@ -905,7 +905,7 @@ _breaker12 = None
 class foo__pc3(yang.adata.MNode):
     level1: foo__pc3__level1
 
-    mut def __init__(self, level1: ?foo__pc3__level1=None):
+    mut def __init__(self, level1: ?foo__pc3__level1=None) -> None:
         self._ns = 'http://example.com/foo'
         self.level1 = level1 if level1 is not None else foo__pc3__level1()
 
@@ -922,7 +922,7 @@ class foo__pc3(yang.adata.MNode):
             return foo__pc3(level1=foo__pc3__level1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'level1'))))
         return None
 
-    def copy(self):
+    def copy(self) -> foo__pc3:
         """Create a deep copy of this adata object"""
         ad = foo__pc3.from_gdata(self.to_gdata())
         if ad is not None:
@@ -933,7 +933,7 @@ class foo__pc3(yang.adata.MNode):
 _breaker13 = None
 class foo__empty_presence(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/foo'
         pass
 
@@ -946,7 +946,7 @@ class foo__empty_presence(yang.adata.MNode):
             return foo__empty_presence()
         return None
 
-    def copy(self):
+    def copy(self) -> foo__empty_presence:
         """Create a deep copy of this adata object"""
         ad = foo__empty_presence.from_gdata(self.to_gdata())
         if ad is not None:
@@ -959,7 +959,7 @@ class foo__c_dot(yang.adata.MNode):
     l_dot1: ?str
     l_dot2: ?str
 
-    mut def __init__(self, l_dot1: ?str, l_dot2: ?str):
+    mut def __init__(self, l_dot1: ?str, l_dot2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l_dot1 = l_dot1
         self.l_dot2 = l_dot2
@@ -979,7 +979,7 @@ class foo__c_dot(yang.adata.MNode):
             return foo__c_dot(l_dot1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l.dot1')), l_dot2=n.get_opt_str(yang.gdata.Id(NS_bar, 'l.dot2')))
         return foo__c_dot()
 
-    def copy(self):
+    def copy(self) -> foo__c_dot:
         """Create a deep copy of this adata object"""
         return foo__c_dot.from_gdata(self.to_gdata())
 
@@ -988,7 +988,7 @@ _breaker15 = None
 class foo__cc__death_entry(yang.adata.MNode):
     name: str
 
-    mut def __init__(self, name: str):
+    mut def __init__(self, name: str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
 
@@ -1003,19 +1003,19 @@ class foo__cc__death_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__cc__death_entry:
         return foo__cc__death_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')))
 
-    def copy(self):
+    def copy(self) -> foo__cc__death_entry:
         """Create a deep copy of this adata object"""
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
 _breaker16 = None
 class foo__cc__death(yang.adata.MNode):
     elements: list[foo__cc__death_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'death'
         self.elements = elements
 
-    mut def create(self, name):
+    mut def create(self, name: str) -> foo__cc__death_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1034,7 +1034,7 @@ class foo__cc__death(yang.adata.MNode):
             return [foo__cc__death_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__cc__death:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1053,7 +1053,7 @@ class foo__cc(yang.adata.MNode):
     cake: ?str
     death: foo__cc__death
 
-    mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]):
+    mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.cake = cake
         self.death = foo__cc__death(elements=death)
@@ -1073,7 +1073,7 @@ class foo__cc(yang.adata.MNode):
             return foo__cc(cake=n.get_opt_str(yang.gdata.Id(NS_foo, 'cake')), death=foo__cc__death.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'death'))))
         return foo__cc()
 
-    def copy(self):
+    def copy(self) -> foo__cc:
         """Create a deep copy of this adata object"""
         return foo__cc.from_gdata(self.to_gdata())
 
@@ -1081,7 +1081,7 @@ class foo__cc(yang.adata.MNode):
 _breaker18 = None
 class foo__f_conflict__f_inner(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/foo'
         pass
 
@@ -1094,7 +1094,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
             return foo__f_conflict__f_inner()
         return None
 
-    def copy(self):
+    def copy(self) -> foo__f_conflict__f_inner:
         """Create a deep copy of this adata object"""
         ad = foo__f_conflict__f_inner.from_gdata(self.to_gdata())
         if ad is not None:
@@ -1105,7 +1105,7 @@ class foo__f_conflict__f_inner(yang.adata.MNode):
 _breaker19 = None
 class foo__f_conflict__bar_inner(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = 'http://example.com/bar'
         pass
 
@@ -1118,7 +1118,7 @@ class foo__f_conflict__bar_inner(yang.adata.MNode):
             return foo__f_conflict__bar_inner()
         return None
 
-    def copy(self):
+    def copy(self) -> foo__f_conflict__bar_inner:
         """Create a deep copy of this adata object"""
         ad = foo__f_conflict__bar_inner.from_gdata(self.to_gdata())
         if ad is not None:
@@ -1133,14 +1133,14 @@ class foo__f_conflict(yang.adata.MNode):
     bar_foo: ?str
     bar_inner: ?foo__f_conflict__bar_inner
 
-    mut def __init__(self, f_foo: ?str, f_inner: ?foo__f_conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__f_conflict__bar_inner=None):
+    mut def __init__(self, f_foo: ?str, f_inner: ?foo__f_conflict__f_inner=None, bar_foo: ?str, bar_inner: ?foo__f_conflict__bar_inner=None) -> None:
         self._ns = 'http://example.com/foo'
         self.f_foo = f_foo
         self.f_inner = f_inner
         self.bar_foo = bar_foo
         self.bar_inner = bar_inner
 
-    mut def create_f_inner(self):
+    mut def create_f_inner(self) -> foo__f_conflict__f_inner:
         existing = self.f_inner
         if existing is not None:
             return existing
@@ -1148,7 +1148,7 @@ class foo__f_conflict(yang.adata.MNode):
         self.f_inner = res
         return res
 
-    mut def create_bar_inner(self):
+    mut def create_bar_inner(self) -> foo__f_conflict__bar_inner:
         existing = self.bar_inner
         if existing is not None:
             return existing
@@ -1175,7 +1175,7 @@ class foo__f_conflict(yang.adata.MNode):
             return foo__f_conflict(f_foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), f_inner=foo__f_conflict__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')), bar_inner=foo__f_conflict__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
         return foo__f_conflict()
 
-    def copy(self):
+    def copy(self) -> foo__f_conflict:
         """Create a deep copy of this adata object"""
         return foo__f_conflict.from_gdata(self.to_gdata())
 
@@ -1184,7 +1184,7 @@ _breaker21 = None
 class foo__special_entry(yang.adata.MNode):
     yes: bool
 
-    mut def __init__(self, yes: bool):
+    mut def __init__(self, yes: bool) -> None:
         self._ns = 'http://example.com/foo'
         self.yes = yes
 
@@ -1199,19 +1199,19 @@ class foo__special_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__special_entry:
         return foo__special_entry(yes=n.get_bool(yang.gdata.Id(NS_foo, 'yes')))
 
-    def copy(self):
+    def copy(self) -> foo__special_entry:
         """Create a deep copy of this adata object"""
         return foo__special_entry.from_gdata(self.to_gdata())
 
 _breaker22 = None
 class foo__special(yang.adata.MNode):
     elements: list[foo__special_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'special'
         self.elements = elements
 
-    mut def create(self, yes):
+    mut def create(self, yes: bool) -> foo__special_entry:
         for e in self:
             match = True
             if e.yes != yes:
@@ -1230,7 +1230,7 @@ class foo__special(yang.adata.MNode):
             return [foo__special_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__special:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1250,7 +1250,7 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key2: str
     baz: ?str
 
-    mut def __init__(self, key1: str, key2: str, baz: ?str):
+    mut def __init__(self, key1: str, key2: str, baz: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.key1 = key1
         self.key2 = key2
@@ -1271,19 +1271,19 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1__li2_entry:
         return foo__nested__f_inner__li1__li2_entry(key1=n.get_str(yang.gdata.Id(NS_foo, 'key1')), key2=n.get_str(yang.gdata.Id(NS_foo, 'key2')), baz=n.get_opt_str(yang.gdata.Id(NS_foo, 'baz')))
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1__li2_entry:
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
 _breaker24 = None
 class foo__nested__f_inner__li1__li2(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1__li2_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li2'
         self.elements = elements
 
-    mut def create(self, key1, key2, baz=None):
+    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
         for e in self:
             match = True
             if e.key1 != key1:
@@ -1307,7 +1307,7 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
             return [foo__nested__f_inner__li1__li2_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1__li2:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1328,7 +1328,7 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     li2: foo__nested__f_inner__li1__li2
     bar_bar: ?str
 
-    mut def __init__(self, name: str, f_bar: ?str, li2: list[foo__nested__f_inner__li1__li2_entry]=[], bar_bar: ?str):
+    mut def __init__(self, name: str, f_bar: ?str, li2: list[foo__nested__f_inner__li1__li2_entry]=[], bar_bar: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.f_bar = f_bar
@@ -1352,19 +1352,19 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__nested__f_inner__li1_entry:
         return foo__nested__f_inner__li1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), f_bar=n.get_opt_str(yang.gdata.Id(NS_foo, 'bar')), li2=foo__nested__f_inner__li1__li2.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li2'))), bar_bar=n.get_opt_str(yang.gdata.Id(NS_bar, 'bar')))
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1_entry:
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
 _breaker26 = None
 class foo__nested__f_inner__li1(yang.adata.MNode):
     elements: list[foo__nested__f_inner__li1_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, name, f_bar=None, bar_bar=None):
+    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -1387,7 +1387,7 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
             return [foo__nested__f_inner__li1_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner__li1:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1406,7 +1406,7 @@ class foo__nested__f_inner(yang.adata.MNode):
     foo: ?str
     li1: foo__nested__f_inner__li1
 
-    mut def __init__(self, foo: ?str, li1: list[foo__nested__f_inner__li1_entry]=[]):
+    mut def __init__(self, foo: ?str, li1: list[foo__nested__f_inner__li1_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self.foo = foo
         self.li1 = foo__nested__f_inner__li1(elements=li1)
@@ -1426,7 +1426,7 @@ class foo__nested__f_inner(yang.adata.MNode):
             return foo__nested__f_inner(foo=n.get_opt_str(yang.gdata.Id(NS_foo, 'foo')), li1=foo__nested__f_inner__li1.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li1'))))
         return foo__nested__f_inner()
 
-    def copy(self):
+    def copy(self) -> foo__nested__f_inner:
         """Create a deep copy of this adata object"""
         return foo__nested__f_inner.from_gdata(self.to_gdata())
 
@@ -1435,7 +1435,7 @@ _breaker28 = None
 class foo__nested__bar_inner(yang.adata.MNode):
     foo: ?str
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self, foo: ?str) -> None:
         self._ns = 'http://example.com/bar'
         self.foo = foo
 
@@ -1452,7 +1452,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
             return foo__nested__bar_inner(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return foo__nested__bar_inner()
 
-    def copy(self):
+    def copy(self) -> foo__nested__bar_inner:
         """Create a deep copy of this adata object"""
         return foo__nested__bar_inner.from_gdata(self.to_gdata())
 
@@ -1462,7 +1462,7 @@ class foo__nested(yang.adata.MNode):
     f_inner: foo__nested__f_inner
     bar_inner: foo__nested__bar_inner
 
-    mut def __init__(self, f_inner: ?foo__nested__f_inner=None, bar_inner: ?foo__nested__bar_inner=None):
+    mut def __init__(self, f_inner: ?foo__nested__f_inner=None, bar_inner: ?foo__nested__bar_inner=None) -> None:
         self._ns = 'http://example.com/foo'
         self.f_inner = f_inner if f_inner is not None else foo__nested__f_inner()
         self.bar_inner = bar_inner if bar_inner is not None else foo__nested__bar_inner()
@@ -1482,7 +1482,7 @@ class foo__nested(yang.adata.MNode):
             return foo__nested(f_inner=foo__nested__f_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'inner'))), bar_inner=foo__nested__bar_inner.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'inner'))))
         return foo__nested()
 
-    def copy(self):
+    def copy(self) -> foo__nested:
         """Create a deep copy of this adata object"""
         return foo__nested.from_gdata(self.to_gdata())
 
@@ -1494,7 +1494,7 @@ class foo__li_union_entry(yang.adata.MNode):
     k3: bytes
     checker: ?value
 
-    mut def __init__(self, k1: str, k2: value, k3: bytes, checker: ?value):
+    mut def __init__(self, k1: str, k2: value, k3: bytes, checker: ?value) -> None:
         self._ns = 'http://example.com/foo'
         self.k1 = k1
         self.k2 = k2
@@ -1518,19 +1518,19 @@ class foo__li_union_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_entry:
         return foo__li_union_entry(k1=n.get_str(yang.gdata.Id(NS_foo, 'k1')), k2=n.get_value(yang.gdata.Id(NS_foo, 'k2')), k3=n.get_bytes(yang.gdata.Id(NS_foo, 'k3')), checker=n.get_opt_value(yang.gdata.Id(NS_foo, 'checker')))
 
-    def copy(self):
+    def copy(self) -> foo__li_union_entry:
         """Create a deep copy of this adata object"""
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
 _breaker31 = None
 class foo__li_union(yang.adata.MNode):
     elements: list[foo__li_union_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li_union_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li-union'
         self.elements = elements
 
-    mut def create(self, k1, k2, k3, checker=None):
+    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
         for e in self:
             match = True
             if e.k1 != k1:
@@ -1569,7 +1569,7 @@ class foo__li_union(yang.adata.MNode):
             return [foo__li_union_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li_union:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1587,7 +1587,7 @@ _breaker32 = None
 class foo__li_union_one_base_entry(yang.adata.MNode):
     k1: value
 
-    mut def __init__(self, k1: value):
+    mut def __init__(self, k1: value) -> None:
         self._ns = 'http://example.com/foo'
         self.k1 = k1
 
@@ -1602,19 +1602,19 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_union_one_base_entry:
         return foo__li_union_one_base_entry(k1=n.get_value(yang.gdata.Id(NS_foo, 'k1')))
 
-    def copy(self):
+    def copy(self) -> foo__li_union_one_base_entry:
         """Create a deep copy of this adata object"""
         return foo__li_union_one_base_entry.from_gdata(self.to_gdata())
 
 _breaker33 = None
 class foo__li_union_one_base(yang.adata.MNode):
     elements: list[foo__li_union_one_base_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li_union_one_base_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li-union-one-base'
         self.elements = elements
 
-    mut def create(self, k1):
+    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
         for e in self:
             match = True
             e_k1 = e.k1
@@ -1635,7 +1635,7 @@ class foo__li_union_one_base(yang.adata.MNode):
             return [foo__li_union_one_base_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li_union_one_base:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -1654,7 +1654,7 @@ class foo__state__c1(yang.adata.MNode):
     l1: ?str
     l2: ?str
 
-    mut def __init__(self, l1: ?str, l2: ?str):
+    mut def __init__(self, l1: ?str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -1674,7 +1674,7 @@ class foo__state__c1(yang.adata.MNode):
             return foo__state__c1(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         return foo__state__c1()
 
-    def copy(self):
+    def copy(self) -> foo__state__c1:
         """Create a deep copy of this adata object"""
         return foo__state__c1.from_gdata(self.to_gdata())
 
@@ -1683,7 +1683,7 @@ _breaker35 = None
 class foo__state(yang.adata.MNode):
     c1: foo__state__c1
 
-    mut def __init__(self, c1: ?foo__state__c1=None):
+    mut def __init__(self, c1: ?foo__state__c1=None) -> None:
         self._ns = 'http://example.com/foo'
         self.c1 = c1 if c1 is not None else foo__state__c1()
 
@@ -1700,7 +1700,7 @@ class foo__state(yang.adata.MNode):
             return foo__state(c1=foo__state__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))))
         return foo__state()
 
-    def copy(self):
+    def copy(self) -> foo__state:
         """Create a deep copy of this adata object"""
         return foo__state.from_gdata(self.to_gdata())
 
@@ -1709,7 +1709,7 @@ _breaker36 = None
 class foo__c2(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
 
@@ -1726,7 +1726,7 @@ class foo__c2(yang.adata.MNode):
             return foo__c2(l1=n.get_opt_str(yang.gdata.Id(NS_foo, 'l1')))
         return foo__c2()
 
-    def copy(self):
+    def copy(self) -> foo__c2:
         """Create a deep copy of this adata object"""
         return foo__c2.from_gdata(self.to_gdata())
 
@@ -1735,7 +1735,7 @@ _breaker37 = None
 class bar__test_idref(yang.adata.MNode):
     idref: list[Identityref]
 
-    mut def __init__(self, idref: ?list[Identityref]=None):
+    mut def __init__(self, idref: ?list[Identityref]=None) -> None:
         self._ns = 'http://example.com/bar'
         self.idref = idref if idref is not None else []
 
@@ -1752,7 +1752,7 @@ class bar__test_idref(yang.adata.MNode):
             return bar__test_idref(idref=n.get_opt_Identityrefs(yang.gdata.Id(NS_bar, 'idref')))
         return bar__test_idref()
 
-    def copy(self):
+    def copy(self) -> bar__test_idref:
         """Create a deep copy of this adata object"""
         return bar__test_idref.from_gdata(self.to_gdata())
 
@@ -1761,7 +1761,7 @@ _breaker38 = None
 class bar__bar_conflict(yang.adata.MNode):
     foo: ?str
 
-    mut def __init__(self, foo: ?str):
+    mut def __init__(self, foo: ?str) -> None:
         self._ns = 'http://example.com/bar'
         self.foo = foo
 
@@ -1778,7 +1778,7 @@ class bar__bar_conflict(yang.adata.MNode):
             return bar__bar_conflict(foo=n.get_opt_str(yang.gdata.Id(NS_bar, 'foo')))
         return bar__bar_conflict()
 
-    def copy(self):
+    def copy(self) -> bar__bar_conflict:
         """Create a deep copy of this adata object"""
         return bar__bar_conflict.from_gdata(self.to_gdata())
 
@@ -1803,7 +1803,7 @@ class root(yang.adata.MNode):
     test_idref: bar__test_idref
     bar_conflict: bar__bar_conflict
 
-    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__f_conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], li_union_one_base: list[foo__li_union_one_base_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__bar_conflict=None):
+    mut def __init__(self, c1: ?foo__c1=None, pc1: ?foo__pc1=None, pc2: ?foo__pc2=None, pc3: ?foo__pc3=None, empty_presence: ?foo__empty_presence=None, c_dot: ?foo__c_dot=None, cc: ?foo__cc=None, f_conflict: ?foo__f_conflict=None, special: list[foo__special_entry]=[], nested: ?foo__nested=None, li_union: list[foo__li_union_entry]=[], li_union_one_base: list[foo__li_union_one_base_entry]=[], state: ?foo__state=None, ll_empty: ?list[str]=None, c2: ?foo__c2=None, test_idref: ?bar__test_idref=None, bar_conflict: ?bar__bar_conflict=None) -> None:
         self._ns = ''
         self.c1 = c1 if c1 is not None else foo__c1()
         self.pc1 = pc1
@@ -1823,7 +1823,7 @@ class root(yang.adata.MNode):
         self.test_idref = test_idref if test_idref is not None else bar__test_idref()
         self.bar_conflict = bar_conflict if bar_conflict is not None else bar__bar_conflict()
 
-    mut def create_pc1(self):
+    mut def create_pc1(self) -> foo__pc1:
         existing = self.pc1
         if existing is not None:
             return existing
@@ -1831,7 +1831,7 @@ class root(yang.adata.MNode):
         self.pc1 = res
         return res
 
-    mut def create_pc2(self):
+    mut def create_pc2(self) -> foo__pc2:
         existing = self.pc2
         if existing is not None:
             return existing
@@ -1839,7 +1839,7 @@ class root(yang.adata.MNode):
         self.pc2 = res
         return res
 
-    mut def create_pc3(self):
+    mut def create_pc3(self) -> foo__pc3:
         existing = self.pc3
         if existing is not None:
             return existing
@@ -1847,7 +1847,7 @@ class root(yang.adata.MNode):
         self.pc3 = res
         return res
 
-    mut def create_empty_presence(self):
+    mut def create_empty_presence(self) -> foo__empty_presence:
         existing = self.empty_presence
         if existing is not None:
             return existing
@@ -1900,7 +1900,7 @@ class root(yang.adata.MNode):
             return root(c1=foo__c1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c1'))), pc1=foo__pc1.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc1'))), pc2=foo__pc2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc2'))), pc3=foo__pc3.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'pc3'))), empty_presence=foo__empty_presence.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'empty-presence'))), c_dot=foo__c_dot.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c.dot'))), cc=foo__cc.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'cc'))), f_conflict=foo__f_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'conflict'))), special=foo__special.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'special'))), nested=foo__nested.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'nested'))), li_union=foo__li_union.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union'))), li_union_one_base=foo__li_union_one_base.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li-union-one-base'))), state=foo__state.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'state'))), ll_empty=n.get_opt_strs(yang.gdata.Id(NS_foo, 'll-empty')), c2=foo__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_foo, 'c2'))), test_idref=bar__test_idref.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'test-idref'))), bar_conflict=bar__bar_conflict.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_bar, 'conflict'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -54,7 +54,7 @@ _breaker1 = None
 class loose_required__c2(yang.adata.MNode):
     l1: ?str
 
-    mut def __init__(self, l1: ?str):
+    mut def __init__(self, l1: ?str) -> None:
         self._ns = 'http://example.com/loose-required'
         self.l1 = l1
 
@@ -71,7 +71,7 @@ class loose_required__c2(yang.adata.MNode):
             return loose_required__c2(l1=n.get_opt_str(yang.gdata.Id(NS_loose_required, 'l1')))
         return loose_required__c2()
 
-    def copy(self):
+    def copy(self) -> loose_required__c2:
         """Create a deep copy of this adata object"""
         return loose_required__c2.from_gdata(self.to_gdata())
 
@@ -80,7 +80,7 @@ _breaker2 = None
 class root(yang.adata.MNode):
     c2: loose_required__c2
 
-    mut def __init__(self, c2: ?loose_required__c2=None):
+    mut def __init__(self, c2: ?loose_required__c2=None) -> None:
         self._ns = ''
         self.c2 = c2 if c2 is not None else loose_required__c2()
 
@@ -97,7 +97,7 @@ class root(yang.adata.MNode):
             return root(c2=loose_required__c2.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_loose_required, 'c2'))))
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -120,7 +120,7 @@ class foo__tc1(yang.adata.MNode):
     l1: str
     l2: ?str
 
-    mut def __init__(self, l1: str, l2: ?str):
+    mut def __init__(self, l1: str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -140,7 +140,7 @@ class foo__tc1(yang.adata.MNode):
             return foo__tc1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         raise ValueError('Missing required subtree foo__tc1')
 
-    def copy(self):
+    def copy(self) -> foo__tc1:
         """Create a deep copy of this adata object"""
         return foo__tc1.from_gdata(self.to_gdata())
 
@@ -150,7 +150,7 @@ class foo__li__c1(yang.adata.MNode):
     l1: str
     l2: ?str
 
-    mut def __init__(self, l1: str, l2: ?str):
+    mut def __init__(self, l1: str, l2: ?str) -> None:
         self._ns = 'http://example.com/foo'
         self.l1 = l1
         self.l2 = l2
@@ -170,7 +170,7 @@ class foo__li__c1(yang.adata.MNode):
             return foo__li__c1(l1=n.get_str(yang.gdata.Id(NS_foo, 'l1')), l2=n.get_opt_str(yang.gdata.Id(NS_foo, 'l2')))
         raise ValueError('Missing required subtree foo__li__c1')
 
-    def copy(self):
+    def copy(self) -> foo__li__c1:
         """Create a deep copy of this adata object"""
         return foo__li__c1.from_gdata(self.to_gdata())
 
@@ -180,7 +180,7 @@ class foo__li_entry(yang.adata.MNode):
     name: str
     c1: foo__li__c1
 
-    mut def __init__(self, name: str, c1: foo__li__c1):
+    mut def __init__(self, name: str, c1: foo__li__c1) -> None:
         self._ns = 'http://example.com/foo'
         self.name = name
         self.c1 = c1
@@ -198,19 +198,19 @@ class foo__li_entry(yang.adata.MNode):
     mut def from_gdata(n: yang.gdata.Node) -> foo__li_entry:
         return foo__li_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), c1=foo__li__c1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'c1'))))
 
-    def copy(self):
+    def copy(self) -> foo__li_entry:
         """Create a deep copy of this adata object"""
         return foo__li_entry.from_gdata(self.to_gdata())
 
 _breaker4 = None
 class foo__li(yang.adata.MNode):
     elements: list[foo__li_entry]
-    mut def __init__(self, elements=[]):
+    mut def __init__(self, elements: list[foo__li_entry]=[]) -> None:
         self._ns = 'http://example.com/foo'
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name, c1):
+    mut def create(self, name: str, c1: foo__li__c1) -> foo__li_entry:
         for e in self:
             match = True
             if e.name != name:
@@ -230,7 +230,7 @@ class foo__li(yang.adata.MNode):
             return [foo__li_entry.from_gdata(e) for e in n.elements]
         return []
 
-    def copy(self):
+    def copy(self) -> foo__li:
         """Create a deep copy of this list object"""
         # Copy each element in the list
         copied_elements = []
@@ -249,7 +249,7 @@ class root(yang.adata.MNode):
     tc1: foo__tc1
     li: foo__li
 
-    mut def __init__(self, tc1: foo__tc1, li: list[foo__li_entry]=[]):
+    mut def __init__(self, tc1: foo__tc1, li: list[foo__li_entry]=[]) -> None:
         self._ns = ''
         self.tc1 = tc1
         self.li = foo__li(elements=li)
@@ -269,7 +269,7 @@ class root(yang.adata.MNode):
             return root(tc1=foo__tc1.from_gdata(n.get_cnt(yang.gdata.Id(NS_foo, 'tc1'))), li=foo__li.from_gdata(n.get_opt_list(yang.gdata.Id(NS_foo, 'li'))))
         raise ValueError('Missing required subtree root')
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -75,7 +75,7 @@ NS_yangrpc = 'http://example.com/yangrpc'
 _breaker1 = None
 class root(yang.adata.MNode):
 
-    mut def __init__(self):
+    mut def __init__(self) -> None:
         self._ns = ''
         pass
 
@@ -88,7 +88,7 @@ class root(yang.adata.MNode):
             return root()
         return root()
 
-    def copy(self):
+    def copy(self) -> root:
         """Create a deep copy of this adata object"""
         return root.from_gdata(self.to_gdata())
 
@@ -97,7 +97,7 @@ _breaker2 = None
 class yangrpc__foo__input__woo(yang.adata.MNode):
     woo_b: ?int
 
-    mut def __init__(self, woo_b: ?int):
+    mut def __init__(self, woo_b: ?int) -> None:
         self._ns = 'http://example.com/yangrpc'
         self.woo_b = woo_b
 
@@ -114,7 +114,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
             return yangrpc__foo__input__woo(woo_b=n.get_opt_int(yang.gdata.Id(NS_yangrpc, 'woo_b')))
         return yangrpc__foo__input__woo()
 
-    def copy(self):
+    def copy(self) -> yangrpc__foo__input__woo:
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input__woo.from_gdata(self.to_gdata())
 
@@ -124,7 +124,7 @@ class yangrpc__foo__input(yang.adata.MNode):
     a: ?str
     woo: yangrpc__foo__input__woo
 
-    mut def __init__(self, a: ?str, woo: ?yangrpc__foo__input__woo=None):
+    mut def __init__(self, a: ?str, woo: ?yangrpc__foo__input__woo=None) -> None:
         self._ns = 'http://example.com/yangrpc'
         self.a = a
         self.woo = woo if woo is not None else yangrpc__foo__input__woo()
@@ -144,7 +144,7 @@ class yangrpc__foo__input(yang.adata.MNode):
             return yangrpc__foo__input(a=n.get_opt_str(yang.gdata.Id(NS_yangrpc, 'a')), woo=yangrpc__foo__input__woo.from_gdata(n.get_opt_cnt(yang.gdata.Id(NS_yangrpc, 'woo'))))
         return yangrpc__foo__input()
 
-    def copy(self):
+    def copy(self) -> yangrpc__foo__input:
         """Create a deep copy of this adata object"""
         return yangrpc__foo__input.from_gdata(self.to_gdata())
 
@@ -153,7 +153,7 @@ _breaker4 = None
 class yangrpc__foo__output(yang.adata.MNode):
     outoo: ?str
 
-    mut def __init__(self, outoo: ?str):
+    mut def __init__(self, outoo: ?str) -> None:
         self._ns = 'http://example.com/yangrpc'
         self.outoo = outoo
 
@@ -170,7 +170,7 @@ class yangrpc__foo__output(yang.adata.MNode):
             return yangrpc__foo__output(outoo=n.get_opt_str(yang.gdata.Id(NS_yangrpc, 'outoo')))
         return yangrpc__foo__output()
 
-    def copy(self):
+    def copy(self) -> yangrpc__foo__output:
         """Create a deep copy of this adata object"""
         return yangrpc__foo__output.from_gdata(self.to_gdata())
 


### PR DESCRIPTION
Generated adata classes still exposed several helper methods without complete function signatures. Constructors, list create helpers, presence-container create helpers, copy methods, and subscription node constructors could therefore appear less typed than the attributes and from_gdata/to_gdata paths around them.

This change extends prdaclass emission to include argument and return annotations on those helpers while preserving the existing optionality rules from the leaf argument type helpers. Nested required containers under presence-container create helpers now use the full generated child path, so annotations name the classes that are actually emitted.

The generated snapshots and data-class fixtures were refreshed so checked-in examples expose the same typed interface as fresh generator output.