### PR TITLE
Emit source YANG bindings as top level assignments

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1873,11 +1873,19 @@ class DRoot(DNodeInner):
 #"""def src_yang():
 #   return {repr(self.src)}
 #"""
-            res.append("def src_yang():")
-            res.append("    res = []")
+            src_yang_names = []
+            i = 0
             for s in schema_yang:
-                res.append('    res.append(r"""{s}""")')
-            res.append("    return res")
+                src_yang_name = "SRC_YANG_{i}"
+                src_yang_names.append(src_yang_name)
+                res.append('{src_yang_name} = r"""{s}"""')
+                res.append("")
+                i += 1
+            res.append("def src_yang():")
+            res.append("    return [")
+            for src_yang_name in src_yang_names:
+                res.append("        {src_yang_name},")
+            res.append("    ]")
             res.append("")
             res.append("")
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1869,11 +1869,19 @@ class DRoot(DNodeInner):
 #"""def src_yang():
 #   return {repr(self.src)}
 #"""
-            res.append("def src_yang():")
-            res.append("    res = []")
+            src_yang_names = []
+            i = 0
             for s in schema_yang:
-                res.append('    res.append(r"""{s}""")')
-            res.append("    return res")
+                src_yang_name = "SRC_YANG_{i}"
+                src_yang_names.append(src_yang_name)
+                res.append('{src_yang_name} = r"""{s}"""')
+                res.append("")
+                i += 1
+            res.append("def src_yang():")
+            res.append("    return [")
+            for src_yang_name in src_yang_names:
+                res.append("        {src_yang_name},")
+            res.append("    ]")
             res.append("")
             res.append("")
 

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -56,9 +56,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/basics':('basics', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module basics {
+SRC_YANG_0 = r"""module basics {
     yang-version "1.1";
     namespace "http://example.com/basics";
     prefix "b";
@@ -135,8 +133,12 @@ def src_yang():
             default id2;
         }
     }
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+    ]
 
 
 NS_basics = 'http://example.com/basics'

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -56,9 +56,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/filter-test':('filter-test', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module filter-test {
+SRC_YANG_0 = r"""module filter-test {
     yang-version "1.1";
     namespace "http://example.com/filter-test";
     prefix "ft";
@@ -123,8 +121,12 @@ def src_yang():
             }
         }
     }
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+    ]
 
 
 NS_filter_test = 'http://example.com/filter-test'

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -183,9 +183,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/foo':('foo', None), 'http://example.com/bar':('bar', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module foo {
+SRC_YANG_0 = r"""module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
     prefix "f";
@@ -425,8 +423,9 @@ def src_yang():
         type string;
     }
 
-}""")
-    res.append(r"""submodule qux {
+}"""
+
+SRC_YANG_1 = r"""submodule qux {
     yang-version "1.1";
     belongs-to foo {
         prefix "f";
@@ -443,8 +442,9 @@ def src_yang():
             type string;
         }
     }
-}""")
-    res.append(r"""module bar {
+}"""
+
+SRC_YANG_2 = r"""module bar {
     yang-version "1.1";
     namespace "http://example.com/bar";
     prefix "bar";
@@ -503,8 +503,14 @@ def src_yang():
             type string;
         }
     }
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+    ]
 
 
 NS_bar = 'http://example.com/bar'

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -183,9 +183,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/foo':('foo', None), 'http://example.com/bar':('bar', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module foo {
+SRC_YANG_0 = r"""module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
     prefix "f";
@@ -425,8 +423,9 @@ def src_yang():
         type string;
     }
 
-}""")
-    res.append(r"""submodule qux {
+}"""
+
+SRC_YANG_1 = r"""submodule qux {
     yang-version "1.1";
     belongs-to foo {
         prefix "f";
@@ -443,8 +442,9 @@ def src_yang():
             type string;
         }
     }
-}""")
-    res.append(r"""module bar {
+}"""
+
+SRC_YANG_2 = r"""module bar {
     yang-version "1.1";
     namespace "http://example.com/bar";
     prefix "bar";
@@ -503,8 +503,14 @@ def src_yang():
             type string;
         }
     }
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+        SRC_YANG_1,
+        SRC_YANG_2,
+    ]
 
 
 NS_bar = 'http://example.com/bar'

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -30,9 +30,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/loose-required':('loose-required', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module loose-required {
+SRC_YANG_0 = r"""module loose-required {
     yang-version "1.1";
     namespace "http://example.com/loose-required";
     prefix "lr";
@@ -43,8 +41,12 @@ def src_yang():
             mandatory true;
         }
     }
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+    ]
 
 
 NS_loose_required = 'http://example.com/loose-required'

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -63,9 +63,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/foo':('foo', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module foo {
+SRC_YANG_0 = r"""module foo {
     yang-version "1.1";
     namespace "http://example.com/foo";
     prefix "f";
@@ -108,8 +106,12 @@ def src_yang():
             }
         }
     }
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+    ]
 
 
 NS_foo = 'http://example.com/foo'

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -47,9 +47,7 @@ SRC_DNODE = DRoot(
     module_metadata={'http://example.com/yangrpc':('yangrpc', None)},
 )
 
-def src_yang():
-    res = []
-    res.append(r"""module yangrpc {
+SRC_YANG_0 = r"""module yangrpc {
   yang-version "1.1";
   namespace "http://example.com/yangrpc";
   prefix "yrpc";
@@ -65,8 +63,12 @@ def src_yang():
     }
   }
   rpc silent;
-}""")
-    return res
+}"""
+
+def src_yang():
+    return [
+        SRC_YANG_0,
+    ]
 
 
 NS_yangrpc = 'http://example.com/yangrpc'


### PR DESCRIPTION
Generated data-class modules currently place every embedded YANG model inside src_yang by appending large raw string literals. For devices with many models this makes the source archive one very large top-level function body, which is rather slow for the parser.

This change emits each embedded source model as a top-level SRC_YANG_N binding and makes src_yang return those bindings in order. The public function still returns the same list of source strings, while generated files expose the large raw strings as separate top-level statements that parses faster and can also potentially be parsed per statement.