### PR TITLE
Fix type-mismatched union keys in create()

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -849,27 +849,29 @@ class DNodeInner(DNode):
             res.append("        for e in self:")
             res.append("            match = True")
             for us_key in list_key_args:
-                # Order-preserving deduplication
-                unique_base_types = []
                 key_dtype = list_key_types[us_key]
                 if isinstance(key_dtype, DTypeUnion):
+                    # Union keys are Acton "value"-typed and have no Eq.
+                    # Narrow with isinstance per union member; if no type
+                    # pair matched (or values differed), treat as mismatch.
+                    # TODO: use Acton unions
+                    unique_base_types = []
                     for t in key_dtype.types:
                         acton_type = yang_type_to_acton_type(t)
                         if acton_type not in unique_base_types:
                             unique_base_types.append(acton_type)
-                    # Union types for mixed unions are Acton "value" types, so
-                    # we need to first attempt to bind them to a more specific type
-                    # TODO: use Acton unions
-                    for t in unique_base_types:
-                        res.append("            e_{us_key} = e.{us_key}")
-                        res.append("            if isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
-                        res.append("                if e_{us_key} != {us_key}:")
-                        res.append("                    match = False")
-                        res.append("                    continue")
+                    res.append("            e_{us_key} = e.{us_key}")
+                    res.append("            {us_key}_match = False")
+                    for i, t in enumerate(unique_base_types):
+                        keyword = "if" if i == 0 else "elif"
+                        res.append("            {keyword} isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
+                        res.append("                if e_{us_key} == {us_key}:")
+                        res.append("                    {us_key}_match = True")
+                    res.append("            if not {us_key}_match:")
+                    res.append("                match = False")
+                    res.append("                continue")
                 else:
-                    # Class attribute is a not a "value" Acton type because it
-                    # is either not an union or it an union that was resolved
-                    # to a single builtin type, it has equality check
+                    # Concrete Acton type with Eq; compare directly.
                     res.append("            if e.{us_key} != {us_key}:")
                     res.append("                match = False")
                     res.append("                continue")

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -86,15 +86,16 @@ class foo__c1__l1(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
+            k2_match = False
             if isinstance(e_k2, u64) and isinstance(k2, u64):
-                if e_k2 != k2:
-                    match = False
-                    continue
-            e_k2 = e.k2
-            if isinstance(e_k2, str) and isinstance(k2, str):
-                if e_k2 != k2:
-                    match = False
-                    continue
+                if e_k2 == k2:
+                    k2_match = True
+            elif isinstance(e_k2, str) and isinstance(k2, str):
+                if e_k2 == k2:
+                    k2_match = True
+            if not k2_match:
+                match = False
+                continue
             if match:
                 e.l1 = l1
                 return e

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -845,27 +845,29 @@ class DNodeInner(DNode):
             res.append("        for e in self:")
             res.append("            match = True")
             for us_key in list_key_args:
-                # Order-preserving deduplication
-                unique_base_types = []
                 key_dtype = list_key_types[us_key]
                 if isinstance(key_dtype, DTypeUnion):
+                    # Union keys are Acton "value"-typed and have no Eq.
+                    # Narrow with isinstance per union member; if no type
+                    # pair matched (or values differed), treat as mismatch.
+                    # TODO: use Acton unions
+                    unique_base_types = []
                     for t in key_dtype.types:
                         acton_type = yang_type_to_acton_type(t)
                         if acton_type not in unique_base_types:
                             unique_base_types.append(acton_type)
-                    # Union types for mixed unions are Acton "value" types, so
-                    # we need to first attempt to bind them to a more specific type
-                    # TODO: use Acton unions
-                    for t in unique_base_types:
-                        res.append("            e_{us_key} = e.{us_key}")
-                        res.append("            if isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
-                        res.append("                if e_{us_key} != {us_key}:")
-                        res.append("                    match = False")
-                        res.append("                    continue")
+                    res.append("            e_{us_key} = e.{us_key}")
+                    res.append("            {us_key}_match = False")
+                    for i, t in enumerate(unique_base_types):
+                        keyword = "if" if i == 0 else "elif"
+                        res.append("            {keyword} isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
+                        res.append("                if e_{us_key} == {us_key}:")
+                        res.append("                    {us_key}_match = True")
+                    res.append("            if not {us_key}_match:")
+                    res.append("                match = False")
+                    res.append("                continue")
                 else:
-                    # Class attribute is a not a "value" Acton type because it
-                    # is either not an union or it an union that was resolved
-                    # to a single builtin type, it has equality check
+                    # Concrete Acton type with Eq; compare directly.
                     res.append("            if e.{us_key} != {us_key}:")
                     res.append("                match = False")
                     res.append("                continue")

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -1543,20 +1543,19 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
+            k2_match = False
             if isinstance(e_k2, u64) and isinstance(k2, u64):
-                if e_k2 != k2:
-                    match = False
-                    continue
-            e_k2 = e.k2
-            if isinstance(e_k2, str) and isinstance(k2, str):
-                if e_k2 != k2:
-                    match = False
-                    continue
-            e_k2 = e.k2
-            if isinstance(e_k2, bytes) and isinstance(k2, bytes):
-                if e_k2 != k2:
-                    match = False
-                    continue
+                if e_k2 == k2:
+                    k2_match = True
+            elif isinstance(e_k2, str) and isinstance(k2, str):
+                if e_k2 == k2:
+                    k2_match = True
+            elif isinstance(e_k2, bytes) and isinstance(k2, bytes):
+                if e_k2 == k2:
+                    k2_match = True
+            if not k2_match:
+                match = False
+                continue
             if e.k3 != k3:
                 match = False
                 continue
@@ -1624,10 +1623,13 @@ class foo__li_union_one_base(yang.adata.MNode):
         for e in self:
             match = True
             e_k1 = e.k1
+            k1_match = False
             if isinstance(e_k1, str) and isinstance(k1, str):
-                if e_k1 != k1:
-                    match = False
-                    continue
+                if e_k1 == k1:
+                    k1_match = True
+            if not k1_match:
+                match = False
+                continue
             if match:
                 return e
 

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -1543,20 +1543,19 @@ class foo__li_union(yang.adata.MNode):
                 match = False
                 continue
             e_k2 = e.k2
+            k2_match = False
             if isinstance(e_k2, u64) and isinstance(k2, u64):
-                if e_k2 != k2:
-                    match = False
-                    continue
-            e_k2 = e.k2
-            if isinstance(e_k2, str) and isinstance(k2, str):
-                if e_k2 != k2:
-                    match = False
-                    continue
-            e_k2 = e.k2
-            if isinstance(e_k2, bytes) and isinstance(k2, bytes):
-                if e_k2 != k2:
-                    match = False
-                    continue
+                if e_k2 == k2:
+                    k2_match = True
+            elif isinstance(e_k2, str) and isinstance(k2, str):
+                if e_k2 == k2:
+                    k2_match = True
+            elif isinstance(e_k2, bytes) and isinstance(k2, bytes):
+                if e_k2 == k2:
+                    k2_match = True
+            if not k2_match:
+                match = False
+                continue
             if e.k3 != k3:
                 match = False
                 continue
@@ -1624,10 +1623,13 @@ class foo__li_union_one_base(yang.adata.MNode):
         for e in self:
             match = True
             e_k1 = e.k1
+            k1_match = False
             if isinstance(e_k1, str) and isinstance(k1, str):
-                if e_k1 != k1:
-                    match = False
-                    continue
+                if e_k1 == k1:
+                    k1_match = True
+            if not k1_match:
+                match = False
+                continue
             if match:
                 return e
 


### PR DESCRIPTION
create() previously compared the existing entry to the caller's key with one isinstance block per Acton type. If the two sides held different concrete types from the union (for example if the caller used a type not part of the union), none of the isinstance blocks fired and the entry was treated as a match.