### PR TITLE
Order list keys by key statement, not schema

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -522,9 +522,10 @@ class DNodeInner(DNode):
         def next_breaker_name(i: int) -> (str, int):
             return ("_breaker{i + 1}", i + 1)
 
-        # Reorder children so that positional arguments, like list keys, come first
+        # Reorder and filter children so that list keys come first - ordered as
+        # they appear in the key statement
         new_children = []
-        pos_child_idx = 0
+        key_children = {}
         for child in self.children:
             if include_state == False and child.config == False:
                 continue
@@ -535,10 +536,14 @@ class DNodeInner(DNode):
             elif isinstance(child, DAnyxml):
                 continue # TODO
             if isinstance(child, DLeaf) and isinstance(self, DList) and child.is_key(self):
-                new_children.insert(pos_child_idx, child)
-                pos_child_idx += 1
+                key_children[child.name] = child
             else:
                 new_children.append(child)
+        if isinstance(self, DList):
+            new_children = [key_children[k] for k in self.key] + new_children
+        # TODO: don't mutate this objects children attribute here. This is
+        # convenient because we can change behavior (DRpc) or skip printing
+        # unsupported nodes (DAny*), but it is lazy and wrong!
         self.children = new_children
 
         unique_namer = UniqueNamer(self)

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -1,0 +1,116 @@
+import base64
+import json
+import xml
+import yang
+import yang.adata
+import yang.gdata
+import yang.xml
+import yang.xpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+
+
+_identities: list[DIdentity] = []
+
+
+SRC_DNODE_CHILD_0 = DList(module='foo', namespace='http://example.com/foo', prefix='foo', name='l1', key=[
+'name',
+'id'
+    ], config=True, min_elements=0, ordered_by='system', children=[
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='id', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='foo', name='other', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+])
+
+SRC_DNODE = DRoot(
+    children=[SRC_DNODE_CHILD_0],
+    identities=[],
+    rpcs=[],
+    module_metadata={'http://example.com/foo':('foo', None)},
+)
+
+NS_foo = 'http://example.com/foo'
+
+
+_breaker1 = None
+class foo__l1_entry(yang.adata.MNode):
+    name: str
+    id: str
+    other: ?str
+
+    mut def __init__(self, name: str, id: str, other: ?str) -> None:
+        self._ns = 'http://example.com/foo'
+        self.name = name
+        self.id = id
+        self.other = other
+
+    def _get_attr(self, name: str) -> ?value:
+        if name == 'name':
+            return self.name
+        if name == 'id':
+            return self.id
+        if name == 'other':
+            return self.other
+
+    mut def to_gdata(self) -> yang.gdata.Node:
+        return yang.adata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])
+
+    @staticmethod
+    mut def from_gdata(n: yang.gdata.Node) -> foo__l1_entry:
+        return foo__l1_entry(name=n.get_str(yang.gdata.Id(NS_foo, 'name')), id=n.get_str(yang.gdata.Id(NS_foo, 'id')), other=n.get_opt_str(yang.gdata.Id(NS_foo, 'other')))
+
+    def copy(self) -> foo__l1_entry:
+        """Create a deep copy of this adata object"""
+        return foo__l1_entry.from_gdata(self.to_gdata())
+
+_breaker2 = None
+class foo__l1(yang.adata.MNode):
+    elements: list[foo__l1_entry]
+    mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
+        self._ns = 'http://example.com/foo'
+        self._name = 'l1'
+        self.elements = elements
+
+    mut def create(self, name: str, id: str, other: ?str=None) -> foo__l1_entry:
+        for e in self:
+            match = True
+            if e.name != name:
+                match = False
+                continue
+            if e.id != id:
+                match = False
+                continue
+            if match:
+                if other is not None:
+                    e.other = other
+                return e
+
+        res = foo__l1_entry(name=name, id=id, other=other)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?yang.gdata.List) -> list[foo__l1_entry]:
+        if n is not None:
+            return [foo__l1_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    def copy(self) -> foo__l1:
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return foo__l1(elements=copied_elements)
+
+extension foo__l1(Iterable[foo__l1_entry]):
+    def __iter__(self) -> Iterator[foo__l1_entry]:
+        return self.elements.__iter__()

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2368,6 +2368,31 @@ def _test_prdaclass_list_key_reorder():
     src = root.prdaclass(top=False, root_path=["foo:l1"])
     return src
 
+def _test_prdaclass_list_multi_key_reorder():
+    """Composite key whose key-statement order differs from the schema
+    declaration order: keys must come first in key-statement order
+    (name then id), not in declaration order (id then name)."""
+    ys = r"""module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "foo";
+    list l1 {
+        key "name id";
+        leaf id {
+            type string;
+        }
+        leaf name {
+            type string;
+        }
+        leaf other {
+            type string;
+        }
+    }
+}"""
+    root = yang.compile([ys])
+    src = root.prdaclass(top=False, root_path=["foo:l1"])
+    return src
+
 def _test_prdaclass_top_conflict():
     ys_foo = r"""module foo {
     yang-version "1.1";

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -518,9 +518,10 @@ class DNodeInner(DNode):
         def next_breaker_name(i: int) -> (str, int):
             return ("_breaker{i + 1}", i + 1)
 
-        # Reorder children so that positional arguments, like list keys, come first
+        # Reorder and filter children so that list keys come first - ordered as
+        # they appear in the key statement
         new_children = []
-        pos_child_idx = 0
+        key_children = {}
         for child in self.children:
             if include_state == False and child.config == False:
                 continue
@@ -531,10 +532,14 @@ class DNodeInner(DNode):
             elif isinstance(child, DAnyxml):
                 continue # TODO
             if isinstance(child, DLeaf) and isinstance(self, DList) and child.is_key(self):
-                new_children.insert(pos_child_idx, child)
-                pos_child_idx += 1
+                key_children[child.name] = child
             else:
                 new_children.append(child)
+        if isinstance(self, DList):
+            new_children = [key_children[k] for k in self.key] + new_children
+        # TODO: don't mutate this objects children attribute here. This is
+        # convenient because we can change behavior (DRpc) or skip printing
+        # unsupported nodes (DAny*), but it is lazy and wrong!
         self.children = new_children
 
         unique_namer = UniqueNamer(self)


### PR DESCRIPTION
The child-reordering step at the top of _prdaclass_rec already moved list keys ahead of non-keys, but inserted them in the order they appeared in the YANG schema. When the key statement listed them in a different order than the leaves were declared, the resulting class attributes, __init__ args, and create() args were out of order.

Now keys are placed at the front in the order given by the key statement, regardless of where the corresponding leaves appear in the schema.