### PR TITLE
Implement Indexed (+ .get()) for adata lists

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -844,47 +844,56 @@ class DNodeInner(DNode):
                         arg = usname(child)
                         list_args_req.append(arg)
                         list_args_req_sig.append("{arg}: {pname(child)}")
+
+            # .get() returns the entry matching all key values, or None
+            if len(list_key_args) > 0:
+                # Keys come first in list_args_req(_sig)
+                get_args_sig = ", ".join(["self"] + list_args_req_sig[:len(list_key_args)])
+                res.append("    def get({get_args_sig}) -> ?{pname()}_entry:")
+                res.append("        for e in self:")
+                for us_key in list_key_args:
+                    key_dtype = list_key_types[us_key]
+                    if isinstance(key_dtype, DTypeUnion):
+                        # Union keys are Acton "value"-typed and have no Eq.
+                        # Narrow with isinstance per union member; if no type
+                        # pair matched (or values differed), treat as mismatch.
+                        # TODO: use Acton unions
+                        unique_base_types = []
+                        for t in key_dtype.types:
+                            acton_type = yang_type_to_acton_type(t)
+                            if acton_type not in unique_base_types:
+                                unique_base_types.append(acton_type)
+                        res.append("            e_{us_key} = e.{us_key}")
+                        res.append("            {us_key}_match = False")
+                        for i, t in enumerate(unique_base_types):
+                            keyword = "if" if i == 0 else "elif"
+                            res.append("            {keyword} isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
+                            res.append("                if e_{us_key} == {us_key}:")
+                            res.append("                    {us_key}_match = True")
+                        res.append("            if not {us_key}_match:")
+                        res.append("                continue")
+                    else:
+                        # Concrete Acton type with Eq; compare directly.
+                        res.append("            if e.{us_key} != {us_key}:")
+                        res.append("                continue")
+                res.append("            return e")
+                res.append("")
+
+            # create() finds an existing entry by key via .get() (when the
+            # list has keys), updates its non-key args, and returns it.
+            # Otherwise it appends a fresh entry.
             list_args_str = ", ".join(["self"] + list_args_req_sig + list_args_opt_sig)
             res.append("    mut def create({list_args_str}) -> {pname()}_entry:")
-            res.append("        for e in self:")
-            res.append("            match = True")
-            for us_key in list_key_args:
-                key_dtype = list_key_types[us_key]
-                if isinstance(key_dtype, DTypeUnion):
-                    # Union keys are Acton "value"-typed and have no Eq.
-                    # Narrow with isinstance per union member; if no type
-                    # pair matched (or values differed), treat as mismatch.
-                    # TODO: use Acton unions
-                    unique_base_types = []
-                    for t in key_dtype.types:
-                        acton_type = yang_type_to_acton_type(t)
-                        if acton_type not in unique_base_types:
-                            unique_base_types.append(acton_type)
-                    res.append("            e_{us_key} = e.{us_key}")
-                    res.append("            {us_key}_match = False")
-                    for i, t in enumerate(unique_base_types):
-                        keyword = "if" if i == 0 else "elif"
-                        res.append("            {keyword} isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
-                        res.append("                if e_{us_key} == {us_key}:")
-                        res.append("                    {us_key}_match = True")
-                    res.append("            if not {us_key}_match:")
-                    res.append("                match = False")
-                    res.append("                continue")
-                else:
-                    # Concrete Acton type with Eq; compare directly.
-                    res.append("            if e.{us_key} != {us_key}:")
-                    res.append("                match = False")
-                    res.append("                continue")
-            res.append("            if match:")
-            for req_arg in list_args_req:
-                if req_arg in list_key_args:
-                    continue
-                res.append("                e.{req_arg} = {req_arg}")
-            for opt_arg in list_args_opt:
-                res.append("                if {opt_arg} is not None:")
-                res.append("                    e.{opt_arg} = {opt_arg}")
-            res.append("                return e")
-            res.append("")
+            if len(list_key_args) > 0:
+                key_call_args = ", ".join(list_args_req[:len(list_key_args)])
+                res.append("        e = self.get({key_call_args})")
+                res.append("        if e is not None:")
+                for req_arg in list_args_req[len(list_key_args):]:
+                    res.append("            e.{req_arg} = {req_arg}")
+                for opt_arg in list_args_opt:
+                    res.append("            if {opt_arg} is not None:")
+                    res.append("                e.{opt_arg} = {opt_arg}")
+                res.append("            return e")
             list_params_str = ", ".join(["{arg}={arg}" for arg in list_args_req + list_args_opt])
             res.append("        res = {pname()}_entry({list_params_str})")
             res.append("        self.elements.append(res)")

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -929,6 +929,36 @@ class DNodeInner(DNode):
             res.append("extension {pname()}(Iterable[{pname()}_entry]):")
             res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
             res.append("        return self.elements.__iter__()")
+
+            # Indexed extension for single-key lists with a non-union key.
+            # Composite keys would need a tuple, union keys are typed as Acton
+            # value; neither can implement Eq
+            if len(list_key_args) == 1:
+                us_key = list_key_args[0]
+                key_dtype = list_key_types[us_key]
+                if not isinstance(key_dtype, DTypeUnion):
+                    key_acton_type = yang_type_to_acton_type(key_dtype)
+                    res.append("")
+                    res.append("extension {pname()}(Indexed[{key_acton_type}, {pname()}_entry]):")
+                    res.append("    def __getitem__(self, k: {key_acton_type}) -> {pname()}_entry:")
+                    res.append("        e = self.get(k)")
+                    res.append("        if e is not None:")
+                    res.append("            return e")
+                    res.append("        raise KeyError(k)")
+                    res.append("")
+                    res.append("    mut def __setitem__(self, k: {key_acton_type}, n: {pname()}_entry) -> None:")
+                    res.append("        for i, e in enumerate(self.elements):")
+                    res.append("            if e.{us_key} == k:")
+                    res.append("                self.elements[i] = n")
+                    res.append("                return")
+                    res.append("        self.elements.append(n)")
+                    res.append("")
+                    res.append("    mut def __delitem__(self, k: {key_acton_type}) -> None:")
+                    res.append("        for i, e in enumerate(self.elements):")
+                    res.append("            if e.{us_key} == k:")
+                    res.append("                del self.elements[i]")
+                    res.append("                return")
+                    res.append("        raise KeyError(k)")
         res.append("")
 
 

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -67,11 +67,6 @@ class base__system_capabilities__per_node_capabilities(yang.adata.MNode):
         self.elements = elements
 
     mut def create(self) -> base__system_capabilities__per_node_capabilities_entry:
-        for e in self:
-            match = True
-            if match:
-                return e
-
         res = base__system_capabilities__per_node_capabilities_entry()
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -76,17 +76,18 @@ class foo__c1__things(yang.adata.MNode):
         self._name = 'things'
         self.elements = elements
 
-    mut def create(self, name: str, id: ?str=None) -> foo__c1__things_entry:
+    def get(self, name: str) -> ?foo__c1__things_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if id is not None:
-                    e.id = id
-                return e
+            return e
 
+    mut def create(self, name: str, id: ?str=None) -> foo__c1__things_entry:
+        e = self.get(name)
+        if e is not None:
+            if id is not None:
+                e.id = id
+            return e
         res = foo__c1__things_entry(name=name, id=id)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -112,6 +112,27 @@ extension foo__c1__things(Iterable[foo__c1__things_entry]):
     def __iter__(self) -> Iterator[foo__c1__things_entry]:
         return self.elements.__iter__()
 
+extension foo__c1__things(Indexed[str, foo__c1__things_entry]):
+    def __getitem__(self, k: str) -> foo__c1__things_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__c1__things_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class foo__c1(yang.adata.MNode):
     things: foo__c1__things

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -88,17 +88,18 @@ class bar__c1__li1(yang.adata.MNode):
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1: str, l2: ?Identityref=None) -> bar__c1__li1_entry:
+    def get(self, l1: str) -> ?bar__c1__li1_entry:
         for e in self:
-            match = True
             if e.l1 != l1:
-                match = False
                 continue
-            if match:
-                if l2 is not None:
-                    e.l2 = l2
-                return e
+            return e
 
+    mut def create(self, l1: str, l2: ?Identityref=None) -> bar__c1__li1_entry:
+        e = self.get(l1)
+        if e is not None:
+            if l2 is not None:
+                e.l2 = l2
+            return e
         res = bar__c1__li1_entry(l1=l1, l2=l2)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -124,6 +124,27 @@ extension bar__c1__li1(Iterable[bar__c1__li1_entry]):
     def __iter__(self) -> Iterator[bar__c1__li1_entry]:
         return self.elements.__iter__()
 
+extension bar__c1__li1(Indexed[str, bar__c1__li1_entry]):
+    def __getitem__(self, k: str) -> bar__c1__li1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: bar__c1__li1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class bar__c1(yang.adata.MNode):
     li1: bar__c1__li1

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -153,6 +153,27 @@ extension main_module__main_container__sub_list(Iterable[main_module__main_conta
     def __iter__(self) -> Iterator[main_module__main_container__sub_list_entry]:
         return self.elements.__iter__()
 
+extension main_module__main_container__sub_list(Indexed[str, main_module__main_container__sub_list_entry]):
+    def __getitem__(self, k: str) -> main_module__main_container__sub_list_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: main_module__main_container__sub_list_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker4 = None
 class main_module__main_container__group_container(yang.adata.MNode):
     group_leaf: str

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -115,19 +115,20 @@ class main_module__main_container__sub_list(yang.adata.MNode):
         self._name = 'sub-list'
         self.elements = elements
 
-    mut def create(self, name: str, sub_value: ?str=None, ref_to_main: ?str=None) -> main_module__main_container__sub_list_entry:
+    def get(self, name: str) -> ?main_module__main_container__sub_list_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if sub_value is not None:
-                    e.sub_value = sub_value
-                if ref_to_main is not None:
-                    e.ref_to_main = ref_to_main
-                return e
+            return e
 
+    mut def create(self, name: str, sub_value: ?str=None, ref_to_main: ?str=None) -> main_module__main_container__sub_list_entry:
+        e = self.get(name)
+        if e is not None:
+            if sub_value is not None:
+                e.sub_value = sub_value
+            if ref_to_main is not None:
+                e.ref_to_main = ref_to_main
+            return e
         res = main_module__main_container__sub_list_entry(name=name, sub_value=sub_value, ref_to_main=ref_to_main)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -66,15 +66,16 @@ class foo__c1__li1(yang.adata.MNode):
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1: str) -> foo__c1__li1_entry:
+    def get(self, l1: str) -> ?foo__c1__li1_entry:
         for e in self:
-            match = True
             if e.l1 != l1:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, l1: str) -> foo__c1__li1_entry:
+        e = self.get(l1)
+        if e is not None:
+            return e
         res = foo__c1__li1_entry(l1=l1)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -100,6 +100,27 @@ extension foo__c1__li1(Iterable[foo__c1__li1_entry]):
     def __iter__(self) -> Iterator[foo__c1__li1_entry]:
         return self.elements.__iter__()
 
+extension foo__c1__li1(Indexed[str, foo__c1__li1_entry]):
+    def __getitem__(self, k: str) -> foo__c1__li1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__c1__li1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class foo__c1(yang.adata.MNode):
     li1: foo__c1__li1

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -105,17 +105,18 @@ class base_module__network_instances__network_instance(yang.adata.MNode):
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name: str, ref: ?str=None) -> base_module__network_instances__network_instance_entry:
+    def get(self, name: str) -> ?base_module__network_instances__network_instance_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if ref is not None:
-                    e.ref = ref
-                return e
+            return e
 
+    mut def create(self, name: str, ref: ?str=None) -> base_module__network_instances__network_instance_entry:
+        e = self.get(name)
+        if e is not None:
+            if ref is not None:
+                e.ref = ref
+            return e
         res = base_module__network_instances__network_instance_entry(name=name, ref=ref)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -141,6 +141,27 @@ extension base_module__network_instances__network_instance(Iterable[base_module_
     def __iter__(self) -> Iterator[base_module__network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
+extension base_module__network_instances__network_instance(Indexed[str, base_module__network_instances__network_instance_entry]):
+    def __getitem__(self, k: str) -> base_module__network_instances__network_instance_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: base_module__network_instances__network_instance_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker4 = None
 class base_module__network_instances(yang.adata.MNode):
     network_instance: base_module__network_instances__network_instance

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -114,6 +114,27 @@ extension other_module__other_network_instances__network_instance(Iterable[other
     def __iter__(self) -> Iterator[other_module__other_network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
+extension other_module__other_network_instances__network_instance(Indexed[str, other_module__other_network_instances__network_instance_entry]):
+    def __getitem__(self, k: str) -> other_module__other_network_instances__network_instance_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: other_module__other_network_instances__network_instance_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class other_module__other_network_instances(yang.adata.MNode):
     network_instance: other_module__other_network_instances__network_instance
@@ -234,6 +255,27 @@ class base_module__base_network_instances__network_instance(yang.adata.MNode):
 extension base_module__base_network_instances__network_instance(Iterable[base_module__base_network_instances__network_instance_entry]):
     def __iter__(self) -> Iterator[base_module__base_network_instances__network_instance_entry]:
         return self.elements.__iter__()
+
+extension base_module__base_network_instances__network_instance(Indexed[str, base_module__base_network_instances__network_instance_entry]):
+    def __getitem__(self, k: str) -> base_module__base_network_instances__network_instance_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: base_module__base_network_instances__network_instance_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
 
 _breaker7 = None
 class base_module__base_network_instances(yang.adata.MNode):

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -80,15 +80,16 @@ class other_module__other_network_instances__network_instance(yang.adata.MNode):
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name: str) -> other_module__other_network_instances__network_instance_entry:
+    def get(self, name: str) -> ?other_module__other_network_instances__network_instance_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> other_module__other_network_instances__network_instance_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = other_module__other_network_instances__network_instance_entry(name=name)
         self.elements.append(res)
         return res
@@ -200,15 +201,16 @@ class base_module__base_network_instances__network_instance(yang.adata.MNode):
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name: str) -> base_module__base_network_instances__network_instance_entry:
+    def get(self, name: str) -> ?base_module__base_network_instances__network_instance_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> base_module__base_network_instances__network_instance_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = base_module__base_network_instances__network_instance_entry(name=name)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -138,6 +138,27 @@ extension base_module__network_instances__network_instance(Iterable[base_module_
     def __iter__(self) -> Iterator[base_module__network_instances__network_instance_entry]:
         return self.elements.__iter__()
 
+extension base_module__network_instances__network_instance(Indexed[str, base_module__network_instances__network_instance_entry]):
+    def __getitem__(self, k: str) -> base_module__network_instances__network_instance_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: base_module__network_instances__network_instance_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker4 = None
 class base_module__network_instances(yang.adata.MNode):
     network_instance: base_module__network_instances__network_instance

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -104,15 +104,16 @@ class base_module__network_instances__network_instance(yang.adata.MNode):
         self._name = 'network-instance'
         self.elements = elements
 
-    mut def create(self, name: str) -> base_module__network_instances__network_instance_entry:
+    def get(self, name: str) -> ?base_module__network_instances__network_instance_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> base_module__network_instances__network_instance_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = base_module__network_instances__network_instance_entry(name=name)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -140,3 +140,24 @@ class foo__c__li(yang.adata.MNode):
 extension foo__c__li(Iterable[foo__c__li_entry]):
     def __iter__(self) -> Iterator[foo__c__li_entry]:
         return self.elements.__iter__()
+
+extension foo__c__li(Indexed[str, foo__c__li_entry]):
+    def __getitem__(self, k: str) -> foo__c__li_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__c__li_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -104,18 +104,19 @@ class foo__c__li(yang.adata.MNode):
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name: str, bar: foo__c__li__bar, foo: ?str=None) -> foo__c__li_entry:
+    def get(self, name: str) -> ?foo__c__li_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                e.bar = bar
-                if foo is not None:
-                    e.foo = foo
-                return e
+            return e
 
+    mut def create(self, name: str, bar: foo__c__li__bar, foo: ?str=None) -> foo__c__li_entry:
+        e = self.get(name)
+        if e is not None:
+            e.bar = bar
+            if foo is not None:
+                e.foo = foo
+            return e
         res = foo__c__li_entry(name=name, bar=bar, foo=foo)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -75,16 +75,17 @@ class base__c1__base_l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, base_k1: str, foo_k1: str) -> base__c1__base_l1_entry:
+    def get(self, base_k1: str) -> ?base__c1__base_l1_entry:
         for e in self:
-            match = True
             if e.base_k1 != base_k1:
-                match = False
                 continue
-            if match:
-                e.foo_k1 = foo_k1
-                return e
+            return e
 
+    mut def create(self, base_k1: str, foo_k1: str) -> base__c1__base_l1_entry:
+        e = self.get(base_k1)
+        if e is not None:
+            e.foo_k1 = foo_k1
+            return e
         res = base__c1__base_l1_entry(base_k1=base_k1, foo_k1=foo_k1)
         self.elements.append(res)
         return res
@@ -140,15 +141,16 @@ class base__c1__foo_l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k2: str) -> base__c1__foo_l1_entry:
+    def get(self, k2: str) -> ?base__c1__foo_l1_entry:
         for e in self:
-            match = True
             if e.k2 != k2:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, k2: str) -> base__c1__foo_l1_entry:
+        e = self.get(k2)
+        if e is not None:
+            return e
         res = base__c1__foo_l1_entry(k2=k2)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -110,6 +110,27 @@ extension base__c1__base_l1(Iterable[base__c1__base_l1_entry]):
     def __iter__(self) -> Iterator[base__c1__base_l1_entry]:
         return self.elements.__iter__()
 
+extension base__c1__base_l1(Indexed[str, base__c1__base_l1_entry]):
+    def __getitem__(self, k: str) -> base__c1__base_l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: base__c1__base_l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.base_k1 == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.base_k1 == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class base__c1__foo_l1_entry(yang.adata.MNode):
     k2: str
@@ -174,6 +195,27 @@ class base__c1__foo_l1(yang.adata.MNode):
 extension base__c1__foo_l1(Iterable[base__c1__foo_l1_entry]):
     def __iter__(self) -> Iterator[base__c1__foo_l1_entry]:
         return self.elements.__iter__()
+
+extension base__c1__foo_l1(Indexed[str, base__c1__foo_l1_entry]):
+    def __getitem__(self, k: str) -> base__c1__foo_l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: base__c1__foo_l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.k2 == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.k2 == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
 
 _breaker5 = None
 class base__c1(yang.adata.MNode):

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -90,18 +90,18 @@ class foo__c1__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k1: str, k2: Identityref) -> foo__c1__l1_entry:
+    def get(self, k1: str, k2: Identityref) -> ?foo__c1__l1_entry:
         for e in self:
-            match = True
             if e.k1 != k1:
-                match = False
                 continue
             if e.k2 != k2:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, k1: str, k2: Identityref) -> foo__c1__l1_entry:
+        e = self.get(k1, k2)
+        if e is not None:
+            return e
         res = foo__c1__l1_entry(k1=k1, k2=k2)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -97,3 +97,24 @@ class foo__l1(yang.adata.MNode):
 extension foo__l1(Iterable[foo__l1_entry]):
     def __iter__(self) -> Iterator[foo__l1_entry]:
         return self.elements.__iter__()
+
+extension foo__l1(Indexed[str, foo__l1_entry]):
+    def __getitem__(self, k: str) -> foo__l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -64,15 +64,16 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name: str) -> foo__l1_entry:
+    def get(self, name: str) -> ?foo__l1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> foo__l1_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = foo__l1_entry(name=name)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -69,17 +69,18 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
+    def get(self, name: str) -> ?foo__l1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if id is not None:
-                    e.id = id
-                return e
+            return e
 
+    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
+        e = self.get(name)
+        if e is not None:
+            if id is not None:
+                e.id = id
+            return e
         res = foo__l1_entry(name=name, id=id)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -104,3 +104,24 @@ class foo__l1(yang.adata.MNode):
 extension foo__l1(Iterable[foo__l1_entry]):
     def __iter__(self) -> Iterator[foo__l1_entry]:
         return self.elements.__iter__()
+
+extension foo__l1(Indexed[str, foo__l1_entry]):
+    def __getitem__(self, k: str) -> foo__l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -77,20 +77,20 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name: str, id: str, other: ?str=None) -> foo__l1_entry:
+    def get(self, name: str, id: str) -> ?foo__l1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
             if e.id != id:
-                match = False
                 continue
-            if match:
-                if other is not None:
-                    e.other = other
-                return e
+            return e
 
+    mut def create(self, name: str, id: str, other: ?str=None) -> foo__l1_entry:
+        e = self.get(name, id)
+        if e is not None:
+            if other is not None:
+                e.other = other
+            return e
         res = foo__l1_entry(name=name, id=id, other=other)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -100,6 +100,27 @@ extension foo__li1(Iterable[foo__li1_entry]):
     def __iter__(self) -> Iterator[foo__li1_entry]:
         return self.elements.__iter__()
 
+extension foo__li1(Indexed[str, foo__li1_entry]):
+    def __getitem__(self, k: str) -> foo__li1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__li1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class root(yang.adata.MNode):
     li1: foo__li1

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -66,15 +66,16 @@ class foo__li1(yang.adata.MNode):
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1: str) -> foo__li1_entry:
+    def get(self, l1: str) -> ?foo__li1_entry:
         for e in self:
-            match = True
             if e.l1 != l1:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, l1: str) -> foo__li1_entry:
+        e = self.get(l1)
+        if e is not None:
+            return e
         res = foo__li1_entry(l1=l1)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -100,6 +100,27 @@ extension foo__li1(Iterable[foo__li1_entry]):
     def __iter__(self) -> Iterator[foo__li1_entry]:
         return self.elements.__iter__()
 
+extension foo__li1(Indexed[str, foo__li1_entry]):
+    def __getitem__(self, k: str) -> foo__li1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__li1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.l1 == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker3 = None
 class root(yang.adata.MNode):
     li1: foo__li1

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -66,15 +66,16 @@ class foo__li1(yang.adata.MNode):
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, l1: str) -> foo__li1_entry:
+    def get(self, l1: str) -> ?foo__li1_entry:
         for e in self:
-            match = True
             if e.l1 != l1:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, l1: str) -> foo__li1_entry:
+        e = self.get(l1)
+        if e is not None:
+            return e
         res = foo__li1_entry(l1=l1)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -102,17 +102,18 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
+    def get(self, name: str) -> ?foo__l1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if id is not None:
-                    e.id = id
-                return e
+            return e
 
+    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
+        e = self.get(name)
+        if e is not None:
+            if id is not None:
+                e.id = id
+            return e
         res = foo__l1_entry(name=name, id=id)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -138,6 +138,27 @@ extension foo__l1(Iterable[foo__l1_entry]):
     def __iter__(self) -> Iterator[foo__l1_entry]:
         return self.elements.__iter__()
 
+extension foo__l1(Indexed[str, foo__l1_entry]):
+    def __getitem__(self, k: str) -> foo__l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker4 = None
 class root(yang.adata.MNode):
     l1: foo__l1

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -103,3 +103,24 @@ class foo__l1(yang.adata.MNode):
 extension foo__l1(Iterable[foo__l1_entry]):
     def __iter__(self) -> Iterator[foo__l1_entry]:
         return self.elements.__iter__()
+
+extension foo__l1(Indexed[str, foo__l1_entry]):
+    def __getitem__(self, k: str) -> foo__l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -69,16 +69,17 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name: str, id: str) -> foo__l1_entry:
+    def get(self, name: str) -> ?foo__l1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                e.id = id
-                return e
+            return e
 
+    mut def create(self, name: str, id: str) -> foo__l1_entry:
+        e = self.get(name)
+        if e is not None:
+            e.id = id
+            return e
         res = foo__l1_entry(name=name, id=id)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -109,15 +109,16 @@ class foo__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, name: str) -> foo__l1_entry:
+    def get(self, name: str) -> ?foo__l1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> foo__l1_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = foo__l1_entry(name=name)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -142,3 +142,24 @@ class foo__l1(yang.adata.MNode):
 extension foo__l1(Iterable[foo__l1_entry]):
     def __iter__(self) -> Iterator[foo__l1_entry]:
         return self.elements.__iter__()
+
+extension foo__l1(Indexed[str, foo__l1_entry]):
+    def __getitem__(self, k: str) -> foo__l1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -79,11 +79,9 @@ class foo__c1__l1(yang.adata.MNode):
         self._name = 'l1'
         self.elements = elements
 
-    mut def create(self, k1: str, k2: value, l1: str) -> foo__c1__l1_entry:
+    def get(self, k1: str, k2: value) -> ?foo__c1__l1_entry:
         for e in self:
-            match = True
             if e.k1 != k1:
-                match = False
                 continue
             e_k2 = e.k2
             k2_match = False
@@ -94,12 +92,14 @@ class foo__c1__l1(yang.adata.MNode):
                 if e_k2 == k2:
                     k2_match = True
             if not k2_match:
-                match = False
                 continue
-            if match:
-                e.l1 = l1
-                return e
+            return e
 
+    mut def create(self, k1: str, k2: value, l1: str) -> foo__c1__l1_entry:
+        e = self.get(k1, k2)
+        if e is not None:
+            e.l1 = l1
+            return e
         res = foo__c1__l1_entry(k1=k1, k2=k2, l1=l1)
         self.elements.append(res)
         return res

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -925,6 +925,36 @@ class DNodeInner(DNode):
             res.append("extension {pname()}(Iterable[{pname()}_entry]):")
             res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
             res.append("        return self.elements.__iter__()")
+
+            # Indexed extension for single-key lists with a non-union key.
+            # Composite keys would need a tuple, union keys are typed as Acton
+            # value; neither can implement Eq
+            if len(list_key_args) == 1:
+                us_key = list_key_args[0]
+                key_dtype = list_key_types[us_key]
+                if not isinstance(key_dtype, DTypeUnion):
+                    key_acton_type = yang_type_to_acton_type(key_dtype)
+                    res.append("")
+                    res.append("extension {pname()}(Indexed[{key_acton_type}, {pname()}_entry]):")
+                    res.append("    def __getitem__(self, k: {key_acton_type}) -> {pname()}_entry:")
+                    res.append("        e = self.get(k)")
+                    res.append("        if e is not None:")
+                    res.append("            return e")
+                    res.append("        raise KeyError(k)")
+                    res.append("")
+                    res.append("    mut def __setitem__(self, k: {key_acton_type}, n: {pname()}_entry) -> None:")
+                    res.append("        for i, e in enumerate(self.elements):")
+                    res.append("            if e.{us_key} == k:")
+                    res.append("                self.elements[i] = n")
+                    res.append("                return")
+                    res.append("        self.elements.append(n)")
+                    res.append("")
+                    res.append("    mut def __delitem__(self, k: {key_acton_type}) -> None:")
+                    res.append("        for i, e in enumerate(self.elements):")
+                    res.append("            if e.{us_key} == k:")
+                    res.append("                del self.elements[i]")
+                    res.append("                return")
+                    res.append("        raise KeyError(k)")
         res.append("")
 
 

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -840,47 +840,56 @@ class DNodeInner(DNode):
                         arg = usname(child)
                         list_args_req.append(arg)
                         list_args_req_sig.append("{arg}: {pname(child)}")
+
+            # .get() returns the entry matching all key values, or None
+            if len(list_key_args) > 0:
+                # Keys come first in list_args_req(_sig)
+                get_args_sig = ", ".join(["self"] + list_args_req_sig[:len(list_key_args)])
+                res.append("    def get({get_args_sig}) -> ?{pname()}_entry:")
+                res.append("        for e in self:")
+                for us_key in list_key_args:
+                    key_dtype = list_key_types[us_key]
+                    if isinstance(key_dtype, DTypeUnion):
+                        # Union keys are Acton "value"-typed and have no Eq.
+                        # Narrow with isinstance per union member; if no type
+                        # pair matched (or values differed), treat as mismatch.
+                        # TODO: use Acton unions
+                        unique_base_types = []
+                        for t in key_dtype.types:
+                            acton_type = yang_type_to_acton_type(t)
+                            if acton_type not in unique_base_types:
+                                unique_base_types.append(acton_type)
+                        res.append("            e_{us_key} = e.{us_key}")
+                        res.append("            {us_key}_match = False")
+                        for i, t in enumerate(unique_base_types):
+                            keyword = "if" if i == 0 else "elif"
+                            res.append("            {keyword} isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
+                            res.append("                if e_{us_key} == {us_key}:")
+                            res.append("                    {us_key}_match = True")
+                        res.append("            if not {us_key}_match:")
+                        res.append("                continue")
+                    else:
+                        # Concrete Acton type with Eq; compare directly.
+                        res.append("            if e.{us_key} != {us_key}:")
+                        res.append("                continue")
+                res.append("            return e")
+                res.append("")
+
+            # create() finds an existing entry by key via .get() (when the
+            # list has keys), updates its non-key args, and returns it.
+            # Otherwise it appends a fresh entry.
             list_args_str = ", ".join(["self"] + list_args_req_sig + list_args_opt_sig)
             res.append("    mut def create({list_args_str}) -> {pname()}_entry:")
-            res.append("        for e in self:")
-            res.append("            match = True")
-            for us_key in list_key_args:
-                key_dtype = list_key_types[us_key]
-                if isinstance(key_dtype, DTypeUnion):
-                    # Union keys are Acton "value"-typed and have no Eq.
-                    # Narrow with isinstance per union member; if no type
-                    # pair matched (or values differed), treat as mismatch.
-                    # TODO: use Acton unions
-                    unique_base_types = []
-                    for t in key_dtype.types:
-                        acton_type = yang_type_to_acton_type(t)
-                        if acton_type not in unique_base_types:
-                            unique_base_types.append(acton_type)
-                    res.append("            e_{us_key} = e.{us_key}")
-                    res.append("            {us_key}_match = False")
-                    for i, t in enumerate(unique_base_types):
-                        keyword = "if" if i == 0 else "elif"
-                        res.append("            {keyword} isinstance(e_{us_key}, {t}) and isinstance({us_key}, {t}):")
-                        res.append("                if e_{us_key} == {us_key}:")
-                        res.append("                    {us_key}_match = True")
-                    res.append("            if not {us_key}_match:")
-                    res.append("                match = False")
-                    res.append("                continue")
-                else:
-                    # Concrete Acton type with Eq; compare directly.
-                    res.append("            if e.{us_key} != {us_key}:")
-                    res.append("                match = False")
-                    res.append("                continue")
-            res.append("            if match:")
-            for req_arg in list_args_req:
-                if req_arg in list_key_args:
-                    continue
-                res.append("                e.{req_arg} = {req_arg}")
-            for opt_arg in list_args_opt:
-                res.append("                if {opt_arg} is not None:")
-                res.append("                    e.{opt_arg} = {opt_arg}")
-            res.append("                return e")
-            res.append("")
+            if len(list_key_args) > 0:
+                key_call_args = ", ".join(list_args_req[:len(list_key_args)])
+                res.append("        e = self.get({key_call_args})")
+                res.append("        if e is not None:")
+                for req_arg in list_args_req[len(list_key_args):]:
+                    res.append("            e.{req_arg} = {req_arg}")
+                for opt_arg in list_args_opt:
+                    res.append("            if {opt_arg} is not None:")
+                    res.append("                e.{opt_arg} = {opt_arg}")
+                res.append("            return e")
             list_params_str = ", ".join(["{arg}={arg}" for arg in list_args_req + list_args_opt])
             res.append("        res = {pname()}_entry({list_params_str})")
             res.append("        self.elements.append(res)")

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -465,6 +465,19 @@ def _test_list_get():
 
     testing.assertNone(r.c1.li.get("missing"))
 
+def _test_list_indexed():
+    r = yang_foo_root()
+    r.c1.li.create("a", val="1")
+    r.c1.li.create("b", val="2")
+
+    testing.assertEqual(r.c1.li["b"].val, "2")
+
+    r.c1.li["b"] = yang_foo.foo__c1__li_entry(name="b", val="22")
+    testing.assertEqual(r.c1.li["b"].val, "22")
+
+    del r.c1.li["b"]
+    testing.assertNone(r.c1.li.get("b"))
+
 def _test_list_get_union_key():
     r = yang_foo_root()
     r.li_union_one_base.create("foo")

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -451,6 +451,54 @@ def _test_list_create_idempotency():
     # TODO: fix this!!!
     return r.to_gdata().to_xmlstr()
 
+def _test_list_get():
+    r = yang_foo_root()
+    e_a = r.c1.li.create("a")
+    e_a.val = "1"
+    e_b = r.c1.li.create("b")
+    e_b.val = "2"
+
+    found = r.c1.li.get("b")
+    testing.assertNotNone(found)
+    if found is not None:
+        testing.assertEqual(found.val, "2")
+
+    testing.assertNone(r.c1.li.get("missing"))
+
+def _test_list_get_union_key():
+    r = yang_foo_root()
+    r.li_union_one_base.create("foo")
+    r.li_union_one_base.create("hello")
+
+    found = r.li_union_one_base.get("hello")
+    testing.assertNotNone(found)
+    if found is not None:
+        k1 = found.k1
+        if isinstance(k1, str):
+            testing.assertEqual(k1, "hello")
+        else:
+            testing.error("k1 in adata is not str")
+
+    testing.assertNone(r.li_union_one_base.get("missing"))
+
+def _test_list_get_compound_key():
+    r = yang_foo_root()
+    r.li_union.create("a", u64(1), "hi".encode())
+    r.li_union.create("a", u64(2), "hi".encode())
+    r.li_union.create("b", u64(1), "hi".encode())
+
+    found = r.li_union.get("a", u64(2), "hi".encode())
+    testing.assertNotNone(found)
+    if found is not None:
+        testing.assertEqual(found.k1, "a")
+        k2 = found.k2
+        if isinstance(k2, u64):
+            testing.assertEqual(k2, u64(2))
+        else:
+            testing.error("k2 in adata is not u64")
+
+    testing.assertNone(r.li_union.get("z", u64(1), "hi".encode()))
+
 def _test_p_container_create_idempotency():
     r = yang_foo_root()
     pc1 = r.create_pc1()

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -383,6 +383,27 @@ extension filter_test__interfaces__interface(Iterable[filter_test__interfaces__i
     def __iter__(self) -> Iterator[filter_test__interfaces__interface_entry]:
         return self.elements.__iter__()
 
+extension filter_test__interfaces__interface(Indexed[str, filter_test__interfaces__interface_entry]):
+    def __getitem__(self, k: str) -> filter_test__interfaces__interface_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: filter_test__interfaces__interface_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker8 = None
 class filter_test__interfaces(yang.adata.MNode):
     interface: filter_test__interfaces__interface

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -337,27 +337,28 @@ class filter_test__interfaces__interface(yang.adata.MNode):
         self._name = 'interface'
         self.elements = elements
 
-    mut def create(self, name: str, description: ?str=None, type: ?str=None, enabled: ?bool=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None) -> filter_test__interfaces__interface_entry:
+    def get(self, name: str) -> ?filter_test__interfaces__interface_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if description is not None:
-                    e.description = description
-                if type is not None:
-                    e.type = type
-                if enabled is not None:
-                    e.enabled = enabled
-                if admin_status is not None:
-                    e.admin_status = admin_status
-                if oper_status is not None:
-                    e.oper_status = oper_status
-                if last_change is not None:
-                    e.last_change = last_change
-                return e
+            return e
 
+    mut def create(self, name: str, description: ?str=None, type: ?str=None, enabled: ?bool=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None) -> filter_test__interfaces__interface_entry:
+        e = self.get(name)
+        if e is not None:
+            if description is not None:
+                e.description = description
+            if type is not None:
+                e.type = type
+            if enabled is not None:
+                e.enabled = enabled
+            if admin_status is not None:
+                e.admin_status = admin_status
+            if oper_status is not None:
+                e.oper_status = oper_status
+            if last_change is not None:
+                e.last_change = last_change
+            return e
         res = filter_test__interfaces__interface_entry(name=name, description=description, type=type, enabled=enabled, admin_status=admin_status, oper_status=oper_status, last_change=last_change)
         self.elements.append(res)
         return res

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -618,6 +618,27 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
     def __iter__(self) -> Iterator[foo__c1__li_entry]:
         return self.elements.__iter__()
 
+extension foo__c1__li(Indexed[str, foo__c1__li_entry]):
+    def __getitem__(self, k: str) -> foo__c1__li_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__c1__li_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker4 = None
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
@@ -1056,6 +1077,27 @@ extension foo__cc__death(Iterable[foo__cc__death_entry]):
     def __iter__(self) -> Iterator[foo__cc__death_entry]:
         return self.elements.__iter__()
 
+extension foo__cc__death(Indexed[str, foo__cc__death_entry]):
+    def __getitem__(self, k: str) -> foo__cc__death_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__cc__death_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker17 = None
 class foo__cc(yang.adata.MNode):
     cake: ?str
@@ -1253,6 +1295,27 @@ extension foo__special(Iterable[foo__special_entry]):
     def __iter__(self) -> Iterator[foo__special_entry]:
         return self.elements.__iter__()
 
+extension foo__special(Indexed[bool, foo__special_entry]):
+    def __getitem__(self, k: bool) -> foo__special_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: bool, n: foo__special_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.yes == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: bool) -> None:
+        for i, e in enumerate(self.elements):
+            if e.yes == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker23 = None
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key1: str
@@ -1410,6 +1473,27 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
 extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
         return self.elements.__iter__()
+
+extension foo__nested__f_inner__li1(Indexed[str, foo__nested__f_inner__li1_entry]):
+    def __getitem__(self, k: str) -> foo__nested__f_inner__li1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__nested__f_inner__li1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
 
 _breaker27 = None
 class foo__nested__f_inner(yang.adata.MNode):

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -582,17 +582,18 @@ class foo__c1__li(yang.adata.MNode):
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
+    def get(self, name: str) -> ?foo__c1__li_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if val is not None:
-                    e.val = val
-                return e
+            return e
 
+    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
+        e = self.get(name)
+        if e is not None:
+            if val is not None:
+                e.val = val
+            return e
         res = foo__c1__li_entry(name=name, val=val)
         self.elements.append(res)
         return res
@@ -1021,15 +1022,16 @@ class foo__cc__death(yang.adata.MNode):
         self._name = 'death'
         self.elements = elements
 
-    mut def create(self, name: str) -> foo__cc__death_entry:
+    def get(self, name: str) -> ?foo__cc__death_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> foo__cc__death_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = foo__cc__death_entry(name=name)
         self.elements.append(res)
         return res
@@ -1217,15 +1219,16 @@ class foo__special(yang.adata.MNode):
         self._name = 'special'
         self.elements = elements
 
-    mut def create(self, yes: bool) -> foo__special_entry:
+    def get(self, yes: bool) -> ?foo__special_entry:
         for e in self:
-            match = True
             if e.yes != yes:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, yes: bool) -> foo__special_entry:
+        e = self.get(yes)
+        if e is not None:
+            return e
         res = foo__special_entry(yes=yes)
         self.elements.append(res)
         return res
@@ -1289,20 +1292,20 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         self._name = 'li2'
         self.elements = elements
 
-    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
+    def get(self, key1: str, key2: str) -> ?foo__nested__f_inner__li1__li2_entry:
         for e in self:
-            match = True
             if e.key1 != key1:
-                match = False
                 continue
             if e.key2 != key2:
-                match = False
                 continue
-            if match:
-                if baz is not None:
-                    e.baz = baz
-                return e
+            return e
 
+    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
+        e = self.get(key1, key2)
+        if e is not None:
+            if baz is not None:
+                e.baz = baz
+            return e
         res = foo__nested__f_inner__li1__li2_entry(key1=key1, key2=key2, baz=baz)
         self.elements.append(res)
         return res
@@ -1370,19 +1373,20 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
+    def get(self, name: str) -> ?foo__nested__f_inner__li1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if f_bar is not None:
-                    e.f_bar = f_bar
-                if bar_bar is not None:
-                    e.bar_bar = bar_bar
-                return e
+            return e
 
+    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
+        e = self.get(name)
+        if e is not None:
+            if f_bar is not None:
+                e.f_bar = f_bar
+            if bar_bar is not None:
+                e.bar_bar = bar_bar
+            return e
         res = foo__nested__f_inner__li1_entry(name=name, f_bar=f_bar, bar_bar=bar_bar)
         self.elements.append(res)
         return res
@@ -1536,11 +1540,9 @@ class foo__li_union(yang.adata.MNode):
         self._name = 'li-union'
         self.elements = elements
 
-    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
+    def get(self, k1: str, k2: value, k3: bytes) -> ?foo__li_union_entry:
         for e in self:
-            match = True
             if e.k1 != k1:
-                match = False
                 continue
             e_k2 = e.k2
             k2_match = False
@@ -1554,16 +1556,17 @@ class foo__li_union(yang.adata.MNode):
                 if e_k2 == k2:
                     k2_match = True
             if not k2_match:
-                match = False
                 continue
             if e.k3 != k3:
-                match = False
                 continue
-            if match:
-                if checker is not None:
-                    e.checker = checker
-                return e
+            return e
 
+    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
+        e = self.get(k1, k2, k3)
+        if e is not None:
+            if checker is not None:
+                e.checker = checker
+            return e
         res = foo__li_union_entry(k1=k1, k2=k2, k3=k3, checker=checker)
         self.elements.append(res)
         return res
@@ -1619,20 +1622,21 @@ class foo__li_union_one_base(yang.adata.MNode):
         self._name = 'li-union-one-base'
         self.elements = elements
 
-    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
+    def get(self, k1: value) -> ?foo__li_union_one_base_entry:
         for e in self:
-            match = True
             e_k1 = e.k1
             k1_match = False
             if isinstance(e_k1, str) and isinstance(k1, str):
                 if e_k1 == k1:
                     k1_match = True
             if not k1_match:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
+        e = self.get(k1)
+        if e is not None:
+            return e
         res = foo__li_union_one_base_entry(k1=k1)
         self.elements.append(res)
         return res

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -618,6 +618,27 @@ extension foo__c1__li(Iterable[foo__c1__li_entry]):
     def __iter__(self) -> Iterator[foo__c1__li_entry]:
         return self.elements.__iter__()
 
+extension foo__c1__li(Indexed[str, foo__c1__li_entry]):
+    def __getitem__(self, k: str) -> foo__c1__li_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__c1__li_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker4 = None
 class foo__c1(yang.adata.MNode):
     f_l1: ?str
@@ -1056,6 +1077,27 @@ extension foo__cc__death(Iterable[foo__cc__death_entry]):
     def __iter__(self) -> Iterator[foo__cc__death_entry]:
         return self.elements.__iter__()
 
+extension foo__cc__death(Indexed[str, foo__cc__death_entry]):
+    def __getitem__(self, k: str) -> foo__cc__death_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__cc__death_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker17 = None
 class foo__cc(yang.adata.MNode):
     cake: ?str
@@ -1253,6 +1295,27 @@ extension foo__special(Iterable[foo__special_entry]):
     def __iter__(self) -> Iterator[foo__special_entry]:
         return self.elements.__iter__()
 
+extension foo__special(Indexed[bool, foo__special_entry]):
+    def __getitem__(self, k: bool) -> foo__special_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: bool, n: foo__special_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.yes == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: bool) -> None:
+        for i, e in enumerate(self.elements):
+            if e.yes == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker23 = None
 class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
     key1: str
@@ -1410,6 +1473,27 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
 extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
     def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
         return self.elements.__iter__()
+
+extension foo__nested__f_inner__li1(Indexed[str, foo__nested__f_inner__li1_entry]):
+    def __getitem__(self, k: str) -> foo__nested__f_inner__li1_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__nested__f_inner__li1_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
 
 _breaker27 = None
 class foo__nested__f_inner(yang.adata.MNode):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -582,17 +582,18 @@ class foo__c1__li(yang.adata.MNode):
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
+    def get(self, name: str) -> ?foo__c1__li_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if val is not None:
-                    e.val = val
-                return e
+            return e
 
+    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
+        e = self.get(name)
+        if e is not None:
+            if val is not None:
+                e.val = val
+            return e
         res = foo__c1__li_entry(name=name, val=val)
         self.elements.append(res)
         return res
@@ -1021,15 +1022,16 @@ class foo__cc__death(yang.adata.MNode):
         self._name = 'death'
         self.elements = elements
 
-    mut def create(self, name: str) -> foo__cc__death_entry:
+    def get(self, name: str) -> ?foo__cc__death_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, name: str) -> foo__cc__death_entry:
+        e = self.get(name)
+        if e is not None:
+            return e
         res = foo__cc__death_entry(name=name)
         self.elements.append(res)
         return res
@@ -1217,15 +1219,16 @@ class foo__special(yang.adata.MNode):
         self._name = 'special'
         self.elements = elements
 
-    mut def create(self, yes: bool) -> foo__special_entry:
+    def get(self, yes: bool) -> ?foo__special_entry:
         for e in self:
-            match = True
             if e.yes != yes:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, yes: bool) -> foo__special_entry:
+        e = self.get(yes)
+        if e is not None:
+            return e
         res = foo__special_entry(yes=yes)
         self.elements.append(res)
         return res
@@ -1289,20 +1292,20 @@ class foo__nested__f_inner__li1__li2(yang.adata.MNode):
         self._name = 'li2'
         self.elements = elements
 
-    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
+    def get(self, key1: str, key2: str) -> ?foo__nested__f_inner__li1__li2_entry:
         for e in self:
-            match = True
             if e.key1 != key1:
-                match = False
                 continue
             if e.key2 != key2:
-                match = False
                 continue
-            if match:
-                if baz is not None:
-                    e.baz = baz
-                return e
+            return e
 
+    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
+        e = self.get(key1, key2)
+        if e is not None:
+            if baz is not None:
+                e.baz = baz
+            return e
         res = foo__nested__f_inner__li1__li2_entry(key1=key1, key2=key2, baz=baz)
         self.elements.append(res)
         return res
@@ -1370,19 +1373,20 @@ class foo__nested__f_inner__li1(yang.adata.MNode):
         self._name = 'li1'
         self.elements = elements
 
-    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
+    def get(self, name: str) -> ?foo__nested__f_inner__li1_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                if f_bar is not None:
-                    e.f_bar = f_bar
-                if bar_bar is not None:
-                    e.bar_bar = bar_bar
-                return e
+            return e
 
+    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
+        e = self.get(name)
+        if e is not None:
+            if f_bar is not None:
+                e.f_bar = f_bar
+            if bar_bar is not None:
+                e.bar_bar = bar_bar
+            return e
         res = foo__nested__f_inner__li1_entry(name=name, f_bar=f_bar, bar_bar=bar_bar)
         self.elements.append(res)
         return res
@@ -1536,11 +1540,9 @@ class foo__li_union(yang.adata.MNode):
         self._name = 'li-union'
         self.elements = elements
 
-    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
+    def get(self, k1: str, k2: value, k3: bytes) -> ?foo__li_union_entry:
         for e in self:
-            match = True
             if e.k1 != k1:
-                match = False
                 continue
             e_k2 = e.k2
             k2_match = False
@@ -1554,16 +1556,17 @@ class foo__li_union(yang.adata.MNode):
                 if e_k2 == k2:
                     k2_match = True
             if not k2_match:
-                match = False
                 continue
             if e.k3 != k3:
-                match = False
                 continue
-            if match:
-                if checker is not None:
-                    e.checker = checker
-                return e
+            return e
 
+    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
+        e = self.get(k1, k2, k3)
+        if e is not None:
+            if checker is not None:
+                e.checker = checker
+            return e
         res = foo__li_union_entry(k1=k1, k2=k2, k3=k3, checker=checker)
         self.elements.append(res)
         return res
@@ -1619,20 +1622,21 @@ class foo__li_union_one_base(yang.adata.MNode):
         self._name = 'li-union-one-base'
         self.elements = elements
 
-    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
+    def get(self, k1: value) -> ?foo__li_union_one_base_entry:
         for e in self:
-            match = True
             e_k1 = e.k1
             k1_match = False
             if isinstance(e_k1, str) and isinstance(k1, str):
                 if e_k1 == k1:
                     k1_match = True
             if not k1_match:
-                match = False
                 continue
-            if match:
-                return e
+            return e
 
+    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
+        e = self.get(k1)
+        if e is not None:
+            return e
         res = foo__li_union_one_base_entry(k1=k1)
         self.elements.append(res)
         return res

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -212,16 +212,17 @@ class foo__li(yang.adata.MNode):
         self._name = 'li'
         self.elements = elements
 
-    mut def create(self, name: str, c1: foo__li__c1) -> foo__li_entry:
+    def get(self, name: str) -> ?foo__li_entry:
         for e in self:
-            match = True
             if e.name != name:
-                match = False
                 continue
-            if match:
-                e.c1 = c1
-                return e
+            return e
 
+    mut def create(self, name: str, c1: foo__li__c1) -> foo__li_entry:
+        e = self.get(name)
+        if e is not None:
+            e.c1 = c1
+            return e
         res = foo__li_entry(name=name, c1=c1)
         self.elements.append(res)
         return res

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -247,6 +247,27 @@ extension foo__li(Iterable[foo__li_entry]):
     def __iter__(self) -> Iterator[foo__li_entry]:
         return self.elements.__iter__()
 
+extension foo__li(Indexed[str, foo__li_entry]):
+    def __getitem__(self, k: str) -> foo__li_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: foo__li_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.name == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
 _breaker5 = None
 class root(yang.adata.MNode):
     tc1: foo__tc1


### PR DESCRIPTION
This implements the `Indexed` protocol for single-key adata lists where the key type is not an union. Composite-key lists need tuple Eq and union keys are Acton "value"-typed (no Eq), so both are skipped.

We generate `.get(k1, ...) -> ?Entry` for all adata lists.

Closes #434 