### PR TITLE
Insert breakers between generated subs classes

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1928,7 +1928,8 @@ class DRoot(DNodeInner):
         res.extend(inner)
         if include_subs:
             res.append("")
-            res.extend(self._prsubsclasses())
+            subs_classes, _breaker_idx = self._prsubsclasses(breaker_idx=_breaker_idx)
+            res.extend(subs_classes)
             res.append("actor DstAdapter(cb: action(?root, ?Exception) -> None):")
             res.append("    on_update: action(?yang.gdata.Node, ?Exception) -> None")
             res.append("    def on_update(n: ?yang.gdata.Node, err: ?Exception) -> None:")
@@ -1947,7 +1948,10 @@ class DRoot(DNodeInner):
 
         return "\n".join(res)
 
-    def _prsubsclasses(self, root_const_name: str="subs") -> list[str]:
+    def _prsubsclasses(self, root_const_name: str="subs", breaker_idx: int=0) -> (list[str], int):
+        def next_breaker_name(i: int) -> (str, int):
+            return ("_breaker{i + 1}", i + 1)
+
         def dnode_path(spath: list[DNodeInner]) -> list[DNode]:
             res: list[DNode] = []
             for node in spath:
@@ -1988,14 +1992,15 @@ class DRoot(DNodeInner):
                     return child
             raise ValueError("Unable to find key leaf {key_name} in list {node.name}")
 
-        def emit_node(spath: list[DNodeInner]) -> list[str]:
+        def emit_node(spath: list[DNodeInner], breaker_idx: int) -> (list[str], int):
             node = spath[-1]
 
             res = []
             inner = inner_children(node)
             selectables = selectable_children(node)
             for child in inner:
-                res.extend(emit_node(spath + [child]))
+                child_res, breaker_idx = emit_node(spath + [child], breaker_idx)
+                res.extend(child_res)
 
             unique_namer = UniqueNamer(node)
             reserved_names = {"subscribe", "filt", "entry", "_segments", "_direct_children"}
@@ -2013,6 +2018,8 @@ class DRoot(DNodeInner):
                 return name
 
             if isinstance(node, DRoot) or isinstance(node, DContainer):
+                breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                res.append("{breaker_name}: None = None")
                 res.append("class {subs_path_name(spath)}(SubscriptionNode):")
                 for child in selectables:
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -2031,9 +2038,33 @@ class DRoot(DNodeInner):
                     res.append("        direct: list[SubscriptionNode] = []")
                 res.append("        return direct")
                 res.append("")
-                return res
+                return (res, breaker_idx)
 
             if isinstance(node, DList):
+                if len(node.key) > 0:
+                    breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                    res.append("{breaker_name}: None = None")
+                    res.append("class {subs_entry_path_name(spath)}(SubscriptionNode):")
+                    for child in selectables:
+                        child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
+                        res.append("    {usname(child)}: {child_type}")
+                    res.append("")
+                    res.append("    pure def __init__(self, path: ?SubscriptionPath=None) -> None:")
+                    res.append("        SubscriptionNode.__init__(self, path)")
+                    for child in selectables:
+                        child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
+                        res.append("        self.{usname(child)} = {child_ctor}(SubscriptionPath(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'), parent=path))")
+                    res.append("")
+                    res.append("    pure def _direct_children(self) -> list[SubscriptionNode]:")
+                    if len(selectables) > 0:
+                        res.append("        direct: list[SubscriptionNode] = [{', '.join(['self.{usname(child)}' for child in selectables])}]")
+                    else:
+                        res.append("        direct: list[SubscriptionNode] = []")
+                    res.append("        return direct")
+                    res.append("")
+
+                breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                res.append("{breaker_name}: None = None")
                 res.append("class {subs_path_name(spath)}(SubscriptionNode):")
                 for child in selectables:
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -2065,35 +2096,14 @@ class DRoot(DNodeInner):
                     res.append("        direct: list[SubscriptionNode] = []")
                 res.append("        return direct")
                 res.append("")
-
-                if len(node.key) > 0:
-                    res.append("class {subs_entry_path_name(spath)}(SubscriptionNode):")
-                    for child in selectables:
-                        child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
-                        res.append("    {usname(child)}: {child_type}")
-                    res.append("")
-                    res.append("    pure def __init__(self, path: ?SubscriptionPath=None) -> None:")
-                    res.append("        SubscriptionNode.__init__(self, path)")
-                    for child in selectables:
-                        child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
-                        res.append("        self.{usname(child)} = {child_ctor}(SubscriptionPath(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'), parent=path))")
-                    res.append("")
-                    res.append("    pure def _direct_children(self) -> list[SubscriptionNode]:")
-                    if len(selectables) > 0:
-                        res.append("        direct: list[SubscriptionNode] = [{', '.join(['self.{usname(child)}' for child in selectables])}]")
-                    else:
-                        res.append("        direct: list[SubscriptionNode] = []")
-                    res.append("        return direct")
-                    res.append("")
-                return res
+                return (res, breaker_idx)
 
             raise ValueError("Unsupported subscription path node type: {type(node)}")
 
-        res = []
-        res.extend(emit_node([self]))
+        res, breaker_idx = emit_node([self], breaker_idx)
         res.append("{root_const_name}: root_subs = root_subs()")
         res.append("")
-        return res
+        return (res, breaker_idx)
 
     def prsubstree(self, root_const_name: str="subs") -> str:
         res = []
@@ -2106,7 +2116,8 @@ class DRoot(DNodeInner):
         res.append("")
         res.extend(["NS_{safe_name(self.module_metadata[ns].module)} = {repr(ns)}" for ns in sorted(self.module_metadata.keys())])
         res.append("")
-        res.extend(self._prsubsclasses(root_const_name=root_const_name))
+        subs_classes, _breaker_idx = self._prsubsclasses(root_const_name=root_const_name)
+        res.extend(subs_classes)
         res.append("actor DstAdapter(cb: action(?yang.gdata.Node, ?Exception) -> None):")
         res.append("    on_update: action(?yang.gdata.Node, ?Exception) -> None")
         res.append("    def on_update(n: ?yang.gdata.Node, err: ?Exception) -> None:")

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -1924,7 +1924,8 @@ class DRoot(DNodeInner):
         res.extend(inner)
         if include_subs:
             res.append("")
-            res.extend(self._prsubsclasses())
+            subs_classes, _breaker_idx = self._prsubsclasses(breaker_idx=_breaker_idx)
+            res.extend(subs_classes)
             res.append("actor DstAdapter(cb: action(?root, ?Exception) -> None):")
             res.append("    on_update: action(?yang.gdata.Node, ?Exception) -> None")
             res.append("    def on_update(n: ?yang.gdata.Node, err: ?Exception) -> None:")
@@ -1943,7 +1944,10 @@ class DRoot(DNodeInner):
 
         return "\n".join(res)
 
-    def _prsubsclasses(self, root_const_name: str="subs") -> list[str]:
+    def _prsubsclasses(self, root_const_name: str="subs", breaker_idx: int=0) -> (list[str], int):
+        def next_breaker_name(i: int) -> (str, int):
+            return ("_breaker{i + 1}", i + 1)
+
         def dnode_path(spath: list[DNodeInner]) -> list[DNode]:
             res: list[DNode] = []
             for node in spath:
@@ -1984,14 +1988,15 @@ class DRoot(DNodeInner):
                     return child
             raise ValueError("Unable to find key leaf {key_name} in list {node.name}")
 
-        def emit_node(spath: list[DNodeInner]) -> list[str]:
+        def emit_node(spath: list[DNodeInner], breaker_idx: int) -> (list[str], int):
             node = spath[-1]
 
             res = []
             inner = inner_children(node)
             selectables = selectable_children(node)
             for child in inner:
-                res.extend(emit_node(spath + [child]))
+                child_res, breaker_idx = emit_node(spath + [child], breaker_idx)
+                res.extend(child_res)
 
             unique_namer = UniqueNamer(node)
             reserved_names = {"subscribe", "filt", "entry", "_segments", "_direct_children"}
@@ -2009,6 +2014,8 @@ class DRoot(DNodeInner):
                 return name
 
             if isinstance(node, DRoot) or isinstance(node, DContainer):
+                breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                res.append("{breaker_name}: None = None")
                 res.append("class {subs_path_name(spath)}(SubscriptionNode):")
                 for child in selectables:
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -2027,9 +2034,33 @@ class DRoot(DNodeInner):
                     res.append("        direct: list[SubscriptionNode] = []")
                 res.append("        return direct")
                 res.append("")
-                return res
+                return (res, breaker_idx)
 
             if isinstance(node, DList):
+                if len(node.key) > 0:
+                    breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                    res.append("{breaker_name}: None = None")
+                    res.append("class {subs_entry_path_name(spath)}(SubscriptionNode):")
+                    for child in selectables:
+                        child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
+                        res.append("    {usname(child)}: {child_type}")
+                    res.append("")
+                    res.append("    pure def __init__(self, path: ?SubscriptionPath=None) -> None:")
+                    res.append("        SubscriptionNode.__init__(self, path)")
+                    for child in selectables:
+                        child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
+                        res.append("        self.{usname(child)} = {child_ctor}(SubscriptionPath(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'), parent=path))")
+                    res.append("")
+                    res.append("    pure def _direct_children(self) -> list[SubscriptionNode]:")
+                    if len(selectables) > 0:
+                        res.append("        direct: list[SubscriptionNode] = [{', '.join(['self.{usname(child)}' for child in selectables])}]")
+                    else:
+                        res.append("        direct: list[SubscriptionNode] = []")
+                    res.append("        return direct")
+                    res.append("")
+
+                breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+                res.append("{breaker_name}: None = None")
                 res.append("class {subs_path_name(spath)}(SubscriptionNode):")
                 for child in selectables:
                     child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
@@ -2061,35 +2092,14 @@ class DRoot(DNodeInner):
                     res.append("        direct: list[SubscriptionNode] = []")
                 res.append("        return direct")
                 res.append("")
-
-                if len(node.key) > 0:
-                    res.append("class {subs_entry_path_name(spath)}(SubscriptionNode):")
-                    for child in selectables:
-                        child_type = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
-                        res.append("    {usname(child)}: {child_type}")
-                    res.append("")
-                    res.append("    pure def __init__(self, path: ?SubscriptionPath=None) -> None:")
-                    res.append("        SubscriptionNode.__init__(self, path)")
-                    for child in selectables:
-                        child_ctor = subs_path_name(spath + [child]) if isinstance(child, DNodeInner) else "SubscriptionNode"
-                        res.append("        self.{usname(child)} = {child_ctor}(SubscriptionPath(yang.gdata.Id(NS_{safe_name(child.module)}, '{child.name}'), parent=path))")
-                    res.append("")
-                    res.append("    pure def _direct_children(self) -> list[SubscriptionNode]:")
-                    if len(selectables) > 0:
-                        res.append("        direct: list[SubscriptionNode] = [{', '.join(['self.{usname(child)}' for child in selectables])}]")
-                    else:
-                        res.append("        direct: list[SubscriptionNode] = []")
-                    res.append("        return direct")
-                    res.append("")
-                return res
+                return (res, breaker_idx)
 
             raise ValueError("Unsupported subscription path node type: {type(node)}")
 
-        res = []
-        res.extend(emit_node([self]))
+        res, breaker_idx = emit_node([self], breaker_idx)
         res.append("{root_const_name}: root_subs = root_subs()")
         res.append("")
-        return res
+        return (res, breaker_idx)
 
     def prsubstree(self, root_const_name: str="subs") -> str:
         res = []
@@ -2102,7 +2112,8 @@ class DRoot(DNodeInner):
         res.append("")
         res.extend(["NS_{safe_name(self.module_metadata[ns].module)} = {repr(ns)}" for ns in sorted(self.module_metadata.keys())])
         res.append("")
-        res.extend(self._prsubsclasses(root_const_name=root_const_name))
+        subs_classes, _breaker_idx = self._prsubsclasses(root_const_name=root_const_name)
+        res.extend(subs_classes)
         res.append("actor DstAdapter(cb: action(?yang.gdata.Node, ?Exception) -> None):")
         res.append("    on_update: action(?yang.gdata.Node, ?Exception) -> None")
         res.append("    def on_update(n: ?yang.gdata.Node, err: ?Exception) -> None:")

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -455,6 +455,7 @@ actor rpc_root(tp: yang.gdata.TreeProvider):
 
 
 
+_breaker10: None = None
 class filter_test__system_state__clock_subs(SubscriptionNode):
     current_datetime: SubscriptionNode
     boot_datetime: SubscriptionNode
@@ -468,6 +469,7 @@ class filter_test__system_state__clock_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.current_datetime, self.boot_datetime]
         return direct
 
+_breaker11: None = None
 class filter_test__system_state_subs(SubscriptionNode):
     clock: filter_test__system_state__clock_subs
 
@@ -479,6 +481,7 @@ class filter_test__system_state_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.clock]
         return direct
 
+_breaker12: None = None
 class filter_test__interfaces__interface__statistics_subs(SubscriptionNode):
     in_octets: SubscriptionNode
     out_octets: SubscriptionNode
@@ -492,6 +495,7 @@ class filter_test__interfaces__interface__statistics_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.in_octets, self.out_octets]
         return direct
 
+_breaker13: None = None
 class filter_test__interfaces__interface__ipv4_subs(SubscriptionNode):
     mtu: SubscriptionNode
 
@@ -503,6 +507,7 @@ class filter_test__interfaces__interface__ipv4_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.mtu]
         return direct
 
+_breaker14: None = None
 class filter_test__interfaces__interface__ipv6_subs(SubscriptionNode):
     mtu: SubscriptionNode
 
@@ -514,6 +519,37 @@ class filter_test__interfaces__interface__ipv6_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.mtu]
         return direct
 
+_breaker15: None = None
+class filter_test__interfaces__interface_entry_subs(SubscriptionNode):
+    name: SubscriptionNode
+    description: SubscriptionNode
+    type: SubscriptionNode
+    enabled: SubscriptionNode
+    admin_status: SubscriptionNode
+    oper_status: SubscriptionNode
+    last_change: SubscriptionNode
+    statistics: filter_test__interfaces__interface__statistics_subs
+    ipv4: filter_test__interfaces__interface__ipv4_subs
+    ipv6: filter_test__interfaces__interface__ipv6_subs
+
+    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
+        SubscriptionNode.__init__(self, path)
+        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'name'), parent=path))
+        self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'description'), parent=path))
+        self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'type'), parent=path))
+        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'enabled'), parent=path))
+        self.admin_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'admin-status'), parent=path))
+        self.oper_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'oper-status'), parent=path))
+        self.last_change = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'last-change'), parent=path))
+        self.statistics = filter_test__interfaces__interface__statistics_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'statistics'), parent=path))
+        self.ipv4 = filter_test__interfaces__interface__ipv4_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'ipv4'), parent=path))
+        self.ipv6 = filter_test__interfaces__interface__ipv6_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'ipv6'), parent=path))
+
+    pure def _direct_children(self) -> list[SubscriptionNode]:
+        direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.enabled, self.admin_status, self.oper_status, self.last_change, self.statistics, self.ipv4, self.ipv6]
+        return direct
+
+_breaker16: None = None
 class filter_test__interfaces__interface_subs(SubscriptionNode):
     name: SubscriptionNode
     description: SubscriptionNode
@@ -549,35 +585,7 @@ class filter_test__interfaces__interface_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.enabled, self.admin_status, self.oper_status, self.last_change, self.statistics, self.ipv4, self.ipv6]
         return direct
 
-class filter_test__interfaces__interface_entry_subs(SubscriptionNode):
-    name: SubscriptionNode
-    description: SubscriptionNode
-    type: SubscriptionNode
-    enabled: SubscriptionNode
-    admin_status: SubscriptionNode
-    oper_status: SubscriptionNode
-    last_change: SubscriptionNode
-    statistics: filter_test__interfaces__interface__statistics_subs
-    ipv4: filter_test__interfaces__interface__ipv4_subs
-    ipv6: filter_test__interfaces__interface__ipv6_subs
-
-    pure def __init__(self, path: ?SubscriptionPath=None) -> None:
-        SubscriptionNode.__init__(self, path)
-        self.name = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'name'), parent=path))
-        self.description = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'description'), parent=path))
-        self.type = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'type'), parent=path))
-        self.enabled = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'enabled'), parent=path))
-        self.admin_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'admin-status'), parent=path))
-        self.oper_status = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'oper-status'), parent=path))
-        self.last_change = SubscriptionNode(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'last-change'), parent=path))
-        self.statistics = filter_test__interfaces__interface__statistics_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'statistics'), parent=path))
-        self.ipv4 = filter_test__interfaces__interface__ipv4_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'ipv4'), parent=path))
-        self.ipv6 = filter_test__interfaces__interface__ipv6_subs(SubscriptionPath(yang.gdata.Id(NS_filter_test, 'ipv6'), parent=path))
-
-    pure def _direct_children(self) -> list[SubscriptionNode]:
-        direct: list[SubscriptionNode] = [self.name, self.description, self.type, self.enabled, self.admin_status, self.oper_status, self.last_change, self.statistics, self.ipv4, self.ipv6]
-        return direct
-
+_breaker17: None = None
 class filter_test__interfaces_subs(SubscriptionNode):
     interface: filter_test__interfaces__interface_subs
 
@@ -589,6 +597,7 @@ class filter_test__interfaces_subs(SubscriptionNode):
         direct: list[SubscriptionNode] = [self.interface]
         return direct
 
+_breaker18: None = None
 class root_subs(SubscriptionNode):
     system_state: filter_test__system_state_subs
     interfaces: filter_test__interfaces_subs


### PR DESCRIPTION
Refactor _prsubsclasses() to return the updated breaker index so generated subscription classes can continue the existing _breakerN sequence used by the adata classes in *_oper.act output.

Also emit list entry subscription classes before their parent list subscription classes so the generated entry() methods do not refer forward across a breaker boundary.