### PR TITLE
Drop is_unique parameter from YangData protocol

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -730,7 +730,7 @@ class DNodeInner(DNode):
         if len(attr_children) > 0:
             res.append("    pure def _get_attr(self, name: str) -> ?value:")
             for child in attr_children:
-                res.append("        if name == '{usname(child)}':")
+                res.append("        if name == '{child.name}:{child.prefix}':")
                 if isinstance(child, DList):
                     res.append("            return iter(self.{usname(child)})")
                 else:

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -98,9 +98,9 @@ class base__system_capabilities__subscription_capabilities(yang.adata.MNode):
         self.supported_excluded_change_type = supported_excluded_change_type if supported_excluded_change_type is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'max_nodes':
+        if name == 'max-nodes:aug':
             return self.max_nodes
-        if name == 'supported_excluded_change_type':
+        if name == 'supported-excluded-change-type:aug':
             return self.supported_excluded_change_type
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -127,9 +127,9 @@ class base__system_capabilities(yang.adata.MNode):
         self.subscription_capabilities = subscription_capabilities if subscription_capabilities is not None else base__system_capabilities__subscription_capabilities()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'per_node_capabilities':
+        if name == 'per-node-capabilities:base':
             return iter(self.per_node_capabilities)
-        if name == 'subscription_capabilities':
+        if name == 'subscription-capabilities:aug':
             return self.subscription_capabilities
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -154,7 +154,7 @@ class root(yang.adata.MNode):
         self.system_capabilities = system_capabilities if system_capabilities is not None else base__system_capabilities()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'system_capabilities':
+        if name == 'system-capabilities:base':
             return self.system_capabilities
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment
+++ b/snapshots/expected/test_yang/compile_augment
@@ -44,9 +44,9 @@ class foo__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:foo':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -71,7 +71,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment_augmented_node
+++ b/snapshots/expected/test_yang/compile_augment_augmented_node
@@ -54,9 +54,9 @@ class base__native__voice__service__voip__sip(yang.adata.MNode):
         self.port = port if port is not None else u64(5060)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bind':
+        if name == 'bind:voice':
             return self.bind
-        if name == 'port':
+        if name == 'port:voice':
             return self.port
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -83,9 +83,9 @@ class base__native__voice__service__voip(yang.adata.MNode):
         self.sip = sip if sip is not None else base__native__voice__service__voip__sip()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'enabled':
+        if name == 'enabled:voice':
             return self.enabled
-        if name == 'sip':
+        if name == 'sip:voice':
             return self.sip
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -110,7 +110,7 @@ class base__native__voice__service(yang.adata.MNode):
         self.voip = voip if voip is not None else base__native__voice__service__voip()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voip':
+        if name == 'voip:voice':
             return self.voip
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -135,7 +135,7 @@ class base__native__voice(yang.adata.MNode):
         self.service = service if service is not None else base__native__voice__service()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'service':
+        if name == 'service:voice':
             return self.service
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -160,7 +160,7 @@ class base__native(yang.adata.MNode):
         self.voice = voice if voice is not None else base__native__voice()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voice':
+        if name == 'voice:voice':
             return self.voice
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -185,7 +185,7 @@ class root(yang.adata.MNode):
         self.native = native if native is not None else base__native()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'native':
+        if name == 'native:base':
             return self.native
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -76,7 +76,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -101,7 +101,7 @@ class foo__r1__input__c3(yang.adata.MNode):
         self.l3 = l3
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l3':
+        if name == 'l3:foo':
             return self.l3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -126,7 +126,7 @@ class foo__r1__input(yang.adata.MNode):
         self.c3 = c3 if c3 is not None else foo__r1__input__c3()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c3':
+        if name == 'c3:foo':
             return self.c3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -151,7 +151,7 @@ class foo__r1__output(yang.adata.MNode):
         self.l4 = l4
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l4':
+        if name == 'l4:foo':
             return self.l4
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment_import
+++ b/snapshots/expected/test_yang/compile_augment_import
@@ -45,9 +45,9 @@ class foo__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -72,7 +72,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment_on_augment
+++ b/snapshots/expected/test_yang/compile_augment_on_augment
@@ -47,9 +47,9 @@ class foo__c1__c2(yang.adata.MNode):
         self.l3 = l3
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l2':
+        if name == 'l2:foo':
             return self.l2
-        if name == 'l3':
+        if name == 'l3:foo':
             return self.l3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -76,9 +76,9 @@ class foo__c1(yang.adata.MNode):
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'c2':
+        if name == 'c2:foo':
             return self.c2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -103,7 +103,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
+++ b/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
@@ -49,9 +49,9 @@ class foo__c1__c2(yang.adata.MNode):
         self.l3 = l3
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
-        if name == 'l3':
+        if name == 'l3:baz':
             return self.l3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -78,9 +78,9 @@ class foo__c1(yang.adata.MNode):
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'c2':
+        if name == 'c2:bar':
             return self.c2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -105,7 +105,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_augment_uses
+++ b/snapshots/expected/test_yang/compile_augment_uses
@@ -46,7 +46,7 @@ class foo__c1__c2(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c2':
+        if name == 'c2:foo':
             return self.c2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -96,7 +96,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_bundle1
+++ b/snapshots/expected/test_yang/compile_bundle1
@@ -45,9 +45,9 @@ class foo__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -72,7 +72,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -51,9 +51,9 @@ class foo__c1__things_entry(yang.adata.MNode):
         self.id = id
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'id':
+        if name == 'id:foo':
             return self.id
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -138,7 +138,7 @@ class foo__c1(yang.adata.MNode):
         self.things = foo__c1__things(elements=things)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'things':
+        if name == 'things:foo':
             return iter(self.things)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -163,7 +163,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_import_hyphenated_prefix
+++ b/snapshots/expected/test_yang/compile_import_hyphenated_prefix
@@ -42,7 +42,7 @@ class acme_foo_bar__c1(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:acme_foo-bar':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -67,7 +67,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else acme_foo_bar__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:acme_foo-bar':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -63,9 +63,9 @@ class bar__c1__li1_entry(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:bar':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -150,7 +150,7 @@ class bar__c1(yang.adata.MNode):
         self.li1 = bar__c1__li1(elements=li1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'li1':
+        if name == 'li1:bar':
             return iter(self.li1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -175,7 +175,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else bar__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:bar':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_refine
+++ b/snapshots/expected/test_yang/compile_refine
@@ -47,7 +47,7 @@ class foo__c1(yang.adata.MNode):
         self.l1 = l1 if l1 is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -72,7 +72,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
@@ -51,9 +51,9 @@ class parent__parent_container(yang.adata.MNode):
         self.augmented_leaf = augmented_leaf
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent_leaf':
+        if name == 'parent-leaf:parent':
             return self.parent_leaf
-        if name == 'augmented_leaf':
+        if name == 'augmented-leaf:parent':
             return self.augmented_leaf
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -80,9 +80,9 @@ class parent__sub_container(yang.adata.MNode):
         self.another_leaf = another_leaf
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'sub_leaf':
+        if name == 'sub-leaf:parent':
             return self.sub_leaf
-        if name == 'another_leaf':
+        if name == 'another-leaf:parent':
             return self.another_leaf
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -109,9 +109,9 @@ class root(yang.adata.MNode):
         self.sub_container = sub_container if sub_container is not None else parent__sub_container()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent_container':
+        if name == 'parent-container:parent':
             return self.parent_container
-        if name == 'sub_container':
+        if name == 'sub-container:parent':
             return self.sub_container
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -58,7 +58,7 @@ class main_module__main_container__sub_group_container(yang.adata.MNode):
         self.sub_group_leaf = sub_group_leaf if sub_group_leaf is not None else "from-submodule"
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'sub_group_leaf':
+        if name == 'sub-group-leaf:main':
             return self.sub_group_leaf
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -87,11 +87,11 @@ class main_module__main_container__sub_list_entry(yang.adata.MNode):
         self.ref_to_main = ref_to_main
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:main':
             return self.name
-        if name == 'sub_value':
+        if name == 'sub-value:main':
             return self.sub_value
-        if name == 'ref_to_main':
+        if name == 'ref-to-main:main':
             return self.ref_to_main
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -180,9 +180,9 @@ class main_module__main_container__group_container(yang.adata.MNode):
         self.augmented_in_group = augmented_in_group
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'group_leaf':
+        if name == 'group-leaf:main':
             return self.group_leaf
-        if name == 'augmented_in_group':
+        if name == 'augmented-in-group:main':
             return self.augmented_in_group
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -215,15 +215,15 @@ class main_module__main_container(yang.adata.MNode):
         self.group_container = group_container if group_container is not None else main_module__main_container__group_container()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main_leaf':
+        if name == 'main-leaf:main':
             return self.main_leaf
-        if name == 'sub_group_container':
+        if name == 'sub-group-container:main':
             return self.sub_group_container
-        if name == 'sub_leaf':
+        if name == 'sub-leaf:main':
             return self.sub_leaf
-        if name == 'sub_list':
+        if name == 'sub-list:main':
             return iter(self.sub_list)
-        if name == 'group_container':
+        if name == 'group-container:main':
             return self.group_container
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -248,7 +248,7 @@ class root(yang.adata.MNode):
         self.main_container = main_container if main_container is not None else main_module__main_container()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main_container':
+        if name == 'main-container:main':
             return self.main_container
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
@@ -50,9 +50,9 @@ class parent__parent_container(yang.adata.MNode):
         self.augmented_leaf = augmented_leaf
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent_leaf':
+        if name == 'parent-leaf:parent':
             return self.parent_leaf
-        if name == 'augmented_leaf':
+        if name == 'augmented-leaf:parent':
             return self.augmented_leaf
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -79,9 +79,9 @@ class parent__sub_container(yang.adata.MNode):
         self.shared_leaf = shared_leaf if shared_leaf is not None else "from-shared"
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'sub_leaf':
+        if name == 'sub-leaf:parent':
             return self.sub_leaf
-        if name == 'shared_leaf':
+        if name == 'shared-leaf:parent':
             return self.shared_leaf
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -108,9 +108,9 @@ class root(yang.adata.MNode):
         self.sub_container = sub_container if sub_container is not None else parent__sub_container()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent_container':
+        if name == 'parent-container:parent':
             return self.parent_container
-        if name == 'sub_container':
+        if name == 'sub-container:parent':
             return self.sub_container
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_submodules1
+++ b/snapshots/expected/test_yang/compile_submodules1
@@ -45,7 +45,7 @@ class foo__c1(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -70,7 +70,7 @@ class foo__c2(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l2':
+        if name == 'l2:foo':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -97,9 +97,9 @@ class root(yang.adata.MNode):
         self.c2 = c2 if c2 is not None else foo__c2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
-        if name == 'c2':
+        if name == 'c2:foo':
             return self.c2
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -43,7 +43,7 @@ class foo__c1__li1_entry(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -126,7 +126,7 @@ class foo__c1(yang.adata.MNode):
         self.li1 = foo__c1__li1(elements=li1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'li1':
+        if name == 'li1:foo':
             return iter(self.li1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -151,7 +151,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/compile_uses_augment
+++ b/snapshots/expected/test_yang/compile_uses_augment
@@ -47,9 +47,9 @@ class foo__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:foo':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -74,7 +74,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/identityref
+++ b/snapshots/expected/test_yang/identityref
@@ -80,7 +80,7 @@ class base__config(yang.adata.MNode):
         self.active_protocol = active_protocol
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'active_protocol':
+        if name == 'active-protocol:base':
             return self.active_protocol
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -105,7 +105,7 @@ class root(yang.adata.MNode):
         self.config = config if config is not None else base__config()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'config':
+        if name == 'config:base':
             return self.config
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -48,7 +48,7 @@ class base_module__network_instances__network_instance__state(yang.adata.MNode):
         self.id = id
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'id':
+        if name == 'id:base':
             return self.id
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -77,11 +77,11 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
         self.ref = ref
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:base':
             return self.name
-        if name == 'state':
+        if name == 'state:base':
             return self.state
-        if name == 'ref':
+        if name == 'ref:aug':
             return self.ref
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -166,7 +166,7 @@ class base_module__network_instances(yang.adata.MNode):
         self.network_instance = base_module__network_instances__network_instance(elements=network_instance)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'network_instance':
+        if name == 'network-instance:base':
             return iter(self.network_instance)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -191,7 +191,7 @@ class root(yang.adata.MNode):
         self.network_instances = network_instances if network_instances is not None else base_module__network_instances()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'network_instances':
+        if name == 'network-instances:base':
             return self.network_instances
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -57,7 +57,7 @@ class other_module__other_network_instances__network_instance_entry(yang.adata.M
         self.name = name
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:other':
             return self.name
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -140,7 +140,7 @@ class other_module__other_network_instances(yang.adata.MNode):
         self.network_instance = other_module__other_network_instances__network_instance(elements=network_instance)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'network_instance':
+        if name == 'network-instance:other':
             return iter(self.network_instance)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -165,7 +165,7 @@ class base_module__base_network_instances__network_instance__config(yang.adata.M
         self.name = name
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:base':
             return self.name
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -192,9 +192,9 @@ class base_module__base_network_instances__network_instance_entry(yang.adata.MNo
         self.config = config if config is not None else base_module__base_network_instances__network_instance__config()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:base':
             return self.name
-        if name == 'config':
+        if name == 'config:base':
             return self.config
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -277,7 +277,7 @@ class base_module__base_network_instances(yang.adata.MNode):
         self.network_instance = base_module__base_network_instances__network_instance(elements=network_instance)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'network_instance':
+        if name == 'network-instance:base':
             return iter(self.network_instance)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -302,7 +302,7 @@ class base_module__uses_leafref(yang.adata.MNode):
         self.ni = ni
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ni':
+        if name == 'ni:base':
             return self.ni
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -331,11 +331,11 @@ class root(yang.adata.MNode):
         self.uses_leafref = uses_leafref if uses_leafref is not None else base_module__uses_leafref()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'other_network_instances':
+        if name == 'network-instances:other':
             return self.other_network_instances
-        if name == 'base_network_instances':
+        if name == 'network-instances:base':
             return self.base_network_instances
-        if name == 'uses_leafref':
+        if name == 'uses-leafref:base':
             return self.uses_leafref
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -51,7 +51,7 @@ class base_module__network_instances__network_instance__config(yang.adata.MNode)
         self.name = name
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:base-pfx':
             return self.name
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -78,9 +78,9 @@ class base_module__network_instances__network_instance_entry(yang.adata.MNode):
         self.config = config if config is not None else base_module__network_instances__network_instance__config()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:base-pfx':
             return self.name
-        if name == 'config':
+        if name == 'config:base-pfx':
             return self.config
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -163,7 +163,7 @@ class base_module__network_instances(yang.adata.MNode):
         self.network_instance = base_module__network_instances__network_instance(elements=network_instance)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'network_instance':
+        if name == 'network-instance:base-pfx':
             return iter(self.network_instance)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -188,7 +188,7 @@ class consumer_module__uses_typedef(yang.adata.MNode):
         self.ni = ni
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ni':
+        if name == 'ni:consumer':
             return self.ni
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -215,9 +215,9 @@ class root(yang.adata.MNode):
         self.uses_typedef = uses_typedef if uses_typedef is not None else consumer_module__uses_typedef()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'network_instances':
+        if name == 'network-instances:base-pfx':
             return self.network_instances
-        if name == 'uses_typedef':
+        if name == 'uses-typedef:consumer':
             return self.uses_typedef
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -47,7 +47,7 @@ class foo__c__li__bar(yang.adata.MNode):
         self.man = man
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'man':
+        if name == 'man:foo':
             return self.man
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -76,11 +76,11 @@ class foo__c__li_entry(yang.adata.MNode):
         self.bar = bar
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'foo':
+        if name == 'foo:foo':
             return self.foo
-        if name == 'bar':
+        if name == 'bar:foo':
             return self.bar
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -50,9 +50,9 @@ class base__c1__base_l1_entry(yang.adata.MNode):
         self.foo_k1 = foo_k1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base_k1':
+        if name == 'k1:base':
             return self.base_k1
-        if name == 'foo_k1':
+        if name == 'k1:foo':
             return self.foo_k1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -136,7 +136,7 @@ class base__c1__foo_l1_entry(yang.adata.MNode):
         self.k2 = k2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k2':
+        if name == 'k2:foo':
             return self.k2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -221,9 +221,9 @@ class base__c1(yang.adata.MNode):
         self.foo_l1 = base__c1__foo_l1(elements=foo_l1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base_l1':
+        if name == 'l1:base':
             return iter(self.base_l1)
-        if name == 'foo_l1':
+        if name == 'l1:foo':
             return iter(self.foo_l1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -248,7 +248,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else base__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:base':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
@@ -47,7 +47,7 @@ class base__c1__base_c2(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:base':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -72,7 +72,7 @@ class base__c1__foo_c2(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:foo':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -99,9 +99,9 @@ class base__c1(yang.adata.MNode):
         self.foo_c2 = foo_c2 if foo_c2 is not None else base__c1__foo_c2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base_c2':
+        if name == 'c2:base':
             return self.base_c2
-        if name == 'foo_c2':
+        if name == 'c2:foo':
             return self.foo_c2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -126,7 +126,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else base__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:base':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_augment_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_name_conflict
@@ -46,9 +46,9 @@ class base__c1(yang.adata.MNode):
         self.foo_foo = foo_foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar_foo':
+        if name == 'foo:bar':
             return self.bar_foo
-        if name == 'foo_foo':
+        if name == 'foo:foo':
             return self.foo_foo
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_dot
+++ b/snapshots/expected/test_yang/prdaclass_dot
@@ -41,7 +41,7 @@ class foo__ieee_802_3(yang.adata.MNode):
         self.ieee_802_3 = ieee_802_3
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ieee_802_3':
+        if name == 'ieee-802.3:foo':
             return self.ieee_802_3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -66,7 +66,7 @@ class root(yang.adata.MNode):
         self.ieee_802_3 = ieee_802_3 if ieee_802_3 is not None else foo__ieee_802_3()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ieee_802_3':
+        if name == 'ieee-802.3:foo':
             return self.ieee_802_3
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_exclude_ext
+++ b/snapshots/expected/test_yang/prdaclass_exclude_ext
@@ -46,7 +46,7 @@ class foo__c1__dynstate(yang.adata.MNode):
         self.ds1 = ds1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ds1':
+        if name == 'ds1:foo':
             return self.ds1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -71,7 +71,7 @@ class foo__c1(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -96,7 +96,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -65,9 +65,9 @@ class foo__c1__l1_entry(yang.adata.MNode):
         self.k2 = k2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k1':
+        if name == 'k1:foo':
             return self.k1
-        if name == 'k2':
+        if name == 'k2:foo':
             return self.k2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -131,7 +131,7 @@ class foo__c1(yang.adata.MNode):
         self.l1 = foo__c1__l1(elements=l1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return iter(self.l1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -156,7 +156,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_keyword_name_import
+++ b/snapshots/expected/test_yang/prdaclass_keyword_name_import
@@ -53,15 +53,15 @@ class foo__c1(yang.adata.MNode):
         self.with_ = with_
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'as_':
+        if name == 'as:foo':
             return self.as_
-        if name == 'for_':
+        if name == 'for:foo':
             return self.for_
-        if name == 'import_':
+        if name == 'import:foo':
             return self.import_
-        if name == 'in_':
+        if name == 'in:foo':
             return self.in_
-        if name == 'with_':
+        if name == 'with:foo':
             return self.with_
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -41,7 +41,7 @@ class foo__l1_entry(yang.adata.MNode):
         self.name = name
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -44,9 +44,9 @@ class foo__l1_entry(yang.adata.MNode):
         self.id = id
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'id':
+        if name == 'id:foo':
             return self.id
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -50,11 +50,11 @@ class foo__l1_entry(yang.adata.MNode):
         self.other = other
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'id':
+        if name == 'id:foo':
             return self.id
-        if name == 'other':
+        if name == 'other:foo':
             return self.other
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_loose_container_in_container
+++ b/snapshots/expected/test_yang/prdaclass_loose_container_in_container
@@ -43,7 +43,7 @@ class foo__foo__bar(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -68,7 +68,7 @@ class foo__foo(yang.adata.MNode):
         self.bar = bar if bar is not None else foo__foo__bar()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar':
+        if name == 'bar:foo':
             return self.bar
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -43,7 +43,7 @@ class foo__foo__bar(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -81,7 +81,7 @@ class foo__foo(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar':
+        if name == 'bar:foo':
             return self.bar
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -43,7 +43,7 @@ class foo__li1_entry(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -128,9 +128,9 @@ class root(yang.adata.MNode):
         self.ll1 = ll1 if ll1 is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'li1':
+        if name == 'li1:foo':
             return iter(self.li1)
-        if name == 'll1':
+        if name == 'll1:foo':
             return self.ll1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -43,7 +43,7 @@ class foo__li1_entry(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -128,9 +128,9 @@ class root(yang.adata.MNode):
         self.ll1 = ll1 if ll1 is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'li1':
+        if name == 'li1:foo':
             return iter(self.li1)
-        if name == 'll1':
+        if name == 'll1:foo':
             return self.ll1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -45,7 +45,7 @@ class foo__l1__bar(yang.adata.MNode):
         self.hi = hi
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'hi':
+        if name == 'hi:foo':
             return self.hi
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -74,11 +74,11 @@ class foo__l1_entry(yang.adata.MNode):
         self.bar = bar if bar is not None else foo__l1__bar()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'id':
+        if name == 'id:foo':
             return self.id
-        if name == 'bar':
+        if name == 'bar:foo':
             return self.bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -163,7 +163,7 @@ class root(yang.adata.MNode):
         self.l1 = foo__l1(elements=l1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return iter(self.l1)
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -78,7 +78,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
         self.woo_b = woo_b
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'woo_b':
+        if name == 'woo_b:yrpc':
             return self.woo_b
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -105,9 +105,9 @@ class yangrpc__foo__input(yang.adata.MNode):
         self.woo = woo if woo is not None else yangrpc__foo__input__woo()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'a':
+        if name == 'a:yrpc':
             return self.a
-        if name == 'woo':
+        if name == 'woo:yrpc':
             return self.woo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -132,7 +132,7 @@ class yangrpc__foo__output(yang.adata.MNode):
         self.outoo = outoo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'outoo':
+        if name == 'outoo:yrpc':
             return self.outoo
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -44,9 +44,9 @@ class foo__l1_entry(yang.adata.MNode):
         self.id = id
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'id':
+        if name == 'id:foo':
             return self.id
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -44,7 +44,7 @@ class foo__l1__bar(yang.adata.MNode):
         self.hi = hi
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'hi':
+        if name == 'hi:foo':
             return self.hi
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -83,9 +83,9 @@ class foo__l1_entry(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:foo':
             return self.name
-        if name == 'bar':
+        if name == 'bar:foo':
             return self.bar
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -50,11 +50,11 @@ class foo__foo__bar(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo_l1':
+        if name == 'l1:foo':
             return self.foo_l1
-        if name == 'bar_l1':
+        if name == 'l1:bar':
             return self.bar_l1
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -93,7 +93,7 @@ class foo__foo(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar':
+        if name == 'bar:foo':
             return self.bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -129,7 +129,7 @@ class root(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:foo':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_top_conflict
+++ b/snapshots/expected/test_yang/prdaclass_top_conflict
@@ -46,7 +46,7 @@ class bar__bar_c1(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:bar':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -71,7 +71,7 @@ class foo__foo_c1(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -98,9 +98,9 @@ class root(yang.adata.MNode):
         self.foo_c1 = foo_c1 if foo_c1 is not None else foo__foo_c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar_c1':
+        if name == 'c1:bar':
             return self.bar_c1
-        if name == 'foo_c1':
+        if name == 'c1:foo':
             return self.foo_c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
+++ b/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
@@ -47,7 +47,7 @@ class foo__c1(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -72,7 +72,7 @@ class foo__pc1__foo(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -97,7 +97,7 @@ class foo__pc1(yang.adata.MNode):
         self.foo = foo if foo is not None else foo__pc1__foo()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:foo':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -135,9 +135,9 @@ class root(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
-        if name == 'pc1':
+        if name == 'pc1:foo':
             return self.pc1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -52,11 +52,11 @@ class foo__c1__l1_entry(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k1':
+        if name == 'k1:foo':
             return self.k1
-        if name == 'k2':
+        if name == 'k2:foo':
             return self.k2
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -129,7 +129,7 @@ class foo__c1(yang.adata.MNode):
         self.l1 = foo__c1__l1(elements=l1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return iter(self.l1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -154,7 +154,7 @@ class root(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:foo':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/resolve_type_union_of_intX
+++ b/snapshots/expected/test_yang/resolve_type_union_of_intX
@@ -51,13 +51,13 @@ class root(yang.adata.MNode):
         self.l4 = l4
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:foo':
             return self.l2
-        if name == 'l3':
+        if name == 'l3:foo':
             return self.l3
-        if name == 'l4':
+        if name == 'l4:foo':
             return self.l4
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/resolve_type_union_of_string
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string
@@ -39,7 +39,7 @@ class root(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
@@ -39,7 +39,7 @@ class root(yang.adata.MNode):
         self.l1 = l1 if l1 is not None else 42
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:foo':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/src/yang/adata.act
+++ b/src/yang/adata.act
@@ -16,29 +16,26 @@ class MNode(object):
         raise NotImplementedError()
 
     def _get_attr(self, name: str) -> ?value:
-        raise NotImplementedError("_get_attrs")
+        raise NotImplementedError("_get_attr")
 
 
 extension MNode (YangData):
-    def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
-        usname = yang.schema.safe_name(name if is_unique else "{schema.prefix}_{name}")
-        maybe_cnt = self._get_attr(usname)
+    def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
+        maybe_cnt = self._get_attr("{name}:{schema.prefix}")
         if maybe_cnt is not None:
             return (op=None, val=maybe_cnt)
 
-    def take_list(self, schema: yang.schema.DList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(op: ?str, key: dict[str, value], val: value)]:
+    def take_list(self, schema: yang.schema.DList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, key: dict[str, value], val: value)]:
         new_path = path + [PathElement(schema)]
-        usname = yang.schema.safe_name(name if is_unique else "{schema.prefix}_{name}")
-        maybe_list = self._get_attr(usname)
+        maybe_list = self._get_attr("{name}:{schema.prefix}")
         if maybe_list is not None and isinstance(maybe_list, Iterator):
-            key_values = lambda element_data: {k: unwrap_key(k, element_data._get_attr(yang.schema.safe_name(k)), new_path) for k in schema.key}
+            key_values = lambda element_data: {k: unwrap_key(k, element_data._get_attr("{k}:{schema.prefix}"), new_path) for k in schema.key}
             return [(op=None, key=key_values(e), val=e) for e in maybe_list]
         return [] # ??
 
-    def take_leaf(self, root: yang.schema.DRoot, schema: yang.schema.DLeaf, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: ?str, t: str, val: ?value):
+    def take_leaf(self, root: yang.schema.DRoot, schema: yang.schema.DLeaf, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, t: str, val: ?value):
         new_path = path + [PathElement(schema)]
-        usname = yang.schema.safe_name(name if is_unique else "{schema.prefix}_{name}")
-        maybe_attr = self._get_attr(usname)
+        maybe_attr = self._get_attr("{name}:{schema.prefix}")
         if maybe_attr is not None:
             schema_type = schema.type_
             tv = try_validate_mnode_value(maybe_attr, schema_type, new_path)
@@ -48,11 +45,10 @@ extension MNode (YangData):
                 return (op=None, t=tv.t, val=tv.val)
             raise YangValidationError(path, schema_type, maybe_attr)
 
-    def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(op: ?str, t: str, val: ?value)]:
+    def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, t: str, val: ?value)]:
         new_path = path + [PathElement(schema)]
         values: list[(op: ?str, t: str, val: ?value)] = []
-        usname = yang.schema.safe_name(name if is_unique else "{schema.prefix}_{name}")
-        children = self._get_attr(usname)
+        children = self._get_attr("{name}:{schema.prefix}")
         if isinstance(children, list):
             schema_type = schema.type_
             for child in children:

--- a/src/yang/data.act
+++ b/src/yang/data.act
@@ -110,14 +110,14 @@ protocol YangData:
     that can carry YANG-modeled data, like XML and JSON
     """
     # TODO: can value implement YangData? Yes, once Acton supports recursive protocol definitions ...
-    take_container: mut(yang.schema.DContainer, str, bool, bool, list[PathElement]) -> ?(op: ?str, val: ?value)
-    take_list: mut(yang.schema.DList, str, bool, bool, list[PathElement]) -> list[(op: ?str, key: dict[str, value], val: value)]
+    take_container: mut(yang.schema.DContainer, str, bool, list[PathElement]) -> ?(op: ?str, val: ?value)
+    take_list: mut(yang.schema.DList, str, bool, list[PathElement]) -> list[(op: ?str, key: dict[str, value], val: value)]
     # Return a typed tuple for leaves. The tuple carries the concrete type name
     # and the parsed value. Missing leaves return None.
-    take_leaf: mut(yang.schema.DRoot, yang.schema.DLeaf, str, bool, bool, list[PathElement]) -> ?(op: ?str, t: str, val: ?value)
+    take_leaf: mut(yang.schema.DRoot, yang.schema.DLeaf, str, bool, list[PathElement]) -> ?(op: ?str, t: str, val: ?value)
     # For leaf-lists, return a list of typed tuples (op, t, val).
     # For identityref items, val holds a PartialIdentityref.
-    take_leaflist: mut(yang.schema.DRoot, yang.schema.DLeafList, str, bool, bool, list[PathElement]) -> list[(op: ?str, t: str, val: ?value)]
+    take_leaflist: mut(yang.schema.DRoot, yang.schema.DLeafList, str, bool, list[PathElement]) -> list[(op: ?str, t: str, val: ?value)]
 
 
 def user_order(ordered_by):
@@ -201,10 +201,6 @@ def from_data_recursive[A(YangData)](root: yang.schema.DRoot, s: yang.schema.DNo
 
     children: dict[yang.gdata.Id, yang.gdata.Node] = {}
 
-    unique_namer = yang.schema.UniqueNamer(s)
-    def is_unique(n) -> bool:
-        return unique_namer.is_unique(n.name)
-
     for child in s.children:
         if skip_nonkeys and isinstance(s, yang.schema.DList) and child.name not in s.key:
             continue
@@ -224,7 +220,7 @@ def from_data_recursive[A(YangData)](root: yang.schema.DRoot, s: yang.schema.DNo
             mod = child.module
 
         if isinstance(child, yang.schema.DContainer):
-            opval = data.take_container(child, child.name, s.namespace != child.namespace, is_unique(child), spath)
+            opval = data.take_container(child, child.name, s.namespace != child.namespace, spath)
             if opval is not None:
                 val = type_narrower(opval.val)
                 cchild = from_data_recursive(root, child, val, type_narrower, loose, set_ns=s.namespace != child.namespace, root_path=root_path, spath=path_with_child())
@@ -253,7 +249,7 @@ def from_data_recursive[A(YangData)](root: yang.schema.DRoot, s: yang.schema.DNo
                         raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find child node with name {child.name}")
 
         elif isinstance(child, yang.schema.DList):
-            list_val = data.take_list(child, child.name, s.namespace != child.namespace, is_unique(child), spath)
+            list_val = data.take_list(child, child.name, s.namespace != child.namespace, spath)
             list_elements = []
 
             for element in list_val:
@@ -275,7 +271,7 @@ def from_data_recursive[A(YangData)](root: yang.schema.DRoot, s: yang.schema.DNo
                 children[fqname(child)] = list_gdata
 
         elif isinstance(child, yang.schema.DLeafList):
-            leaflist_val = data.take_leaflist(root, child, child.name, s.namespace != child.namespace, is_unique(child), spath)
+            leaflist_val = data.take_leaflist(root, child, child.name, s.namespace != child.namespace, spath)
             if len(leaflist_val) > 0:
                 entries: list[yang.gdata.LeafListEntry] = []
                 for item in leaflist_val:
@@ -302,7 +298,7 @@ def from_data_recursive[A(YangData)](root: yang.schema.DRoot, s: yang.schema.DNo
                 raise ValueError("Error reading {format_schema_path(path_with_child())}: Missing non-optional leaf-list value")
 
         elif isinstance(child, yang.schema.DLeaf):
-            typed = data.take_leaf(root, child, child.name, s.namespace != child.namespace, is_unique(child), spath)
+            typed = data.take_leaf(root, child, child.name, s.namespace != child.namespace, spath)
             if typed is not None:
                 wleaf = None
                 if typed.op == OP_REMOVE:

--- a/src/yang/json.act
+++ b/src/yang/json.act
@@ -9,7 +9,7 @@ import yang.schema
 
 
 extension dict[A(Hashable), B] (YangData):
-    def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
+    def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             maybe = None
             # For cross-namespace children, only accept module-qualified keys
@@ -21,7 +21,7 @@ extension dict[A(Hashable), B] (YangData):
                 return (op=None, val=maybe)
         return None
 
-    def take_list(self, schema: yang.schema.DList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(op: ?str, key: dict[str, value], val: value)]:
+    def take_list(self, schema: yang.schema.DList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, key: dict[str, value], val: value)]:
         new_path = path + [PathElement(schema)]
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             lv = None
@@ -40,7 +40,7 @@ extension dict[A(Hashable), B] (YangData):
                 return [(op=None, key=key_values(le), val=le) for le in lv]
         return []
 
-    def take_leaf(self, root: yang.schema.DRoot, schema: yang.schema.DLeaf, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: ?str, t: str, val: ?value):
+    def take_leaf(self, root: yang.schema.DRoot, schema: yang.schema.DLeaf, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, t: str, val: ?value):
         new_path = path + [PathElement(schema)]
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             leaf_value = None
@@ -57,7 +57,7 @@ extension dict[A(Hashable), B] (YangData):
         else:
             return None
 
-    def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(op: ?str, t: str, val: ?value)]:
+    def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, t: str, val: ?value)]:
         values: list[(op: ?str, t: str, val: ?value)] = []
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             leaflist_data = None

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -726,7 +726,7 @@ class DNodeInner(DNode):
         if len(attr_children) > 0:
             res.append("    pure def _get_attr(self, name: str) -> ?value:")
             for child in attr_children:
-                res.append("        if name == '{usname(child)}':")
+                res.append("        if name == '{child.name}:{child.prefix}':")
                 if isinstance(child, DList):
                     res.append("            return iter(self.{usname(child)})")
                 else:

--- a/src/yang/test_data.act
+++ b/src/yang/test_data.act
@@ -247,11 +247,11 @@ class _test_leafref_c(yang.adata.MNode):
         self.refs = refs
 
     def _get_attr(self, name: str) -> ?value:
-        if name == "n":
+        if name == "n:y1":
             return self.n
-        if name == "ref":
+        if name == "ref:y1":
             return self.ref
-        if name == "refs":
+        if name == "refs:y1":
             return self.refs
         return None
 
@@ -270,7 +270,7 @@ class _test_leafref_root(yang.adata.MNode):
         self.c = c
 
     def _get_attr(self, name: str) -> ?value:
-        if name == "c":
+        if name == "c:y1":
             return self.c
         return None
 

--- a/src/yang/xml.act
+++ b/src/yang/xml.act
@@ -66,14 +66,14 @@ def _test_get_nc_op_pref_ancestor():
 
 
 extension xml.Node (YangData):
-    def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: str, val: ?value):
+    def take_container(self, schema: yang.schema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: str, val: ?value):
         child_node = yang.gdata.get_xml_opt_child(self, name, schema.namespace if ns_qualified else None)
         if child_node is not None:
             op = _get_netconf_operation(child_node)
             return (op=op, val=child_node)
         return None
 
-    def take_list(self, schema: yang.schema.DList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(op: str, key: dict[str, value], val: value)]:
+    def take_list(self, schema: yang.schema.DList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: str, key: dict[str, value], val: value)]:
         new_path = path + [PathElement(schema)]
         elements = yang.gdata.get_xml_children(self, name, schema.namespace if ns_qualified else None)
 
@@ -86,7 +86,7 @@ extension xml.Node (YangData):
 
         return [(op=_get_netconf_operation(e), key=extract_key(e), val=e) for e in elements]
 
-    mut def take_leaf(self, root: yang.schema.DRoot, schema: yang.schema.DLeaf, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> ?(op: str, t: str, val: ?value):
+    mut def take_leaf(self, root: yang.schema.DRoot, schema: yang.schema.DLeaf, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: str, t: str, val: ?value):
         new_path = path + [PathElement(schema)]
         maybe_node = yang.gdata.get_xml_opt_child(self, name, schema.namespace if ns_qualified else None)
         if maybe_node is not None:
@@ -99,7 +99,7 @@ extension xml.Node (YangData):
         else:
             return None
 
-    def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, is_unique: bool, path: list[PathElement]=[]) -> list[(op: str, t: str, val: ?value)]:
+    def take_leaflist(self, root: yang.schema.DRoot, schema: yang.schema.DLeafList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: str, t: str, val: ?value)]:
         new_path = path + [PathElement(schema)]
         values: list[(op: str, t: str, val: ?value)] = []
         children = yang.gdata.get_xml_children(self, name, schema.namespace if ns_qualified else None)

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -176,27 +176,27 @@ class basics__c(yang.adata.MNode):
             raise ValueError('Invalid default value for identityref leaf c: {error}')
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l_str_def':
+        if name == 'l_str_def:b':
             return self.l_str_def
-        if name == 'l_str_def_quoted':
+        if name == 'l_str_def_quoted:b':
             return self.l_str_def_quoted
-        if name == 'l_uint64_def':
+        if name == 'l_uint64_def:b':
             return self.l_uint64_def
-        if name == 'l_decimal64_def':
+        if name == 'l_decimal64_def:b':
             return self.l_decimal64_def
-        if name == 'l_union_def_str':
+        if name == 'l_union_def_str:b':
             return self.l_union_def_str
-        if name == 'l_union_def_int':
+        if name == 'l_union_def_int:b':
             return self.l_union_def_int
-        if name == 'l_union_def_float':
+        if name == 'l_union_def_float:b':
             return self.l_union_def_float
-        if name == 'l_union_def_bool':
+        if name == 'l_union_def_bool:b':
             return self.l_union_def_bool
-        if name == 'l_union_def_enumeration':
+        if name == 'l_union_def_enumeration:b':
             return self.l_union_def_enumeration
-        if name == 'l_binary_def':
+        if name == 'l_binary_def:b':
             return self.l_binary_def
-        if name == 'l_identityref_def':
+        if name == 'l_identityref_def:b':
             return self.l_identityref_def
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -221,7 +221,7 @@ class root(yang.adata.MNode):
         self.c = c if c is not None else basics__c()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c':
+        if name == 'c:b':
             return self.c
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -142,9 +142,9 @@ class filter_test__system_state__clock(yang.adata.MNode):
         self.boot_datetime = boot_datetime
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'current_datetime':
+        if name == 'current-datetime:ft':
             return self.current_datetime
-        if name == 'boot_datetime':
+        if name == 'boot-datetime:ft':
             return self.boot_datetime
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -169,7 +169,7 @@ class filter_test__system_state(yang.adata.MNode):
         self.clock = clock if clock is not None else filter_test__system_state__clock()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'clock':
+        if name == 'clock:ft':
             return self.clock
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -196,9 +196,9 @@ class filter_test__interfaces__interface__statistics(yang.adata.MNode):
         self.out_octets = out_octets
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'in_octets':
+        if name == 'in-octets:ft':
             return self.in_octets
-        if name == 'out_octets':
+        if name == 'out-octets:ft':
             return self.out_octets
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -223,7 +223,7 @@ class filter_test__interfaces__interface__ipv4(yang.adata.MNode):
         self.mtu = mtu
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'mtu':
+        if name == 'mtu:ft':
             return self.mtu
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -248,7 +248,7 @@ class filter_test__interfaces__interface__ipv6(yang.adata.MNode):
         self.mtu = mtu
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'mtu':
+        if name == 'mtu:ft':
             return self.mtu
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -291,25 +291,25 @@ class filter_test__interfaces__interface_entry(yang.adata.MNode):
         self.ipv6 = ipv6 if ipv6 is not None else filter_test__interfaces__interface__ipv6()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:ft':
             return self.name
-        if name == 'description':
+        if name == 'description:ft':
             return self.description
-        if name == 'type':
+        if name == 'type:ft':
             return self.type
-        if name == 'enabled':
+        if name == 'enabled:ft':
             return self.enabled
-        if name == 'admin_status':
+        if name == 'admin-status:ft':
             return self.admin_status
-        if name == 'oper_status':
+        if name == 'oper-status:ft':
             return self.oper_status
-        if name == 'last_change':
+        if name == 'last-change:ft':
             return self.last_change
-        if name == 'statistics':
+        if name == 'statistics:ft':
             return self.statistics
-        if name == 'ipv4':
+        if name == 'ipv4:ft':
             return self.ipv4
-        if name == 'ipv6':
+        if name == 'ipv6:ft':
             return self.ipv6
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -404,7 +404,7 @@ class filter_test__interfaces(yang.adata.MNode):
         self.interface = filter_test__interfaces__interface(elements=interface)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'interface':
+        if name == 'interface:ft':
             return iter(self.interface)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -431,9 +431,9 @@ class root(yang.adata.MNode):
         self.interfaces = interfaces if interfaces is not None else filter_test__interfaces()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'system_state':
+        if name == 'system-state:ft':
             return self.system_state
-        if name == 'interfaces':
+        if name == 'interfaces:ft':
             return self.interfaces
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -525,7 +525,7 @@ class foo__c1__li__c4(yang.adata.MNode):
         self.l5 = l5
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l5':
+        if name == 'l5:f':
             return self.l5
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -554,11 +554,11 @@ class foo__c1__li_entry(yang.adata.MNode):
         self.c4 = c4 if c4 is not None else foo__c1__li__c4()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
-        if name == 'val':
+        if name == 'val:f':
             return self.val
-        if name == 'c4':
+        if name == 'c4:f':
             return self.c4
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -671,35 +671,35 @@ class foo__c1(yang.adata.MNode):
         self.l_leafref = l_leafref
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f_l1':
+        if name == 'l1:f':
             return self.f_l1
-        if name == 'l3':
+        if name == 'l3:f':
             return self.l3
-        if name == 'l_empty':
+        if name == 'l_empty:f':
             return self.l_empty
-        if name == 'l_empty_delete':
+        if name == 'l_empty_delete:f':
             return self.l_empty_delete
-        if name == 'l_decimal64':
+        if name == 'l_decimal64:f':
             return self.l_decimal64
-        if name == 'li':
+        if name == 'li:f':
             return iter(self.li)
-        if name == 'll_uint64':
+        if name == 'll_uint64:f':
             return self.ll_uint64
-        if name == 'll_str':
+        if name == 'll_str:f':
             return self.ll_str
-        if name == 'l_identityref':
+        if name == 'l_identityref:f':
             return self.l_identityref
-        if name == 'll_identityref':
+        if name == 'll_identityref:f':
             return self.ll_identityref
-        if name == 'l_identityref_noval':
+        if name == 'l_identityref_noval:f':
             return self.l_identityref_noval
-        if name == 'l4':
+        if name == 'l4:f':
             return self.l4
-        if name == 'bar_l1':
+        if name == 'l1:bar':
             return self.bar_l1
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
-        if name == 'l_leafref':
+        if name == 'l_leafref:bar':
             return self.l_leafref
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -724,7 +724,7 @@ class foo__pc1__foo(yang.adata.MNode):
         self.l1 = l1 if l1 is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -749,7 +749,7 @@ class foo__pc1(yang.adata.MNode):
         self.foo = foo if foo is not None else foo__pc1__foo()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:f':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -777,7 +777,7 @@ class foo__pc2__foo(yang.adata.MNode):
         self.l_mandatory = l_mandatory
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l_mandatory':
+        if name == 'l_mandatory:f':
             return self.l_mandatory
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -802,7 +802,7 @@ class foo__pc2(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:f':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -832,9 +832,9 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         self.l3_optional = l3_optional
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l3':
+        if name == 'l3:f':
             return self.l3
-        if name == 'l3_optional':
+        if name == 'l3-optional:f':
             return self.l3_optional
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -863,11 +863,11 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         self.level3 = level3
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l2':
+        if name == 'l2:f':
             return self.l2
-        if name == 'l2_optional':
+        if name == 'l2-optional:f':
             return self.l2_optional
-        if name == 'level3':
+        if name == 'level3:f':
             return self.level3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -896,11 +896,11 @@ class foo__pc3__level1(yang.adata.MNode):
         self.level2 = level2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
-        if name == 'l1_optional':
+        if name == 'l1-optional:f':
             return self.l1_optional
-        if name == 'level2':
+        if name == 'level2:f':
             return self.level2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -925,7 +925,7 @@ class foo__pc3(yang.adata.MNode):
         self.level1 = level1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'level1':
+        if name == 'level1:f':
             return self.level1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -978,9 +978,9 @@ class foo__c_dot(yang.adata.MNode):
         self.l_dot2 = l_dot2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l_dot1':
+        if name == 'l.dot1:f':
             return self.l_dot1
-        if name == 'l_dot2':
+        if name == 'l.dot2:bar':
             return self.l_dot2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1005,7 +1005,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         self.name = name
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1090,9 +1090,9 @@ class foo__cc(yang.adata.MNode):
         self.death = foo__cc__death(elements=death)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'cake':
+        if name == 'cake:f':
             return self.cake
-        if name == 'death':
+        if name == 'death:f':
             return iter(self.death)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1185,13 +1185,13 @@ class foo__f_conflict(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f_foo':
+        if name == 'foo:f':
             return self.f_foo
-        if name == 'f_inner':
+        if name == 'inner:f':
             return self.f_inner
-        if name == 'bar_foo':
+        if name == 'foo:bar':
             return self.bar_foo
-        if name == 'bar_inner':
+        if name == 'inner:bar':
             return self.bar_inner
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1216,7 +1216,7 @@ class foo__special_entry(yang.adata.MNode):
         self.yes = yes
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yes':
+        if name == 'yes:f':
             return self.yes
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1303,11 +1303,11 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         self.baz = baz
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'key1':
+        if name == 'key1:f':
             return self.key1
-        if name == 'key2':
+        if name == 'key2:f':
             return self.key2
-        if name == 'baz':
+        if name == 'baz:f':
             return self.baz
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1379,13 +1379,13 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         self.bar_bar = bar_bar
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
-        if name == 'f_bar':
+        if name == 'bar:f':
             return self.f_bar
-        if name == 'li2':
+        if name == 'li2:f':
             return iter(self.li2)
-        if name == 'bar_bar':
+        if name == 'bar:bar':
             return self.bar_bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1474,9 +1474,9 @@ class foo__nested__f_inner(yang.adata.MNode):
         self.li1 = foo__nested__f_inner__li1(elements=li1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:f':
             return self.foo
-        if name == 'li1':
+        if name == 'li1:f':
             return iter(self.li1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1501,7 +1501,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:bar':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1528,9 +1528,9 @@ class foo__nested(yang.adata.MNode):
         self.bar_inner = bar_inner if bar_inner is not None else foo__nested__bar_inner()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f_inner':
+        if name == 'inner:f':
             return self.f_inner
-        if name == 'bar_inner':
+        if name == 'inner:bar':
             return self.bar_inner
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1561,13 +1561,13 @@ class foo__li_union_entry(yang.adata.MNode):
         self.checker = checker
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k1':
+        if name == 'k1:f':
             return self.k1
-        if name == 'k2':
+        if name == 'k2:f':
             return self.k2
-        if name == 'k3':
+        if name == 'k3:f':
             return self.k3
-        if name == 'checker':
+        if name == 'checker:f':
             return self.checker
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1646,7 +1646,7 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
         self.k1 = k1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k1':
+        if name == 'k1:f':
             return self.k1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1715,9 +1715,9 @@ class foo__state__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:f':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1742,7 +1742,7 @@ class foo__state(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__state__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:f':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1767,7 +1767,7 @@ class foo__c2(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1792,7 +1792,7 @@ class bar__test_idref(yang.adata.MNode):
         self.idref = idref if idref is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'idref':
+        if name == 'idref:bar':
             return self.idref
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1817,7 +1817,7 @@ class bar__bar_conflict(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:bar':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1908,39 +1908,39 @@ class root(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:f':
             return self.c1
-        if name == 'pc1':
+        if name == 'pc1:f':
             return self.pc1
-        if name == 'pc2':
+        if name == 'pc2:f':
             return self.pc2
-        if name == 'pc3':
+        if name == 'pc3:f':
             return self.pc3
-        if name == 'empty_presence':
+        if name == 'empty-presence:f':
             return self.empty_presence
-        if name == 'c_dot':
+        if name == 'c.dot:f':
             return self.c_dot
-        if name == 'cc':
+        if name == 'cc:f':
             return self.cc
-        if name == 'f_conflict':
+        if name == 'conflict:f':
             return self.f_conflict
-        if name == 'special':
+        if name == 'special:f':
             return iter(self.special)
-        if name == 'nested':
+        if name == 'nested:f':
             return self.nested
-        if name == 'li_union':
+        if name == 'li-union:f':
             return iter(self.li_union)
-        if name == 'li_union_one_base':
+        if name == 'li-union-one-base:f':
             return iter(self.li_union_one_base)
-        if name == 'state':
+        if name == 'state:f':
             return self.state
-        if name == 'll_empty':
+        if name == 'll-empty:f':
             return self.ll_empty
-        if name == 'c2':
+        if name == 'c2:f':
             return self.c2
-        if name == 'test_idref':
+        if name == 'test-idref:bar':
             return self.test_idref
-        if name == 'bar_conflict':
+        if name == 'conflict:bar':
             return self.bar_conflict
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -525,7 +525,7 @@ class foo__c1__li__c4(yang.adata.MNode):
         self.l5 = l5
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l5':
+        if name == 'l5:f':
             return self.l5
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -554,11 +554,11 @@ class foo__c1__li_entry(yang.adata.MNode):
         self.c4 = c4 if c4 is not None else foo__c1__li__c4()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
-        if name == 'val':
+        if name == 'val:f':
             return self.val
-        if name == 'c4':
+        if name == 'c4:f':
             return self.c4
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -671,35 +671,35 @@ class foo__c1(yang.adata.MNode):
         self.l_leafref = l_leafref
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f_l1':
+        if name == 'l1:f':
             return self.f_l1
-        if name == 'l3':
+        if name == 'l3:f':
             return self.l3
-        if name == 'l_empty':
+        if name == 'l_empty:f':
             return self.l_empty
-        if name == 'l_empty_delete':
+        if name == 'l_empty_delete:f':
             return self.l_empty_delete
-        if name == 'l_decimal64':
+        if name == 'l_decimal64:f':
             return self.l_decimal64
-        if name == 'li':
+        if name == 'li:f':
             return iter(self.li)
-        if name == 'll_uint64':
+        if name == 'll_uint64:f':
             return self.ll_uint64
-        if name == 'll_str':
+        if name == 'll_str:f':
             return self.ll_str
-        if name == 'l_identityref':
+        if name == 'l_identityref:f':
             return self.l_identityref
-        if name == 'll_identityref':
+        if name == 'll_identityref:f':
             return self.ll_identityref
-        if name == 'l_identityref_noval':
+        if name == 'l_identityref_noval:f':
             return self.l_identityref_noval
-        if name == 'l4':
+        if name == 'l4:f':
             return self.l4
-        if name == 'bar_l1':
+        if name == 'l1:bar':
             return self.bar_l1
-        if name == 'l2':
+        if name == 'l2:bar':
             return self.l2
-        if name == 'l_leafref':
+        if name == 'l_leafref:bar':
             return self.l_leafref
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -724,7 +724,7 @@ class foo__pc1__foo(yang.adata.MNode):
         self.l1 = l1 if l1 is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -749,7 +749,7 @@ class foo__pc1(yang.adata.MNode):
         self.foo = foo if foo is not None else foo__pc1__foo()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:f':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -777,7 +777,7 @@ class foo__pc2__foo(yang.adata.MNode):
         self.l_mandatory = l_mandatory
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l_mandatory':
+        if name == 'l_mandatory:f':
             return self.l_mandatory
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -802,7 +802,7 @@ class foo__pc2(yang.adata.MNode):
         self.foo = foo if foo is not None else foo__pc2__foo()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:f':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -832,9 +832,9 @@ class foo__pc3__level1__level2__level3(yang.adata.MNode):
         self.l3_optional = l3_optional
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l3':
+        if name == 'l3:f':
             return self.l3
-        if name == 'l3_optional':
+        if name == 'l3-optional:f':
             return self.l3_optional
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -863,11 +863,11 @@ class foo__pc3__level1__level2(yang.adata.MNode):
         self.level3 = level3 if level3 is not None else foo__pc3__level1__level2__level3()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l2':
+        if name == 'l2:f':
             return self.l2
-        if name == 'l2_optional':
+        if name == 'l2-optional:f':
             return self.l2_optional
-        if name == 'level3':
+        if name == 'level3:f':
             return self.level3
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -896,11 +896,11 @@ class foo__pc3__level1(yang.adata.MNode):
         self.level2 = level2 if level2 is not None else foo__pc3__level1__level2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
-        if name == 'l1_optional':
+        if name == 'l1-optional:f':
             return self.l1_optional
-        if name == 'level2':
+        if name == 'level2:f':
             return self.level2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -925,7 +925,7 @@ class foo__pc3(yang.adata.MNode):
         self.level1 = level1 if level1 is not None else foo__pc3__level1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'level1':
+        if name == 'level1:f':
             return self.level1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -978,9 +978,9 @@ class foo__c_dot(yang.adata.MNode):
         self.l_dot2 = l_dot2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l_dot1':
+        if name == 'l.dot1:f':
             return self.l_dot1
-        if name == 'l_dot2':
+        if name == 'l.dot2:bar':
             return self.l_dot2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1005,7 +1005,7 @@ class foo__cc__death_entry(yang.adata.MNode):
         self.name = name
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1090,9 +1090,9 @@ class foo__cc(yang.adata.MNode):
         self.death = foo__cc__death(elements=death)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'cake':
+        if name == 'cake:f':
             return self.cake
-        if name == 'death':
+        if name == 'death:f':
             return iter(self.death)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1185,13 +1185,13 @@ class foo__f_conflict(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f_foo':
+        if name == 'foo:f':
             return self.f_foo
-        if name == 'f_inner':
+        if name == 'inner:f':
             return self.f_inner
-        if name == 'bar_foo':
+        if name == 'foo:bar':
             return self.bar_foo
-        if name == 'bar_inner':
+        if name == 'inner:bar':
             return self.bar_inner
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1216,7 +1216,7 @@ class foo__special_entry(yang.adata.MNode):
         self.yes = yes
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yes':
+        if name == 'yes:f':
             return self.yes
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1303,11 +1303,11 @@ class foo__nested__f_inner__li1__li2_entry(yang.adata.MNode):
         self.baz = baz
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'key1':
+        if name == 'key1:f':
             return self.key1
-        if name == 'key2':
+        if name == 'key2:f':
             return self.key2
-        if name == 'baz':
+        if name == 'baz:f':
             return self.baz
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1379,13 +1379,13 @@ class foo__nested__f_inner__li1_entry(yang.adata.MNode):
         self.bar_bar = bar_bar
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
-        if name == 'f_bar':
+        if name == 'bar:f':
             return self.f_bar
-        if name == 'li2':
+        if name == 'li2:f':
             return iter(self.li2)
-        if name == 'bar_bar':
+        if name == 'bar:bar':
             return self.bar_bar
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1474,9 +1474,9 @@ class foo__nested__f_inner(yang.adata.MNode):
         self.li1 = foo__nested__f_inner__li1(elements=li1)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:f':
             return self.foo
-        if name == 'li1':
+        if name == 'li1:f':
             return iter(self.li1)
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1501,7 +1501,7 @@ class foo__nested__bar_inner(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:bar':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1528,9 +1528,9 @@ class foo__nested(yang.adata.MNode):
         self.bar_inner = bar_inner if bar_inner is not None else foo__nested__bar_inner()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f_inner':
+        if name == 'inner:f':
             return self.f_inner
-        if name == 'bar_inner':
+        if name == 'inner:bar':
             return self.bar_inner
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1561,13 +1561,13 @@ class foo__li_union_entry(yang.adata.MNode):
         self.checker = checker
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k1':
+        if name == 'k1:f':
             return self.k1
-        if name == 'k2':
+        if name == 'k2:f':
             return self.k2
-        if name == 'k3':
+        if name == 'k3:f':
             return self.k3
-        if name == 'checker':
+        if name == 'checker:f':
             return self.checker
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1646,7 +1646,7 @@ class foo__li_union_one_base_entry(yang.adata.MNode):
         self.k1 = k1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'k1':
+        if name == 'k1:f':
             return self.k1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1715,9 +1715,9 @@ class foo__state__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:f':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1742,7 +1742,7 @@ class foo__state(yang.adata.MNode):
         self.c1 = c1 if c1 is not None else foo__state__c1()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:f':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1767,7 +1767,7 @@ class foo__c2(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1792,7 +1792,7 @@ class bar__test_idref(yang.adata.MNode):
         self.idref = idref if idref is not None else []
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'idref':
+        if name == 'idref:bar':
             return self.idref
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1817,7 +1817,7 @@ class bar__bar_conflict(yang.adata.MNode):
         self.foo = foo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo':
+        if name == 'foo:bar':
             return self.foo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -1906,39 +1906,39 @@ class root(yang.adata.MNode):
         return res
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c1':
+        if name == 'c1:f':
             return self.c1
-        if name == 'pc1':
+        if name == 'pc1:f':
             return self.pc1
-        if name == 'pc2':
+        if name == 'pc2:f':
             return self.pc2
-        if name == 'pc3':
+        if name == 'pc3:f':
             return self.pc3
-        if name == 'empty_presence':
+        if name == 'empty-presence:f':
             return self.empty_presence
-        if name == 'c_dot':
+        if name == 'c.dot:f':
             return self.c_dot
-        if name == 'cc':
+        if name == 'cc:f':
             return self.cc
-        if name == 'f_conflict':
+        if name == 'conflict:f':
             return self.f_conflict
-        if name == 'special':
+        if name == 'special:f':
             return iter(self.special)
-        if name == 'nested':
+        if name == 'nested:f':
             return self.nested
-        if name == 'li_union':
+        if name == 'li-union:f':
             return iter(self.li_union)
-        if name == 'li_union_one_base':
+        if name == 'li-union-one-base:f':
             return iter(self.li_union_one_base)
-        if name == 'state':
+        if name == 'state:f':
             return self.state
-        if name == 'll_empty':
+        if name == 'll-empty:f':
             return self.ll_empty
-        if name == 'c2':
+        if name == 'c2:f':
             return self.c2
-        if name == 'test_idref':
+        if name == 'test-idref:bar':
             return self.test_idref
-        if name == 'bar_conflict':
+        if name == 'conflict:bar':
             return self.bar_conflict
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -60,7 +60,7 @@ class loose_required__c2(yang.adata.MNode):
         self.l1 = l1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:lr':
             return self.l1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -85,7 +85,7 @@ class root(yang.adata.MNode):
         self.c2 = c2 if c2 is not None else loose_required__c2()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'c2':
+        if name == 'c2:lr':
             return self.c2
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -127,9 +127,9 @@ class foo__tc1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:f':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -156,9 +156,9 @@ class foo__li__c1(yang.adata.MNode):
         self.l2 = l2
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'l1':
+        if name == 'l1:f':
             return self.l1
-        if name == 'l2':
+        if name == 'l2:f':
             return self.l2
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -185,9 +185,9 @@ class foo__li_entry(yang.adata.MNode):
         self.c1 = c1
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'name':
+        if name == 'name:f':
             return self.name
-        if name == 'c1':
+        if name == 'c1:f':
             return self.c1
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -273,9 +273,9 @@ class root(yang.adata.MNode):
         self.li = foo__li(elements=li)
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'tc1':
+        if name == 'tc1:f':
             return self.tc1
-        if name == 'li':
+        if name == 'li:f':
             return iter(self.li)
 
     mut def to_gdata(self) -> yang.gdata.Node:

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -102,7 +102,7 @@ class yangrpc__foo__input__woo(yang.adata.MNode):
         self.woo_b = woo_b
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'woo_b':
+        if name == 'woo_b:yrpc':
             return self.woo_b
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -129,9 +129,9 @@ class yangrpc__foo__input(yang.adata.MNode):
         self.woo = woo if woo is not None else yangrpc__foo__input__woo()
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'a':
+        if name == 'a:yrpc':
             return self.a
-        if name == 'woo':
+        if name == 'woo:yrpc':
             return self.woo
 
     mut def to_gdata(self) -> yang.gdata.Node:
@@ -156,7 +156,7 @@ class yangrpc__foo__output(yang.adata.MNode):
         self.outoo = outoo
 
     pure def _get_attr(self, name: str) -> ?value:
-        if name == 'outoo':
+        if name == 'outoo:yrpc':
             return self.outoo
 
     mut def to_gdata(self) -> yang.gdata.Node:


### PR DESCRIPTION
The parameter was only used in the adata parser implementation to lookup the attribute value. Because the parser has full schema information it can directly lookup an (unique) qualified name without the added cost of checking the parent node for duplicate names.