### PR TITLE
Speed up UniqueNamer

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -4292,22 +4292,16 @@ def safe_name(name: str, safe_kw=True) -> str:
     return new
 
 
-pure def _mut_avoider(node: DNodeInner):
-    # Even with "pure" comprehensions, the "mut" effect leaks out of UniqueNamer.__init__ if this function is inlined?!
-    names = [child.name for child in node.children]
-    def count(n):
-        # TODO: refactor this to use list.count() once implemented in Acton
-        c = 0
-        for e in names:
-            if e == n:
-                c += 1
-        return c
-    return {name for name in names if count(name) > 1}
-
 class UniqueNamer(object):
-
     def __init__(self, node: DNodeInner):
-        self._name_conflicts = _mut_avoider(node)
+        seen = set()
+        dups = set()
+        for child in node.children:
+            if child.name in seen:
+                dups.add(child.name)
+            else:
+                seen.add(child.name)
+        self._name_conflicts = dups
 
     def unique_name(self, name, prefix):
         if name not in self._name_conflicts:

--- a/src/yang/data.act
+++ b/src/yang/data.act
@@ -59,8 +59,15 @@ def format_schema_path(path: list[PathElement]) -> str:
             if not isinstance(prev, yang.schema.DRoot):
                 path_str = path_str + "/"
             if isinstance(prev, yang.schema.DNodeInner):
-                un = yang.schema.UniqueNamer(prev)
-                path_str = path_str + un.unique_name(elem.node.name, elem.node.prefix)
+                # TODO: replace with yang.schema.UniqueNamer(prev).unique_name(...) once
+                # the Acton compiler stops leaking function mut effect through to callers
+                # (which would make format_schema_path mut and break __str__'s purity).
+                names = [c.name for c in prev.children]
+                conflicts = {n for n in names if names.count(n) > 1}
+                name = elem.node.name
+                if name in conflicts:
+                    name = "{elem.node.prefix}:{name}"
+                path_str = path_str + name
                 keys_dict = elem.keys
                 if keys_dict is not None and len(keys_dict) > 0:
                     predicates = ["{k}='{(v if isinstance(v, str) else str(v)).replace("'", "\\'")}'" for k, v in keys_dict.items()]

--- a/src/yang/schema.act
+++ b/src/yang/schema.act
@@ -4288,22 +4288,16 @@ def safe_name(name: str, safe_kw=True) -> str:
     return new
 
 
-pure def _mut_avoider(node: DNodeInner):
-    # Even with "pure" comprehensions, the "mut" effect leaks out of UniqueNamer.__init__ if this function is inlined?!
-    names = [child.name for child in node.children]
-    def count(n):
-        # TODO: refactor this to use list.count() once implemented in Acton
-        c = 0
-        for e in names:
-            if e == n:
-                c += 1
-        return c
-    return {name for name in names if count(name) > 1}
-
 class UniqueNamer(object):
-
     def __init__(self, node: DNodeInner):
-        self._name_conflicts = _mut_avoider(node)
+        seen = set()
+        dups = set()
+        for child in node.children:
+            if child.name in seen:
+                dups.add(child.name)
+            else:
+                seen.add(child.name)
+        self._name_conflicts = dups
 
     def unique_name(self, name, prefix):
         if name not in self._name_conflicts:


### PR DESCRIPTION
UniqueNamer now finds duplicate sibling names in a single pass over the node children.