### PR TITLE
Add --mode device

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,15 @@ test:
 	acton test
 	$(MAKE) test-daclass
 	$(MAKE) test-data-source-roundtrip
+	$(MAKE) test-device-mode
+
+.PHONY: test-device-mode-gen
+test-device-mode-gen:
+	cd test/test_device_mode && ../../out/bin/ayangc compile --infile yang -s adata -m device -o src/m.act
+
+.PHONY: test-device-mode
+test-device-mode: test-device-mode-gen
+	cd test/test_device_mode && acton test
 
 .PHONY: test-daclass-gen
 test-daclass-gen:
@@ -46,6 +55,8 @@ test-accept:
 	cd test/test_data_classes_gen && acton build && out/bin/gen
 	cd test/test_data_classes && acton test --accept
 	cd test/test_data_source_roundtrip && acton test --accept
+	$(MAKE) test-device-mode-gen
+	cd test/test_device_mode && acton test --accept
 
 test-yang-compile-accept:
 	cd test/test_yang_compile && acton test --max-time 600000 --min-iter 1 --max-iter 1 --release=fast --accept

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -388,7 +388,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, device=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -511,7 +511,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, device=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -584,7 +584,7 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, device=device, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
             res.extend(child_res)
 
         def excluded(n):
@@ -736,71 +736,72 @@ class DNodeInner(DNode):
                 res.append("        return res")
                 res.append("")
 
-        if len(attr_children) > 0:
-            res.append("    pure def _get_attr(self, name: str) -> ?value:")
-            for child in attr_children:
-                res.append("        if name == '{child.prefix}:{child.name}':")
-                if isinstance(child, DList):
-                    res.append("            return iter(self.{usname(child)})")
-                else:
-                    res.append("            return self.{usname(child)}")
+        if not device:
+            if len(attr_children) > 0:
+                res.append("    pure def _get_attr(self, name: str) -> ?value:")
+                for child in attr_children:
+                    res.append("        if name == '{child.prefix}:{child.name}':")
+                    if isinstance(child, DList):
+                        res.append("            return iter(self.{usname(child)})")
+                    else:
+                        res.append("            return self.{usname(child)}")
+                res.append("")
+
+            # .to_gdata()
+            res.append("    mut def to_gdata(self) -> ygdata.Node:")
+            if isinstance(self, DRoot):
+                res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose})")
+            else:
+                root_path = ["{'{node.module}:' if prev.module != node.module else ''}{node.name}" if node is not None else None for prev, node in zip(spath, spath[1:] + [None])]
+                res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose}, root_path={repr(root_path[:-1])})")
             res.append("")
 
-        # .to_gdata()
-        res.append("    mut def to_gdata(self) -> ygdata.Node:")
-        if isinstance(self, DRoot):
-            res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose})")
-        else:
-            root_path = ["{'{node.module}:' if prev.module != node.module else ''}{node.name}" if node is not None else None for prev, node in zip(spath, spath[1:] + [None])]
-            res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose}, root_path={repr(root_path[:-1])})")
-        res.append("")
+            # .from_gdata()
+            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
+            from_gdata_args_list = []
+            for child in attr_children:
+                if isinstance(child, DNodeLeaf):
+                    from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
+                else:
+                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}')))")
+            from_gdata_args = ", ".join(from_gdata_args_list)
+            res.append("    @staticmethod")
+            if isinstance(self, DList):
+                res.append("    mut def from_gdata(n: ygdata.Node) -> {pname()}_entry:")
+                res.append("        return {pname()}_entry({from_gdata_args})")
+            else:
+                opt_cnt = True if isinstance(self, DContainer) and self.presence else False
+                res.append("    mut def from_gdata(n: ?ygdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
+                res.append("        if n is not None:")
+                res.append("            return {pname()}({from_gdata_args})")
+                if opt_cnt:
+                    res.append("        return None")
+                elif loose or optional_subtree(self):
+                    res.append("        return {pname()}()")
+                else:
+                    res.append("        raise ValueError('Missing required subtree {pname()}')")
+            res.append("")
 
-        # .from_gdata()
-        # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
-        from_gdata_args_list = []
-        for child in attr_children:
-            if isinstance(child, DNodeLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
+            # .copy() method
+            if isinstance(self, DList):
+                res.append("    mut def copy(self) -> {pname()}_entry:")
             else:
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}')))")
-        from_gdata_args = ", ".join(from_gdata_args_list)
-        res.append("    @staticmethod")
-        if isinstance(self, DList):
-            res.append("    mut def from_gdata(n: ygdata.Node) -> {pname()}_entry:")
-            res.append("        return {pname()}_entry({from_gdata_args})")
-        else:
-            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append("    mut def from_gdata(n: ?ygdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
-            res.append("        if n is not None:")
-            res.append("            return {pname()}({from_gdata_args})")
-            if opt_cnt:
-                res.append("        return None")
-            elif loose or optional_subtree(self):
-                res.append("        return {pname()}()")
+                res.append("    mut def copy(self) -> {pname()}:")
+            res.append('        """Create a deep copy of this adata object"""')
+            if isinstance(self, DList):
+                res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
             else:
-                res.append("        raise ValueError('Missing required subtree {pname()}')")
-        res.append("")
-
-        # .copy() method
-        if isinstance(self, DList):
-            res.append("    mut def copy(self) -> {pname()}_entry:")
-        else:
-            res.append("    mut def copy(self) -> {pname()}:")
-        res.append('        """Create a deep copy of this adata object"""')
-        if isinstance(self, DList):
-            res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
-        else:
-            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
-            # But since we're copying an instance, the output of .copy() is non-optional.
-            if opt_cnt:
-                res.append("        ad = {pname()}.from_gdata(self.to_gdata())")
-                res.append("        if ad is not None:")
-                res.append("            return ad")
-                res.append("        raise Exception('Unreachable in {pname()}.copy()')")
-            else:
-                res.append("        return {pname()}.from_gdata(self.to_gdata())")
-        res.append("")
+                opt_cnt = True if isinstance(self, DContainer) and self.presence else False
+                # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
+                # But since we're copying an instance, the output of .copy() is non-optional.
+                if opt_cnt:
+                    res.append("        ad = {pname()}.from_gdata(self.to_gdata())")
+                    res.append("        if ad is not None:")
+                    res.append("            return ad")
+                    res.append("        raise Exception('Unreachable in {pname()}.copy()')")
+                else:
+                    res.append("        return {pname()}.from_gdata(self.to_gdata())")
+            res.append("")
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -904,31 +905,33 @@ class DNodeInner(DNode):
             res.append("        return res")
             res.append("")
 
-#            # .from_gdata()
-#            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
-            res.append("    @staticmethod")
-            res.append("    mut def from_gdata(n: ?ygdata.List) -> list[{pname()}_entry]:")
-            res.append("        if n is not None:")
-            res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
-            res.append("        return []")
-            #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
-            # TODO: trying to use list(map(lambda)) here results in an error,
-            # why? Above code that iterates over n.elements works fine... Error is:
-            # ERROR: Error when compiling y_cfs module: Type error
-            # mut must be a subclass of pure
-            res.append("")
+            # list wrapper from_gdata/copy use the entry's, also dropped in device mode
+            if not device:
+#                # .from_gdata()
+#                # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
+                res.append("    @staticmethod")
+                res.append("    mut def from_gdata(n: ?ygdata.List) -> list[{pname()}_entry]:")
+                res.append("        if n is not None:")
+                res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
+                res.append("        return []")
+                #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
+                # TODO: trying to use list(map(lambda)) here results in an error,
+                # why? Above code that iterates over n.elements works fine... Error is:
+                # ERROR: Error when compiling y_cfs module: Type error
+                # mut must be a subclass of pure
+                res.append("")
 
-            # .copy() method for list wrapper
-            res.append("    mut def copy(self) -> {pname()}:")
-            res.append('        """Create a deep copy of this list object"""')
-            res.append("        # Copy each element in the list")
-            res.append("        copied_elements = []")
-            res.append("        for e in self:")
-            res.append("            ce = e.copy()")
-            res.append("            if ce is not None:")
-            res.append("                copied_elements.append(ce)")
-            res.append("        return {pname()}(elements=copied_elements)")
-            res.append("")
+                # .copy() method for list wrapper
+                res.append("    mut def copy(self) -> {pname()}:")
+                res.append('        """Create a deep copy of this list object"""')
+                res.append("        # Copy each element in the list")
+                res.append("        copied_elements = []")
+                res.append("        for e in self:")
+                res.append("            ce = e.copy()")
+                res.append("            if ce is not None:")
+                res.append("                copied_elements.append(ce)")
+                res.append("        return {pname()}(elements=copied_elements)")
+                res.append("")
             # Generate Iterable extension for the list class
             res.append("extension {pname()}(Iterable[{pname()}_entry]):")
             res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
@@ -973,7 +976,8 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
+                    # rpc subtrees keep serialization (device=False) so rpc_root compiles
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, device=False, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -1762,7 +1766,7 @@ class DRoot(DNodeInner):
             ("module_metadata", self.module_metadata),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False) -> str:
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, device=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False) -> str:
         def build_spath(spath: list[DNode]):
             if len(root_path) == len(spath) - 1:
                 return spath
@@ -1780,7 +1784,7 @@ class DRoot(DNodeInner):
         # adata code generator ...
         spath = build_spath([self])
         pname_cache: dict[str, str] = {}
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext, pname_cache=pname_cache)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, device=device, exclude_ext=exclude_ext, pname_cache=pname_cache)
 
         res = []
         res.append("import base64")

--- a/src/ayangc.act
+++ b/src/ayangc.act
@@ -82,6 +82,13 @@ proc def cmd_compile(env, file_cap, args):
     """
     infiles = args.get_strlist("infile")
     loose = args.get_bool("loose")
+    mode = args.get_str("mode")
+    device = False
+    if mode == "device":
+        device = True
+    elif mode != "full":
+        print("Error: invalid --mode '{mode}', expected 'full' or 'device'", err=True)
+        env.exit(1)
     exclude_patterns = args.get_strlist("exclude")
     stage = args.get_str("stage")
     outfile = args.get_str("output")
@@ -180,7 +187,7 @@ proc def cmd_compile(env, file_cap, args):
             t1 = sw.elapsed()
             print("Compiled {len(yang_sources)} YANG modules in {t1.to_float()}s", err=True)
             sw.reset()
-            stage_output = root.prdaclass(loose=loose)
+            stage_output = root.prdaclass(loose=loose, device=device)
             t2 = sw.elapsed()
             print("Generated adata in {t2.to_float()}s", err=True)
         else:
@@ -239,6 +246,7 @@ actor main(env):
     compile_cmd = p.add_cmd("compile", "compile YANG modules together", _cmd_compile)
     compile_cmd.add_option("infile", "strlist", "+", [], "input YANG file(s) or directory(s)")
     compile_cmd.add_bool("loose", "generate loose validation mode classes", short="l")
+    compile_cmd.add_option("mode", "str", default="full", help="adata generation mode: 'full' (default) or 'device' (drop from_gdata/to_gdata/copy/_get_attr for a structure-only on-device class shape)", short="m")
     compile_cmd.add_option("exclude", "strlist", "*", [], "glob pattern(s) to exclude files", short="e")
     compile_cmd.add_option("stage", "str", default="", help="compile stage (adata, dnode-src, schema-tree, dnode-tree, statement, default full compile only)", short="s")
     compile_cmd.add_option("output", "str", default="", help="write stage output to file (use '-' for stdout)", short="o")

--- a/src/schema.act
+++ b/src/schema.act
@@ -384,7 +384,7 @@ class DNode(object):
 
         raise ValueError("Unable to get child from non-inner node")
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, device=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
         """Print the data class for this schema node
         """
         raise NotImplementedError('DNode pdc: {type(self)} - {get_path(spath)}')
@@ -507,7 +507,7 @@ class DNode(object):
 class DNodeInner(DNode):
     children: list[DNode]
 
-    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
+    def _prdaclass_rec(self, spath: list[DNode], loose=False, top=True, set_ns=True, include_state=False, device=False, exclude_ext: list[(name: str, namespace: str)]=[], breaker_idx: int=0, pname_cache: dict[str, str]={}) -> (list[str], int):
         """Print the data class for this schema node
         """
         def path_with_child(c):
@@ -580,7 +580,7 @@ class DNodeInner(DNode):
         for child in self.children:
             if isinstance(child, DNodeLeaf):
                 continue
-            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
+            child_res, breaker_idx = child._prdaclass_rec(path_with_child(child), loose=loose, top=False, set_ns=child.namespace!=self.namespace, include_state=include_state, device=device, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
             res.extend(child_res)
 
         def excluded(n):
@@ -732,71 +732,72 @@ class DNodeInner(DNode):
                 res.append("        return res")
                 res.append("")
 
-        if len(attr_children) > 0:
-            res.append("    pure def _get_attr(self, name: str) -> ?value:")
-            for child in attr_children:
-                res.append("        if name == '{child.prefix}:{child.name}':")
-                if isinstance(child, DList):
-                    res.append("            return iter(self.{usname(child)})")
-                else:
-                    res.append("            return self.{usname(child)}")
+        if not device:
+            if len(attr_children) > 0:
+                res.append("    pure def _get_attr(self, name: str) -> ?value:")
+                for child in attr_children:
+                    res.append("        if name == '{child.prefix}:{child.name}':")
+                    if isinstance(child, DList):
+                        res.append("            return iter(self.{usname(child)})")
+                    else:
+                        res.append("            return self.{usname(child)}")
+                res.append("")
+
+            # .to_gdata()
+            res.append("    mut def to_gdata(self) -> ygdata.Node:")
+            if isinstance(self, DRoot):
+                res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose})")
+            else:
+                root_path = ["{'{node.module}:' if prev.module != node.module else ''}{node.name}" if node is not None else None for prev, node in zip(spath, spath[1:] + [None])]
+                res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose}, root_path={repr(root_path[:-1])})")
             res.append("")
 
-        # .to_gdata()
-        res.append("    mut def to_gdata(self) -> ygdata.Node:")
-        if isinstance(self, DRoot):
-            res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose})")
-        else:
-            root_path = ["{'{node.module}:' if prev.module != node.module else ''}{node.name}" if node is not None else None for prev, node in zip(spath, spath[1:] + [None])]
-            res.append("        return yadata.from_adata(SRC_DNODE, self, loose={loose}, root_path={repr(root_path[:-1])})")
-        res.append("")
+            # .from_gdata()
+            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
+            from_gdata_args_list = []
+            for child in attr_children:
+                if isinstance(child, DNodeLeaf):
+                    from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
+                else:
+                    from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}')))")
+            from_gdata_args = ", ".join(from_gdata_args_list)
+            res.append("    @staticmethod")
+            if isinstance(self, DList):
+                res.append("    mut def from_gdata(n: ygdata.Node) -> {pname()}_entry:")
+                res.append("        return {pname()}_entry({from_gdata_args})")
+            else:
+                opt_cnt = True if isinstance(self, DContainer) and self.presence else False
+                res.append("    mut def from_gdata(n: ?ygdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
+                res.append("        if n is not None:")
+                res.append("            return {pname()}({from_gdata_args})")
+                if opt_cnt:
+                    res.append("        return None")
+                elif loose or optional_subtree(self):
+                    res.append("        return {pname()}()")
+                else:
+                    res.append("        raise ValueError('Missing required subtree {pname()}')")
+            res.append("")
 
-        # .from_gdata()
-        # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
-        from_gdata_args_list = []
-        for child in attr_children:
-            if isinstance(child, DNodeLeaf):
-                from_gdata_args_list.append("{usname(child)}=n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}'))")
+            # .copy() method
+            if isinstance(self, DList):
+                res.append("    mut def copy(self) -> {pname()}_entry:")
             else:
-                from_gdata_args_list.append("{usname(child)}={pname(child)}.from_gdata(n.{taker_name(child, list_keys(self), loose=loose)}(ygdata.Id(NS_{safe_name(child.module)}, '{child.name}')))")
-        from_gdata_args = ", ".join(from_gdata_args_list)
-        res.append("    @staticmethod")
-        if isinstance(self, DList):
-            res.append("    mut def from_gdata(n: ygdata.Node) -> {pname()}_entry:")
-            res.append("        return {pname()}_entry({from_gdata_args})")
-        else:
-            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            res.append("    mut def from_gdata(n: ?ygdata.Node) -> {'?' if opt_cnt else ''}{pname()}:")
-            res.append("        if n is not None:")
-            res.append("            return {pname()}({from_gdata_args})")
-            if opt_cnt:
-                res.append("        return None")
-            elif loose or optional_subtree(self):
-                res.append("        return {pname()}()")
+                res.append("    mut def copy(self) -> {pname()}:")
+            res.append('        """Create a deep copy of this adata object"""')
+            if isinstance(self, DList):
+                res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
             else:
-                res.append("        raise ValueError('Missing required subtree {pname()}')")
-        res.append("")
-
-        # .copy() method
-        if isinstance(self, DList):
-            res.append("    mut def copy(self) -> {pname()}_entry:")
-        else:
-            res.append("    mut def copy(self) -> {pname()}:")
-        res.append('        """Create a deep copy of this adata object"""')
-        if isinstance(self, DList):
-            res.append("        return {pname()}_entry.from_gdata(self.to_gdata())")
-        else:
-            opt_cnt = True if isinstance(self, DContainer) and self.presence else False
-            # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
-            # But since we're copying an instance, the output of .copy() is non-optional.
-            if opt_cnt:
-                res.append("        ad = {pname()}.from_gdata(self.to_gdata())")
-                res.append("        if ad is not None:")
-                res.append("            return ad")
-                res.append("        raise Exception('Unreachable in {pname()}.copy()')")
-            else:
-                res.append("        return {pname()}.from_gdata(self.to_gdata())")
-        res.append("")
+                opt_cnt = True if isinstance(self, DContainer) and self.presence else False
+                # AdataPContainer.from_gdata(n) -> ?AdataPContainer, return type is optional.
+                # But since we're copying an instance, the output of .copy() is non-optional.
+                if opt_cnt:
+                    res.append("        ad = {pname()}.from_gdata(self.to_gdata())")
+                    res.append("        if ad is not None:")
+                    res.append("            return ad")
+                    res.append("        raise Exception('Unreachable in {pname()}.copy()')")
+                else:
+                    res.append("        return {pname()}.from_gdata(self.to_gdata())")
+            res.append("")
 
         if isinstance(self, DList):
             # List has special handling as it actually results in two classes:
@@ -900,31 +901,33 @@ class DNodeInner(DNode):
             res.append("        return res")
             res.append("")
 
-#            # .from_gdata()
-#            # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
-            res.append("    @staticmethod")
-            res.append("    mut def from_gdata(n: ?ygdata.List) -> list[{pname()}_entry]:")
-            res.append("        if n is not None:")
-            res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
-            res.append("        return []")
-            #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
-            # TODO: trying to use list(map(lambda)) here results in an error,
-            # why? Above code that iterates over n.elements works fine... Error is:
-            # ERROR: Error when compiling y_cfs module: Type error
-            # mut must be a subclass of pure
-            res.append("")
+            # list wrapper from_gdata/copy use the entry's, also dropped in device mode
+            if not device:
+#                # .from_gdata()
+#                # TODO: should .from_gdata() not take a specific data node instead, like Container instead of ygdata.Node?
+                res.append("    @staticmethod")
+                res.append("    mut def from_gdata(n: ?ygdata.List) -> list[{pname()}_entry]:")
+                res.append("        if n is not None:")
+                res.append("            return [{pname()}_entry.from_gdata(e) for e in n.elements]")
+                res.append("        return []")
+                #res.append("        return list(map(lambda x: %s_entry.from_gdata(x), n.elements))" % pname())
+                # TODO: trying to use list(map(lambda)) here results in an error,
+                # why? Above code that iterates over n.elements works fine... Error is:
+                # ERROR: Error when compiling y_cfs module: Type error
+                # mut must be a subclass of pure
+                res.append("")
 
-            # .copy() method for list wrapper
-            res.append("    mut def copy(self) -> {pname()}:")
-            res.append('        """Create a deep copy of this list object"""')
-            res.append("        # Copy each element in the list")
-            res.append("        copied_elements = []")
-            res.append("        for e in self:")
-            res.append("            ce = e.copy()")
-            res.append("            if ce is not None:")
-            res.append("                copied_elements.append(ce)")
-            res.append("        return {pname()}(elements=copied_elements)")
-            res.append("")
+                # .copy() method for list wrapper
+                res.append("    mut def copy(self) -> {pname()}:")
+                res.append('        """Create a deep copy of this list object"""')
+                res.append("        # Copy each element in the list")
+                res.append("        copied_elements = []")
+                res.append("        for e in self:")
+                res.append("            ce = e.copy()")
+                res.append("            if ce is not None:")
+                res.append("                copied_elements.append(ce)")
+                res.append("        return {pname()}(elements=copied_elements)")
+                res.append("")
             # Generate Iterable extension for the list class
             res.append("extension {pname()}(Iterable[{pname()}_entry]):")
             res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
@@ -969,7 +972,8 @@ class DNodeInner(DNode):
                 # - set_ns: from DRpc (=True)
                 # - include_state=True
                 for child in rpc.children:
-                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
+                    # rpc subtrees keep serialization (device=False) so rpc_root compiles
+                    child_class_src, breaker_idx = child._prdaclass_rec(spath + [rpc, child], loose=loose, top=False, set_ns=set_ns, include_state=True, device=False, exclude_ext=exclude_ext, breaker_idx=breaker_idx, pname_cache=pname_cache)
                     res.extend(child_class_src)
 
             # TODO: unique safe name for RPC function!
@@ -1758,7 +1762,7 @@ class DRoot(DNodeInner):
             ("module_metadata", self.module_metadata),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False) -> str:
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, device=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False) -> str:
         def build_spath(spath: list[DNode]):
             if len(root_path) == len(spath) - 1:
                 return spath
@@ -1776,7 +1780,7 @@ class DRoot(DNodeInner):
         # adata code generator ...
         spath = build_spath([self])
         pname_cache: dict[str, str] = {}
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, exclude_ext=exclude_ext, pname_cache=pname_cache)
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, device=device, exclude_ext=exclude_ext, pname_cache=pname_cache)
 
         res = []
         res.append("import base64")

--- a/test/test_device_mode/Build.act
+++ b/test/test_device_mode/Build.act
@@ -1,0 +1,7 @@
+name = "ayang_test_device_mode"
+fingerprint = 0xfde1bcea1d5fbeef
+dependencies = {    "yang": (
+        path="../../"
+    )
+}
+zig_dependencies = {}

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -1,0 +1,208 @@
+import base64
+import json
+import std.xml as xml
+import yang.adata as yadata
+import yang.gdata as ygdata
+import yang.xml as yxml
+import yang.xpath as yxpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+
+
+_identities: list[DIdentity] = []
+
+
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='m', namespace='urn:example:m', prefix='m', name='cfg', config=True, presence=False, children=[
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='enabled', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='m', namespace='urn:example:m', prefix='m', name='sub', config=True, presence=False, children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='detail', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
+    DList(module='m', namespace='urn:example:m', prefix='m', name='items', key=['id'], config=True, min_elements=0, ordered_by='system', children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='id', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='val', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+    ])
+])
+
+SRC_DNODE_RPC_0: DRpc = DRpc(module='m', namespace='urn:example:m', prefix='m', name='ping', input=DInput(module='m', namespace='urn:example:m', prefix='m', children=[
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+]), output=DOutput(module='m', namespace='urn:example:m', prefix='m', children=[
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='reply', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+]), children=[
+    DInput(module='m', namespace='urn:example:m', prefix='m', children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
+    DOutput(module='m', namespace='urn:example:m', prefix='m', children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='reply', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ])
+])
+
+SRC_DNODE: DRoot = DRoot(
+    children=[SRC_DNODE_CHILD_0],
+    identities=[],
+    rpcs=[SRC_DNODE_RPC_0],
+    module_metadata={'urn:example:m':('m', None)},
+)
+
+NS_m: str = 'urn:example:m'
+
+
+_breaker1: None = None
+class m__cfg__sub(yadata.MNode):
+    detail: ?str
+
+    mut def __init__(self, detail: ?str) -> None:
+        self.detail = detail
+
+
+_breaker2: None = None
+class m__cfg__items_entry(yadata.MNode):
+    id: str
+    val: ?u64
+
+    mut def __init__(self, id: str, val: ?u64) -> None:
+        self.id = id
+        self.val = val
+
+_breaker3: None = None
+class m__cfg__items(yadata.MNode):
+    elements: list[m__cfg__items_entry]
+    mut def __init__(self, elements: list[m__cfg__items_entry]=[]) -> None:
+        self.elements = elements
+
+    pure def get(self, id: str) -> ?m__cfg__items_entry:
+        for e in self:
+            if e.id != id:
+                continue
+            return e
+
+    mut def create(self, id: str, val: ?u64=None) -> m__cfg__items_entry:
+        e = self.get(id)
+        if e is not None:
+            if val is not None:
+                e.val = val
+            return e
+        res = m__cfg__items_entry(id=id, val=val)
+        self.elements.append(res)
+        return res
+
+extension m__cfg__items(Iterable[m__cfg__items_entry]):
+    def __iter__(self) -> Iterator[m__cfg__items_entry]:
+        return self.elements.__iter__()
+
+extension m__cfg__items(Indexed[str, m__cfg__items_entry]):
+    def __getitem__(self, k: str) -> m__cfg__items_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: m__cfg__items_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.id == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.id == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
+_breaker4: None = None
+class m__cfg(yadata.MNode):
+    name: ?str
+    enabled: ?bool
+    sub: m__cfg__sub
+    items: m__cfg__items
+
+    mut def __init__(self, name: ?str, enabled: ?bool, sub: ?m__cfg__sub=None, items: list[m__cfg__items_entry]=[]) -> None:
+        self.name = name
+        self.enabled = enabled
+        self.sub = sub if sub is not None else m__cfg__sub()
+        self.items = m__cfg__items(elements=items)
+
+
+_breaker5: None = None
+class root(yadata.MNode):
+    cfg: m__cfg
+
+    mut def __init__(self, cfg: ?m__cfg=None) -> None:
+        self.cfg = cfg if cfg is not None else m__cfg()
+
+
+_breaker6: None = None
+class m__ping__input(yadata.MNode):
+    msg: ?str
+
+    mut def __init__(self, msg: ?str) -> None:
+        self.msg = msg
+
+    pure def _get_attr(self, name: str) -> ?value:
+        if name == 'm:msg':
+            return self.msg
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['m:ping', 'input'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> m__ping__input:
+        if n is not None:
+            return m__ping__input(msg=n.get_opt_str(ygdata.Id(NS_m, 'msg')))
+        return m__ping__input()
+
+    mut def copy(self) -> m__ping__input:
+        """Create a deep copy of this adata object"""
+        return m__ping__input.from_gdata(self.to_gdata())
+
+
+_breaker7: None = None
+class m__ping__output(yadata.MNode):
+    reply: ?str
+
+    mut def __init__(self, reply: ?str) -> None:
+        self.reply = reply
+
+    pure def _get_attr(self, name: str) -> ?value:
+        if name == 'm:reply':
+            return self.reply
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['m:ping', 'output'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> m__ping__output:
+        if n is not None:
+            return m__ping__output(reply=n.get_opt_str(ygdata.Id(NS_m, 'reply')))
+        return m__ping__output()
+
+    mut def copy(self) -> m__ping__output:
+        """Create a deep copy of this adata object"""
+        return m__ping__output.from_gdata(self.to_gdata())
+
+
+actor rpc_root(tp: ygdata.TreeProvider):
+    def ping(cb: action(?m__ping__output, ?Exception) -> None, inp: ?m__ping__input):
+        def cb_wrap(res: ?xml.Node, err: ?Exception):
+            if res is not None:
+                gdata_res = yxml.from_xml(SRC_DNODE, res, False, ["m:ping", "output"])
+                adata_res = m__ping__output.from_gdata(gdata_res)
+                cb(adata_res, err)
+            else:
+                cb(None, err)
+
+        rpc_xml = xml.Node('ping', nsdefs=[(None, 'urn:example:m')])
+        if inp is not None:
+            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["m:ping", "input"])
+            rpc_xml.children.extend(gdata_inp.to_xml())
+        tp.rpc_xml(cb_wrap, rpc_xml)
+
+

--- a/test/test_device_mode/src/test_device_mode.act
+++ b/test/test_device_mode/src/test_device_mode.act
@@ -1,0 +1,33 @@
+"""Device-mode compile test.
+
+src/m.act is generated from yang/m.yang with `ayangc compile -m device`, which
+drops all serialization (from_gdata, to_gdata, copy, _get_attr) from the config
+data classes, leaving only structure: typed fields, __init__, and the
+navigation/mutation surface. RPC input/output subtrees keep serialization so the
+rpc_root actor still compiles.
+
+The point of the test is that the generated module *compiles at all* with stock
+acton (no __get_attr__ compiler dependency); here we also exercise the retained
+list navigation.
+"""
+
+import testing
+import m
+
+def _test_device_navigation():
+    lst = m.m__cfg__items()
+    lst.create(id="i1", val=u64(7))
+    lst.create(id="i2")
+    testing.assertNotNone(lst.get("i1"), "list get failed")
+    testing.assertNone(lst.get("nope"), "unexpected entry present")
+    n = 0
+    for _it in lst:
+        n += 1
+    testing.assertEqual(n, 2, "list iteration count")
+
+def _test_device_construct():
+    # config tree has no serialization methods; just structure + navigation
+    r = m.root(cfg=m.m__cfg(name="dev1", enabled=True, sub=m.m__cfg__sub(detail="d")))
+    r.cfg.items.create(id="x", val=u64(1))
+    testing.assertEqual(r.cfg.name, "dev1", "field roundtrip")
+    testing.assertNotNone(r.cfg.items.get("x"), "nested list get")

--- a/test/test_device_mode/yang/m.yang
+++ b/test/test_device_mode/yang/m.yang
@@ -1,0 +1,20 @@
+module m {
+  namespace "urn:example:m";
+  prefix m;
+  container cfg {
+    leaf name { type string; }
+    leaf enabled { type boolean; }
+    container sub {
+      leaf detail { type string; }
+    }
+    list items {
+      key id;
+      leaf id { type string; }
+      leaf val { type uint32; }
+    }
+  }
+  rpc ping {
+    input  { leaf msg { type string; } }
+    output { leaf reply { type string; } }
+  }
+}


### PR DESCRIPTION
Add `ayangc compile --mode device`, which generates a structure-only adata class shape: it drops from_gdata, to_gdata, copy, AND the per-class _get_attr from the config data classes, leaving only typed fields, __init__, and the navigation/mutation surface (list create/get/__iter__/__setitem__, keyed accessors). The point is to compile modules WITHOUT any serialization so we can see how aggressively the compiler's dead-code elimination prunes un-navigated subtrees.