### PR TITLE
Split SRC_DNODE and SRC_YANG into a separate module

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1242,8 +1242,6 @@ class DIdentity(DNode):
         if len(identities) == 0:
             return ["_identities: list[DIdentity] = []", "", ""]
 
-        result = []
-
         # Sort identities topologically (bases before derived)
         sorted_identities = []
         visited = set()
@@ -1261,26 +1259,43 @@ class DIdentity(DNode):
         for identity in identities:
             visit(identity)
 
-        # Assign (base) identity var name
-        base_var_map = {}
-        for identity in identities:
-            base_var_map[identity.key()] = identity.format_base_var_name()
-
         # Print variable declarations for identities in order of precedence
+        result = []
         for identity in sorted_identities:
-            var_name = base_var_map[identity.key()]
-            base_refs = [base_var_map[base.key()] for base in identity.base]
-            result.append("{var_name}: DIdentity = DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base=[{', '.join(base_refs)}])")
+            result.append("{identity.format_base_var_name()}: DIdentity = DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base={DIdentity.format_base_identity_var_name_list(identity.base)})")
 
         # Build the global _identities list
         result.append("_identities: list[DIdentity] = [")
         for identity in identities:
-            # Reference the variable
-            result.append("    {base_var_map[identity.key()]},")
+            result.append("    {identity.format_base_var_name()},")
         result.append("]")
         result.append("")
         result.append("")
 
+        return result
+
+    @staticmethod
+    def format_identity_public_exports(identities: list[DIdentity]) -> list[str]:
+        """Public module constants for identities, emitted only in the separate dnode module.
+        """
+        result = []
+        for identity in identities:
+            result.append("{identity.format_base_var_name(prefix="BASE_")}: DIdentity = {identity.format_base_var_name()}")
+        result.append("IDENTITIES: list[DIdentity] = _identities")
+        result.append("")
+        result.append("")
+        return result
+
+    @staticmethod
+    def format_identity_aliases(identities: list[DIdentity], dnode_module: str) -> list[str]:
+        """Private module constants for identities, aliases from the separate dnode module.
+        """
+        result = []
+        for identity in identities:
+            result.append("{identity.format_base_var_name()}: DIdentity = {dnode_module}.{identity.format_base_var_name(prefix="BASE_")}")
+        result.append("_identities: list[DIdentity] = {dnode_module}.IDENTITIES")
+        result.append("")
+        result.append("")
         return result
 
     @staticmethod
@@ -1307,8 +1322,8 @@ class DIdentity(DNode):
     def format_base_identity_var_name_list(identities: list[DIdentity]) -> str:
         return "[{", ".join([b.format_base_var_name() for b in identities])}]"
 
-    def format_base_var_name(self):
-        return safe_name("_base_{self.module}_{self.name}", safe_kw=False)
+    def format_base_var_name(self, prefix="_base_"):
+        return safe_name("{prefix}{self.module}_{self.name}", safe_kw=False)
 
 class DInput(DNodeInner):
     must: list[DMust]
@@ -1766,49 +1781,14 @@ class DRoot(DNodeInner):
             ("module_metadata", self.module_metadata),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, device=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False) -> str:
-        def build_spath(spath: list[DNode]):
-            if len(root_path) == len(spath) - 1:
-                return spath
+    def _pr_src_dnode_consts(self) -> list[str]:
+        """Emit SRC_DNODE constants (SRC_DNODE, SRC_DNODE_CHILD_*, ...).
 
-            next = root_path[len(spath) - 1]
-            module, local_name = split_prefix_name(next)
-            child = spath[-1].get(local_name, module=module, allow_unqualified=False)
-            return build_spath(spath + [child])
-
-        # HACK: DNodeInner._prdaclass_rec mutates the children list - it removes
-        # config false nodes, and reorders list keys! Obviously this is very bad
-        # and we  should really do this elsewhere (get_dnode_children?), or add
-        # arguments to the parsers for oper data handling. Right now I just need
-        # the SRC_DNODE constant to have the same view of the schema as the
-        # adata code generator ...
-        spath = build_spath([self])
-        pname_cache: dict[str, str] = {}
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, device=device, exclude_ext=exclude_ext, pname_cache=pname_cache)
-
+        Shared by prdaclass (inline mode) and prdnode (separate schema module).
+        Deep hierarchies are split into top-level constants so the Acton compiler
+        does not have to parse one giant nested expression.
+        """
         res = []
-        res.append("import base64")
-        res.append("import json")
-        res.append("import std.xml as xml")
-        res.append("import yang.adata as yadata")
-        res.append("import yang.gdata as ygdata")
-        res.append("import yang.xml as yxml")
-        res.append("import yang.xpath as yxpath")
-        res.append("from yang.identityref import Identityref, PartialIdentityref")
-        res.append("from yang.pattern import YangPattern")
-        res.append("from yang.schema import *")
-        res.append("from yang.type import Decimal, Ranges")
-        if include_subs:
-            res.append("from yang.sdata import SubscriptionPath, SubscriptionNode")
-        res.append("")
-        res.append("# == This file is generated ==")
-        res.append("")
-        res.append("")
-        res.append("")
-        res.append("")
-        res.extend(DIdentity.format_identity_list(self.identities))
-        res.extend(DIdentity.format_identityref_constants(self.identities))
-
         const_counters = {}
 
         def _next_const(prefix: str) -> str:
@@ -1917,23 +1897,119 @@ class DRoot(DNodeInner):
         res.append("    module_metadata={repr(self.module_metadata)},")
         res.append(")")
         res.append("")
+        return res
+
+    @staticmethod
+    def _pr_src_yang(schema_yang: list[str]) -> list[str]:
+        """Emit the SRC_YANG_* raw-source constants and the src_yang() accessor.
+
+        Shared by prdnode (separate schema module) and prdaclass (inline mode).
+        """
+        res = []
+        src_yang_names = []
+        i = 0
+        for s in schema_yang:
+            src_yang_name = "SRC_YANG_{i}"
+            src_yang_names.append(src_yang_name)
+            res.append('{src_yang_name}: str = r"""{s}"""')
+            res.append("")
+            i += 1
+        res.append("pure def src_yang() -> list[str]:")
+        res.append("    return [")
+        for src_yang_name in src_yang_names:
+            res.append("        {src_yang_name},")
+        res.append("    ]")
+        res.append("")
+        res.append("")
+        return res
+
+    def prdnode(self, schema_yang: ?list[str]=None) -> str:
+        """Print a standalone Acton module holding SRC_DNODE (and, when given, the
+        SRC_YANG raw schema source) plus their dependencies.
+
+        Emitted as a separate `{module}_src_dnode.act` file and imported by the
+        main `{module}.act` adata module. Keeping the SRC_DNODE expression and
+        SRC_YANG strings in their own file means the Acton compiler does not
+        re-parse them when the usages of the generated adata types change.
+        """
+        res = []
+        res.append("import base64")
+        res.append("import yang.xpath as yxpath")
+        res.append("from yang.identityref import Identityref, PartialIdentityref")
+        res.append("from yang.pattern import YangPattern")
+        res.append("from yang.schema import *")
+        res.append("from yang.type import Decimal, Ranges")
+        res.append("")
+        res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
+        res.extend(DIdentity.format_identity_list(self.identities))
+        res.extend(DIdentity.format_identity_public_exports(self.identities))
+        res.extend(self._pr_src_dnode_consts())
+        if schema_yang is not None:
+            res.extend(DRoot._pr_src_yang(schema_yang))
+        return "\n".join(res)
+
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, device=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False, dnode_module: ?str=None) -> str:
+        def build_spath(spath: list[DNode]):
+            if len(root_path) == len(spath) - 1:
+                return spath
+
+            next = root_path[len(spath) - 1]
+            module, local_name = split_prefix_name(next)
+            child = spath[-1].get(local_name, module=module, allow_unqualified=False)
+            return build_spath(spath + [child])
+
+        # HACK: DNodeInner._prdaclass_rec mutates the children list - it removes
+        # config false nodes, and reorders list keys! Obviously this is very bad
+        # and we should really do this elsewhere (get_dnode_children?), or add
+        # arguments to the parsers for oper data handling. Right now I just need
+        # the SRC_DNODE constant to have the same view of the schema as the
+        # adata code generator ...
+        spath = build_spath([self])
+        pname_cache: dict[str, str] = {}
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, device=device, exclude_ext=exclude_ext, pname_cache=pname_cache)
+
+        res = []
+        res.append("import base64")
+        res.append("import json")
+        res.append("import std.xml as xml")
+        res.append("import yang.adata as yadata")
+        res.append("import yang.gdata as ygdata")
+        res.append("import yang.xml as yxml")
+        res.append("import yang.xpath as yxpath")
+        res.append("from yang.identityref import Identityref, PartialIdentityref")
+        res.append("from yang.pattern import YangPattern")
+        res.append("from yang.schema import *")
+        res.append("from yang.type import Decimal, Ranges")
+        if include_subs:
+            res.append("from yang.sdata import SubscriptionPath, SubscriptionNode")
+        if dnode_module is not None:
+            res.append("import {dnode_module}")
+        res.append("")
+        res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
+        res.append("")
+        res.append("")
+        if dnode_module is not None:
+            res.extend(DIdentity.format_identity_aliases(self.identities, dnode_module))
+            res.extend(DIdentity.format_identityref_constants(self.identities))
+            res.append("SRC_DNODE: DRoot = {dnode_module}.SRC_DNODE")
+            res.append("")
+        else:
+            res.extend(DIdentity.format_identity_list(self.identities))
+            res.extend(DIdentity.format_identityref_constants(self.identities))
+            res.extend(self._pr_src_dnode_consts())
 
         if schema_yang is not None:
-            src_yang_names = []
-            i = 0
-            for s in schema_yang:
-                src_yang_name = "SRC_YANG_{i}"
-                src_yang_names.append(src_yang_name)
-                res.append('{src_yang_name}: str = r"""{s}"""')
+            if dnode_module is not None:
+                res.append("pure def src_yang() -> list[str]:")
+                res.append("    return {dnode_module}.src_yang()")
                 res.append("")
-                i += 1
-            res.append("pure def src_yang() -> list[str]:")
-            res.append("    return [")
-            for src_yang_name in src_yang_names:
-                res.append("        {src_yang_name},")
-            res.append("    ]")
-            res.append("")
-            res.append("")
+                res.append("")
+            else:
+                res.extend(DRoot._pr_src_yang(schema_yang))
 
         res.extend(["NS_{safe_name(self.module_metadata[ns].module)}: str = {repr(ns)}" for ns in sorted(self.module_metadata.keys())])
         res.append("")

--- a/snapshots/expected/test_yang/prdaclass_split_dnode
+++ b/snapshots/expected/test_yang/prdaclass_split_dnode
@@ -1,0 +1,171 @@
+# ===== foo_src_dnode.act (prdnode) =====
+
+import base64
+import yang.xpath as yxpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+_base_foo_base_id: DIdentity = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='base_id', base=[])
+_base_foo_der_id: DIdentity = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='der_id', base=[_base_foo_base_id])
+_identities: list[DIdentity] = [
+    _base_foo_base_id,
+    _base_foo_der_id,
+]
+
+
+BASE_foo_base_id: DIdentity = _base_foo_base_id
+BASE_foo_der_id: DIdentity = _base_foo_der_id
+IDENTITIES: list[DIdentity] = _identities
+
+
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=True, presence=False, children=[
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='lid', config=True, default='der_id', mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_base_id], identities=_identities))
+])
+
+SRC_DNODE_IDENTITY_0: DIdentity = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='base_id')
+
+SRC_DNODE_IDENTITY_1: DIdentity = DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='der_id', base=[
+        DIdentity(module='foo', namespace='http://example.com/foo', prefix='f', name='base_id')
+    ])
+
+SRC_DNODE: DRoot = DRoot(
+    children=[SRC_DNODE_CHILD_0],
+    identities=[SRC_DNODE_IDENTITY_0, SRC_DNODE_IDENTITY_1],
+    rpcs=[],
+    module_metadata={'http://example.com/foo':('foo', None)},
+)
+
+SRC_YANG_0: str = r"""module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "f";
+    identity base_id;
+    identity der_id {
+        base base_id;
+    }
+    container c1 {
+        leaf l1 {
+            type string;
+        }
+        leaf lid {
+            type identityref {
+                base base_id;
+            }
+            default der_id;
+        }
+    }
+}"""
+
+pure def src_yang() -> list[str]:
+    return [
+        SRC_YANG_0,
+    ]
+
+
+
+# ===== foo.act (prdaclass dnode_module='foo_src_dnode') =====
+
+import base64
+import json
+import std.xml as xml
+import yang.adata as yadata
+import yang.gdata as ygdata
+import yang.xml as yxml
+import yang.xpath as yxpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+import foo_src_dnode
+
+# == This file is generated ==
+
+
+
+
+_base_foo_base_id: DIdentity = foo_src_dnode.BASE_foo_base_id
+_base_foo_der_id: DIdentity = foo_src_dnode.BASE_foo_der_id
+_identities: list[DIdentity] = foo_src_dnode.IDENTITIES
+
+
+# Identityref constants
+foo_base_id: Identityref = Identityref('base_id', ns='http://example.com/foo', mod='foo', pfx='f')
+foo_der_id: Identityref = Identityref('der_id', ns='http://example.com/foo', mod='foo', pfx='f')
+
+
+SRC_DNODE: DRoot = foo_src_dnode.SRC_DNODE
+
+pure def src_yang() -> list[str]:
+    return foo_src_dnode.src_yang()
+
+
+NS_foo: str = 'http://example.com/foo'
+
+
+_breaker1: None = None
+class foo__c1(yadata.MNode):
+    l1: ?str
+    lid: Identityref
+
+    mut def __init__(self, l1: ?str, lid: ?Identityref=None) -> None:
+        self.l1 = l1
+        _default_lid, error = complete_and_validate_identityref(Identityref.from_adata('der_id'), _identities, [_base_foo_base_id], 'foo')
+        if _default_lid is not None:
+            self.lid = lid if lid is not None else _default_lid
+        else:
+            raise ValueError('Invalid default value for identityref leaf c1: {error}')
+
+    pure def _get_attr(self, name: str) -> ?value:
+        if name == 'f:l1':
+            return self.l1
+        if name == 'f:lid':
+            return self.lid
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> foo__c1:
+        if n is not None:
+            return foo__c1(l1=n.get_opt_str(ygdata.Id(NS_foo, 'l1')), lid=n.get_opt_Identityref(ygdata.Id(NS_foo, 'lid')))
+        return foo__c1()
+
+    mut def copy(self) -> foo__c1:
+        """Create a deep copy of this adata object"""
+        return foo__c1.from_gdata(self.to_gdata())
+
+
+_breaker2: None = None
+class root(yadata.MNode):
+    c1: foo__c1
+
+    mut def __init__(self, c1: ?foo__c1=None) -> None:
+        self.c1 = c1 if c1 is not None else foo__c1()
+
+    pure def _get_attr(self, name: str) -> ?value:
+        if name == 'f:c1':
+            return self.c1
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False)
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> root:
+        if n is not None:
+            return root(c1=foo__c1.from_gdata(n.get_opt_cnt(ygdata.Id(NS_foo, 'c1'))))
+        return root()
+
+    mut def copy(self) -> root:
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+
+actor rpc_root(tp: ygdata.TreeProvider):
+    pass
+

--- a/src/ayangc.act
+++ b/src/ayangc.act
@@ -11,6 +11,27 @@ import transform_unions
 import transform_explicit_cases
 
 
+def _dnode_target(outfile: str) -> (str, str):
+    """From an output module path, derive (dnode_module_import, dnode_file_path).
+
+    SRC_DNODE is emitted into a sibling `<name>_src_dnode.act` module. The import
+    name is the main module's dotted path relative to the project `src/` dir with
+    `_src_dnode` appended; with no `src` component we fall back to the basename.
+    """
+    stem = outfile[:-4] if outfile.endswith(".act") else outfile
+    dnode_file = stem + "_src_dnode.act"
+    parts = stem.split("/")
+    src_idx = -1
+    for i, p in enumerate(parts):
+        if p == "src":
+            src_idx = i
+    if src_idx >= 0 and src_idx + 1 < len(parts):
+        mod_parts = parts[src_idx + 1:]
+    else:
+        mod_parts = [parts[-1]]
+    return (".".join(mod_parts) + "_src_dnode", dnode_file)
+
+
 proc def cmd_transform(env, file_cap, args):
     """Transform command: Parse a YANG file and apply transformations
 
@@ -187,7 +208,22 @@ proc def cmd_compile(env, file_cap, args):
             t1 = sw.elapsed()
             print("Compiled {len(yang_sources)} YANG modules in {t1.to_float()}s", err=True)
             sw.reset()
-            stage_output = root.prdaclass(loose=loose, device=device)
+            if device and outfile != "-":
+                # Device mode also implies split modules (separate SRC_DNODE, SRC_YANG)
+                dnode_module, dnode_filename = _dnode_target(outfile)
+                stage_output = root.prdaclass(loose=loose, device=device, dnode_module=dnode_module)
+                try:
+                    wfc = file.WriteFileCap(file_cap)
+                    dwf = file.WriteFile(wfc, dnode_filename)
+                    dwf.write(root.prdnode().encode())
+                    dwf.close()
+                    print("Wrote SRC_DNODE module to {dnode_filename}", err=True)
+                except OSError as e:
+                    print("Error writing file {dnode_filename}: {e}", err=True)
+                    env.exit(1)
+            else:
+                # Full mode (or stdout): emit SRC_DNODE inline.
+                stage_output = root.prdaclass(loose=loose, device=device)
             t2 = sw.elapsed()
             print("Generated adata in {t2.to_float()}s", err=True)
         else:

--- a/src/schema.act
+++ b/src/schema.act
@@ -1238,8 +1238,6 @@ class DIdentity(DNode):
         if len(identities) == 0:
             return ["_identities: list[DIdentity] = []", "", ""]
 
-        result = []
-
         # Sort identities topologically (bases before derived)
         sorted_identities = []
         visited = set()
@@ -1257,26 +1255,43 @@ class DIdentity(DNode):
         for identity in identities:
             visit(identity)
 
-        # Assign (base) identity var name
-        base_var_map = {}
-        for identity in identities:
-            base_var_map[identity.key()] = identity.format_base_var_name()
-
         # Print variable declarations for identities in order of precedence
+        result = []
         for identity in sorted_identities:
-            var_name = base_var_map[identity.key()]
-            base_refs = [base_var_map[base.key()] for base in identity.base]
-            result.append("{var_name}: DIdentity = DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base=[{', '.join(base_refs)}])")
+            result.append("{identity.format_base_var_name()}: DIdentity = DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base={DIdentity.format_base_identity_var_name_list(identity.base)})")
 
         # Build the global _identities list
         result.append("_identities: list[DIdentity] = [")
         for identity in identities:
-            # Reference the variable
-            result.append("    {base_var_map[identity.key()]},")
+            result.append("    {identity.format_base_var_name()},")
         result.append("]")
         result.append("")
         result.append("")
 
+        return result
+
+    @staticmethod
+    def format_identity_public_exports(identities: list[DIdentity]) -> list[str]:
+        """Public module constants for identities, emitted only in the separate dnode module.
+        """
+        result = []
+        for identity in identities:
+            result.append("{identity.format_base_var_name(prefix="BASE_")}: DIdentity = {identity.format_base_var_name()}")
+        result.append("IDENTITIES: list[DIdentity] = _identities")
+        result.append("")
+        result.append("")
+        return result
+
+    @staticmethod
+    def format_identity_aliases(identities: list[DIdentity], dnode_module: str) -> list[str]:
+        """Private module constants for identities, aliases from the separate dnode module.
+        """
+        result = []
+        for identity in identities:
+            result.append("{identity.format_base_var_name()}: DIdentity = {dnode_module}.{identity.format_base_var_name(prefix="BASE_")}")
+        result.append("_identities: list[DIdentity] = {dnode_module}.IDENTITIES")
+        result.append("")
+        result.append("")
         return result
 
     @staticmethod
@@ -1303,8 +1318,8 @@ class DIdentity(DNode):
     def format_base_identity_var_name_list(identities: list[DIdentity]) -> str:
         return "[{", ".join([b.format_base_var_name() for b in identities])}]"
 
-    def format_base_var_name(self):
-        return safe_name("_base_{self.module}_{self.name}", safe_kw=False)
+    def format_base_var_name(self, prefix="_base_"):
+        return safe_name("{prefix}{self.module}_{self.name}", safe_kw=False)
 
 class DInput(DNodeInner):
     must: list[DMust]
@@ -1762,49 +1777,14 @@ class DRoot(DNodeInner):
             ("module_metadata", self.module_metadata),
         ]
 
-    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, device=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False) -> str:
-        def build_spath(spath: list[DNode]):
-            if len(root_path) == len(spath) - 1:
-                return spath
+    def _pr_src_dnode_consts(self) -> list[str]:
+        """Emit SRC_DNODE constants (SRC_DNODE, SRC_DNODE_CHILD_*, ...).
 
-            next = root_path[len(spath) - 1]
-            module, local_name = split_prefix_name(next)
-            child = spath[-1].get(local_name, module=module, allow_unqualified=False)
-            return build_spath(spath + [child])
-
-        # HACK: DNodeInner._prdaclass_rec mutates the children list - it removes
-        # config false nodes, and reorders list keys! Obviously this is very bad
-        # and we  should really do this elsewhere (get_dnode_children?), or add
-        # arguments to the parsers for oper data handling. Right now I just need
-        # the SRC_DNODE constant to have the same view of the schema as the
-        # adata code generator ...
-        spath = build_spath([self])
-        pname_cache: dict[str, str] = {}
-        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, device=device, exclude_ext=exclude_ext, pname_cache=pname_cache)
-
+        Shared by prdaclass (inline mode) and prdnode (separate schema module).
+        Deep hierarchies are split into top-level constants so the Acton compiler
+        does not have to parse one giant nested expression.
+        """
         res = []
-        res.append("import base64")
-        res.append("import json")
-        res.append("import std.xml as xml")
-        res.append("import yang.adata as yadata")
-        res.append("import yang.gdata as ygdata")
-        res.append("import yang.xml as yxml")
-        res.append("import yang.xpath as yxpath")
-        res.append("from yang.identityref import Identityref, PartialIdentityref")
-        res.append("from yang.pattern import YangPattern")
-        res.append("from yang.schema import *")
-        res.append("from yang.type import Decimal, Ranges")
-        if include_subs:
-            res.append("from yang.sdata import SubscriptionPath, SubscriptionNode")
-        res.append("")
-        res.append("# == This file is generated ==")
-        res.append("")
-        res.append("")
-        res.append("")
-        res.append("")
-        res.extend(DIdentity.format_identity_list(self.identities))
-        res.extend(DIdentity.format_identityref_constants(self.identities))
-
         const_counters = {}
 
         def _next_const(prefix: str) -> str:
@@ -1913,23 +1893,119 @@ class DRoot(DNodeInner):
         res.append("    module_metadata={repr(self.module_metadata)},")
         res.append(")")
         res.append("")
+        return res
+
+    @staticmethod
+    def _pr_src_yang(schema_yang: list[str]) -> list[str]:
+        """Emit the SRC_YANG_* raw-source constants and the src_yang() accessor.
+
+        Shared by prdnode (separate schema module) and prdaclass (inline mode).
+        """
+        res = []
+        src_yang_names = []
+        i = 0
+        for s in schema_yang:
+            src_yang_name = "SRC_YANG_{i}"
+            src_yang_names.append(src_yang_name)
+            res.append('{src_yang_name}: str = r"""{s}"""')
+            res.append("")
+            i += 1
+        res.append("pure def src_yang() -> list[str]:")
+        res.append("    return [")
+        for src_yang_name in src_yang_names:
+            res.append("        {src_yang_name},")
+        res.append("    ]")
+        res.append("")
+        res.append("")
+        return res
+
+    def prdnode(self, schema_yang: ?list[str]=None) -> str:
+        """Print a standalone Acton module holding SRC_DNODE (and, when given, the
+        SRC_YANG raw schema source) plus their dependencies.
+
+        Emitted as a separate `{module}_src_dnode.act` file and imported by the
+        main `{module}.act` adata module. Keeping the SRC_DNODE expression and
+        SRC_YANG strings in their own file means the Acton compiler does not
+        re-parse them when the usages of the generated adata types change.
+        """
+        res = []
+        res.append("import base64")
+        res.append("import yang.xpath as yxpath")
+        res.append("from yang.identityref import Identityref, PartialIdentityref")
+        res.append("from yang.pattern import YangPattern")
+        res.append("from yang.schema import *")
+        res.append("from yang.type import Decimal, Ranges")
+        res.append("")
+        res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
+        res.extend(DIdentity.format_identity_list(self.identities))
+        res.extend(DIdentity.format_identity_public_exports(self.identities))
+        res.extend(self._pr_src_dnode_consts())
+        if schema_yang is not None:
+            res.extend(DRoot._pr_src_yang(schema_yang))
+        return "\n".join(res)
+
+    def prdaclass(self, schema_yang: ?list[str]=None, loose=False, device=False, include_state=False, top=True, root_path: list[str]=[], exclude_ext: list[(name: str, namespace: str)]=[], include_subs=False, dnode_module: ?str=None) -> str:
+        def build_spath(spath: list[DNode]):
+            if len(root_path) == len(spath) - 1:
+                return spath
+
+            next = root_path[len(spath) - 1]
+            module, local_name = split_prefix_name(next)
+            child = spath[-1].get(local_name, module=module, allow_unqualified=False)
+            return build_spath(spath + [child])
+
+        # HACK: DNodeInner._prdaclass_rec mutates the children list - it removes
+        # config false nodes, and reorders list keys! Obviously this is very bad
+        # and we should really do this elsewhere (get_dnode_children?), or add
+        # arguments to the parsers for oper data handling. Right now I just need
+        # the SRC_DNODE constant to have the same view of the schema as the
+        # adata code generator ...
+        spath = build_spath([self])
+        pname_cache: dict[str, str] = {}
+        inner, _breaker_idx = spath[-1]._prdaclass_rec(spath, loose=loose, top=top, set_ns=True, include_state=include_state, device=device, exclude_ext=exclude_ext, pname_cache=pname_cache)
+
+        res = []
+        res.append("import base64")
+        res.append("import json")
+        res.append("import std.xml as xml")
+        res.append("import yang.adata as yadata")
+        res.append("import yang.gdata as ygdata")
+        res.append("import yang.xml as yxml")
+        res.append("import yang.xpath as yxpath")
+        res.append("from yang.identityref import Identityref, PartialIdentityref")
+        res.append("from yang.pattern import YangPattern")
+        res.append("from yang.schema import *")
+        res.append("from yang.type import Decimal, Ranges")
+        if include_subs:
+            res.append("from yang.sdata import SubscriptionPath, SubscriptionNode")
+        if dnode_module is not None:
+            res.append("import {dnode_module}")
+        res.append("")
+        res.append("# == This file is generated ==")
+        res.append("")
+        res.append("")
+        res.append("")
+        res.append("")
+        if dnode_module is not None:
+            res.extend(DIdentity.format_identity_aliases(self.identities, dnode_module))
+            res.extend(DIdentity.format_identityref_constants(self.identities))
+            res.append("SRC_DNODE: DRoot = {dnode_module}.SRC_DNODE")
+            res.append("")
+        else:
+            res.extend(DIdentity.format_identity_list(self.identities))
+            res.extend(DIdentity.format_identityref_constants(self.identities))
+            res.extend(self._pr_src_dnode_consts())
 
         if schema_yang is not None:
-            src_yang_names = []
-            i = 0
-            for s in schema_yang:
-                src_yang_name = "SRC_YANG_{i}"
-                src_yang_names.append(src_yang_name)
-                res.append('{src_yang_name}: str = r"""{s}"""')
+            if dnode_module is not None:
+                res.append("pure def src_yang() -> list[str]:")
+                res.append("    return {dnode_module}.src_yang()")
                 res.append("")
-                i += 1
-            res.append("pure def src_yang() -> list[str]:")
-            res.append("    return [")
-            for src_yang_name in src_yang_names:
-                res.append("        {src_yang_name},")
-            res.append("    ]")
-            res.append("")
-            res.append("")
+                res.append("")
+            else:
+                res.extend(DRoot._pr_src_yang(schema_yang))
 
         res.extend(["NS_{safe_name(self.module_metadata[ns].module)}: str = {repr(ns)}" for ns in sorted(self.module_metadata.keys())])
         res.append("")

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -2184,6 +2184,38 @@ def _test_prdaclass_req_arg():
     src = root.prdaclass(loose=True)
     return src
 
+def _test_prdaclass_split_dnode():
+    ys = r"""module foo {
+    yang-version "1.1";
+    namespace "http://example.com/foo";
+    prefix "f";
+    identity base_id;
+    identity der_id {
+        base base_id;
+    }
+    container c1 {
+        leaf l1 {
+            type string;
+        }
+        leaf lid {
+            type identityref {
+                base base_id;
+            }
+            default der_id;
+        }
+    }
+}"""
+    root = yang.compile([ys])
+    return "\n".join([
+        "# ===== foo_src_dnode.act (prdnode) =====",
+        "",
+        root.prdnode(schema_yang=[ys]),
+        "",
+        "# ===== foo.act (prdaclass dnode_module='foo_src_dnode') =====",
+        "",
+        root.prdaclass(dnode_module="foo_src_dnode", schema_yang=[ys]),
+    ])
+
 def _test_prdaclass_loose_p_container_with_mandatory_leaf():
     ys = r"""module foo {
   yang-version "1.1";

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -9,46 +9,17 @@ from yang.identityref import Identityref, PartialIdentityref
 from yang.pattern import YangPattern
 from yang.schema import *
 from yang.type import Decimal, Ranges
+import m_src_dnode
 
 # == This file is generated ==
 
 
 
 
-_identities: list[DIdentity] = []
+_identities: list[DIdentity] = m_src_dnode.IDENTITIES
 
 
-SRC_DNODE_CHILD_0: DContainer = DContainer(module='m', namespace='urn:example:m', prefix='m', name='cfg', config=True, presence=False, children=[
-    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='enabled', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
-    DContainer(module='m', namespace='urn:example:m', prefix='m', name='sub', config=True, presence=False, children=[
-        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='detail', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-    ]),
-    DList(module='m', namespace='urn:example:m', prefix='m', name='items', key=['id'], config=True, min_elements=0, ordered_by='system', children=[
-        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='id', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='val', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
-    ])
-])
-
-SRC_DNODE_RPC_0: DRpc = DRpc(module='m', namespace='urn:example:m', prefix='m', name='ping', input=DInput(module='m', namespace='urn:example:m', prefix='m', children=[
-    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-]), output=DOutput(module='m', namespace='urn:example:m', prefix='m', children=[
-    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='reply', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-]), children=[
-    DInput(module='m', namespace='urn:example:m', prefix='m', children=[
-        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-    ]),
-    DOutput(module='m', namespace='urn:example:m', prefix='m', children=[
-        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='reply', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-    ])
-])
-
-SRC_DNODE: DRoot = DRoot(
-    children=[SRC_DNODE_CHILD_0],
-    identities=[],
-    rpcs=[SRC_DNODE_RPC_0],
-    module_metadata={'urn:example:m':('m', None)},
-)
+SRC_DNODE: DRoot = m_src_dnode.SRC_DNODE
 
 NS_m: str = 'urn:example:m'
 

--- a/test/test_device_mode/src/m_src_dnode.act
+++ b/test/test_device_mode/src/m_src_dnode.act
@@ -1,0 +1,47 @@
+import base64
+import yang.xpath as yxpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+_identities: list[DIdentity] = []
+
+
+IDENTITIES: list[DIdentity] = _identities
+
+
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='m', namespace='urn:example:m', prefix='m', name='cfg', config=True, presence=False, children=[
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='enabled', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DContainer(module='m', namespace='urn:example:m', prefix='m', name='sub', config=True, presence=False, children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='detail', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
+    DList(module='m', namespace='urn:example:m', prefix='m', name='items', key=['id'], config=True, min_elements=0, ordered_by='system', children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='id', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='val', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
+    ])
+])
+
+SRC_DNODE_RPC_0: DRpc = DRpc(module='m', namespace='urn:example:m', prefix='m', name='ping', input=DInput(module='m', namespace='urn:example:m', prefix='m', children=[
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+]), output=DOutput(module='m', namespace='urn:example:m', prefix='m', children=[
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='reply', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+]), children=[
+    DInput(module='m', namespace='urn:example:m', prefix='m', children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ]),
+    DOutput(module='m', namespace='urn:example:m', prefix='m', children=[
+        DLeaf(module='m', namespace='urn:example:m', prefix='m', name='reply', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ])
+])
+
+SRC_DNODE: DRoot = DRoot(
+    children=[SRC_DNODE_CHILD_0],
+    identities=[],
+    rpcs=[SRC_DNODE_RPC_0],
+    module_metadata={'urn:example:m':('m', None)},
+)


### PR DESCRIPTION
Generated adata modules embed the entire SRC_DNODE schema tree and the raw SRC_YANG source as module constants next to the data classes, so every codegen-triggered edit to the generated classes forces the compiler to re-parse them even though they are unchanged.

Add a split: emit SRC_DNODE (+ identities) and SRC_YANG into a sibling `{module}_src_dnode.act` that the data-class module imports and only sets up aliases in the main adata module. The public interface of the sibling module then remains constant, only the main adata module changes.

DRoot.prdnode() emits the schema module; prdaclass(dnode_module=...) emits the import/alias block (and the src_yang wrapper) instead of the inline definitions and is otherwise unchanged, so inline output is byte-identical. prdnode is rendered after prdaclass so the split SRC_DNODE reflects the same view the classes were built from (prdaclass reorders list keys in place). The split will eventually converge with the WIP device-mode. Until such time the code paths remain separate for easier testing.