### PR TITLE
Refactor internal DIdentity module constants printing 

### DIFF
--- a/gen/schema-footer.act
+++ b/gen/schema-footer.act
@@ -288,17 +288,6 @@ def is_derived_from(identity: DIdentity, bases: list[DIdentity]) -> bool:
     return True
 
 
-# partial is a union of Identityref, PartialIdentityref
-def complete_and_validate_identityref(partial: value, identities: list[DIdentity], bases: list[DIdentity], current_module: str) -> (?Identityref, ?str):
-    identityref, identity, error = complete_identityref(partial, identities, current_module)
-    if identity is not None:
-        if is_derived_from(identity, bases):
-            return identityref, None
-        else:
-            return None, "Identityref {identityref} not derived from all of the required bases: {bases}"
-    return None, error
-
-
 def list_keys(node: DNodeInner) -> ?list[str]:
     if isinstance(node, DList):
         return node.key

--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -674,11 +674,16 @@ class DNodeInner(DNode):
                 if not loose and child_default is not None:
                     child_type = child.type_
                     if isinstance(child_type, DTypeIdentityref):
-                        res.append("        _default_{usname(child)}, error = complete_and_validate_identityref(Identityref.from_adata('{child_default}'), _identities, {DIdentity.format_base_identity_var_name_list(child_type.identity_bases)}, {repr(child.module)})")
-                        res.append("        if _default_{usname(child)} is not None:")
-                        res.append("            self.{usname(child)} = {usname(child)} if {usname(child)} is not None else _default_{usname(child)}")
-                        res.append("        else:")
-                        res.append("            raise ValueError('Invalid default value for identityref leaf {self.name}: {{error}}')")
+                        root = spath[0]
+                        if isinstance(root, DRoot):
+                            _ref, identity, error = complete_identityref(Identityref.from_adata(child_default), root.identities, child.module)
+                            if identity is not None and is_derived_from(identity, child_type.identity_bases):
+                                default = safe_name("{identity.module}_{identity.name}", safe_kw=False)
+                                res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {default}")
+                            else:
+                                raise ValueError("Invalid default '{child_default}' for identityref leaf {self.name}.{child.name}: {error}")
+                        else:
+                            raise ValueError("Expected DRoot at start of spath, got {type(root)}")
                     else:
                         res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {prsrc_literal(child_type.builtin_type, child_default)}")
                 else:
@@ -1264,7 +1269,7 @@ class DIdentity(DNode):
         for identity in sorted_identities:
             result.append("{identity.format_base_var_name()}: DIdentity = DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base={DIdentity.format_base_identity_var_name_list(identity.base)})")
 
-        # Build the global _identities list
+        # Build the global identities list
         result.append("_identities: list[DIdentity] = [")
         for identity in identities:
             result.append("    {identity.format_base_var_name()},")
@@ -1272,30 +1277,6 @@ class DIdentity(DNode):
         result.append("")
         result.append("")
 
-        return result
-
-    @staticmethod
-    def format_identity_public_exports(identities: list[DIdentity]) -> list[str]:
-        """Public module constants for identities, emitted only in the separate schema module.
-        """
-        result = []
-        for identity in identities:
-            result.append("{identity.format_base_var_name(prefix="BASE_")}: DIdentity = {identity.format_base_var_name()}")
-        result.append("IDENTITIES: list[DIdentity] = _identities")
-        result.append("")
-        result.append("")
-        return result
-
-    @staticmethod
-    def format_identity_aliases(identities: list[DIdentity], schema_module: str) -> list[str]:
-        """Private module constants for identities, aliases from the separate schema module.
-        """
-        result = []
-        for identity in identities:
-            result.append("{identity.format_base_var_name()}: DIdentity = {schema_module}.{identity.format_base_var_name(prefix="BASE_")}")
-        result.append("_identities: list[DIdentity] = {schema_module}.IDENTITIES")
-        result.append("")
-        result.append("")
         return result
 
     @staticmethod
@@ -1322,8 +1303,8 @@ class DIdentity(DNode):
     def format_base_identity_var_name_list(identities: list[DIdentity]) -> str:
         return "[{", ".join([b.format_base_var_name() for b in identities])}]"
 
-    def format_base_var_name(self, prefix="_base_"):
-        return safe_name("{prefix}{self.module}_{self.name}", safe_kw=False)
+    def format_base_var_name(self):
+        return safe_name("_base_{self.module}_{self.name}", safe_kw=False)
 
 class DInput(DNodeInner):
     must: list[DMust]
@@ -1944,7 +1925,6 @@ class DRoot(DNodeInner):
         res.append("")
         res.append("")
         res.extend(DIdentity.format_identity_list(self.identities))
-        res.extend(DIdentity.format_identity_public_exports(self.identities))
         res.extend(self._pr_src_dnode_consts())
         if schema_yang is not None:
             res.extend(DRoot._pr_src_yang(schema_yang))
@@ -1993,7 +1973,6 @@ class DRoot(DNodeInner):
         res.append("")
         res.append("")
         if schema_module is not None:
-            res.extend(DIdentity.format_identity_aliases(self.identities, schema_module))
             res.extend(DIdentity.format_identityref_constants(self.identities))
             res.append("SRC_DNODE: DRoot = {schema_module}.SRC_DNODE")
             res.append("")

--- a/snapshots/expected/test_yang/prdaclass_split_schema
+++ b/snapshots/expected/test_yang/prdaclass_split_schema
@@ -18,11 +18,6 @@ _identities: list[DIdentity] = [
 ]
 
 
-BASE_foo_base_id: DIdentity = _base_foo_base_id
-BASE_foo_der_id: DIdentity = _base_foo_der_id
-IDENTITIES: list[DIdentity] = _identities
-
-
 SRC_DNODE_CHILD_0: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='lid', config=True, default='der_id', mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_base_id], identities=_identities))
@@ -89,11 +84,6 @@ import foo_schema
 
 
 
-_base_foo_base_id: DIdentity = foo_schema.BASE_foo_base_id
-_base_foo_der_id: DIdentity = foo_schema.BASE_foo_der_id
-_identities: list[DIdentity] = foo_schema.IDENTITIES
-
-
 # Identityref constants
 foo_base_id: Identityref = Identityref('base_id', ns='http://example.com/foo', mod='foo', pfx='f')
 foo_der_id: Identityref = Identityref('der_id', ns='http://example.com/foo', mod='foo', pfx='f')
@@ -115,11 +105,7 @@ class foo__c1(yadata.MNode):
 
     mut def __init__(self, l1: ?str, lid: ?Identityref=None) -> None:
         self.l1 = l1
-        _default_lid, error = complete_and_validate_identityref(Identityref.from_adata('der_id'), _identities, [_base_foo_base_id], 'foo')
-        if _default_lid is not None:
-            self.lid = lid if lid is not None else _default_lid
-        else:
-            raise ValueError('Invalid default value for identityref leaf c1: {error}')
+        self.lid = lid if lid is not None else foo_der_id
 
     pure def _get_attr(self, name: str) -> ?value:
         if name == 'f:l1':

--- a/src/schema.act
+++ b/src/schema.act
@@ -670,11 +670,16 @@ class DNodeInner(DNode):
                 if not loose and child_default is not None:
                     child_type = child.type_
                     if isinstance(child_type, DTypeIdentityref):
-                        res.append("        _default_{usname(child)}, error = complete_and_validate_identityref(Identityref.from_adata('{child_default}'), _identities, {DIdentity.format_base_identity_var_name_list(child_type.identity_bases)}, {repr(child.module)})")
-                        res.append("        if _default_{usname(child)} is not None:")
-                        res.append("            self.{usname(child)} = {usname(child)} if {usname(child)} is not None else _default_{usname(child)}")
-                        res.append("        else:")
-                        res.append("            raise ValueError('Invalid default value for identityref leaf {self.name}: {{error}}')")
+                        root = spath[0]
+                        if isinstance(root, DRoot):
+                            _ref, identity, error = complete_identityref(Identityref.from_adata(child_default), root.identities, child.module)
+                            if identity is not None and is_derived_from(identity, child_type.identity_bases):
+                                default = safe_name("{identity.module}_{identity.name}", safe_kw=False)
+                                res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {default}")
+                            else:
+                                raise ValueError("Invalid default '{child_default}' for identityref leaf {self.name}.{child.name}: {error}")
+                        else:
+                            raise ValueError("Expected DRoot at start of spath, got {type(root)}")
                     else:
                         res.append("        self.{usname(child)} = {usname(child)} if {usname(child)} is not None else {prsrc_literal(child_type.builtin_type, child_default)}")
                 else:
@@ -1260,7 +1265,7 @@ class DIdentity(DNode):
         for identity in sorted_identities:
             result.append("{identity.format_base_var_name()}: DIdentity = DIdentity(module={repr(identity.module)}, namespace={repr(identity.namespace)}, prefix={repr(identity.prefix)}, name={repr(identity.name)}, base={DIdentity.format_base_identity_var_name_list(identity.base)})")
 
-        # Build the global _identities list
+        # Build the global identities list
         result.append("_identities: list[DIdentity] = [")
         for identity in identities:
             result.append("    {identity.format_base_var_name()},")
@@ -1268,30 +1273,6 @@ class DIdentity(DNode):
         result.append("")
         result.append("")
 
-        return result
-
-    @staticmethod
-    def format_identity_public_exports(identities: list[DIdentity]) -> list[str]:
-        """Public module constants for identities, emitted only in the separate schema module.
-        """
-        result = []
-        for identity in identities:
-            result.append("{identity.format_base_var_name(prefix="BASE_")}: DIdentity = {identity.format_base_var_name()}")
-        result.append("IDENTITIES: list[DIdentity] = _identities")
-        result.append("")
-        result.append("")
-        return result
-
-    @staticmethod
-    def format_identity_aliases(identities: list[DIdentity], schema_module: str) -> list[str]:
-        """Private module constants for identities, aliases from the separate schema module.
-        """
-        result = []
-        for identity in identities:
-            result.append("{identity.format_base_var_name()}: DIdentity = {schema_module}.{identity.format_base_var_name(prefix="BASE_")}")
-        result.append("_identities: list[DIdentity] = {schema_module}.IDENTITIES")
-        result.append("")
-        result.append("")
         return result
 
     @staticmethod
@@ -1318,8 +1299,8 @@ class DIdentity(DNode):
     def format_base_identity_var_name_list(identities: list[DIdentity]) -> str:
         return "[{", ".join([b.format_base_var_name() for b in identities])}]"
 
-    def format_base_var_name(self, prefix="_base_"):
-        return safe_name("{prefix}{self.module}_{self.name}", safe_kw=False)
+    def format_base_var_name(self):
+        return safe_name("_base_{self.module}_{self.name}", safe_kw=False)
 
 class DInput(DNodeInner):
     must: list[DMust]
@@ -1940,7 +1921,6 @@ class DRoot(DNodeInner):
         res.append("")
         res.append("")
         res.extend(DIdentity.format_identity_list(self.identities))
-        res.extend(DIdentity.format_identity_public_exports(self.identities))
         res.extend(self._pr_src_dnode_consts())
         if schema_yang is not None:
             res.extend(DRoot._pr_src_yang(schema_yang))
@@ -1989,7 +1969,6 @@ class DRoot(DNodeInner):
         res.append("")
         res.append("")
         if schema_module is not None:
-            res.extend(DIdentity.format_identity_aliases(self.identities, schema_module))
             res.extend(DIdentity.format_identityref_constants(self.identities))
             res.append("SRC_DNODE: DRoot = {schema_module}.SRC_DNODE")
             res.append("")
@@ -11378,17 +11357,6 @@ def is_derived_from(identity: DIdentity, bases: list[DIdentity]) -> bool:
         else:
             return False
     return True
-
-
-# partial is a union of Identityref, PartialIdentityref
-def complete_and_validate_identityref(partial: value, identities: list[DIdentity], bases: list[DIdentity], current_module: str) -> (?Identityref, ?str):
-    identityref, identity, error = complete_identityref(partial, identities, current_module)
-    if identity is not None:
-        if is_derived_from(identity, bases):
-            return identityref, None
-        else:
-            return None, "Identityref {identityref} not derived from all of the required bases: {bases}"
-    return None, error
 
 
 def list_keys(node: DNodeInner) -> ?list[str]:

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -168,11 +168,7 @@ class basics__c(yadata.MNode):
         self.l_union_def_bool = l_union_def_bool if l_union_def_bool is not None else False
         self.l_union_def_enumeration = l_union_def_enumeration if l_union_def_enumeration is not None else "unlimited"
         self.l_binary_def = l_binary_def if l_binary_def is not None else base64.decode('SGVsbG8gQWN0b24g8J+roQ=='.encode())
-        _default_l_identityref_def, error = complete_and_validate_identityref(Identityref.from_adata('id2'), _identities, [_base_basics_id1], 'basics')
-        if _default_l_identityref_def is not None:
-            self.l_identityref_def = l_identityref_def if l_identityref_def is not None else _default_l_identityref_def
-        else:
-            raise ValueError('Invalid default value for identityref leaf c: {error}')
+        self.l_identityref_def = l_identityref_def if l_identityref_def is not None else basics_id2
 
     pure def _get_attr(self, name: str) -> ?value:
         if name == 'b:l_str_def':

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -16,7 +16,16 @@ import m_schema
 
 
 
+_base_m_protocol: DIdentity = m_schema.BASE_m_protocol
+_base_m_http: DIdentity = m_schema.BASE_m_http
+_base_m_https: DIdentity = m_schema.BASE_m_https
 _identities: list[DIdentity] = m_schema.IDENTITIES
+
+
+# Identityref constants
+m_protocol: Identityref = Identityref('protocol', ns='urn:example:m', mod='m', pfx='m')
+m_http: Identityref = Identityref('http', ns='urn:example:m', mod='m', pfx='m')
+m_https: Identityref = Identityref('https', ns='urn:example:m', mod='m', pfx='m')
 
 
 SRC_DNODE: DRoot = m_schema.SRC_DNODE
@@ -96,12 +105,18 @@ _breaker4: None = None
 class m__cfg(yadata.MNode):
     name: ?str
     enabled: ?bool
+    proto: Identityref
     sub: m__cfg__sub
     items: m__cfg__items
 
-    mut def __init__(self, name: ?str, enabled: ?bool, sub: ?m__cfg__sub=None, items: list[m__cfg__items_entry]=[]) -> None:
+    mut def __init__(self, name: ?str, enabled: ?bool, proto: ?Identityref=None, sub: ?m__cfg__sub=None, items: list[m__cfg__items_entry]=[]) -> None:
         self.name = name
         self.enabled = enabled
+        _default_proto, error = complete_and_validate_identityref(Identityref.from_adata('https'), _identities, [_base_m_protocol], 'm')
+        if _default_proto is not None:
+            self.proto = proto if proto is not None else _default_proto
+        else:
+            raise ValueError('Invalid default value for identityref leaf cfg: {error}')
         self.sub = sub if sub is not None else m__cfg__sub()
         self.items = m__cfg__items(elements=items)
 

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -16,12 +16,6 @@ import m_schema
 
 
 
-_base_m_protocol: DIdentity = m_schema.BASE_m_protocol
-_base_m_http: DIdentity = m_schema.BASE_m_http
-_base_m_https: DIdentity = m_schema.BASE_m_https
-_identities: list[DIdentity] = m_schema.IDENTITIES
-
-
 # Identityref constants
 m_protocol: Identityref = Identityref('protocol', ns='urn:example:m', mod='m', pfx='m')
 m_http: Identityref = Identityref('http', ns='urn:example:m', mod='m', pfx='m')
@@ -112,11 +106,7 @@ class m__cfg(yadata.MNode):
     mut def __init__(self, name: ?str, enabled: ?bool, proto: ?Identityref=None, sub: ?m__cfg__sub=None, items: list[m__cfg__items_entry]=[]) -> None:
         self.name = name
         self.enabled = enabled
-        _default_proto, error = complete_and_validate_identityref(Identityref.from_adata('https'), _identities, [_base_m_protocol], 'm')
-        if _default_proto is not None:
-            self.proto = proto if proto is not None else _default_proto
-        else:
-            raise ValueError('Invalid default value for identityref leaf cfg: {error}')
+        self.proto = proto if proto is not None else m_https
         self.sub = sub if sub is not None else m__cfg__sub()
         self.items = m__cfg__items(elements=items)
 

--- a/test/test_device_mode/src/m_schema.act
+++ b/test/test_device_mode/src/m_schema.act
@@ -8,15 +8,26 @@ from yang.type import Decimal, Ranges
 # == This file is generated ==
 
 
-_identities: list[DIdentity] = []
+_base_m_protocol: DIdentity = DIdentity(module='m', namespace='urn:example:m', prefix='m', name='protocol', base=[])
+_base_m_http: DIdentity = DIdentity(module='m', namespace='urn:example:m', prefix='m', name='http', base=[_base_m_protocol])
+_base_m_https: DIdentity = DIdentity(module='m', namespace='urn:example:m', prefix='m', name='https', base=[_base_m_http])
+_identities: list[DIdentity] = [
+    _base_m_protocol,
+    _base_m_http,
+    _base_m_https,
+]
 
 
+BASE_m_protocol: DIdentity = _base_m_protocol
+BASE_m_http: DIdentity = _base_m_http
+BASE_m_https: DIdentity = _base_m_https
 IDENTITIES: list[DIdentity] = _identities
 
 
 SRC_DNODE_CHILD_0: DContainer = DContainer(module='m', namespace='urn:example:m', prefix='m', name='cfg', config=True, presence=False, children=[
     DLeaf(module='m', namespace='urn:example:m', prefix='m', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='m', namespace='urn:example:m', prefix='m', name='enabled', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),
+    DLeaf(module='m', namespace='urn:example:m', prefix='m', name='proto', config=True, default='https', mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_m_protocol], identities=_identities)),
     DContainer(module='m', namespace='urn:example:m', prefix='m', name='sub', config=True, presence=False, children=[
         DLeaf(module='m', namespace='urn:example:m', prefix='m', name='detail', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
     ]),
@@ -25,6 +36,18 @@ SRC_DNODE_CHILD_0: DContainer = DContainer(module='m', namespace='urn:example:m'
         DLeaf(module='m', namespace='urn:example:m', prefix='m', name='val', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(0, 4294967295)])))
     ])
 ])
+
+SRC_DNODE_IDENTITY_0: DIdentity = DIdentity(module='m', namespace='urn:example:m', prefix='m', name='protocol')
+
+SRC_DNODE_IDENTITY_1: DIdentity = DIdentity(module='m', namespace='urn:example:m', prefix='m', name='http', base=[
+        DIdentity(module='m', namespace='urn:example:m', prefix='m', name='protocol')
+    ])
+
+SRC_DNODE_IDENTITY_2: DIdentity = DIdentity(module='m', namespace='urn:example:m', prefix='m', name='https', base=[
+        DIdentity(module='m', namespace='urn:example:m', prefix='m', name='http', base=[
+                DIdentity(module='m', namespace='urn:example:m', prefix='m', name='protocol')
+            ])
+    ])
 
 SRC_DNODE_RPC_0: DRpc = DRpc(module='m', namespace='urn:example:m', prefix='m', name='ping', input=DInput(module='m', namespace='urn:example:m', prefix='m', children=[
     DLeaf(module='m', namespace='urn:example:m', prefix='m', name='msg', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
@@ -41,7 +64,7 @@ SRC_DNODE_RPC_0: DRpc = DRpc(module='m', namespace='urn:example:m', prefix='m', 
 
 SRC_DNODE: DRoot = DRoot(
     children=[SRC_DNODE_CHILD_0],
-    identities=[],
+    identities=[SRC_DNODE_IDENTITY_0, SRC_DNODE_IDENTITY_1, SRC_DNODE_IDENTITY_2],
     rpcs=[SRC_DNODE_RPC_0],
     module_metadata={'urn:example:m':('m', None)},
 )
@@ -49,9 +72,26 @@ SRC_DNODE: DRoot = DRoot(
 SRC_YANG_0: str = r"""module m {
   namespace "urn:example:m";
   prefix m;
+
+  identity protocol {
+    description "Base identity for transport protocols.";
+  }
+  identity http {
+    base protocol;
+  }
+  identity https {
+    base http;
+  }
+
   container cfg {
     leaf name { type string; }
     leaf enabled { type boolean; }
+    leaf proto {
+      type identityref {
+        base protocol;
+      }
+      default https;
+    }
     container sub {
       leaf detail { type string; }
     }

--- a/test/test_device_mode/src/m_schema.act
+++ b/test/test_device_mode/src/m_schema.act
@@ -18,12 +18,6 @@ _identities: list[DIdentity] = [
 ]
 
 
-BASE_m_protocol: DIdentity = _base_m_protocol
-BASE_m_http: DIdentity = _base_m_http
-BASE_m_https: DIdentity = _base_m_https
-IDENTITIES: list[DIdentity] = _identities
-
-
 SRC_DNODE_CHILD_0: DContainer = DContainer(module='m', namespace='urn:example:m', prefix='m', name='cfg', config=True, presence=False, children=[
     DLeaf(module='m', namespace='urn:example:m', prefix='m', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='m', namespace='urn:example:m', prefix='m', name='enabled', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)),

--- a/test/test_device_mode/yang/m.yang
+++ b/test/test_device_mode/yang/m.yang
@@ -1,9 +1,26 @@
 module m {
   namespace "urn:example:m";
   prefix m;
+
+  identity protocol {
+    description "Base identity for transport protocols.";
+  }
+  identity http {
+    base protocol;
+  }
+  identity https {
+    base http;
+  }
+
   container cfg {
     leaf name { type string; }
     leaf enabled { type boolean; }
+    leaf proto {
+      type identityref {
+        base protocol;
+      }
+      default https;
+    }
     container sub {
       leaf detail { type string; }
     }


### PR DESCRIPTION
Each DIdentity is a single private module constant (_base_<id>,
_identities) in the module that owns SRC_DNODE, whether that schema
module is split out or inline.

Identityref leaf defaults are resolved and validated at generation time.
Runtime identityref values validate through DType.validate_value.