### PR TITLE
Use synthesized MNode.__get_attr__ for adata parsing

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -742,16 +742,6 @@ class DNodeInner(DNode):
                 res.append("")
 
         if not device:
-            if len(attr_children) > 0:
-                res.append("    pure def _get_attr(self, name: str) -> ?value:")
-                for child in attr_children:
-                    res.append("        if name == '{child.prefix}:{child.name}':")
-                    if isinstance(child, DList):
-                        res.append("            return iter(self.{usname(child)})")
-                    else:
-                        res.append("            return self.{usname(child)}")
-                res.append("")
-
             # .to_gdata()
             res.append("    mut def to_gdata(self) -> ygdata.Node:")
             if isinstance(self, DRoot):

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -96,12 +96,6 @@ class base__system_capabilities__subscription_capabilities(yadata.MNode):
         self.max_nodes = max_nodes if max_nodes is not None else u64(42)
         self.supported_excluded_change_type = supported_excluded_change_type if supported_excluded_change_type is not None else []
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'aug:max-nodes':
-            return self.max_nodes
-        if name == 'aug:supported-excluded-change-type':
-            return self.supported_excluded_change_type
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:system-capabilities', 'augmenter:subscription-capabilities'])
 
@@ -125,12 +119,6 @@ class base__system_capabilities(yadata.MNode):
         self.per_node_capabilities = base__system_capabilities__per_node_capabilities(elements=per_node_capabilities)
         self.subscription_capabilities = subscription_capabilities if subscription_capabilities is not None else base__system_capabilities__subscription_capabilities()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:per-node-capabilities':
-            return iter(self.per_node_capabilities)
-        if name == 'aug:subscription-capabilities':
-            return self.subscription_capabilities
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:system-capabilities'])
 
@@ -151,10 +139,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, system_capabilities: ?base__system_capabilities=None) -> None:
         self.system_capabilities = system_capabilities if system_capabilities is not None else base__system_capabilities()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:system-capabilities':
-            return self.system_capabilities
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment
+++ b/snapshots/expected/test_yang/compile_augment
@@ -42,12 +42,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'foo:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -68,10 +62,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_augmented_node
+++ b/snapshots/expected/test_yang/compile_augment_augmented_node
@@ -52,12 +52,6 @@ class base__native__voice__service__voip__sip(yadata.MNode):
         self.bind = bind
         self.port = port if port is not None else u64(5060)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voice:bind':
-            return self.bind
-        if name == 'voice:port':
-            return self.port
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice', 'service', 'voip', 'sip'])
 
@@ -81,12 +75,6 @@ class base__native__voice__service__voip(yadata.MNode):
         self.enabled = enabled if enabled is not None else False
         self.sip = sip if sip is not None else base__native__voice__service__voip__sip()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voice:enabled':
-            return self.enabled
-        if name == 'voice:sip':
-            return self.sip
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice', 'service', 'voip'])
 
@@ -107,10 +95,6 @@ class base__native__voice__service(yadata.MNode):
 
     mut def __init__(self, voip: ?base__native__voice__service__voip=None) -> None:
         self.voip = voip if voip is not None else base__native__voice__service__voip()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voice:voip':
-            return self.voip
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice', 'service'])
@@ -133,10 +117,6 @@ class base__native__voice(yadata.MNode):
     mut def __init__(self, service: ?base__native__voice__service=None) -> None:
         self.service = service if service is not None else base__native__voice__service()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voice:service':
-            return self.service
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native', 'voice:voice'])
 
@@ -158,10 +138,6 @@ class base__native(yadata.MNode):
     mut def __init__(self, voice: ?base__native__voice=None) -> None:
         self.voice = voice if voice is not None else base__native__voice()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'voice:voice':
-            return self.voice
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:native'])
 
@@ -182,10 +158,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, native: ?base__native=None) -> None:
         self.native = native if native is not None else base__native()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:native':
-            return self.native
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -74,10 +74,6 @@ class root(yadata.MNode):
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)
 
@@ -98,10 +94,6 @@ class foo__r1__input__c3(yadata.MNode):
 
     mut def __init__(self, l3: ?str) -> None:
         self.l3 = l3
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l3':
-            return self.l3
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:r1', 'input', 'c3'])
@@ -124,10 +116,6 @@ class foo__r1__input(yadata.MNode):
     mut def __init__(self, c3: ?foo__r1__input__c3=None) -> None:
         self.c3 = c3 if c3 is not None else foo__r1__input__c3()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c3':
-            return self.c3
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:r1', 'input'])
 
@@ -148,10 +136,6 @@ class foo__r1__output(yadata.MNode):
 
     mut def __init__(self, l4: ?str) -> None:
         self.l4 = l4
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l4':
-            return self.l4
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:r1', 'output'])

--- a/snapshots/expected/test_yang/compile_augment_import
+++ b/snapshots/expected/test_yang/compile_augment_import
@@ -43,12 +43,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'bar:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -69,10 +63,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_on_augment
+++ b/snapshots/expected/test_yang/compile_augment_on_augment
@@ -45,12 +45,6 @@ class foo__c1__c2(yadata.MNode):
         self.l2 = l2
         self.l3 = l3
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l2':
-            return self.l2
-        if name == 'foo:l3':
-            return self.l3
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'c2'])
 
@@ -74,12 +68,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'foo:c2':
-            return self.c2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -100,10 +88,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
+++ b/snapshots/expected/test_yang/compile_augment_on_augment_across_modules
@@ -47,12 +47,6 @@ class foo__c1__c2(yadata.MNode):
         self.l2 = l2
         self.l3 = l3
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:l2':
-            return self.l2
-        if name == 'baz:l3':
-            return self.l3
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'bar:c2'])
 
@@ -76,12 +70,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'bar:c2':
-            return self.c2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -102,10 +90,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_augment_uses
+++ b/snapshots/expected/test_yang/compile_augment_uses
@@ -44,10 +44,6 @@ class foo__c1__c2(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'c2'])
 
@@ -69,10 +65,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, c2: ?foo__c1__c2=None) -> None:
         self.c2 = c2 if c2 is not None else foo__c1__c2()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c2':
-            return self.c2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -93,10 +85,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_bundle1
+++ b/snapshots/expected/test_yang/compile_bundle1
@@ -43,12 +43,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'bar:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -69,10 +63,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -49,12 +49,6 @@ class foo__c1__things_entry(yadata.MNode):
         self.name = name
         self.id = id
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:id':
-            return self.id
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'things'])
 
@@ -136,10 +130,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, things: list[foo__c1__things_entry]=[]) -> None:
         self.things = foo__c1__things(elements=things)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:things':
-            return iter(self.things)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -160,10 +150,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_import_hyphenated_prefix
+++ b/snapshots/expected/test_yang/compile_import_hyphenated_prefix
@@ -40,10 +40,6 @@ class acme_foo_bar__c1(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'acme_foo-bar:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['acme_foo-bar:c1'])
 
@@ -64,10 +60,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?acme_foo_bar__c1=None) -> None:
         self.c1 = c1 if c1 is not None else acme_foo_bar__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'acme_foo-bar:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -61,12 +61,6 @@ class bar__c1__li1_entry(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:l1':
-            return self.l1
-        if name == 'bar:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:c1', 'li1'])
 
@@ -148,10 +142,6 @@ class bar__c1(yadata.MNode):
     mut def __init__(self, li1: list[bar__c1__li1_entry]=[]) -> None:
         self.li1 = bar__c1__li1(elements=li1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:li1':
-            return iter(self.li1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:c1'])
 
@@ -172,10 +162,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?bar__c1=None) -> None:
         self.c1 = c1 if c1 is not None else bar__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_refine
+++ b/snapshots/expected/test_yang/compile_refine
@@ -45,10 +45,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, l1: ?list[str]=None) -> None:
         self.l1 = l1 if l1 is not None else []
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -69,10 +65,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_conflicting_import_prefix
@@ -49,12 +49,6 @@ class parent__parent_container(yadata.MNode):
         self.parent_leaf = parent_leaf
         self.augmented_leaf = augmented_leaf
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent:parent-leaf':
-            return self.parent_leaf
-        if name == 'parent:augmented-leaf':
-            return self.augmented_leaf
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:parent-container'])
 
@@ -78,12 +72,6 @@ class parent__sub_container(yadata.MNode):
         self.sub_leaf = sub_leaf
         self.another_leaf = another_leaf
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent:sub-leaf':
-            return self.sub_leaf
-        if name == 'parent:another-leaf':
-            return self.another_leaf
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:sub-container'])
 
@@ -106,12 +94,6 @@ class root(yadata.MNode):
     mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None) -> None:
         self.parent_container = parent_container if parent_container is not None else parent__parent_container()
         self.sub_container = sub_container if sub_container is not None else parent__sub_container()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent:parent-container':
-            return self.parent_container
-        if name == 'parent:sub-container':
-            return self.sub_container
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -56,10 +56,6 @@ class main_module__main_container__sub_group_container(yadata.MNode):
     mut def __init__(self, sub_group_leaf: ?str=None) -> None:
         self.sub_group_leaf = sub_group_leaf if sub_group_leaf is not None else "from-submodule"
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main:sub-group-leaf':
-            return self.sub_group_leaf
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'sub-group-container'])
 
@@ -84,14 +80,6 @@ class main_module__main_container__sub_list_entry(yadata.MNode):
         self.name = name
         self.sub_value = sub_value
         self.ref_to_main = ref_to_main
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main:name':
-            return self.name
-        if name == 'main:sub-value':
-            return self.sub_value
-        if name == 'main:ref-to-main':
-            return self.ref_to_main
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'sub-list'])
@@ -178,12 +166,6 @@ class main_module__main_container__group_container(yadata.MNode):
         self.group_leaf = group_leaf if group_leaf is not None else "refined-default"
         self.augmented_in_group = augmented_in_group
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main:group-leaf':
-            return self.group_leaf
-        if name == 'main:augmented-in-group':
-            return self.augmented_in_group
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container', 'group-container'])
 
@@ -213,18 +195,6 @@ class main_module__main_container(yadata.MNode):
         self.sub_list = main_module__main_container__sub_list(elements=sub_list)
         self.group_container = group_container if group_container is not None else main_module__main_container__group_container()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main:main-leaf':
-            return self.main_leaf
-        if name == 'main:sub-group-container':
-            return self.sub_group_container
-        if name == 'main:sub-leaf':
-            return self.sub_leaf
-        if name == 'main:sub-list':
-            return iter(self.sub_list)
-        if name == 'main:group-container':
-            return self.group_container
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['main-module:main-container'])
 
@@ -245,10 +215,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, main_container: ?main_module__main_container=None) -> None:
         self.main_container = main_container if main_container is not None else main_module__main_container()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'main:main-container':
-            return self.main_container
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_same_module_different_prefix
@@ -48,12 +48,6 @@ class parent__parent_container(yadata.MNode):
         self.parent_leaf = parent_leaf
         self.augmented_leaf = augmented_leaf
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent:parent-leaf':
-            return self.parent_leaf
-        if name == 'parent:augmented-leaf':
-            return self.augmented_leaf
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:parent-container'])
 
@@ -77,12 +71,6 @@ class parent__sub_container(yadata.MNode):
         self.sub_leaf = sub_leaf
         self.shared_leaf = shared_leaf if shared_leaf is not None else "from-shared"
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent:sub-leaf':
-            return self.sub_leaf
-        if name == 'parent:shared-leaf':
-            return self.shared_leaf
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['parent:sub-container'])
 
@@ -105,12 +93,6 @@ class root(yadata.MNode):
     mut def __init__(self, parent_container: ?parent__parent_container=None, sub_container: ?parent__sub_container=None) -> None:
         self.parent_container = parent_container if parent_container is not None else parent__parent_container()
         self.sub_container = sub_container if sub_container is not None else parent__sub_container()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'parent:parent-container':
-            return self.parent_container
-        if name == 'parent:sub-container':
-            return self.sub_container
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_submodules1
+++ b/snapshots/expected/test_yang/compile_submodules1
@@ -43,10 +43,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -67,10 +63,6 @@ class foo__c2(yadata.MNode):
 
     mut def __init__(self, l2: ?str) -> None:
         self.l2 = l2
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l2':
-            return self.l2
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c2'])
@@ -94,12 +86,6 @@ class root(yadata.MNode):
     mut def __init__(self, c1: ?foo__c1=None, c2: ?foo__c2=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
         self.c2 = c2 if c2 is not None else foo__c2()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
-        if name == 'foo:c2':
-            return self.c2
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -41,10 +41,6 @@ class foo__c1__li1_entry(yadata.MNode):
     mut def __init__(self, l1: str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li1'])
 
@@ -124,10 +120,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, li1: list[foo__c1__li1_entry]=[]) -> None:
         self.li1 = foo__c1__li1(elements=li1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:li1':
-            return iter(self.li1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -148,10 +140,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/compile_uses_augment
+++ b/snapshots/expected/test_yang/compile_uses_augment
@@ -45,12 +45,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'foo:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -71,10 +65,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/identityref
+++ b/snapshots/expected/test_yang/identityref
@@ -78,10 +78,6 @@ class base__config(yadata.MNode):
     mut def __init__(self, active_protocol: ?Identityref) -> None:
         self.active_protocol = active_protocol
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:active-protocol':
-            return self.active_protocol
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:config'])
 
@@ -102,10 +98,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, config: ?base__config=None) -> None:
         self.config = config if config is not None else base__config()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:config':
-            return self.config
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -46,10 +46,6 @@ class base_module__network_instances__network_instance__state(yadata.MNode):
     mut def __init__(self, id: ?str) -> None:
         self.id = id
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:id':
-            return self.id
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance', 'state'])
 
@@ -74,14 +70,6 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
         self.name = name
         self.state = state if state is not None else base_module__network_instances__network_instance__state()
         self.ref = ref
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:name':
-            return self.name
-        if name == 'base:state':
-            return self.state
-        if name == 'aug:ref':
-            return self.ref
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance'])
@@ -164,10 +152,6 @@ class base_module__network_instances(yadata.MNode):
     mut def __init__(self, network_instance: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self.network_instance = base_module__network_instances__network_instance(elements=network_instance)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:network-instance':
-            return iter(self.network_instance)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances'])
 
@@ -188,10 +172,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, network_instances: ?base_module__network_instances=None) -> None:
         self.network_instances = network_instances if network_instances is not None else base_module__network_instances()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:network-instances':
-            return self.network_instances
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -55,10 +55,6 @@ class other_module__other_network_instances__network_instance_entry(yadata.MNode
     mut def __init__(self, name: str) -> None:
         self.name = name
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'other:name':
-            return self.name
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['other-module:network-instances', 'network-instance'])
 
@@ -138,10 +134,6 @@ class other_module__other_network_instances(yadata.MNode):
     mut def __init__(self, network_instance: list[other_module__other_network_instances__network_instance_entry]=[]) -> None:
         self.network_instance = other_module__other_network_instances__network_instance(elements=network_instance)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'other:network-instance':
-            return iter(self.network_instance)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['other-module:network-instances'])
 
@@ -162,10 +154,6 @@ class base_module__base_network_instances__network_instance__config(yadata.MNode
 
     mut def __init__(self, name: ?str) -> None:
         self.name = name
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:name':
-            return self.name
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance', 'config'])
@@ -189,12 +177,6 @@ class base_module__base_network_instances__network_instance_entry(yadata.MNode):
     mut def __init__(self, name: str, config: ?base_module__base_network_instances__network_instance__config=None) -> None:
         self.name = name
         self.config = config if config is not None else base_module__base_network_instances__network_instance__config()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:name':
-            return self.name
-        if name == 'base:config':
-            return self.config
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance'])
@@ -275,10 +257,6 @@ class base_module__base_network_instances(yadata.MNode):
     mut def __init__(self, network_instance: list[base_module__base_network_instances__network_instance_entry]=[]) -> None:
         self.network_instance = base_module__base_network_instances__network_instance(elements=network_instance)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:network-instance':
-            return iter(self.network_instance)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances'])
 
@@ -299,10 +277,6 @@ class base_module__uses_leafref(yadata.MNode):
 
     mut def __init__(self, ni: ?str) -> None:
         self.ni = ni
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:ni':
-            return self.ni
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:uses-leafref'])
@@ -328,14 +302,6 @@ class root(yadata.MNode):
         self.other_network_instances = other_network_instances if other_network_instances is not None else other_module__other_network_instances()
         self.base_network_instances = base_network_instances if base_network_instances is not None else base_module__base_network_instances()
         self.uses_leafref = uses_leafref if uses_leafref is not None else base_module__uses_leafref()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'other:network-instances':
-            return self.other_network_instances
-        if name == 'base:network-instances':
-            return self.base_network_instances
-        if name == 'base:uses-leafref':
-            return self.uses_leafref
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -49,10 +49,6 @@ class base_module__network_instances__network_instance__config(yadata.MNode):
     mut def __init__(self, name: ?str) -> None:
         self.name = name
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base-pfx:name':
-            return self.name
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance', 'config'])
 
@@ -75,12 +71,6 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
     mut def __init__(self, name: str, config: ?base_module__network_instances__network_instance__config=None) -> None:
         self.name = name
         self.config = config if config is not None else base_module__network_instances__network_instance__config()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base-pfx:name':
-            return self.name
-        if name == 'base-pfx:config':
-            return self.config
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances', 'network-instance'])
@@ -161,10 +151,6 @@ class base_module__network_instances(yadata.MNode):
     mut def __init__(self, network_instance: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self.network_instance = base_module__network_instances__network_instance(elements=network_instance)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base-pfx:network-instance':
-            return iter(self.network_instance)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base-module:network-instances'])
 
@@ -185,10 +171,6 @@ class consumer_module__uses_typedef(yadata.MNode):
 
     mut def __init__(self, ni: ?str) -> None:
         self.ni = ni
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'consumer:ni':
-            return self.ni
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['consumer-module:uses-typedef'])
@@ -212,12 +194,6 @@ class root(yadata.MNode):
     mut def __init__(self, network_instances: ?base_module__network_instances=None, uses_typedef: ?consumer_module__uses_typedef=None) -> None:
         self.network_instances = network_instances if network_instances is not None else base_module__network_instances()
         self.uses_typedef = uses_typedef if uses_typedef is not None else consumer_module__uses_typedef()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base-pfx:network-instances':
-            return self.network_instances
-        if name == 'consumer:uses-typedef':
-            return self.uses_typedef
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -45,10 +45,6 @@ class foo__c__li__bar(yadata.MNode):
     mut def __init__(self, man: str) -> None:
         self.man = man
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:man':
-            return self.man
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c', 'li', 'bar'])
 
@@ -73,14 +69,6 @@ class foo__c__li_entry(yadata.MNode):
         self.name = name
         self.foo = foo if foo is not None else "banana"
         self.bar = bar
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:foo':
-            return self.foo
-        if name == 'foo:bar':
-            return self.bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c', 'li'])

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -48,12 +48,6 @@ class base__c1__base_l1_entry(yadata.MNode):
         self.base_k1 = base_k1
         self.foo_k1 = foo_k1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:k1':
-            return self.base_k1
-        if name == 'foo:k1':
-            return self.foo_k1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'l1'])
 
@@ -133,10 +127,6 @@ class base__c1__foo_l1_entry(yadata.MNode):
 
     mut def __init__(self, k2: str) -> None:
         self.k2 = k2
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:k2':
-            return self.k2
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'foo:l1'])
@@ -219,12 +209,6 @@ class base__c1(yadata.MNode):
         self.base_l1 = base__c1__base_l1(elements=base_l1)
         self.foo_l1 = base__c1__foo_l1(elements=foo_l1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:l1':
-            return iter(self.base_l1)
-        if name == 'foo:l1':
-            return iter(self.foo_l1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1'])
 
@@ -245,10 +229,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?base__c1=None) -> None:
         self.c1 = c1 if c1 is not None else base__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_name_conflict
@@ -45,10 +45,6 @@ class base__c1__base_c2(yadata.MNode):
     mut def __init__(self, foo: ?str) -> None:
         self.foo = foo
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:foo':
-            return self.foo
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'c2'])
 
@@ -69,10 +65,6 @@ class base__c1__foo_c2(yadata.MNode):
 
     mut def __init__(self, foo: ?str) -> None:
         self.foo = foo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1', 'foo:c2'])
@@ -97,12 +89,6 @@ class base__c1(yadata.MNode):
         self.base_c2 = base_c2 if base_c2 is not None else base__c1__base_c2()
         self.foo_c2 = foo_c2 if foo_c2 is not None else base__c1__foo_c2()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:c2':
-            return self.base_c2
-        if name == 'foo:c2':
-            return self.foo_c2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1'])
 
@@ -123,10 +109,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?base__c1=None) -> None:
         self.c1 = c1 if c1 is not None else base__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'base:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_augment_name_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_name_conflict
@@ -44,12 +44,6 @@ class base__c1(yadata.MNode):
         self.bar_foo = bar_foo
         self.foo_foo = foo_foo
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:foo':
-            return self.bar_foo
-        if name == 'foo:foo':
-            return self.foo_foo
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['base:c1'])
 

--- a/snapshots/expected/test_yang/prdaclass_dot
+++ b/snapshots/expected/test_yang/prdaclass_dot
@@ -39,10 +39,6 @@ class foo__ieee_802_3(yadata.MNode):
     mut def __init__(self, ieee_802_3: ?str) -> None:
         self.ieee_802_3 = ieee_802_3
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:ieee-802.3':
-            return self.ieee_802_3
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:ieee-802.3'])
 
@@ -63,10 +59,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, ieee_802_3: ?foo__ieee_802_3=None) -> None:
         self.ieee_802_3 = ieee_802_3 if ieee_802_3 is not None else foo__ieee_802_3()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:ieee-802.3':
-            return self.ieee_802_3
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_exclude_ext
+++ b/snapshots/expected/test_yang/prdaclass_exclude_ext
@@ -44,10 +44,6 @@ class foo__c1__dynstate(yadata.MNode):
     mut def __init__(self, ds1: ?str) -> None:
         self.ds1 = ds1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:ds1':
-            return self.ds1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'dynstate'])
 
@@ -69,10 +65,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -93,10 +85,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -63,12 +63,6 @@ class foo__c1__l1_entry(yadata.MNode):
         self.k1 = k1
         self.k2 = k2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:k1':
-            return self.k1
-        if name == 'foo:k2':
-            return self.k2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'l1'])
 
@@ -129,10 +123,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, l1: list[foo__c1__l1_entry]=[]) -> None:
         self.l1 = foo__c1__l1(elements=l1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return iter(self.l1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -153,10 +143,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_keyword_name_import
+++ b/snapshots/expected/test_yang/prdaclass_keyword_name_import
@@ -51,18 +51,6 @@ class foo__c1(yadata.MNode):
         self.in_ = in_
         self.with_ = with_
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:as':
-            return self.as_
-        if name == 'foo:for':
-            return self.for_
-        if name == 'foo:import':
-            return self.import_
-        if name == 'foo:in':
-            return self.in_
-        if name == 'foo:with':
-            return self.with_
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -39,10 +39,6 @@ class foo__l1_entry(yadata.MNode):
     mut def __init__(self, name: str) -> None:
         self.name = name
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])
 

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -42,12 +42,6 @@ class foo__l1_entry(yadata.MNode):
         self.name = name
         self.id = id
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:id':
-            return self.id
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])
 

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -48,14 +48,6 @@ class foo__l1_entry(yadata.MNode):
         self.id = id
         self.other = other
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:id':
-            return self.id
-        if name == 'foo:other':
-            return self.other
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])
 

--- a/snapshots/expected/test_yang/prdaclass_loose_container_in_container
+++ b/snapshots/expected/test_yang/prdaclass_loose_container_in_container
@@ -41,10 +41,6 @@ class foo__foo__bar(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo', 'bar'])
 
@@ -65,10 +61,6 @@ class foo__foo(yadata.MNode):
 
     mut def __init__(self, bar: ?foo__foo__bar=None) -> None:
         self.bar = bar if bar is not None else foo__foo__bar()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:bar':
-            return self.bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo'])

--- a/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_loose_p_container_with_mandatory_leaf
@@ -41,10 +41,6 @@ class foo__foo__bar(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo', 'bar'])
 
@@ -78,10 +74,6 @@ class foo__foo(yadata.MNode):
         res = foo__foo__bar(l1=l1)
         self.bar = res
         return res
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:bar':
-            return self.bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:foo'])

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -41,10 +41,6 @@ class foo__li1_entry(yadata.MNode):
     mut def __init__(self, l1: str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li1'])
 
@@ -125,12 +121,6 @@ class root(yadata.MNode):
     mut def __init__(self, li1: list[foo__li1_entry]=[], ll1: ?list[str]=None) -> None:
         self.li1 = foo__li1(elements=li1)
         self.ll1 = ll1 if ll1 is not None else []
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:li1':
-            return iter(self.li1)
-        if name == 'foo:ll1':
-            return self.ll1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -41,10 +41,6 @@ class foo__li1_entry(yadata.MNode):
     mut def __init__(self, l1: str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li1'])
 
@@ -125,12 +121,6 @@ class root(yadata.MNode):
     mut def __init__(self, li1: list[foo__li1_entry]=[], ll1: ?list[str]=None) -> None:
         self.li1 = foo__li1(elements=li1)
         self.ll1 = ll1 if ll1 is not None else []
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:li1':
-            return iter(self.li1)
-        if name == 'foo:ll1':
-            return self.ll1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -43,10 +43,6 @@ class foo__l1__bar(yadata.MNode):
     mut def __init__(self, hi: ?str) -> None:
         self.hi = hi
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:hi':
-            return self.hi
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:l1', 'bar'])
 
@@ -71,14 +67,6 @@ class foo__l1_entry(yadata.MNode):
         self.name = name
         self.id = id
         self.bar = bar if bar is not None else foo__l1__bar()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:id':
-            return self.id
-        if name == 'foo:bar':
-            return self.bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:l1'])
@@ -160,10 +148,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, l1: list[foo__l1_entry]=[]) -> None:
         self.l1 = foo__l1(elements=l1)
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return iter(self.l1)
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True)

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -76,10 +76,6 @@ class yangrpc__foo__input__woo(yadata.MNode):
     mut def __init__(self, woo_b: ?int) -> None:
         self.woo_b = woo_b
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yrpc:woo_b':
-            return self.woo_b
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
 
@@ -103,12 +99,6 @@ class yangrpc__foo__input(yadata.MNode):
         self.a = a
         self.woo = woo if woo is not None else yangrpc__foo__input__woo()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yrpc:a':
-            return self.a
-        if name == 'yrpc:woo':
-            return self.woo
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input'])
 
@@ -129,10 +119,6 @@ class yangrpc__foo__output(yadata.MNode):
 
     mut def __init__(self, outoo: ?str) -> None:
         self.outoo = outoo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yrpc:outoo':
-            return self.outoo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'output'])

--- a/snapshots/expected/test_yang/prdaclass_split_schema
+++ b/snapshots/expected/test_yang/prdaclass_split_schema
@@ -107,12 +107,6 @@ class foo__c1(yadata.MNode):
         self.l1 = l1
         self.lid = lid if lid is not None else foo_der_id
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:lid':
-            return self.lid
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -133,10 +127,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -42,12 +42,6 @@ class foo__l1_entry(yadata.MNode):
         self.name = name
         self.id = id
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:id':
-            return self.id
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])
 

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -42,10 +42,6 @@ class foo__l1__bar(yadata.MNode):
     mut def __init__(self, hi: str) -> None:
         self.hi = hi
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:hi':
-            return self.hi
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1', 'bar'])
 
@@ -80,12 +76,6 @@ class foo__l1_entry(yadata.MNode):
         res = foo__l1__bar(hi=hi)
         self.bar = res
         return res
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:name':
-            return self.name
-        if name == 'foo:bar':
-            return self.bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:l1'])

--- a/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_p_container_with_mandatory_leaf
@@ -48,14 +48,6 @@ class foo__foo__bar(yadata.MNode):
         self.bar_l1 = bar_l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.foo_l1
-        if name == 'bar:l1':
-            return self.bar_l1
-        if name == 'bar:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:foo', 'bar'])
 
@@ -91,10 +83,6 @@ class foo__foo(yadata.MNode):
         self.bar = res
         return res
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:bar':
-            return self.bar
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:foo'])
 
@@ -126,10 +114,6 @@ class root(yadata.MNode):
         res = foo__foo()
         self.foo = res
         return res
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_top_conflict
+++ b/snapshots/expected/test_yang/prdaclass_top_conflict
@@ -44,10 +44,6 @@ class bar__bar_c1(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:c1'])
 
@@ -68,10 +64,6 @@ class foo__foo_c1(yadata.MNode):
 
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
@@ -95,12 +87,6 @@ class root(yadata.MNode):
     mut def __init__(self, bar_c1: ?bar__bar_c1=None, foo_c1: ?foo__foo_c1=None) -> None:
         self.bar_c1 = bar_c1 if bar_c1 is not None else bar__bar_c1()
         self.foo_c1 = foo_c1 if foo_c1 is not None else foo__foo_c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:c1':
-            return self.bar_c1
-        if name == 'foo:c1':
-            return self.foo_c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
+++ b/snapshots/expected/test_yang/prdaclass_top_container_from_xml_opt
@@ -45,10 +45,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -70,10 +66,6 @@ class foo__pc1__foo(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1', 'foo'])
 
@@ -94,10 +86,6 @@ class foo__pc1(yadata.MNode):
 
     mut def __init__(self, foo: ?foo__pc1__foo=None) -> None:
         self.foo = foo if foo is not None else foo__pc1__foo()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1'])
@@ -132,12 +120,6 @@ class root(yadata.MNode):
         res = foo__pc1()
         self.pc1 = res
         return res
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
-        if name == 'foo:pc1':
-            return self.pc1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -50,14 +50,6 @@ class foo__c1__l1_entry(yadata.MNode):
         self.k2 = k2
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:k1':
-            return self.k1
-        if name == 'foo:k2':
-            return self.k2
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'l1'])
 
@@ -127,10 +119,6 @@ class foo__c1(yadata.MNode):
     mut def __init__(self, l1: list[foo__c1__l1_entry]=[]) -> None:
         self.l1 = foo__c1__l1(elements=l1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return iter(self.l1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -151,10 +139,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/snapshots/expected/test_yang/resolve_type_union_of_intX
+++ b/snapshots/expected/test_yang/resolve_type_union_of_intX
@@ -49,16 +49,6 @@ class root(yadata.MNode):
         self.l3 = l3
         self.l4 = l4
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-        if name == 'foo:l2':
-            return self.l2
-        if name == 'foo:l3':
-            return self.l3
-        if name == 'foo:l4':
-            return self.l4
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_string
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string
@@ -37,10 +37,6 @@ class root(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)
 

--- a/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
+++ b/snapshots/expected/test_yang/resolve_type_union_of_string_and_int
@@ -37,10 +37,6 @@ class root(yadata.MNode):
     mut def __init__(self, l1: ?value=None) -> None:
         self.l1 = l1 if l1 is not None else 42
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'foo:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)
 

--- a/src/adata.act
+++ b/src/adata.act
@@ -15,27 +15,30 @@ class MNode(object):
         """Create a deep copy of this adata object"""
         raise NotImplementedError()
 
-    def _get_attr(self, name: str) -> ?value:
-        raise NotImplementedError("_get_attr")
-
 
 extension MNode (YangData):
     def take_container(self, schema: yschema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
-        maybe_cnt = self._get_attr("{schema.prefix}:{name}")
+        maybe_cnt = self.__get_attr__(name)
         if maybe_cnt is not None:
             return (op=None, val=maybe_cnt)
 
     def take_list(self, schema: yschema.DList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, key: dict[str, value], val: value)]:
         new_path = path + [PathElement(schema)]
-        maybe_list = self._get_attr("{schema.prefix}:{name}")
-        if maybe_list is not None and isinstance(maybe_list, Iterator):
-            key_values = lambda element_data: {k: unwrap_key(k, element_data._get_attr("{schema.prefix}:{k}"), new_path) for k in schema.key}
-            return [(op=None, key=key_values(e), val=e) for e in maybe_list]
-        return [] # ??
+        maybe_list = self.__get_attr__(name)
+        if isinstance(maybe_list, MNode):
+            elements = maybe_list.__get_attr__("elements")
+            if isinstance(elements, list):
+                # TODO: actonlang/acton#2969 - pin expected type of entries to MNode
+                entries: list[MNode] = elements
+                key_namer = yschema.UniqueNamer(schema)
+                def element_key(entry: MNode) -> dict[str, value]:
+                    return {k: unwrap_key(k, entry.__get_attr__(key_namer.unique_safe_name(k, schema.prefix)), new_path) for k in schema.key}
+                return [(op=None, key=element_key(e), val=e) for e in entries]
+        return []
 
     def take_leaf(self, root: yschema.DRoot, schema: yschema.DLeaf, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, t: str, val: ?value):
         new_path = path + [PathElement(schema)]
-        maybe_attr = self._get_attr("{schema.prefix}:{name}")
+        maybe_attr = self.__get_attr__(name)
         if maybe_attr is not None:
             schema_type = schema.type_
             tv = try_validate_mnode_value(maybe_attr, schema_type, new_path)
@@ -48,7 +51,7 @@ extension MNode (YangData):
     def take_leaflist(self, root: yschema.DRoot, schema: yschema.DLeafList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, t: str, val: ?value)]:
         new_path = path + [PathElement(schema)]
         values: list[(op: ?str, t: str, val: ?value)] = []
-        children = self._get_attr("{schema.prefix}:{name}")
+        children = self.__get_attr__(name)
         if isinstance(children, list):
             schema_type = schema.type_
             for child in children:

--- a/src/data.act
+++ b/src/data.act
@@ -208,6 +208,10 @@ def from_data_recursive[A(YangData)](root: yschema.DRoot, s: yschema.DNodeInner,
 
     children: dict[ygdata.Id, ygdata.Node] = {}
 
+    unique_namer = yschema.UniqueNamer(s)
+    def usname(n) -> str:
+        return unique_namer.unique_safe_name(n.name, n.prefix)
+
     for child in s.children:
         if skip_nonkeys and isinstance(s, yschema.DList) and child.name not in s.key:
             continue
@@ -227,7 +231,7 @@ def from_data_recursive[A(YangData)](root: yschema.DRoot, s: yschema.DNodeInner,
             mod = child.module
 
         if isinstance(child, yschema.DContainer):
-            opval = data.take_container(child, child.name, s.namespace != child.namespace, spath)
+            opval = data.take_container(child, usname(child), s.namespace != child.namespace, spath)
             if opval is not None:
                 val = type_narrower(opval.val)
                 cchild = from_data_recursive(root, child, val, type_narrower, loose, set_ns=s.namespace != child.namespace, root_path=root_path, spath=path_with_child())
@@ -256,7 +260,7 @@ def from_data_recursive[A(YangData)](root: yschema.DRoot, s: yschema.DNodeInner,
                         raise ValueError("Error reading {format_schema_path(path_with_child())}: Cannot find child node with name {child.name}")
 
         elif isinstance(child, yschema.DList):
-            list_val = data.take_list(child, child.name, s.namespace != child.namespace, spath)
+            list_val = data.take_list(child, usname(child), s.namespace != child.namespace, spath)
             list_elements = []
 
             for element in list_val:
@@ -278,7 +282,7 @@ def from_data_recursive[A(YangData)](root: yschema.DRoot, s: yschema.DNodeInner,
                 children[fqname(child)] = list_gdata
 
         elif isinstance(child, yschema.DLeafList):
-            leaflist_val = data.take_leaflist(root, child, child.name, s.namespace != child.namespace, spath)
+            leaflist_val = data.take_leaflist(root, child, usname(child), s.namespace != child.namespace, spath)
             if len(leaflist_val) > 0:
                 entries: list[ygdata.LeafListEntry] = []
                 for item in leaflist_val:
@@ -305,7 +309,7 @@ def from_data_recursive[A(YangData)](root: yschema.DRoot, s: yschema.DNodeInner,
                 raise ValueError("Error reading {format_schema_path(path_with_child())}: Missing non-optional leaf-list value")
 
         elif isinstance(child, yschema.DLeaf):
-            typed = data.take_leaf(root, child, child.name, s.namespace != child.namespace, spath)
+            typed = data.take_leaf(root, child, usname(child), s.namespace != child.namespace, spath)
             if typed is not None:
                 wleaf = None
                 if typed.op == OP_REMOVE:

--- a/src/json.act
+++ b/src/json.act
@@ -14,9 +14,9 @@ extension dict[A(Hashable), B] (YangData):
             maybe = None
             # For cross-namespace children, only accept module-qualified keys
             if ns_qualified and schema.module is not None and schema.module != "":
-                maybe = self.get(f"{schema.module}:{name}")
+                maybe = self.get(f"{schema.module}:{schema.name}")
             else:
-                maybe = self.get(name)
+                maybe = self.get(schema.name)
             if isinstance(maybe, dict):
                 return (op=None, val=maybe)
         return None
@@ -26,9 +26,9 @@ extension dict[A(Hashable), B] (YangData):
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             lv = None
             if ns_qualified and schema.module is not None and schema.module != "":
-                lv = self.get(f"{schema.module}:{name}")
+                lv = self.get(f"{schema.module}:{schema.name}")
             else:
-                lv = self.get(name)
+                lv = self.get(schema.name)
             if isinstance(lv, list):
                 # Actually, the following code has no right to assume anything about the type of lv's elements.
                 # Still the type-checker accepts it because we don't yet have the existential types machinery available
@@ -45,9 +45,9 @@ extension dict[A(Hashable), B] (YangData):
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             leaf_value = None
             if ns_qualified and schema.module is not None and schema.module != "":
-                leaf_value = self.get(f"{schema.module}:{name}")
+                leaf_value = self.get(f"{schema.module}:{schema.name}")
             else:
-                leaf_value = self.get(name)
+                leaf_value = self.get(schema.name)
             if leaf_value is not None:
                 tv = try_parse_json_value(leaf_value, schema, schema.type_, new_path, root)
                 if tv is not None:
@@ -62,9 +62,9 @@ extension dict[A(Hashable), B] (YangData):
         if isinstance(self, dict):  # This test is only needed because of a temporary shortcoming of the type-checker
             leaflist_data = None
             if ns_qualified and schema.module is not None and schema.module != "":
-                leaflist_data = self.get(f"{schema.module}:{name}")
+                leaflist_data = self.get(f"{schema.module}:{schema.name}")
             else:
-                leaflist_data = self.get(name)
+                leaflist_data = self.get(schema.name)
             if isinstance(leaflist_data, list):
                 new_path = path + [PathElement(schema)]
                 for item in leaflist_data:

--- a/src/schema.act
+++ b/src/schema.act
@@ -738,16 +738,6 @@ class DNodeInner(DNode):
                 res.append("")
 
         if not device:
-            if len(attr_children) > 0:
-                res.append("    pure def _get_attr(self, name: str) -> ?value:")
-                for child in attr_children:
-                    res.append("        if name == '{child.prefix}:{child.name}':")
-                    if isinstance(child, DList):
-                        res.append("            return iter(self.{usname(child)})")
-                    else:
-                        res.append("            return self.{usname(child)}")
-                res.append("")
-
             # .to_gdata()
             res.append("    mut def to_gdata(self) -> ygdata.Node:")
             if isinstance(self, DRoot):

--- a/src/test_data.act
+++ b/src/test_data.act
@@ -246,15 +246,6 @@ class _test_leafref_c(yadata.MNode):
         self.ref = ref
         self.refs = refs
 
-    def _get_attr(self, name: str) -> ?value:
-        if name == "y1:n":
-            return self.n
-        if name == "y1:ref":
-            return self.ref
-        if name == "y1:refs":
-            return self.refs
-        return None
-
     mut def to_gdata(self) -> ygdata.Node:
         raise NotImplementedError("to_gdata")
 
@@ -268,11 +259,6 @@ class _test_leafref_root(yadata.MNode):
     mut def __init__(self, c: ?_test_leafref_c):
         self._ns = "urn:example:y1"
         self.c = c
-
-    def _get_attr(self, name: str) -> ?value:
-        if name == "y1:c":
-            return self.c
-        return None
 
     mut def to_gdata(self) -> ygdata.Node:
         raise NotImplementedError("to_gdata")

--- a/src/xml.act
+++ b/src/xml.act
@@ -130,7 +130,7 @@ def _test_get_nc_op_pref_ancestor():
 
 extension xml.Node (YangData):
     def take_container(self, schema: yschema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: str, val: ?value):
-        child_node = ygdata.get_xml_opt_child(self, name, schema.namespace if ns_qualified else None)
+        child_node = ygdata.get_xml_opt_child(self, schema.name, schema.namespace if ns_qualified else None)
         if child_node is not None:
             op = _get_netconf_operation(child_node)
             return (op=op, val=child_node)
@@ -138,7 +138,7 @@ extension xml.Node (YangData):
 
     def take_list(self, schema: yschema.DList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: str, key: dict[str, value], val: value)]:
         new_path = path + [PathElement(schema)]
-        elements = ygdata.get_xml_children(self, name, schema.namespace if ns_qualified else None)
+        elements = ygdata.get_xml_children(self, schema.name, schema.namespace if ns_qualified else None)
 
         def extract_key(element_data):
             key_values = {}
@@ -151,7 +151,7 @@ extension xml.Node (YangData):
 
     mut def take_leaf(self, root: yschema.DRoot, schema: yschema.DLeaf, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: str, t: str, val: ?value):
         new_path = path + [PathElement(schema)]
-        maybe_node = ygdata.get_xml_opt_child(self, name, schema.namespace if ns_qualified else None)
+        maybe_node = ygdata.get_xml_opt_child(self, schema.name, schema.namespace if ns_qualified else None)
         if maybe_node is not None:
             op = _get_netconf_operation(maybe_node)
             tv = try_parse_xml_value(maybe_node.text, schema, schema.type_, new_path, maybe_node.nsdefs, root)
@@ -165,7 +165,7 @@ extension xml.Node (YangData):
     def take_leaflist(self, root: yschema.DRoot, schema: yschema.DLeafList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: str, t: str, val: ?value)]:
         new_path = path + [PathElement(schema)]
         values: list[(op: str, t: str, val: ?value)] = []
-        children = ygdata.get_xml_children(self, name, schema.namespace if ns_qualified else None)
+        children = ygdata.get_xml_children(self, schema.name, schema.namespace if ns_qualified else None)
         for child in children:
             if isinstance(child, xml.Node):
                 op = _get_netconf_operation(child)

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -170,30 +170,6 @@ class basics__c(yadata.MNode):
         self.l_binary_def = l_binary_def if l_binary_def is not None else base64.decode('SGVsbG8gQWN0b24g8J+roQ=='.encode())
         self.l_identityref_def = l_identityref_def if l_identityref_def is not None else basics_id2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'b:l_str_def':
-            return self.l_str_def
-        if name == 'b:l_str_def_quoted':
-            return self.l_str_def_quoted
-        if name == 'b:l_uint64_def':
-            return self.l_uint64_def
-        if name == 'b:l_decimal64_def':
-            return self.l_decimal64_def
-        if name == 'b:l_union_def_str':
-            return self.l_union_def_str
-        if name == 'b:l_union_def_int':
-            return self.l_union_def_int
-        if name == 'b:l_union_def_float':
-            return self.l_union_def_float
-        if name == 'b:l_union_def_bool':
-            return self.l_union_def_bool
-        if name == 'b:l_union_def_enumeration':
-            return self.l_union_def_enumeration
-        if name == 'b:l_binary_def':
-            return self.l_binary_def
-        if name == 'b:l_identityref_def':
-            return self.l_identityref_def
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['basics:c'])
 
@@ -214,10 +190,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c: ?basics__c=None) -> None:
         self.c = c if c is not None else basics__c()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'b:c':
-            return self.c
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -140,12 +140,6 @@ class filter_test__system_state__clock(yadata.MNode):
         self.current_datetime = current_datetime
         self.boot_datetime = boot_datetime
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:current-datetime':
-            return self.current_datetime
-        if name == 'ft:boot-datetime':
-            return self.boot_datetime
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:system-state', 'clock'])
 
@@ -166,10 +160,6 @@ class filter_test__system_state(yadata.MNode):
 
     mut def __init__(self, clock: ?filter_test__system_state__clock=None) -> None:
         self.clock = clock if clock is not None else filter_test__system_state__clock()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:clock':
-            return self.clock
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:system-state'])
@@ -194,12 +184,6 @@ class filter_test__interfaces__interface__statistics(yadata.MNode):
         self.in_octets = in_octets
         self.out_octets = out_octets
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:in-octets':
-            return self.in_octets
-        if name == 'ft:out-octets':
-            return self.out_octets
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:interfaces', 'interface', 'statistics'])
 
@@ -221,10 +205,6 @@ class filter_test__interfaces__interface__ipv4(yadata.MNode):
     mut def __init__(self, mtu: ?u64) -> None:
         self.mtu = mtu
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:mtu':
-            return self.mtu
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:interfaces', 'interface', 'ipv4'])
 
@@ -245,10 +225,6 @@ class filter_test__interfaces__interface__ipv6(yadata.MNode):
 
     mut def __init__(self, mtu: ?u64) -> None:
         self.mtu = mtu
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:mtu':
-            return self.mtu
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:interfaces', 'interface', 'ipv6'])
@@ -288,28 +264,6 @@ class filter_test__interfaces__interface_entry(yadata.MNode):
         self.statistics = statistics if statistics is not None else filter_test__interfaces__interface__statistics()
         self.ipv4 = ipv4 if ipv4 is not None else filter_test__interfaces__interface__ipv4()
         self.ipv6 = ipv6 if ipv6 is not None else filter_test__interfaces__interface__ipv6()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:name':
-            return self.name
-        if name == 'ft:description':
-            return self.description
-        if name == 'ft:type':
-            return self.type
-        if name == 'ft:enabled':
-            return self.enabled
-        if name == 'ft:admin-status':
-            return self.admin_status
-        if name == 'ft:oper-status':
-            return self.oper_status
-        if name == 'ft:last-change':
-            return self.last_change
-        if name == 'ft:statistics':
-            return self.statistics
-        if name == 'ft:ipv4':
-            return self.ipv4
-        if name == 'ft:ipv6':
-            return self.ipv6
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:interfaces', 'interface'])
@@ -402,10 +356,6 @@ class filter_test__interfaces(yadata.MNode):
     mut def __init__(self, interface: list[filter_test__interfaces__interface_entry]=[]) -> None:
         self.interface = filter_test__interfaces__interface(elements=interface)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:interface':
-            return iter(self.interface)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['filter-test:interfaces'])
 
@@ -428,12 +378,6 @@ class root(yadata.MNode):
     mut def __init__(self, system_state: ?filter_test__system_state=None, interfaces: ?filter_test__interfaces=None) -> None:
         self.system_state = system_state if system_state is not None else filter_test__system_state()
         self.interfaces = interfaces if interfaces is not None else filter_test__interfaces()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'ft:system-state':
-            return self.system_state
-        if name == 'ft:interfaces':
-            return self.interfaces
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -528,10 +528,6 @@ class foo__c1__li__c4(yadata.MNode):
     mut def __init__(self, l5: ?str) -> None:
         self.l5 = l5
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l5':
-            return self.l5
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li', 'c4'])
 
@@ -556,14 +552,6 @@ class foo__c1__li_entry(yadata.MNode):
         self.name = name
         self.val = val
         self.c4 = c4 if c4 is not None else foo__c1__li__c4()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
-        if name == 'f:val':
-            return self.val
-        if name == 'f:c4':
-            return self.c4
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1', 'li'])
@@ -674,38 +662,6 @@ class foo__c1(yadata.MNode):
         self.l2 = l2
         self.l_leafref = l_leafref
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.f_l1
-        if name == 'f:l3':
-            return self.l3
-        if name == 'f:l_empty':
-            return self.l_empty
-        if name == 'f:l_empty_delete':
-            return self.l_empty_delete
-        if name == 'f:l_decimal64':
-            return self.l_decimal64
-        if name == 'f:li':
-            return iter(self.li)
-        if name == 'f:ll_uint64':
-            return self.ll_uint64
-        if name == 'f:ll_str':
-            return self.ll_str
-        if name == 'f:l_identityref':
-            return self.l_identityref
-        if name == 'f:ll_identityref':
-            return self.ll_identityref
-        if name == 'f:l_identityref_noval':
-            return self.l_identityref_noval
-        if name == 'f:l4':
-            return self.l4
-        if name == 'bar:l1':
-            return self.bar_l1
-        if name == 'bar:l2':
-            return self.l2
-        if name == 'bar:l_leafref':
-            return self.l_leafref
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c1'])
 
@@ -727,10 +683,6 @@ class foo__pc1__foo(yadata.MNode):
     mut def __init__(self, l1: ?list[bytes]=None) -> None:
         self.l1 = l1 if l1 is not None else []
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1', 'foo'])
 
@@ -751,10 +703,6 @@ class foo__pc1(yadata.MNode):
 
     mut def __init__(self, foo: ?foo__pc1__foo=None) -> None:
         self.foo = foo if foo is not None else foo__pc1__foo()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc1'])
@@ -782,12 +730,6 @@ class foo__pc2__foo(yadata.MNode):
         self.l_mandatory = l_mandatory
         self.l_empty_mandatory = l_empty_mandatory
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l_mandatory':
-            return self.l_mandatory
-        if name == 'f:l_empty_mandatory':
-            return self.l_empty_mandatory
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2', 'foo'])
 
@@ -808,10 +750,6 @@ class foo__pc2(yadata.MNode):
 
     mut def __init__(self, foo: foo__pc2__foo) -> None:
         self.foo = foo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc2'])
@@ -839,12 +777,6 @@ class foo__pc3__level1__level2__level3(yadata.MNode):
         self.l3 = l3
         self.l3_optional = l3_optional
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l3':
-            return self.l3
-        if name == 'f:l3-optional':
-            return self.l3_optional
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
@@ -869,14 +801,6 @@ class foo__pc3__level1__level2(yadata.MNode):
         self.l2 = l2
         self.l2_optional = l2_optional
         self.level3 = level3
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l2':
-            return self.l2
-        if name == 'f:l2-optional':
-            return self.l2_optional
-        if name == 'f:level3':
-            return self.level3
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1', 'level2'])
@@ -903,14 +827,6 @@ class foo__pc3__level1(yadata.MNode):
         self.l1_optional = l1_optional
         self.level2 = level2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:l1-optional':
-            return self.l1_optional
-        if name == 'f:level2':
-            return self.level2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3', 'level1'])
 
@@ -931,10 +847,6 @@ class foo__pc3(yadata.MNode):
 
     mut def __init__(self, level1: foo__pc3__level1) -> None:
         self.level1 = level1
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:level1':
-            return self.level1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:pc3'])
@@ -985,12 +897,6 @@ class foo__c_dot(yadata.MNode):
         self.l_dot1 = l_dot1
         self.l_dot2 = l_dot2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l.dot1':
-            return self.l_dot1
-        if name == 'bar:l.dot2':
-            return self.l_dot2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c.dot'])
 
@@ -1011,10 +917,6 @@ class foo__cc__death_entry(yadata.MNode):
 
     mut def __init__(self, name: str) -> None:
         self.name = name
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc', 'death'])
@@ -1096,12 +998,6 @@ class foo__cc(yadata.MNode):
     mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]) -> None:
         self.cake = cake
         self.death = foo__cc__death(elements=death)
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:cake':
-            return self.cake
-        if name == 'f:death':
-            return iter(self.death)
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:cc'])
@@ -1192,16 +1088,6 @@ class foo__f_conflict(yadata.MNode):
         self.bar_inner = res
         return res
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.f_foo
-        if name == 'f:inner':
-            return self.f_inner
-        if name == 'bar:foo':
-            return self.bar_foo
-        if name == 'bar:inner':
-            return self.bar_inner
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:conflict'])
 
@@ -1222,10 +1108,6 @@ class foo__special_entry(yadata.MNode):
 
     mut def __init__(self, yes: bool) -> None:
         self.yes = yes
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:yes':
-            return self.yes
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:special'])
@@ -1310,14 +1192,6 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
         self.key2 = key2
         self.baz = baz
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:key1':
-            return self.key1
-        if name == 'f:key2':
-            return self.key2
-        if name == 'f:baz':
-            return self.baz
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
@@ -1385,16 +1259,6 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
         self.f_bar = f_bar
         self.li2 = foo__nested__f_inner__li1__li2(elements=li2)
         self.bar_bar = bar_bar
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
-        if name == 'f:bar':
-            return self.f_bar
-        if name == 'f:li2':
-            return iter(self.li2)
-        if name == 'bar:bar':
-            return self.bar_bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner', 'li1'])
@@ -1481,12 +1345,6 @@ class foo__nested__f_inner(yadata.MNode):
         self.foo = foo
         self.li1 = foo__nested__f_inner__li1(elements=li1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.foo
-        if name == 'f:li1':
-            return iter(self.li1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'inner'])
 
@@ -1507,10 +1365,6 @@ class foo__nested__bar_inner(yadata.MNode):
 
     mut def __init__(self, foo: ?str) -> None:
         self.foo = foo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested', 'bar:inner'])
@@ -1534,12 +1388,6 @@ class foo__nested(yadata.MNode):
     mut def __init__(self, f_inner: ?foo__nested__f_inner=None, bar_inner: ?foo__nested__bar_inner=None) -> None:
         self.f_inner = f_inner if f_inner is not None else foo__nested__f_inner()
         self.bar_inner = bar_inner if bar_inner is not None else foo__nested__bar_inner()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:inner':
-            return self.f_inner
-        if name == 'bar:inner':
-            return self.bar_inner
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:nested'])
@@ -1567,16 +1415,6 @@ class foo__li_union_entry(yadata.MNode):
         self.k2 = k2
         self.k3 = k3
         self.checker = checker
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:k1':
-            return self.k1
-        if name == 'f:k2':
-            return self.k2
-        if name == 'f:k3':
-            return self.k3
-        if name == 'f:checker':
-            return self.checker
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union'])
@@ -1653,10 +1491,6 @@ class foo__li_union_one_base_entry(yadata.MNode):
     mut def __init__(self, k1: value) -> None:
         self.k1 = k1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:k1':
-            return self.k1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li-union-one-base'])
 
@@ -1722,12 +1556,6 @@ class foo__state__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state', 'c1'])
 
@@ -1748,10 +1576,6 @@ class foo__state(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__state__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__state__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:state'])
@@ -1774,10 +1598,6 @@ class foo__c2(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:c2'])
 
@@ -1799,10 +1619,6 @@ class bar__test_idref(yadata.MNode):
     mut def __init__(self, idref: ?list[Identityref]=None) -> None:
         self.idref = idref if idref is not None else []
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:idref':
-            return self.idref
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:test-idref'])
 
@@ -1823,10 +1639,6 @@ class bar__bar_conflict(yadata.MNode):
 
     mut def __init__(self, foo: ?str) -> None:
         self.foo = foo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['bar:conflict'])
@@ -1914,42 +1726,6 @@ class root(yadata.MNode):
         res = foo__empty_presence()
         self.empty_presence = res
         return res
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:c1':
-            return self.c1
-        if name == 'f:pc1':
-            return self.pc1
-        if name == 'f:pc2':
-            return self.pc2
-        if name == 'f:pc3':
-            return self.pc3
-        if name == 'f:empty-presence':
-            return self.empty_presence
-        if name == 'f:c.dot':
-            return self.c_dot
-        if name == 'f:cc':
-            return self.cc
-        if name == 'f:conflict':
-            return self.f_conflict
-        if name == 'f:special':
-            return iter(self.special)
-        if name == 'f:nested':
-            return self.nested
-        if name == 'f:li-union':
-            return iter(self.li_union)
-        if name == 'f:li-union-one-base':
-            return iter(self.li_union_one_base)
-        if name == 'f:state':
-            return self.state
-        if name == 'f:ll-empty':
-            return self.ll_empty
-        if name == 'f:c2':
-            return self.c2
-        if name == 'bar:test-idref':
-            return self.test_idref
-        if name == 'bar:conflict':
-            return self.bar_conflict
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -528,10 +528,6 @@ class foo__c1__li__c4(yadata.MNode):
     mut def __init__(self, l5: ?str) -> None:
         self.l5 = l5
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l5':
-            return self.l5
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li', 'c4'])
 
@@ -556,14 +552,6 @@ class foo__c1__li_entry(yadata.MNode):
         self.name = name
         self.val = val
         self.c4 = c4 if c4 is not None else foo__c1__li__c4()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
-        if name == 'f:val':
-            return self.val
-        if name == 'f:c4':
-            return self.c4
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1', 'li'])
@@ -674,38 +662,6 @@ class foo__c1(yadata.MNode):
         self.l2 = l2
         self.l_leafref = l_leafref
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.f_l1
-        if name == 'f:l3':
-            return self.l3
-        if name == 'f:l_empty':
-            return self.l_empty
-        if name == 'f:l_empty_delete':
-            return self.l_empty_delete
-        if name == 'f:l_decimal64':
-            return self.l_decimal64
-        if name == 'f:li':
-            return iter(self.li)
-        if name == 'f:ll_uint64':
-            return self.ll_uint64
-        if name == 'f:ll_str':
-            return self.ll_str
-        if name == 'f:l_identityref':
-            return self.l_identityref
-        if name == 'f:ll_identityref':
-            return self.ll_identityref
-        if name == 'f:l_identityref_noval':
-            return self.l_identityref_noval
-        if name == 'f:l4':
-            return self.l4
-        if name == 'bar:l1':
-            return self.bar_l1
-        if name == 'bar:l2':
-            return self.l2
-        if name == 'bar:l_leafref':
-            return self.l_leafref
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c1'])
 
@@ -727,10 +683,6 @@ class foo__pc1__foo(yadata.MNode):
     mut def __init__(self, l1: ?list[bytes]=None) -> None:
         self.l1 = l1 if l1 is not None else []
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1', 'foo'])
 
@@ -751,10 +703,6 @@ class foo__pc1(yadata.MNode):
 
     mut def __init__(self, foo: ?foo__pc1__foo=None) -> None:
         self.foo = foo if foo is not None else foo__pc1__foo()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc1'])
@@ -782,12 +730,6 @@ class foo__pc2__foo(yadata.MNode):
         self.l_mandatory = l_mandatory
         self.l_empty_mandatory = l_empty_mandatory
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l_mandatory':
-            return self.l_mandatory
-        if name == 'f:l_empty_mandatory':
-            return self.l_empty_mandatory
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2', 'foo'])
 
@@ -808,10 +750,6 @@ class foo__pc2(yadata.MNode):
 
     mut def __init__(self, foo: ?foo__pc2__foo=None) -> None:
         self.foo = foo if foo is not None else foo__pc2__foo()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc2'])
@@ -839,12 +777,6 @@ class foo__pc3__level1__level2__level3(yadata.MNode):
         self.l3 = l3
         self.l3_optional = l3_optional
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l3':
-            return self.l3
-        if name == 'f:l3-optional':
-            return self.l3_optional
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2', 'level3'])
 
@@ -869,14 +801,6 @@ class foo__pc3__level1__level2(yadata.MNode):
         self.l2 = l2
         self.l2_optional = l2_optional
         self.level3 = level3 if level3 is not None else foo__pc3__level1__level2__level3()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l2':
-            return self.l2
-        if name == 'f:l2-optional':
-            return self.l2_optional
-        if name == 'f:level3':
-            return self.level3
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1', 'level2'])
@@ -903,14 +827,6 @@ class foo__pc3__level1(yadata.MNode):
         self.l1_optional = l1_optional
         self.level2 = level2 if level2 is not None else foo__pc3__level1__level2()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:l1-optional':
-            return self.l1_optional
-        if name == 'f:level2':
-            return self.level2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3', 'level1'])
 
@@ -931,10 +847,6 @@ class foo__pc3(yadata.MNode):
 
     mut def __init__(self, level1: ?foo__pc3__level1=None) -> None:
         self.level1 = level1 if level1 is not None else foo__pc3__level1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:level1':
-            return self.level1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:pc3'])
@@ -985,12 +897,6 @@ class foo__c_dot(yadata.MNode):
         self.l_dot1 = l_dot1
         self.l_dot2 = l_dot2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l.dot1':
-            return self.l_dot1
-        if name == 'bar:l.dot2':
-            return self.l_dot2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c.dot'])
 
@@ -1011,10 +917,6 @@ class foo__cc__death_entry(yadata.MNode):
 
     mut def __init__(self, name: str) -> None:
         self.name = name
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc', 'death'])
@@ -1096,12 +998,6 @@ class foo__cc(yadata.MNode):
     mut def __init__(self, cake: ?str, death: list[foo__cc__death_entry]=[]) -> None:
         self.cake = cake
         self.death = foo__cc__death(elements=death)
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:cake':
-            return self.cake
-        if name == 'f:death':
-            return iter(self.death)
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:cc'])
@@ -1192,16 +1088,6 @@ class foo__f_conflict(yadata.MNode):
         self.bar_inner = res
         return res
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.f_foo
-        if name == 'f:inner':
-            return self.f_inner
-        if name == 'bar:foo':
-            return self.bar_foo
-        if name == 'bar:inner':
-            return self.bar_inner
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:conflict'])
 
@@ -1222,10 +1108,6 @@ class foo__special_entry(yadata.MNode):
 
     mut def __init__(self, yes: bool) -> None:
         self.yes = yes
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:yes':
-            return self.yes
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:special'])
@@ -1310,14 +1192,6 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
         self.key2 = key2
         self.baz = baz
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:key1':
-            return self.key1
-        if name == 'f:key2':
-            return self.key2
-        if name == 'f:baz':
-            return self.baz
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1', 'li2'])
 
@@ -1385,16 +1259,6 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
         self.f_bar = f_bar
         self.li2 = foo__nested__f_inner__li1__li2(elements=li2)
         self.bar_bar = bar_bar
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
-        if name == 'f:bar':
-            return self.f_bar
-        if name == 'f:li2':
-            return iter(self.li2)
-        if name == 'bar:bar':
-            return self.bar_bar
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner', 'li1'])
@@ -1481,12 +1345,6 @@ class foo__nested__f_inner(yadata.MNode):
         self.foo = foo
         self.li1 = foo__nested__f_inner__li1(elements=li1)
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:foo':
-            return self.foo
-        if name == 'f:li1':
-            return iter(self.li1)
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'inner'])
 
@@ -1507,10 +1365,6 @@ class foo__nested__bar_inner(yadata.MNode):
 
     mut def __init__(self, foo: ?str) -> None:
         self.foo = foo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested', 'bar:inner'])
@@ -1534,12 +1388,6 @@ class foo__nested(yadata.MNode):
     mut def __init__(self, f_inner: ?foo__nested__f_inner=None, bar_inner: ?foo__nested__bar_inner=None) -> None:
         self.f_inner = f_inner if f_inner is not None else foo__nested__f_inner()
         self.bar_inner = bar_inner if bar_inner is not None else foo__nested__bar_inner()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:inner':
-            return self.f_inner
-        if name == 'bar:inner':
-            return self.bar_inner
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:nested'])
@@ -1567,16 +1415,6 @@ class foo__li_union_entry(yadata.MNode):
         self.k2 = k2
         self.k3 = k3
         self.checker = checker
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:k1':
-            return self.k1
-        if name == 'f:k2':
-            return self.k2
-        if name == 'f:k3':
-            return self.k3
-        if name == 'f:checker':
-            return self.checker
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union'])
@@ -1653,10 +1491,6 @@ class foo__li_union_one_base_entry(yadata.MNode):
     mut def __init__(self, k1: value) -> None:
         self.k1 = k1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:k1':
-            return self.k1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:li-union-one-base'])
 
@@ -1722,12 +1556,6 @@ class foo__state__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state', 'c1'])
 
@@ -1748,10 +1576,6 @@ class foo__state(yadata.MNode):
 
     mut def __init__(self, c1: ?foo__state__c1=None) -> None:
         self.c1 = c1 if c1 is not None else foo__state__c1()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:state'])
@@ -1774,10 +1598,6 @@ class foo__c2(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['foo:c2'])
 
@@ -1799,10 +1619,6 @@ class bar__test_idref(yadata.MNode):
     mut def __init__(self, idref: ?list[Identityref]=None) -> None:
         self.idref = idref if idref is not None else []
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:idref':
-            return self.idref
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:test-idref'])
 
@@ -1823,10 +1639,6 @@ class bar__bar_conflict(yadata.MNode):
 
     mut def __init__(self, foo: ?str) -> None:
         self.foo = foo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'bar:foo':
-            return self.foo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['bar:conflict'])
@@ -1912,42 +1724,6 @@ class root(yadata.MNode):
         res = foo__empty_presence()
         self.empty_presence = res
         return res
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:c1':
-            return self.c1
-        if name == 'f:pc1':
-            return self.pc1
-        if name == 'f:pc2':
-            return self.pc2
-        if name == 'f:pc3':
-            return self.pc3
-        if name == 'f:empty-presence':
-            return self.empty_presence
-        if name == 'f:c.dot':
-            return self.c_dot
-        if name == 'f:cc':
-            return self.cc
-        if name == 'f:conflict':
-            return self.f_conflict
-        if name == 'f:special':
-            return iter(self.special)
-        if name == 'f:nested':
-            return self.nested
-        if name == 'f:li-union':
-            return iter(self.li_union)
-        if name == 'f:li-union-one-base':
-            return iter(self.li_union_one_base)
-        if name == 'f:state':
-            return self.state
-        if name == 'f:ll-empty':
-            return self.ll_empty
-        if name == 'f:c2':
-            return self.c2
-        if name == 'bar:test-idref':
-            return self.test_idref
-        if name == 'bar:conflict':
-            return self.bar_conflict
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True)

--- a/test/test_data_classes/src/yang_loose_required.act
+++ b/test/test_data_classes/src/yang_loose_required.act
@@ -58,10 +58,6 @@ class loose_required__c2(yadata.MNode):
     mut def __init__(self, l1: ?str) -> None:
         self.l1 = l1
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'lr:l1':
-            return self.l1
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True, root_path=['loose-required:c2'])
 
@@ -82,10 +78,6 @@ class root(yadata.MNode):
 
     mut def __init__(self, c2: ?loose_required__c2=None) -> None:
         self.c2 = c2 if c2 is not None else loose_required__c2()
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'lr:c2':
-            return self.c2
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=True)

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -125,12 +125,6 @@ class foo__tc1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:tc1'])
 
@@ -154,12 +148,6 @@ class foo__li__c1(yadata.MNode):
         self.l1 = l1
         self.l2 = l2
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:l1':
-            return self.l1
-        if name == 'f:l2':
-            return self.l2
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li', 'c1'])
 
@@ -182,12 +170,6 @@ class foo__li_entry(yadata.MNode):
     mut def __init__(self, name: str, c1: foo__li__c1) -> None:
         self.name = name
         self.c1 = c1
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:name':
-            return self.name
-        if name == 'f:c1':
-            return self.c1
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['foo:li'])
@@ -270,12 +252,6 @@ class root(yadata.MNode):
     mut def __init__(self, tc1: foo__tc1, li: list[foo__li_entry]=[]) -> None:
         self.tc1 = tc1
         self.li = foo__li(elements=li)
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'f:tc1':
-            return self.tc1
-        if name == 'f:li':
-            return iter(self.li)
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False)

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -100,10 +100,6 @@ class yangrpc__foo__input__woo(yadata.MNode):
     mut def __init__(self, woo_b: ?int) -> None:
         self.woo_b = woo_b
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yrpc:woo_b':
-            return self.woo_b
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input', 'woo'])
 
@@ -127,12 +123,6 @@ class yangrpc__foo__input(yadata.MNode):
         self.a = a
         self.woo = woo if woo is not None else yangrpc__foo__input__woo()
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yrpc:a':
-            return self.a
-        if name == 'yrpc:woo':
-            return self.woo
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'input'])
 
@@ -153,10 +143,6 @@ class yangrpc__foo__output(yadata.MNode):
 
     mut def __init__(self, outoo: ?str) -> None:
         self.outoo = outoo
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'yrpc:outoo':
-            return self.outoo
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['yangrpc:foo', 'output'])

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -126,10 +126,6 @@ class m__ping__input(yadata.MNode):
     mut def __init__(self, msg: ?str) -> None:
         self.msg = msg
 
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'm:msg':
-            return self.msg
-
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['m:ping', 'input'])
 
@@ -150,10 +146,6 @@ class m__ping__output(yadata.MNode):
 
     mut def __init__(self, reply: ?str) -> None:
         self.reply = reply
-
-    pure def _get_attr(self, name: str) -> ?value:
-        if name == 'm:reply':
-            return self.reply
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['m:ping', 'output'])


### PR DESCRIPTION
Stop generating MNode._get_attr() methods that enumerate all attributes. With this optimzation the compiler can build a view of the referenced attributes at compile time and only emit code for those, allowing it to prune the object graph more aggressively.