### PR TITLE
Skip rpc_root in "device" mode

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -964,7 +964,9 @@ class DNodeInner(DNode):
         res.append("")
 
 
-        if isinstance(self, DRoot):
+        # rpc_root serializes RPC input via yadata.from_adata, which relies on
+        # __get_attr__ reflection, so skip RPCs entirely in device mode for now
+        if isinstance(self, DRoot) and not device:
             # First generate data classes for RPC input/output
             for rpc in self.rpcs:
                 # Generate adata classes for DInput, DOutput, but override:

--- a/src/ayangc.act
+++ b/src/ayangc.act
@@ -282,7 +282,7 @@ actor main(env):
     compile_cmd = p.add_cmd("compile", "compile YANG modules together", _cmd_compile)
     compile_cmd.add_option("infile", "strlist", "+", [], "input YANG file(s) or directory(s)")
     compile_cmd.add_bool("loose", "generate loose validation mode classes", short="l")
-    compile_cmd.add_option("mode", "str", default="full", help="adata generation mode: 'full' (default) or 'device' (drop from_gdata/to_gdata/copy/_get_attr for a structure-only on-device class shape)", short="m")
+    compile_cmd.add_option("mode", "str", default="full", help="adata generation mode: 'full' (default) or 'device' (drop from_gdata/to_gdata/copy for a structure-only on-device class shape)", short="m")
     compile_cmd.add_option("exclude", "strlist", "*", [], "glob pattern(s) to exclude files", short="e")
     compile_cmd.add_option("stage", "str", default="", help="compile stage (adata, dnode-src, schema-tree, dnode-tree, statement, default full compile only)", short="s")
     compile_cmd.add_option("output", "str", default="", help="write stage output to file (use '-' for stdout)", short="o")

--- a/src/schema.act
+++ b/src/schema.act
@@ -960,7 +960,9 @@ class DNodeInner(DNode):
         res.append("")
 
 
-        if isinstance(self, DRoot):
+        # rpc_root serializes RPC input via yadata.from_adata, which relies on
+        # __get_attr__ reflection, so skip RPCs entirely in device mode for now
+        if isinstance(self, DRoot) and not device:
             # First generate data classes for RPC input/output
             for rpc in self.rpcs:
                 # Generate adata classes for DInput, DOutput, but override:

--- a/test/test_device_mode/src/test_device_mode.act
+++ b/test/test_device_mode/src/test_device_mode.act
@@ -1,10 +1,11 @@
 """Device-mode compile test.
 
 src/m.act is generated from yang/m.yang with `ayangc compile -m device`, which
-drops all serialization (from_gdata, to_gdata, copy, _get_attr) from the config
+drops all serialization (from_gdata, to_gdata, copy) from the config
 data classes, leaving only structure: typed fields, __init__, and the
-navigation/mutation surface. RPC input/output subtrees keep serialization so the
-rpc_root actor still compiles.
+navigation/mutation surface. RPCs (input/output classes and the rpc_root actor)
+are skipped entirely for now: rpc_root serializes input via yadata.from_adata,
+which relies on __get_attr__ reflection.
 
 The point of the test is that the generated module *compiles at all* with stock
 acton (no __get_attr__ compiler dependency); here we also exercise the retained


### PR DESCRIPTION
Avoid reflection in the action input adata -> gdata conversion.