### PR TITLE
Define adata list elements in MList

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -805,8 +805,7 @@ class DNodeInner(DNode):
             # Here we create the list class, list entry class was created above
             breaker_name, breaker_idx = next_breaker_name(breaker_idx)
             res.append("{breaker_name}: None = None")
-            res.append("class {pname()}(yadata.MNode):")
-            res.append("    elements: list[{pname()}_entry]")
+            res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
 
             init_args = ["self"]
             init_args.append("elements: list[{pname()}_entry]=[]")
@@ -927,10 +926,6 @@ class DNodeInner(DNode):
                 res.append("                copied_elements.append(ce)")
                 res.append("        return {pname()}(elements=copied_elements)")
                 res.append("")
-            # Generate Iterable extension for the list class
-            res.append("extension {pname()}(Iterable[{pname()}_entry]):")
-            res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
-            res.append("        return self.elements.__iter__()")
 
             # Indexed extension for single-key lists with a non-union key.
             # Composite keys would need a tuple, union keys are typed as Acton

--- a/snapshots/expected/test_yang/augment_with_uses_refine
+++ b/snapshots/expected/test_yang/augment_with_uses_refine
@@ -57,8 +57,7 @@ class base__system_capabilities__per_node_capabilities_entry(yadata.MNode):
         return base__system_capabilities__per_node_capabilities_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class base__system_capabilities__per_node_capabilities(yadata.MNode):
-    elements: list[base__system_capabilities__per_node_capabilities_entry]
+class base__system_capabilities__per_node_capabilities(yadata.MList[base__system_capabilities__per_node_capabilities_entry]):
     mut def __init__(self, elements: list[base__system_capabilities__per_node_capabilities_entry]=[]) -> None:
         self.elements = elements
 
@@ -83,9 +82,6 @@ class base__system_capabilities__per_node_capabilities(yadata.MNode):
                 copied_elements.append(ce)
         return base__system_capabilities__per_node_capabilities(elements=copied_elements)
 
-extension base__system_capabilities__per_node_capabilities(Iterable[base__system_capabilities__per_node_capabilities_entry]):
-    def __iter__(self) -> Iterator[base__system_capabilities__per_node_capabilities_entry]:
-        return self.elements.__iter__()
 
 _breaker3: None = None
 class base__system_capabilities__subscription_capabilities(yadata.MNode):

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -61,8 +61,7 @@ class foo__c1__things_entry(yadata.MNode):
         return foo__c1__things_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__things(yadata.MNode):
-    elements: list[foo__c1__things_entry]
+class foo__c1__things(yadata.MList[foo__c1__things_entry]):
     mut def __init__(self, elements: list[foo__c1__things_entry]=[]) -> None:
         self.elements = elements
 
@@ -98,9 +97,6 @@ class foo__c1__things(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c1__things(elements=copied_elements)
 
-extension foo__c1__things(Iterable[foo__c1__things_entry]):
-    def __iter__(self) -> Iterator[foo__c1__things_entry]:
-        return self.elements.__iter__()
 
 extension foo__c1__things(Indexed[str, foo__c1__things_entry]):
     def __getitem__(self, k: str) -> foo__c1__things_entry:

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -73,8 +73,7 @@ class bar__c1__li1_entry(yadata.MNode):
         return bar__c1__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class bar__c1__li1(yadata.MNode):
-    elements: list[bar__c1__li1_entry]
+class bar__c1__li1(yadata.MList[bar__c1__li1_entry]):
     mut def __init__(self, elements: list[bar__c1__li1_entry]=[]) -> None:
         self.elements = elements
 
@@ -110,9 +109,6 @@ class bar__c1__li1(yadata.MNode):
                 copied_elements.append(ce)
         return bar__c1__li1(elements=copied_elements)
 
-extension bar__c1__li1(Iterable[bar__c1__li1_entry]):
-    def __iter__(self) -> Iterator[bar__c1__li1_entry]:
-        return self.elements.__iter__()
 
 extension bar__c1__li1(Indexed[str, bar__c1__li1_entry]):
     def __getitem__(self, k: str) -> bar__c1__li1_entry:

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -93,8 +93,7 @@ class main_module__main_container__sub_list_entry(yadata.MNode):
         return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class main_module__main_container__sub_list(yadata.MNode):
-    elements: list[main_module__main_container__sub_list_entry]
+class main_module__main_container__sub_list(yadata.MList[main_module__main_container__sub_list_entry]):
     mut def __init__(self, elements: list[main_module__main_container__sub_list_entry]=[]) -> None:
         self.elements = elements
 
@@ -132,9 +131,6 @@ class main_module__main_container__sub_list(yadata.MNode):
                 copied_elements.append(ce)
         return main_module__main_container__sub_list(elements=copied_elements)
 
-extension main_module__main_container__sub_list(Iterable[main_module__main_container__sub_list_entry]):
-    def __iter__(self) -> Iterator[main_module__main_container__sub_list_entry]:
-        return self.elements.__iter__()
 
 extension main_module__main_container__sub_list(Indexed[str, main_module__main_container__sub_list_entry]):
     def __getitem__(self, k: str) -> main_module__main_container__sub_list_entry:

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -53,8 +53,7 @@ class foo__c1__li1_entry(yadata.MNode):
         return foo__c1__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__li1(yadata.MNode):
-    elements: list[foo__c1__li1_entry]
+class foo__c1__li1(yadata.MList[foo__c1__li1_entry]):
     mut def __init__(self, elements: list[foo__c1__li1_entry]=[]) -> None:
         self.elements = elements
 
@@ -88,9 +87,6 @@ class foo__c1__li1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c1__li1(elements=copied_elements)
 
-extension foo__c1__li1(Iterable[foo__c1__li1_entry]):
-    def __iter__(self) -> Iterator[foo__c1__li1_entry]:
-        return self.elements.__iter__()
 
 extension foo__c1__li1(Indexed[str, foo__c1__li1_entry]):
     def __getitem__(self, k: str) -> foo__c1__li1_entry:

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -83,8 +83,7 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class base_module__network_instances__network_instance(yadata.MNode):
-    elements: list[base_module__network_instances__network_instance_entry]
+class base_module__network_instances__network_instance(yadata.MList[base_module__network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self.elements = elements
 
@@ -120,9 +119,6 @@ class base_module__network_instances__network_instance(yadata.MNode):
                 copied_elements.append(ce)
         return base_module__network_instances__network_instance(elements=copied_elements)
 
-extension base_module__network_instances__network_instance(Iterable[base_module__network_instances__network_instance_entry]):
-    def __iter__(self) -> Iterator[base_module__network_instances__network_instance_entry]:
-        return self.elements.__iter__()
 
 extension base_module__network_instances__network_instance(Indexed[str, base_module__network_instances__network_instance_entry]):
     def __getitem__(self, k: str) -> base_module__network_instances__network_instance_entry:

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -67,8 +67,7 @@ class other_module__other_network_instances__network_instance_entry(yadata.MNode
         return other_module__other_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class other_module__other_network_instances__network_instance(yadata.MNode):
-    elements: list[other_module__other_network_instances__network_instance_entry]
+class other_module__other_network_instances__network_instance(yadata.MList[other_module__other_network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[other_module__other_network_instances__network_instance_entry]=[]) -> None:
         self.elements = elements
 
@@ -102,9 +101,6 @@ class other_module__other_network_instances__network_instance(yadata.MNode):
                 copied_elements.append(ce)
         return other_module__other_network_instances__network_instance(elements=copied_elements)
 
-extension other_module__other_network_instances__network_instance(Iterable[other_module__other_network_instances__network_instance_entry]):
-    def __iter__(self) -> Iterator[other_module__other_network_instances__network_instance_entry]:
-        return self.elements.__iter__()
 
 extension other_module__other_network_instances__network_instance(Indexed[str, other_module__other_network_instances__network_instance_entry]):
     def __getitem__(self, k: str) -> other_module__other_network_instances__network_instance_entry:
@@ -190,8 +186,7 @@ class base_module__base_network_instances__network_instance_entry(yadata.MNode):
         return base_module__base_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker6: None = None
-class base_module__base_network_instances__network_instance(yadata.MNode):
-    elements: list[base_module__base_network_instances__network_instance_entry]
+class base_module__base_network_instances__network_instance(yadata.MList[base_module__base_network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__base_network_instances__network_instance_entry]=[]) -> None:
         self.elements = elements
 
@@ -225,9 +220,6 @@ class base_module__base_network_instances__network_instance(yadata.MNode):
                 copied_elements.append(ce)
         return base_module__base_network_instances__network_instance(elements=copied_elements)
 
-extension base_module__base_network_instances__network_instance(Iterable[base_module__base_network_instances__network_instance_entry]):
-    def __iter__(self) -> Iterator[base_module__base_network_instances__network_instance_entry]:
-        return self.elements.__iter__()
 
 extension base_module__base_network_instances__network_instance(Indexed[str, base_module__base_network_instances__network_instance_entry]):
     def __getitem__(self, k: str) -> base_module__base_network_instances__network_instance_entry:

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -84,8 +84,7 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class base_module__network_instances__network_instance(yadata.MNode):
-    elements: list[base_module__network_instances__network_instance_entry]
+class base_module__network_instances__network_instance(yadata.MList[base_module__network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
         self.elements = elements
 
@@ -119,9 +118,6 @@ class base_module__network_instances__network_instance(yadata.MNode):
                 copied_elements.append(ce)
         return base_module__network_instances__network_instance(elements=copied_elements)
 
-extension base_module__network_instances__network_instance(Iterable[base_module__network_instances__network_instance_entry]):
-    def __iter__(self) -> Iterator[base_module__network_instances__network_instance_entry]:
-        return self.elements.__iter__()
 
 extension base_module__network_instances__network_instance(Indexed[str, base_module__network_instances__network_instance_entry]):
     def __getitem__(self, k: str) -> base_module__network_instances__network_instance_entry:

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -82,8 +82,7 @@ class foo__c__li_entry(yadata.MNode):
         return foo__c__li_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__c__li(yadata.MNode):
-    elements: list[foo__c__li_entry]
+class foo__c__li(yadata.MList[foo__c__li_entry]):
     mut def __init__(self, elements: list[foo__c__li_entry]=[]) -> None:
         self.elements = elements
 
@@ -120,9 +119,6 @@ class foo__c__li(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c__li(elements=copied_elements)
 
-extension foo__c__li(Iterable[foo__c__li_entry]):
-    def __iter__(self) -> Iterator[foo__c__li_entry]:
-        return self.elements.__iter__()
 
 extension foo__c__li(Indexed[str, foo__c__li_entry]):
     def __getitem__(self, k: str) -> foo__c__li_entry:

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -60,8 +60,7 @@ class base__c1__base_l1_entry(yadata.MNode):
         return base__c1__base_l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class base__c1__base_l1(yadata.MNode):
-    elements: list[base__c1__base_l1_entry]
+class base__c1__base_l1(yadata.MList[base__c1__base_l1_entry]):
     mut def __init__(self, elements: list[base__c1__base_l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -96,9 +95,6 @@ class base__c1__base_l1(yadata.MNode):
                 copied_elements.append(ce)
         return base__c1__base_l1(elements=copied_elements)
 
-extension base__c1__base_l1(Iterable[base__c1__base_l1_entry]):
-    def __iter__(self) -> Iterator[base__c1__base_l1_entry]:
-        return self.elements.__iter__()
 
 extension base__c1__base_l1(Indexed[str, base__c1__base_l1_entry]):
     def __getitem__(self, k: str) -> base__c1__base_l1_entry:
@@ -140,8 +136,7 @@ class base__c1__foo_l1_entry(yadata.MNode):
         return base__c1__foo_l1_entry.from_gdata(self.to_gdata())
 
 _breaker4: None = None
-class base__c1__foo_l1(yadata.MNode):
-    elements: list[base__c1__foo_l1_entry]
+class base__c1__foo_l1(yadata.MList[base__c1__foo_l1_entry]):
     mut def __init__(self, elements: list[base__c1__foo_l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -175,9 +170,6 @@ class base__c1__foo_l1(yadata.MNode):
                 copied_elements.append(ce)
         return base__c1__foo_l1(elements=copied_elements)
 
-extension base__c1__foo_l1(Iterable[base__c1__foo_l1_entry]):
-    def __iter__(self) -> Iterator[base__c1__foo_l1_entry]:
-        return self.elements.__iter__()
 
 extension base__c1__foo_l1(Indexed[str, base__c1__foo_l1_entry]):
     def __getitem__(self, k: str) -> base__c1__foo_l1_entry:

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -75,8 +75,7 @@ class foo__c1__l1_entry(yadata.MNode):
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__l1(yadata.MNode):
-    elements: list[foo__c1__l1_entry]
+class foo__c1__l1(yadata.MList[foo__c1__l1_entry]):
     mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -112,9 +111,6 @@ class foo__c1__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c1__l1(elements=copied_elements)
 
-extension foo__c1__l1(Iterable[foo__c1__l1_entry]):
-    def __iter__(self) -> Iterator[foo__c1__l1_entry]:
-        return self.elements.__iter__()
 
 _breaker3: None = None
 class foo__c1(yadata.MNode):

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -51,8 +51,7 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MNode):
-    elements: list[foo__l1_entry]
+class foo__l1(yadata.MList[foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -86,9 +85,6 @@ class foo__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-extension foo__l1(Iterable[foo__l1_entry]):
-    def __iter__(self) -> Iterator[foo__l1_entry]:
-        return self.elements.__iter__()
 
 extension foo__l1(Indexed[str, foo__l1_entry]):
     def __getitem__(self, k: str) -> foo__l1_entry:

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -54,8 +54,7 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MNode):
-    elements: list[foo__l1_entry]
+class foo__l1(yadata.MList[foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -91,9 +90,6 @@ class foo__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-extension foo__l1(Iterable[foo__l1_entry]):
-    def __iter__(self) -> Iterator[foo__l1_entry]:
-        return self.elements.__iter__()
 
 extension foo__l1(Indexed[str, foo__l1_entry]):
     def __getitem__(self, k: str) -> foo__l1_entry:

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -60,8 +60,7 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MNode):
-    elements: list[foo__l1_entry]
+class foo__l1(yadata.MList[foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -99,6 +98,3 @@ class foo__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-extension foo__l1(Iterable[foo__l1_entry]):
-    def __iter__(self) -> Iterator[foo__l1_entry]:
-        return self.elements.__iter__()

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -53,8 +53,7 @@ class foo__li1_entry(yadata.MNode):
         return foo__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__li1(yadata.MNode):
-    elements: list[foo__li1_entry]
+class foo__li1(yadata.MList[foo__li1_entry]):
     mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
         self.elements = elements
 
@@ -88,9 +87,6 @@ class foo__li1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li1(elements=copied_elements)
 
-extension foo__li1(Iterable[foo__li1_entry]):
-    def __iter__(self) -> Iterator[foo__li1_entry]:
-        return self.elements.__iter__()
 
 extension foo__li1(Indexed[str, foo__li1_entry]):
     def __getitem__(self, k: str) -> foo__li1_entry:

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -53,8 +53,7 @@ class foo__li1_entry(yadata.MNode):
         return foo__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__li1(yadata.MNode):
-    elements: list[foo__li1_entry]
+class foo__li1(yadata.MList[foo__li1_entry]):
     mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
         self.elements = elements
 
@@ -88,9 +87,6 @@ class foo__li1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li1(elements=copied_elements)
 
-extension foo__li1(Iterable[foo__li1_entry]):
-    def __iter__(self) -> Iterator[foo__li1_entry]:
-        return self.elements.__iter__()
 
 extension foo__li1(Indexed[str, foo__li1_entry]):
     def __getitem__(self, k: str) -> foo__li1_entry:

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -80,8 +80,7 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__l1(yadata.MNode):
-    elements: list[foo__l1_entry]
+class foo__l1(yadata.MList[foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -117,9 +116,6 @@ class foo__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-extension foo__l1(Iterable[foo__l1_entry]):
-    def __iter__(self) -> Iterator[foo__l1_entry]:
-        return self.elements.__iter__()
 
 extension foo__l1(Indexed[str, foo__l1_entry]):
     def __getitem__(self, k: str) -> foo__l1_entry:

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -54,8 +54,7 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MNode):
-    elements: list[foo__l1_entry]
+class foo__l1(yadata.MList[foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -90,9 +89,6 @@ class foo__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-extension foo__l1(Iterable[foo__l1_entry]):
-    def __iter__(self) -> Iterator[foo__l1_entry]:
-        return self.elements.__iter__()
 
 extension foo__l1(Indexed[str, foo__l1_entry]):
     def __getitem__(self, k: str) -> foo__l1_entry:

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -89,8 +89,7 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__l1(yadata.MNode):
-    elements: list[foo__l1_entry]
+class foo__l1(yadata.MList[foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -124,9 +123,6 @@ class foo__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-extension foo__l1(Iterable[foo__l1_entry]):
-    def __iter__(self) -> Iterator[foo__l1_entry]:
-        return self.elements.__iter__()
 
 extension foo__l1(Indexed[str, foo__l1_entry]):
     def __getitem__(self, k: str) -> foo__l1_entry:

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -62,8 +62,7 @@ class foo__c1__l1_entry(yadata.MNode):
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__l1(yadata.MNode):
-    elements: list[foo__c1__l1_entry]
+class foo__c1__l1(yadata.MList[foo__c1__l1_entry]):
     mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
         self.elements = elements
 
@@ -108,9 +107,6 @@ class foo__c1__l1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c1__l1(elements=copied_elements)
 
-extension foo__c1__l1(Iterable[foo__c1__l1_entry]):
-    def __iter__(self) -> Iterator[foo__c1__l1_entry]:
-        return self.elements.__iter__()
 
 _breaker3: None = None
 class foo__c1(yadata.MNode):

--- a/src/adata.act
+++ b/src/adata.act
@@ -16,6 +16,17 @@ class MNode(object):
         raise NotImplementedError()
 
 
+class MList[T(MNode)](MNode):
+    elements: list[T]
+    mut def __init__(self, elements: list[T]) -> None:
+        self.elements = elements
+
+
+extension MList[T(MNode)](Iterable[T]):
+    def __iter__(self) -> Iterator[T]:
+        return self.elements.__iter__()
+
+
 extension MNode (YangData):
     def take_container(self, schema: yschema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
         maybe_cnt = self.__get_attr__(name)
@@ -25,15 +36,11 @@ extension MNode (YangData):
     def take_list(self, schema: yschema.DList, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> list[(op: ?str, key: dict[str, value], val: value)]:
         new_path = path + [PathElement(schema)]
         maybe_list = self.__get_attr__(name)
-        if isinstance(maybe_list, MNode):
-            elements = maybe_list.__get_attr__("elements")
-            if isinstance(elements, list):
-                # TODO: actonlang/acton#2969 - pin expected type of entries to MNode
-                entries: list[MNode] = elements
-                key_namer = yschema.UniqueNamer(schema)
-                def element_key(entry: MNode) -> dict[str, value]:
-                    return {k: unwrap_key(k, entry.__get_attr__(key_namer.unique_safe_name(k, schema.prefix)), new_path) for k in schema.key}
-                return [(op=None, key=element_key(e), val=e) for e in entries]
+        if isinstance(maybe_list, MList):
+            key_namer = yschema.UniqueNamer(schema)
+            def element_key(entry: MNode) -> dict[str, value]:
+                return {k: unwrap_key(k, entry.__get_attr__(key_namer.unique_safe_name(k, schema.prefix)), new_path) for k in schema.key}
+            return [(op=None, key=element_key(e), val=e) for e in maybe_list]
         return []
 
     def take_leaf(self, root: yschema.DRoot, schema: yschema.DLeaf, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, t: str, val: ?value):

--- a/src/schema.act
+++ b/src/schema.act
@@ -801,8 +801,7 @@ class DNodeInner(DNode):
             # Here we create the list class, list entry class was created above
             breaker_name, breaker_idx = next_breaker_name(breaker_idx)
             res.append("{breaker_name}: None = None")
-            res.append("class {pname()}(yadata.MNode):")
-            res.append("    elements: list[{pname()}_entry]")
+            res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
 
             init_args = ["self"]
             init_args.append("elements: list[{pname()}_entry]=[]")
@@ -923,10 +922,6 @@ class DNodeInner(DNode):
                 res.append("                copied_elements.append(ce)")
                 res.append("        return {pname()}(elements=copied_elements)")
                 res.append("")
-            # Generate Iterable extension for the list class
-            res.append("extension {pname()}(Iterable[{pname()}_entry]):")
-            res.append("    def __iter__(self) -> Iterator[{pname()}_entry]:")
-            res.append("        return self.elements.__iter__()")
 
             # Indexed extension for single-key lists with a non-union key.
             # Composite keys would need a tuple, union keys are typed as Acton

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -277,8 +277,7 @@ class filter_test__interfaces__interface_entry(yadata.MNode):
         return filter_test__interfaces__interface_entry.from_gdata(self.to_gdata())
 
 _breaker7: None = None
-class filter_test__interfaces__interface(yadata.MNode):
-    elements: list[filter_test__interfaces__interface_entry]
+class filter_test__interfaces__interface(yadata.MList[filter_test__interfaces__interface_entry]):
     mut def __init__(self, elements: list[filter_test__interfaces__interface_entry]=[]) -> None:
         self.elements = elements
 
@@ -324,9 +323,6 @@ class filter_test__interfaces__interface(yadata.MNode):
                 copied_elements.append(ce)
         return filter_test__interfaces__interface(elements=copied_elements)
 
-extension filter_test__interfaces__interface(Iterable[filter_test__interfaces__interface_entry]):
-    def __iter__(self) -> Iterator[filter_test__interfaces__interface_entry]:
-        return self.elements.__iter__()
 
 extension filter_test__interfaces__interface(Indexed[str, filter_test__interfaces__interface_entry]):
     def __getitem__(self, k: str) -> filter_test__interfaces__interface_entry:

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -565,8 +565,7 @@ class foo__c1__li_entry(yadata.MNode):
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__c1__li(yadata.MNode):
-    elements: list[foo__c1__li_entry]
+class foo__c1__li(yadata.MList[foo__c1__li_entry]):
     mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
         self.elements = elements
 
@@ -602,9 +601,6 @@ class foo__c1__li(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c1__li(elements=copied_elements)
 
-extension foo__c1__li(Iterable[foo__c1__li_entry]):
-    def __iter__(self) -> Iterator[foo__c1__li_entry]:
-        return self.elements.__iter__()
 
 extension foo__c1__li(Indexed[str, foo__c1__li_entry]):
     def __getitem__(self, k: str) -> foo__c1__li_entry:
@@ -930,8 +926,7 @@ class foo__cc__death_entry(yadata.MNode):
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
 _breaker16: None = None
-class foo__cc__death(yadata.MNode):
-    elements: list[foo__cc__death_entry]
+class foo__cc__death(yadata.MList[foo__cc__death_entry]):
     mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
         self.elements = elements
 
@@ -965,9 +960,6 @@ class foo__cc__death(yadata.MNode):
                 copied_elements.append(ce)
         return foo__cc__death(elements=copied_elements)
 
-extension foo__cc__death(Iterable[foo__cc__death_entry]):
-    def __iter__(self) -> Iterator[foo__cc__death_entry]:
-        return self.elements.__iter__()
 
 extension foo__cc__death(Indexed[str, foo__cc__death_entry]):
     def __getitem__(self, k: str) -> foo__cc__death_entry:
@@ -1121,8 +1113,7 @@ class foo__special_entry(yadata.MNode):
         return foo__special_entry.from_gdata(self.to_gdata())
 
 _breaker22: None = None
-class foo__special(yadata.MNode):
-    elements: list[foo__special_entry]
+class foo__special(yadata.MList[foo__special_entry]):
     mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
         self.elements = elements
 
@@ -1156,9 +1147,6 @@ class foo__special(yadata.MNode):
                 copied_elements.append(ce)
         return foo__special(elements=copied_elements)
 
-extension foo__special(Iterable[foo__special_entry]):
-    def __iter__(self) -> Iterator[foo__special_entry]:
-        return self.elements.__iter__()
 
 extension foo__special(Indexed[bool, foo__special_entry]):
     def __getitem__(self, k: bool) -> foo__special_entry:
@@ -1204,8 +1192,7 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
 _breaker24: None = None
-class foo__nested__f_inner__li1__li2(yadata.MNode):
-    elements: list[foo__nested__f_inner__li1__li2_entry]
+class foo__nested__f_inner__li1__li2(yadata.MList[foo__nested__f_inner__li1__li2_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
         self.elements = elements
 
@@ -1243,9 +1230,6 @@ class foo__nested__f_inner__li1__li2(yadata.MNode):
                 copied_elements.append(ce)
         return foo__nested__f_inner__li1__li2(elements=copied_elements)
 
-extension foo__nested__f_inner__li1__li2(Iterable[foo__nested__f_inner__li1__li2_entry]):
-    def __iter__(self) -> Iterator[foo__nested__f_inner__li1__li2_entry]:
-        return self.elements.__iter__()
 
 _breaker25: None = None
 class foo__nested__f_inner__li1_entry(yadata.MNode):
@@ -1272,8 +1256,7 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
 _breaker26: None = None
-class foo__nested__f_inner__li1(yadata.MNode):
-    elements: list[foo__nested__f_inner__li1_entry]
+class foo__nested__f_inner__li1(yadata.MList[foo__nested__f_inner__li1_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
         self.elements = elements
 
@@ -1311,9 +1294,6 @@ class foo__nested__f_inner__li1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__nested__f_inner__li1(elements=copied_elements)
 
-extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
-    def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
-        return self.elements.__iter__()
 
 extension foo__nested__f_inner__li1(Indexed[str, foo__nested__f_inner__li1_entry]):
     def __getitem__(self, k: str) -> foo__nested__f_inner__li1_entry:
@@ -1428,8 +1408,7 @@ class foo__li_union_entry(yadata.MNode):
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
 _breaker31: None = None
-class foo__li_union(yadata.MNode):
-    elements: list[foo__li_union_entry]
+class foo__li_union(yadata.MList[foo__li_union_entry]):
     mut def __init__(self, elements: list[foo__li_union_entry]=[]) -> None:
         self.elements = elements
 
@@ -1480,9 +1459,6 @@ class foo__li_union(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li_union(elements=copied_elements)
 
-extension foo__li_union(Iterable[foo__li_union_entry]):
-    def __iter__(self) -> Iterator[foo__li_union_entry]:
-        return self.elements.__iter__()
 
 _breaker32: None = None
 class foo__li_union_one_base_entry(yadata.MNode):
@@ -1503,8 +1479,7 @@ class foo__li_union_one_base_entry(yadata.MNode):
         return foo__li_union_one_base_entry.from_gdata(self.to_gdata())
 
 _breaker33: None = None
-class foo__li_union_one_base(yadata.MNode):
-    elements: list[foo__li_union_one_base_entry]
+class foo__li_union_one_base(yadata.MList[foo__li_union_one_base_entry]):
     mut def __init__(self, elements: list[foo__li_union_one_base_entry]=[]) -> None:
         self.elements = elements
 
@@ -1543,9 +1518,6 @@ class foo__li_union_one_base(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li_union_one_base(elements=copied_elements)
 
-extension foo__li_union_one_base(Iterable[foo__li_union_one_base_entry]):
-    def __iter__(self) -> Iterator[foo__li_union_one_base_entry]:
-        return self.elements.__iter__()
 
 _breaker34: None = None
 class foo__state__c1(yadata.MNode):

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -565,8 +565,7 @@ class foo__c1__li_entry(yadata.MNode):
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__c1__li(yadata.MNode):
-    elements: list[foo__c1__li_entry]
+class foo__c1__li(yadata.MList[foo__c1__li_entry]):
     mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
         self.elements = elements
 
@@ -602,9 +601,6 @@ class foo__c1__li(yadata.MNode):
                 copied_elements.append(ce)
         return foo__c1__li(elements=copied_elements)
 
-extension foo__c1__li(Iterable[foo__c1__li_entry]):
-    def __iter__(self) -> Iterator[foo__c1__li_entry]:
-        return self.elements.__iter__()
 
 extension foo__c1__li(Indexed[str, foo__c1__li_entry]):
     def __getitem__(self, k: str) -> foo__c1__li_entry:
@@ -930,8 +926,7 @@ class foo__cc__death_entry(yadata.MNode):
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
 _breaker16: None = None
-class foo__cc__death(yadata.MNode):
-    elements: list[foo__cc__death_entry]
+class foo__cc__death(yadata.MList[foo__cc__death_entry]):
     mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
         self.elements = elements
 
@@ -965,9 +960,6 @@ class foo__cc__death(yadata.MNode):
                 copied_elements.append(ce)
         return foo__cc__death(elements=copied_elements)
 
-extension foo__cc__death(Iterable[foo__cc__death_entry]):
-    def __iter__(self) -> Iterator[foo__cc__death_entry]:
-        return self.elements.__iter__()
 
 extension foo__cc__death(Indexed[str, foo__cc__death_entry]):
     def __getitem__(self, k: str) -> foo__cc__death_entry:
@@ -1121,8 +1113,7 @@ class foo__special_entry(yadata.MNode):
         return foo__special_entry.from_gdata(self.to_gdata())
 
 _breaker22: None = None
-class foo__special(yadata.MNode):
-    elements: list[foo__special_entry]
+class foo__special(yadata.MList[foo__special_entry]):
     mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
         self.elements = elements
 
@@ -1156,9 +1147,6 @@ class foo__special(yadata.MNode):
                 copied_elements.append(ce)
         return foo__special(elements=copied_elements)
 
-extension foo__special(Iterable[foo__special_entry]):
-    def __iter__(self) -> Iterator[foo__special_entry]:
-        return self.elements.__iter__()
 
 extension foo__special(Indexed[bool, foo__special_entry]):
     def __getitem__(self, k: bool) -> foo__special_entry:
@@ -1204,8 +1192,7 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
 _breaker24: None = None
-class foo__nested__f_inner__li1__li2(yadata.MNode):
-    elements: list[foo__nested__f_inner__li1__li2_entry]
+class foo__nested__f_inner__li1__li2(yadata.MList[foo__nested__f_inner__li1__li2_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
         self.elements = elements
 
@@ -1243,9 +1230,6 @@ class foo__nested__f_inner__li1__li2(yadata.MNode):
                 copied_elements.append(ce)
         return foo__nested__f_inner__li1__li2(elements=copied_elements)
 
-extension foo__nested__f_inner__li1__li2(Iterable[foo__nested__f_inner__li1__li2_entry]):
-    def __iter__(self) -> Iterator[foo__nested__f_inner__li1__li2_entry]:
-        return self.elements.__iter__()
 
 _breaker25: None = None
 class foo__nested__f_inner__li1_entry(yadata.MNode):
@@ -1272,8 +1256,7 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
 _breaker26: None = None
-class foo__nested__f_inner__li1(yadata.MNode):
-    elements: list[foo__nested__f_inner__li1_entry]
+class foo__nested__f_inner__li1(yadata.MList[foo__nested__f_inner__li1_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
         self.elements = elements
 
@@ -1311,9 +1294,6 @@ class foo__nested__f_inner__li1(yadata.MNode):
                 copied_elements.append(ce)
         return foo__nested__f_inner__li1(elements=copied_elements)
 
-extension foo__nested__f_inner__li1(Iterable[foo__nested__f_inner__li1_entry]):
-    def __iter__(self) -> Iterator[foo__nested__f_inner__li1_entry]:
-        return self.elements.__iter__()
 
 extension foo__nested__f_inner__li1(Indexed[str, foo__nested__f_inner__li1_entry]):
     def __getitem__(self, k: str) -> foo__nested__f_inner__li1_entry:
@@ -1428,8 +1408,7 @@ class foo__li_union_entry(yadata.MNode):
         return foo__li_union_entry.from_gdata(self.to_gdata())
 
 _breaker31: None = None
-class foo__li_union(yadata.MNode):
-    elements: list[foo__li_union_entry]
+class foo__li_union(yadata.MList[foo__li_union_entry]):
     mut def __init__(self, elements: list[foo__li_union_entry]=[]) -> None:
         self.elements = elements
 
@@ -1480,9 +1459,6 @@ class foo__li_union(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li_union(elements=copied_elements)
 
-extension foo__li_union(Iterable[foo__li_union_entry]):
-    def __iter__(self) -> Iterator[foo__li_union_entry]:
-        return self.elements.__iter__()
 
 _breaker32: None = None
 class foo__li_union_one_base_entry(yadata.MNode):
@@ -1503,8 +1479,7 @@ class foo__li_union_one_base_entry(yadata.MNode):
         return foo__li_union_one_base_entry.from_gdata(self.to_gdata())
 
 _breaker33: None = None
-class foo__li_union_one_base(yadata.MNode):
-    elements: list[foo__li_union_one_base_entry]
+class foo__li_union_one_base(yadata.MList[foo__li_union_one_base_entry]):
     mut def __init__(self, elements: list[foo__li_union_one_base_entry]=[]) -> None:
         self.elements = elements
 
@@ -1543,9 +1518,6 @@ class foo__li_union_one_base(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li_union_one_base(elements=copied_elements)
 
-extension foo__li_union_one_base(Iterable[foo__li_union_one_base_entry]):
-    def __iter__(self) -> Iterator[foo__li_union_one_base_entry]:
-        return self.elements.__iter__()
 
 _breaker34: None = None
 class foo__state__c1(yadata.MNode):

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -183,8 +183,7 @@ class foo__li_entry(yadata.MNode):
         return foo__li_entry.from_gdata(self.to_gdata())
 
 _breaker4: None = None
-class foo__li(yadata.MNode):
-    elements: list[foo__li_entry]
+class foo__li(yadata.MList[foo__li_entry]):
     mut def __init__(self, elements: list[foo__li_entry]=[]) -> None:
         self.elements = elements
 
@@ -219,9 +218,6 @@ class foo__li(yadata.MNode):
                 copied_elements.append(ce)
         return foo__li(elements=copied_elements)
 
-extension foo__li(Iterable[foo__li_entry]):
-    def __iter__(self) -> Iterator[foo__li_entry]:
-        return self.elements.__iter__()
 
 extension foo__li(Indexed[str, foo__li_entry]):
     def __getitem__(self, k: str) -> foo__li_entry:

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -49,8 +49,7 @@ class m__cfg__items_entry(yadata.MNode):
         self.val = val
 
 _breaker3: None = None
-class m__cfg__items(yadata.MNode):
-    elements: list[m__cfg__items_entry]
+class m__cfg__items(yadata.MList[m__cfg__items_entry]):
     mut def __init__(self, elements: list[m__cfg__items_entry]=[]) -> None:
         self.elements = elements
 
@@ -70,9 +69,6 @@ class m__cfg__items(yadata.MNode):
         self.elements.append(res)
         return res
 
-extension m__cfg__items(Iterable[m__cfg__items_entry]):
-    def __iter__(self) -> Iterator[m__cfg__items_entry]:
-        return self.elements.__iter__()
 
 extension m__cfg__items(Indexed[str, m__cfg__items_entry]):
     def __getitem__(self, k: str) -> m__cfg__items_entry:


### PR DESCRIPTION
Uplift the `elements` attribute to `adata.MList` type, which then allows us to implement the `Iterable[T]` (where T is MNode) extension once, instead of generating the extension implementation for individual list types.