### PR TITLE
Use generic MKeyedList with tuple keys for adata lists

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -807,16 +807,6 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list class, list entry class was created above
-            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
-            res.append("{breaker_name}: None = None")
-            res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
-
-            init_args = ["self"]
-            init_args.append("elements: list[{pname()}_entry]=[]")
-            init_args_str: str = ", ".join(init_args)
-            res.append("    mut def __init__({init_args_str}) -> None:")
-            res.append("        self.elements = elements")
-            res.append("")
 
             # list_args_req contains the list keys names and also any
             # non-optional children. We use unique safe names for both to avoid conflicts.
@@ -848,11 +838,47 @@ class DNodeInner(DNode):
                         list_args_req.append(arg)
                         list_args_req_sig.append("{arg}: {pname(child)}")
 
-            # .get() returns the entry matching all key values, or None
-            if len(list_key_args) > 0:
-                # Keys come first in list_args_req(_sig)
-                get_args_sig = ", ".join(["self"] + list_args_req_sig[:len(list_key_args)])
-                res.append("    pure def get({get_args_sig}) -> ?{pname()}_entry:")
+            # Lists whose key leaves all map to concrete Acton types (not value,
+            # concrete types/tuples where Eq is (automatically) implemented)
+            # subclass MKeyedList[K, T], where K is the Acton type for the key
+            # (scalar value or tuple) and T is the adata entry type.
+            # If any of the keys maps to Acton value type, we must use MList[T]
+            # and generate the .get() method here, and also lose out on Indexed[K, T] protocol.
+            key_acton_types = [yang_type_to_acton_type(list_key_types[k]) for k in list_key_args]
+            key_impl_eq = len(list_key_args) > 0 and "value" not in key_acton_types
+
+            single_key = len(list_key_args) == 1
+            def as_tuple(parts: list[str]) -> str:
+                return "({", ".join(parts)})"
+
+            # Destructure a named tuple (or scalar) into local vars:
+            # `name = <target>` for a single key, or `(name=name, id=id) = <target>` for a compount key
+            def unpack_key(target):
+                lhs = list_key_args[0] if single_key else as_tuple(["{k}={k}" for k in list_key_args])
+                return "{lhs} = {target}"
+
+            # bare `str` for a single key, named tuple `(name: str, id: str)` for a compound key
+            key_type = key_acton_types[0] if single_key else as_tuple(["{list_key_args[i]}: {key_acton_types[i]}" for i in range(len(list_key_args))])
+
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name}: None = None")
+            if key_impl_eq:
+                key_expr = "e.{list_key_args[0]}" if single_key else as_tuple(["e.{k}" for k in list_key_args])
+                res.append("class {pname()}(yadata.MKeyedList[{key_type}, {pname()}_entry]):")
+                res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")
+                res.append("        yadata.MKeyedList.__init__(self, lambda e: {key_expr}, elements)")
+            else:
+                res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
+                res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")
+                res.append("        self.elements = elements")
+            res.append("")
+
+            # .get(key) returns the entry matching the key, or None. We generate
+            # it here for lists where one of the keys maps to Acton value type.
+            if len(list_key_args) > 0 and not key_impl_eq:
+                res.append("    pure def get(self, key: {key_type}) -> ?{pname()}_entry:")
+                # Bind scalar key to name or destructure the named tuple
+                res.append("        {unpack_key('key')}")
                 res.append("        for e in self:")
                 for us_key in list_key_args:
                     key_dtype = list_key_types[us_key]
@@ -885,11 +911,21 @@ class DNodeInner(DNode):
             # create() finds an existing entry by key via .get() (when the
             # list has keys), updates its non-key args, and returns it.
             # Otherwise it appends a fresh entry.
-            list_args_str = ", ".join(["self"] + list_args_req_sig + list_args_opt_sig)
+            non_key_arg_names = list_args_req + list_args_opt
+            # Disambiguate the "key" parameter name in case there is another
+            # parameter with the same name.
+            key_param = "key"
+            while key_param in non_key_arg_names:
+                key_param = key_param + "_"
+            create_sig = ["self"]
+            if len(list_key_args) > 0:
+                create_sig.append("{key_param}: {key_type}")
+            create_sig.extend(list_args_req_sig[len(list_key_args):])
+            create_sig.extend(list_args_opt_sig)
+            list_args_str = ", ".join(create_sig)
             res.append("    mut def create({list_args_str}) -> {pname()}_entry:")
             if len(list_key_args) > 0:
-                key_call_args = ", ".join(list_args_req[:len(list_key_args)])
-                res.append("        e = self.get({key_call_args})")
+                res.append("        e = self.get({key_param})")
                 res.append("        if e is not None:")
                 for req_arg in list_args_req[len(list_key_args):]:
                     res.append("            e.{req_arg} = {req_arg}")
@@ -897,6 +933,8 @@ class DNodeInner(DNode):
                     res.append("            if {opt_arg} is not None:")
                     res.append("                e.{opt_arg} = {opt_arg}")
                 res.append("            return e")
+                # Bind scalar key to name or destructure the named tuple
+                res.append("        {unpack_key(key_param)}")
             list_params_str = ", ".join(["{arg}={arg}" for arg in list_args_req + list_args_opt])
             res.append("        res = {pname()}_entry({list_params_str})")
             res.append("        self.elements.append(res)")
@@ -931,35 +969,6 @@ class DNodeInner(DNode):
                 res.append("        return {pname()}(elements=copied_elements)")
                 res.append("")
 
-            # Indexed extension for single-key lists with a non-union key.
-            # Composite keys would need a tuple, union keys are typed as Acton
-            # value; neither can implement Eq
-            if len(list_key_args) == 1:
-                us_key = list_key_args[0]
-                key_dtype = list_key_types[us_key]
-                if not isinstance(key_dtype, DTypeUnion):
-                    key_acton_type = yang_type_to_acton_type(key_dtype)
-                    res.append("")
-                    res.append("extension {pname()}(Indexed[{key_acton_type}, {pname()}_entry]):")
-                    res.append("    def __getitem__(self, k: {key_acton_type}) -> {pname()}_entry:")
-                    res.append("        e = self.get(k)")
-                    res.append("        if e is not None:")
-                    res.append("            return e")
-                    res.append("        raise KeyError(k)")
-                    res.append("")
-                    res.append("    mut def __setitem__(self, k: {key_acton_type}, n: {pname()}_entry) -> None:")
-                    res.append("        for i, e in enumerate(self.elements):")
-                    res.append("            if e.{us_key} == k:")
-                    res.append("                self.elements[i] = n")
-                    res.append("                return")
-                    res.append("        self.elements.append(n)")
-                    res.append("")
-                    res.append("    mut def __delitem__(self, k: {key_acton_type}) -> None:")
-                    res.append("        for i, e in enumerate(self.elements):")
-                    res.append("            if e.{us_key} == k:")
-                    res.append("                del self.elements[i]")
-                    res.append("                return")
-                    res.append("        raise KeyError(k)")
         res.append("")
 
 

--- a/snapshots/expected/data/pradata
+++ b/snapshots/expected/data/pradata
@@ -11,10 +11,10 @@ ad.c1.decimal = Decimal(bigint("314"), bigint("-2"))
 c2 = ad.c1.create_c2('required value', l1='inner value')
 
 # List /c1/li1 element: item1,1
-li1_element = ad.c1.li1.create('item1', 1, value=100)
+li1_element = ad.c1.li1.create((name='item1', extra_key=1), value=100)
 
 # List /c1/li1 element: item2,2
-li1_element = ad.c1.li1.create('item2', 2, value=200)
+li1_element = ad.c1.li1.create((name='item2', extra_key=2), value=200)
 
 # Container: /c1/li1[name='item2',extra-key='2']/c3
 li1_element.c3.nested_leaf = 'birb'

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -61,22 +61,17 @@ class foo__c1__things_entry(yadata.MNode):
         return foo__c1__things_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__things(yadata.MList[foo__c1__things_entry]):
+class foo__c1__things(yadata.MKeyedList[str, foo__c1__things_entry]):
     mut def __init__(self, elements: list[foo__c1__things_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__c1__things_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, id: ?str=None) -> foo__c1__things_entry:
-        e = self.get(name)
+    mut def create(self, key: str, id: ?str=None) -> foo__c1__things_entry:
+        e = self.get(key)
         if e is not None:
             if id is not None:
                 e.id = id
             return e
+        name = key
         res = foo__c1__things_entry(name=name, id=id)
         self.elements.append(res)
         return res
@@ -97,27 +92,6 @@ class foo__c1__things(yadata.MList[foo__c1__things_entry]):
                 copied_elements.append(ce)
         return foo__c1__things(elements=copied_elements)
 
-
-extension foo__c1__things(Indexed[str, foo__c1__things_entry]):
-    def __getitem__(self, k: str) -> foo__c1__things_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__c1__things_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker3: None = None
 class foo__c1(yadata.MNode):

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -73,22 +73,17 @@ class bar__c1__li1_entry(yadata.MNode):
         return bar__c1__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class bar__c1__li1(yadata.MList[bar__c1__li1_entry]):
+class bar__c1__li1(yadata.MKeyedList[str, bar__c1__li1_entry]):
     mut def __init__(self, elements: list[bar__c1__li1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
 
-    pure def get(self, l1: str) -> ?bar__c1__li1_entry:
-        for e in self:
-            if e.l1 != l1:
-                continue
-            return e
-
-    mut def create(self, l1: str, l2: ?Identityref=None) -> bar__c1__li1_entry:
-        e = self.get(l1)
+    mut def create(self, key: str, l2: ?Identityref=None) -> bar__c1__li1_entry:
+        e = self.get(key)
         if e is not None:
             if l2 is not None:
                 e.l2 = l2
             return e
+        l1 = key
         res = bar__c1__li1_entry(l1=l1, l2=l2)
         self.elements.append(res)
         return res
@@ -109,27 +104,6 @@ class bar__c1__li1(yadata.MList[bar__c1__li1_entry]):
                 copied_elements.append(ce)
         return bar__c1__li1(elements=copied_elements)
 
-
-extension bar__c1__li1(Indexed[str, bar__c1__li1_entry]):
-    def __getitem__(self, k: str) -> bar__c1__li1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: bar__c1__li1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker3: None = None
 class bar__c1(yadata.MNode):

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -93,24 +93,19 @@ class main_module__main_container__sub_list_entry(yadata.MNode):
         return main_module__main_container__sub_list_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class main_module__main_container__sub_list(yadata.MList[main_module__main_container__sub_list_entry]):
+class main_module__main_container__sub_list(yadata.MKeyedList[str, main_module__main_container__sub_list_entry]):
     mut def __init__(self, elements: list[main_module__main_container__sub_list_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?main_module__main_container__sub_list_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, sub_value: ?str=None, ref_to_main: ?str=None) -> main_module__main_container__sub_list_entry:
-        e = self.get(name)
+    mut def create(self, key: str, sub_value: ?str=None, ref_to_main: ?str=None) -> main_module__main_container__sub_list_entry:
+        e = self.get(key)
         if e is not None:
             if sub_value is not None:
                 e.sub_value = sub_value
             if ref_to_main is not None:
                 e.ref_to_main = ref_to_main
             return e
+        name = key
         res = main_module__main_container__sub_list_entry(name=name, sub_value=sub_value, ref_to_main=ref_to_main)
         self.elements.append(res)
         return res
@@ -131,27 +126,6 @@ class main_module__main_container__sub_list(yadata.MList[main_module__main_conta
                 copied_elements.append(ce)
         return main_module__main_container__sub_list(elements=copied_elements)
 
-
-extension main_module__main_container__sub_list(Indexed[str, main_module__main_container__sub_list_entry]):
-    def __getitem__(self, k: str) -> main_module__main_container__sub_list_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: main_module__main_container__sub_list_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class main_module__main_container__group_container(yadata.MNode):

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -53,20 +53,15 @@ class foo__c1__li1_entry(yadata.MNode):
         return foo__c1__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__li1(yadata.MList[foo__c1__li1_entry]):
+class foo__c1__li1(yadata.MKeyedList[str, foo__c1__li1_entry]):
     mut def __init__(self, elements: list[foo__c1__li1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
 
-    pure def get(self, l1: str) -> ?foo__c1__li1_entry:
-        for e in self:
-            if e.l1 != l1:
-                continue
-            return e
-
-    mut def create(self, l1: str) -> foo__c1__li1_entry:
-        e = self.get(l1)
+    mut def create(self, key: str) -> foo__c1__li1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        l1 = key
         res = foo__c1__li1_entry(l1=l1)
         self.elements.append(res)
         return res
@@ -87,27 +82,6 @@ class foo__c1__li1(yadata.MList[foo__c1__li1_entry]):
                 copied_elements.append(ce)
         return foo__c1__li1(elements=copied_elements)
 
-
-extension foo__c1__li1(Indexed[str, foo__c1__li1_entry]):
-    def __getitem__(self, k: str) -> foo__c1__li1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__c1__li1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker3: None = None
 class foo__c1(yadata.MNode):

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -83,22 +83,17 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class base_module__network_instances__network_instance(yadata.MList[base_module__network_instances__network_instance_entry]):
+class base_module__network_instances__network_instance(yadata.MKeyedList[str, base_module__network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?base_module__network_instances__network_instance_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, ref: ?str=None) -> base_module__network_instances__network_instance_entry:
-        e = self.get(name)
+    mut def create(self, key: str, ref: ?str=None) -> base_module__network_instances__network_instance_entry:
+        e = self.get(key)
         if e is not None:
             if ref is not None:
                 e.ref = ref
             return e
+        name = key
         res = base_module__network_instances__network_instance_entry(name=name, ref=ref)
         self.elements.append(res)
         return res
@@ -119,27 +114,6 @@ class base_module__network_instances__network_instance(yadata.MList[base_module_
                 copied_elements.append(ce)
         return base_module__network_instances__network_instance(elements=copied_elements)
 
-
-extension base_module__network_instances__network_instance(Indexed[str, base_module__network_instances__network_instance_entry]):
-    def __getitem__(self, k: str) -> base_module__network_instances__network_instance_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: base_module__network_instances__network_instance_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class base_module__network_instances(yadata.MNode):

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -67,20 +67,15 @@ class other_module__other_network_instances__network_instance_entry(yadata.MNode
         return other_module__other_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class other_module__other_network_instances__network_instance(yadata.MList[other_module__other_network_instances__network_instance_entry]):
+class other_module__other_network_instances__network_instance(yadata.MKeyedList[str, other_module__other_network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[other_module__other_network_instances__network_instance_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?other_module__other_network_instances__network_instance_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> other_module__other_network_instances__network_instance_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> other_module__other_network_instances__network_instance_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = other_module__other_network_instances__network_instance_entry(name=name)
         self.elements.append(res)
         return res
@@ -101,27 +96,6 @@ class other_module__other_network_instances__network_instance(yadata.MList[other
                 copied_elements.append(ce)
         return other_module__other_network_instances__network_instance(elements=copied_elements)
 
-
-extension other_module__other_network_instances__network_instance(Indexed[str, other_module__other_network_instances__network_instance_entry]):
-    def __getitem__(self, k: str) -> other_module__other_network_instances__network_instance_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: other_module__other_network_instances__network_instance_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker3: None = None
 class other_module__other_network_instances(yadata.MNode):
@@ -186,20 +160,15 @@ class base_module__base_network_instances__network_instance_entry(yadata.MNode):
         return base_module__base_network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker6: None = None
-class base_module__base_network_instances__network_instance(yadata.MList[base_module__base_network_instances__network_instance_entry]):
+class base_module__base_network_instances__network_instance(yadata.MKeyedList[str, base_module__base_network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__base_network_instances__network_instance_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?base_module__base_network_instances__network_instance_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> base_module__base_network_instances__network_instance_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> base_module__base_network_instances__network_instance_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = base_module__base_network_instances__network_instance_entry(name=name)
         self.elements.append(res)
         return res
@@ -220,27 +189,6 @@ class base_module__base_network_instances__network_instance(yadata.MList[base_mo
                 copied_elements.append(ce)
         return base_module__base_network_instances__network_instance(elements=copied_elements)
 
-
-extension base_module__base_network_instances__network_instance(Indexed[str, base_module__base_network_instances__network_instance_entry]):
-    def __getitem__(self, k: str) -> base_module__base_network_instances__network_instance_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: base_module__base_network_instances__network_instance_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker7: None = None
 class base_module__base_network_instances(yadata.MNode):

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -84,20 +84,15 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
         return base_module__network_instances__network_instance_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class base_module__network_instances__network_instance(yadata.MList[base_module__network_instances__network_instance_entry]):
+class base_module__network_instances__network_instance(yadata.MKeyedList[str, base_module__network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?base_module__network_instances__network_instance_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> base_module__network_instances__network_instance_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> base_module__network_instances__network_instance_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = base_module__network_instances__network_instance_entry(name=name)
         self.elements.append(res)
         return res
@@ -118,27 +113,6 @@ class base_module__network_instances__network_instance(yadata.MList[base_module_
                 copied_elements.append(ce)
         return base_module__network_instances__network_instance(elements=copied_elements)
 
-
-extension base_module__network_instances__network_instance(Indexed[str, base_module__network_instances__network_instance_entry]):
-    def __getitem__(self, k: str) -> base_module__network_instances__network_instance_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: base_module__network_instances__network_instance_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class base_module__network_instances(yadata.MNode):

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -82,23 +82,18 @@ class foo__c__li_entry(yadata.MNode):
         return foo__c__li_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__c__li(yadata.MList[foo__c__li_entry]):
+class foo__c__li(yadata.MKeyedList[str, foo__c__li_entry]):
     mut def __init__(self, elements: list[foo__c__li_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__c__li_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, bar: foo__c__li__bar, foo: ?str=None) -> foo__c__li_entry:
-        e = self.get(name)
+    mut def create(self, key: str, bar: foo__c__li__bar, foo: ?str=None) -> foo__c__li_entry:
+        e = self.get(key)
         if e is not None:
             e.bar = bar
             if foo is not None:
                 e.foo = foo
             return e
+        name = key
         res = foo__c__li_entry(name=name, bar=bar, foo=foo)
         self.elements.append(res)
         return res
@@ -119,24 +114,3 @@ class foo__c__li(yadata.MList[foo__c__li_entry]):
                 copied_elements.append(ce)
         return foo__c__li(elements=copied_elements)
 
-
-extension foo__c__li(Indexed[str, foo__c__li_entry]):
-    def __getitem__(self, k: str) -> foo__c__li_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__c__li_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -60,21 +60,16 @@ class base__c1__base_l1_entry(yadata.MNode):
         return base__c1__base_l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class base__c1__base_l1(yadata.MList[base__c1__base_l1_entry]):
+class base__c1__base_l1(yadata.MKeyedList[str, base__c1__base_l1_entry]):
     mut def __init__(self, elements: list[base__c1__base_l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.base_k1, elements)
 
-    pure def get(self, base_k1: str) -> ?base__c1__base_l1_entry:
-        for e in self:
-            if e.base_k1 != base_k1:
-                continue
-            return e
-
-    mut def create(self, base_k1: str, foo_k1: str) -> base__c1__base_l1_entry:
-        e = self.get(base_k1)
+    mut def create(self, key: str, foo_k1: str) -> base__c1__base_l1_entry:
+        e = self.get(key)
         if e is not None:
             e.foo_k1 = foo_k1
             return e
+        base_k1 = key
         res = base__c1__base_l1_entry(base_k1=base_k1, foo_k1=foo_k1)
         self.elements.append(res)
         return res
@@ -96,27 +91,6 @@ class base__c1__base_l1(yadata.MList[base__c1__base_l1_entry]):
         return base__c1__base_l1(elements=copied_elements)
 
 
-extension base__c1__base_l1(Indexed[str, base__c1__base_l1_entry]):
-    def __getitem__(self, k: str) -> base__c1__base_l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: base__c1__base_l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.base_k1 == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.base_k1 == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
-
 _breaker3: None = None
 class base__c1__foo_l1_entry(yadata.MNode):
     k2: str
@@ -136,20 +110,15 @@ class base__c1__foo_l1_entry(yadata.MNode):
         return base__c1__foo_l1_entry.from_gdata(self.to_gdata())
 
 _breaker4: None = None
-class base__c1__foo_l1(yadata.MList[base__c1__foo_l1_entry]):
+class base__c1__foo_l1(yadata.MKeyedList[str, base__c1__foo_l1_entry]):
     mut def __init__(self, elements: list[base__c1__foo_l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.k2, elements)
 
-    pure def get(self, k2: str) -> ?base__c1__foo_l1_entry:
-        for e in self:
-            if e.k2 != k2:
-                continue
-            return e
-
-    mut def create(self, k2: str) -> base__c1__foo_l1_entry:
-        e = self.get(k2)
+    mut def create(self, key: str) -> base__c1__foo_l1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        k2 = key
         res = base__c1__foo_l1_entry(k2=k2)
         self.elements.append(res)
         return res
@@ -170,27 +139,6 @@ class base__c1__foo_l1(yadata.MList[base__c1__foo_l1_entry]):
                 copied_elements.append(ce)
         return base__c1__foo_l1(elements=copied_elements)
 
-
-extension base__c1__foo_l1(Indexed[str, base__c1__foo_l1_entry]):
-    def __getitem__(self, k: str) -> base__c1__foo_l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: base__c1__foo_l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.k2 == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.k2 == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker5: None = None
 class base__c1(yadata.MNode):

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -75,22 +75,15 @@ class foo__c1__l1_entry(yadata.MNode):
         return foo__c1__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__c1__l1(yadata.MList[foo__c1__l1_entry]):
+class foo__c1__l1(yadata.MKeyedList[(k1: str, k2: Identityref), foo__c1__l1_entry]):
     mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: (e.k1, e.k2), elements)
 
-    pure def get(self, k1: str, k2: Identityref) -> ?foo__c1__l1_entry:
-        for e in self:
-            if e.k1 != k1:
-                continue
-            if e.k2 != k2:
-                continue
-            return e
-
-    mut def create(self, k1: str, k2: Identityref) -> foo__c1__l1_entry:
-        e = self.get(k1, k2)
+    mut def create(self, key: (k1: str, k2: Identityref)) -> foo__c1__l1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        (k1=k1, k2=k2) = key
         res = foo__c1__l1_entry(k1=k1, k2=k2)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -51,20 +51,15 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MList[foo__l1_entry]):
+class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__l1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> foo__l1_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> foo__l1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = foo__l1_entry(name=name)
         self.elements.append(res)
         return res
@@ -85,24 +80,3 @@ class foo__l1(yadata.MList[foo__l1_entry]):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-
-extension foo__l1(Indexed[str, foo__l1_entry]):
-    def __getitem__(self, k: str) -> foo__l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -54,22 +54,17 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MList[foo__l1_entry]):
+class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__l1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
-        e = self.get(name)
+    mut def create(self, key: str, id: ?str=None) -> foo__l1_entry:
+        e = self.get(key)
         if e is not None:
             if id is not None:
                 e.id = id
             return e
+        name = key
         res = foo__l1_entry(name=name, id=id)
         self.elements.append(res)
         return res
@@ -90,24 +85,3 @@ class foo__l1(yadata.MList[foo__l1_entry]):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-
-extension foo__l1(Indexed[str, foo__l1_entry]):
-    def __getitem__(self, k: str) -> foo__l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -60,24 +60,17 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MList[foo__l1_entry]):
+class foo__l1(yadata.MKeyedList[(name: str, id: str), foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: (e.name, e.id), elements)
 
-    pure def get(self, name: str, id: str) -> ?foo__l1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            if e.id != id:
-                continue
-            return e
-
-    mut def create(self, name: str, id: str, other: ?str=None) -> foo__l1_entry:
-        e = self.get(name, id)
+    mut def create(self, key: (name: str, id: str), other: ?str=None) -> foo__l1_entry:
+        e = self.get(key)
         if e is not None:
             if other is not None:
                 e.other = other
             return e
+        (name=name, id=id) = key
         res = foo__l1_entry(name=name, id=id, other=other)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -53,20 +53,15 @@ class foo__li1_entry(yadata.MNode):
         return foo__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__li1(yadata.MList[foo__li1_entry]):
+class foo__li1(yadata.MKeyedList[str, foo__li1_entry]):
     mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
 
-    pure def get(self, l1: str) -> ?foo__li1_entry:
-        for e in self:
-            if e.l1 != l1:
-                continue
-            return e
-
-    mut def create(self, l1: str) -> foo__li1_entry:
-        e = self.get(l1)
+    mut def create(self, key: str) -> foo__li1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        l1 = key
         res = foo__li1_entry(l1=l1)
         self.elements.append(res)
         return res
@@ -87,27 +82,6 @@ class foo__li1(yadata.MList[foo__li1_entry]):
                 copied_elements.append(ce)
         return foo__li1(elements=copied_elements)
 
-
-extension foo__li1(Indexed[str, foo__li1_entry]):
-    def __getitem__(self, k: str) -> foo__li1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__li1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker3: None = None
 class root(yadata.MNode):

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -53,20 +53,15 @@ class foo__li1_entry(yadata.MNode):
         return foo__li1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__li1(yadata.MList[foo__li1_entry]):
+class foo__li1(yadata.MKeyedList[str, foo__li1_entry]):
     mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
 
-    pure def get(self, l1: str) -> ?foo__li1_entry:
-        for e in self:
-            if e.l1 != l1:
-                continue
-            return e
-
-    mut def create(self, l1: str) -> foo__li1_entry:
-        e = self.get(l1)
+    mut def create(self, key: str) -> foo__li1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        l1 = key
         res = foo__li1_entry(l1=l1)
         self.elements.append(res)
         return res
@@ -87,27 +82,6 @@ class foo__li1(yadata.MList[foo__li1_entry]):
                 copied_elements.append(ce)
         return foo__li1(elements=copied_elements)
 
-
-extension foo__li1(Indexed[str, foo__li1_entry]):
-    def __getitem__(self, k: str) -> foo__li1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__li1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.l1 == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker3: None = None
 class root(yadata.MNode):

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -80,22 +80,17 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__l1(yadata.MList[foo__l1_entry]):
+class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__l1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, id: ?str=None) -> foo__l1_entry:
-        e = self.get(name)
+    mut def create(self, key: str, id: ?str=None) -> foo__l1_entry:
+        e = self.get(key)
         if e is not None:
             if id is not None:
                 e.id = id
             return e
+        name = key
         res = foo__l1_entry(name=name, id=id)
         self.elements.append(res)
         return res
@@ -116,27 +111,6 @@ class foo__l1(yadata.MList[foo__l1_entry]):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-
-extension foo__l1(Indexed[str, foo__l1_entry]):
-    def __getitem__(self, k: str) -> foo__l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class root(yadata.MNode):

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -54,21 +54,16 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker2: None = None
-class foo__l1(yadata.MList[foo__l1_entry]):
+class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__l1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, id: str) -> foo__l1_entry:
-        e = self.get(name)
+    mut def create(self, key: str, id: str) -> foo__l1_entry:
+        e = self.get(key)
         if e is not None:
             e.id = id
             return e
+        name = key
         res = foo__l1_entry(name=name, id=id)
         self.elements.append(res)
         return res
@@ -89,24 +84,3 @@ class foo__l1(yadata.MList[foo__l1_entry]):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-
-extension foo__l1(Indexed[str, foo__l1_entry]):
-    def __getitem__(self, k: str) -> foo__l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -89,20 +89,15 @@ class foo__l1_entry(yadata.MNode):
         return foo__l1_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__l1(yadata.MList[foo__l1_entry]):
+class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__l1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> foo__l1_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> foo__l1_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = foo__l1_entry(name=name)
         self.elements.append(res)
         return res
@@ -123,24 +118,3 @@ class foo__l1(yadata.MList[foo__l1_entry]):
                 copied_elements.append(ce)
         return foo__l1(elements=copied_elements)
 
-
-extension foo__l1(Indexed[str, foo__l1_entry]):
-    def __getitem__(self, k: str) -> foo__l1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__l1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)

--- a/snapshots/expected/test_yang/prdaclass_union_list_key
+++ b/snapshots/expected/test_yang/prdaclass_union_list_key
@@ -66,7 +66,8 @@ class foo__c1__l1(yadata.MList[foo__c1__l1_entry]):
     mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
         self.elements = elements
 
-    pure def get(self, k1: str, k2: value) -> ?foo__c1__l1_entry:
+    pure def get(self, key: (k1: str, k2: value)) -> ?foo__c1__l1_entry:
+        (k1=k1, k2=k2) = key
         for e in self:
             if e.k1 != k1:
                 continue
@@ -82,11 +83,12 @@ class foo__c1__l1(yadata.MList[foo__c1__l1_entry]):
                 continue
             return e
 
-    mut def create(self, k1: str, k2: value, l1: str) -> foo__c1__l1_entry:
-        e = self.get(k1, k2)
+    mut def create(self, key: (k1: str, k2: value), l1: str) -> foo__c1__l1_entry:
+        e = self.get(key)
         if e is not None:
             e.l1 = l1
             return e
+        (k1=k1, k2=k2) = key
         res = foo__c1__l1_entry(k1=k1, k2=k2, l1=l1)
         self.elements.append(res)
         return res

--- a/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
+++ b/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
@@ -107,22 +107,17 @@ class svc__register__input__servers_entry(yadata.MNode):
         return svc__register__input__servers_entry.from_gdata(self.to_gdata())
 
 _breaker4: None = None
-class svc__register__input__servers(yadata.MList[svc__register__input__servers_entry]):
+class svc__register__input__servers(yadata.MKeyedList[str, svc__register__input__servers_entry]):
     mut def __init__(self, elements: list[svc__register__input__servers_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.id, elements)
 
-    pure def get(self, id: str) -> ?svc__register__input__servers_entry:
-        for e in self:
-            if e.id != id:
-                continue
-            return e
-
-    mut def create(self, id: str, port: ?u64=None) -> svc__register__input__servers_entry:
-        e = self.get(id)
+    mut def create(self, key: str, port: ?u64=None) -> svc__register__input__servers_entry:
+        e = self.get(key)
         if e is not None:
             if port is not None:
                 e.port = port
             return e
+        id = key
         res = svc__register__input__servers_entry(id=id, port=port)
         self.elements.append(res)
         return res
@@ -143,27 +138,6 @@ class svc__register__input__servers(yadata.MList[svc__register__input__servers_e
                 copied_elements.append(ce)
         return svc__register__input__servers(elements=copied_elements)
 
-
-extension svc__register__input__servers(Indexed[str, svc__register__input__servers_entry]):
-    def __getitem__(self, k: str) -> svc__register__input__servers_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: svc__register__input__servers_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.id == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.id == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker5: None = None
 class svc__register__input(yadata.MNode):

--- a/src/adata.act
+++ b/src/adata.act
@@ -27,6 +27,48 @@ extension MList[T(MNode)](Iterable[T]):
         return self.elements.__iter__()
 
 
+class MKeyedList[K(Eq), T(MNode)](MList[T]):
+    """List with (compound) key of Acton type K
+
+    K is the Acton type of the scalar key leaf, or a tuple of the key leaf types
+    for lists with compound keys. In any case, this only matches for key types
+    that are not Acton "value".
+    """
+    @property
+    _key_of: pure(T) -> K
+
+    mut def __init__(self, key_of: pure(T) -> K, elements: list[T]) -> None:
+        MList.__init__(self, elements)
+        self._key_of = key_of
+
+    pure def get(self, key: K) -> ?T:
+        for e in self.elements:
+            if self._key_of(e) == key:
+                return e
+
+
+extension MKeyedList[K(Eq), T(MNode)](Indexed[K, T]):
+    def __getitem__(self, key: K) -> T:
+        e = self.get(key)
+        if e is not None:
+            return e
+        raise KeyError(key)
+
+    mut def __setitem__(self, key: K, n: T) -> None:
+        for i, e in enumerate(self.elements):
+            if self._key_of(e) == key:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, key: K) -> None:
+        for i, e in enumerate(self.elements):
+            if self._key_of(e) == key:
+                del self.elements[i]
+                return
+        raise KeyError(key)
+
+
 extension MNode (YangData):
     def take_container(self, schema: yschema.DContainer, name: str, ns_qualified: bool, path: list[PathElement]=[]) -> ?(op: ?str, val: ?value):
         maybe_cnt = self.__get_attr__(name)

--- a/src/data.act
+++ b/src/data.act
@@ -567,7 +567,15 @@ def _pradata_recursive(s: yschema.DNodeInner, node: ygdata.Node, self_name: str,
 
                     res.extend(list(reversed(non_optional_containers)))
 
-                    create_args_str = ", ".join(non_optional_args + list_opt_leaf_args)
+                    num_keys = len(child.key)
+                    if num_keys > 1:
+                        key_namer = yschema.UniqueNamer(child)
+                        key_pairs = ["{key_namer.unique_safe_name(child.key[i], child.prefix)}={non_optional_args[i]}" for i in range(num_keys)]
+                        key_arg = "({", ".join(key_pairs)})"
+                        create_call_args = [key_arg] + non_optional_args[num_keys:] + list_opt_leaf_args
+                    else:
+                        create_call_args = non_optional_args + list_opt_leaf_args
+                    create_args_str = ", ".join(create_call_args)
                     res.append("{list_element_var} = {self_name}.{usname(child)}.create({create_args_str})")
                     # Recursive call to pradata() for the list element
                     res.extend(_pradata_recursive(child, element, list_element_var, loose, list_element=True, root_path=root_path, spath=path_with_child(element.key_values(fq_list_keys(child))), path_var_names=path_var_names, reserved_names=reserved_names, create_consumed_leaves=list_consumed_leaf_args).splitlines())

--- a/src/schema.act
+++ b/src/schema.act
@@ -803,16 +803,6 @@ class DNodeInner(DNode):
             # - the list itself
             # - the list entry class
             # Here we create the list class, list entry class was created above
-            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
-            res.append("{breaker_name}: None = None")
-            res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
-
-            init_args = ["self"]
-            init_args.append("elements: list[{pname()}_entry]=[]")
-            init_args_str: str = ", ".join(init_args)
-            res.append("    mut def __init__({init_args_str}) -> None:")
-            res.append("        self.elements = elements")
-            res.append("")
 
             # list_args_req contains the list keys names and also any
             # non-optional children. We use unique safe names for both to avoid conflicts.
@@ -844,11 +834,47 @@ class DNodeInner(DNode):
                         list_args_req.append(arg)
                         list_args_req_sig.append("{arg}: {pname(child)}")
 
-            # .get() returns the entry matching all key values, or None
-            if len(list_key_args) > 0:
-                # Keys come first in list_args_req(_sig)
-                get_args_sig = ", ".join(["self"] + list_args_req_sig[:len(list_key_args)])
-                res.append("    pure def get({get_args_sig}) -> ?{pname()}_entry:")
+            # Lists whose key leaves all map to concrete Acton types (not value,
+            # concrete types/tuples where Eq is (automatically) implemented)
+            # subclass MKeyedList[K, T], where K is the Acton type for the key
+            # (scalar value or tuple) and T is the adata entry type.
+            # If any of the keys maps to Acton value type, we must use MList[T]
+            # and generate the .get() method here, and also lose out on Indexed[K, T] protocol.
+            key_acton_types = [yang_type_to_acton_type(list_key_types[k]) for k in list_key_args]
+            key_impl_eq = len(list_key_args) > 0 and "value" not in key_acton_types
+
+            single_key = len(list_key_args) == 1
+            def as_tuple(parts: list[str]) -> str:
+                return "({", ".join(parts)})"
+
+            # Destructure a named tuple (or scalar) into local vars:
+            # `name = <target>` for a single key, or `(name=name, id=id) = <target>` for a compount key
+            def unpack_key(target):
+                lhs = list_key_args[0] if single_key else as_tuple(["{k}={k}" for k in list_key_args])
+                return "{lhs} = {target}"
+
+            # bare `str` for a single key, named tuple `(name: str, id: str)` for a compound key
+            key_type = key_acton_types[0] if single_key else as_tuple(["{list_key_args[i]}: {key_acton_types[i]}" for i in range(len(list_key_args))])
+
+            breaker_name, breaker_idx = next_breaker_name(breaker_idx)
+            res.append("{breaker_name}: None = None")
+            if key_impl_eq:
+                key_expr = "e.{list_key_args[0]}" if single_key else as_tuple(["e.{k}" for k in list_key_args])
+                res.append("class {pname()}(yadata.MKeyedList[{key_type}, {pname()}_entry]):")
+                res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")
+                res.append("        yadata.MKeyedList.__init__(self, lambda e: {key_expr}, elements)")
+            else:
+                res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
+                res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")
+                res.append("        self.elements = elements")
+            res.append("")
+
+            # .get(key) returns the entry matching the key, or None. We generate
+            # it here for lists where one of the keys maps to Acton value type.
+            if len(list_key_args) > 0 and not key_impl_eq:
+                res.append("    pure def get(self, key: {key_type}) -> ?{pname()}_entry:")
+                # Bind scalar key to name or destructure the named tuple
+                res.append("        {unpack_key('key')}")
                 res.append("        for e in self:")
                 for us_key in list_key_args:
                     key_dtype = list_key_types[us_key]
@@ -881,11 +907,21 @@ class DNodeInner(DNode):
             # create() finds an existing entry by key via .get() (when the
             # list has keys), updates its non-key args, and returns it.
             # Otherwise it appends a fresh entry.
-            list_args_str = ", ".join(["self"] + list_args_req_sig + list_args_opt_sig)
+            non_key_arg_names = list_args_req + list_args_opt
+            # Disambiguate the "key" parameter name in case there is another
+            # parameter with the same name.
+            key_param = "key"
+            while key_param in non_key_arg_names:
+                key_param = key_param + "_"
+            create_sig = ["self"]
+            if len(list_key_args) > 0:
+                create_sig.append("{key_param}: {key_type}")
+            create_sig.extend(list_args_req_sig[len(list_key_args):])
+            create_sig.extend(list_args_opt_sig)
+            list_args_str = ", ".join(create_sig)
             res.append("    mut def create({list_args_str}) -> {pname()}_entry:")
             if len(list_key_args) > 0:
-                key_call_args = ", ".join(list_args_req[:len(list_key_args)])
-                res.append("        e = self.get({key_call_args})")
+                res.append("        e = self.get({key_param})")
                 res.append("        if e is not None:")
                 for req_arg in list_args_req[len(list_key_args):]:
                     res.append("            e.{req_arg} = {req_arg}")
@@ -893,6 +929,8 @@ class DNodeInner(DNode):
                     res.append("            if {opt_arg} is not None:")
                     res.append("                e.{opt_arg} = {opt_arg}")
                 res.append("            return e")
+                # Bind scalar key to name or destructure the named tuple
+                res.append("        {unpack_key(key_param)}")
             list_params_str = ", ".join(["{arg}={arg}" for arg in list_args_req + list_args_opt])
             res.append("        res = {pname()}_entry({list_params_str})")
             res.append("        self.elements.append(res)")
@@ -927,35 +965,6 @@ class DNodeInner(DNode):
                 res.append("        return {pname()}(elements=copied_elements)")
                 res.append("")
 
-            # Indexed extension for single-key lists with a non-union key.
-            # Composite keys would need a tuple, union keys are typed as Acton
-            # value; neither can implement Eq
-            if len(list_key_args) == 1:
-                us_key = list_key_args[0]
-                key_dtype = list_key_types[us_key]
-                if not isinstance(key_dtype, DTypeUnion):
-                    key_acton_type = yang_type_to_acton_type(key_dtype)
-                    res.append("")
-                    res.append("extension {pname()}(Indexed[{key_acton_type}, {pname()}_entry]):")
-                    res.append("    def __getitem__(self, k: {key_acton_type}) -> {pname()}_entry:")
-                    res.append("        e = self.get(k)")
-                    res.append("        if e is not None:")
-                    res.append("            return e")
-                    res.append("        raise KeyError(k)")
-                    res.append("")
-                    res.append("    mut def __setitem__(self, k: {key_acton_type}, n: {pname()}_entry) -> None:")
-                    res.append("        for i, e in enumerate(self.elements):")
-                    res.append("            if e.{us_key} == k:")
-                    res.append("                self.elements[i] = n")
-                    res.append("                return")
-                    res.append("        self.elements.append(n)")
-                    res.append("")
-                    res.append("    mut def __delitem__(self, k: {key_acton_type}) -> None:")
-                    res.append("        for i, e in enumerate(self.elements):")
-                    res.append("            if e.{us_key} == k:")
-                    res.append("                del self.elements[i]")
-                    res.append("                return")
-                    res.append("        raise KeyError(k)")
         res.append("")
 
 

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -480,6 +480,22 @@ def _test_list_indexed():
     del r.c1.li["b"]
     testing.assertNone(r.c1.li.get("b"))
 
+def _test_list_multi_key():
+    r = yang_foo_root()
+    li1_e = r.nested.f_inner.li1.create("l1")
+    li1_e.li2.create(("a", "1"), baz="one")
+    li1_e.li2.create(("a", "2"), baz="two")
+
+    found = li1_e.li2.get(("a", "2"))
+    testing.assertNotNone(found)
+    if found is not None:
+        testing.assertEqual(found.baz, "two")
+    testing.assertNone(li1_e.li2.get(("a", "3")))
+
+    testing.assertEqual(li1_e.li2[(key1="a", key2="1")].baz, "one")
+    del li1_e.li2[(key1="a", key2="1")]
+    testing.assertNone(li1_e.li2.get((key1="a", key2="1")))
+
 def _test_list_get_union_key():
     r = yang_foo_root()
     r.li_union_one_base.create("foo")
@@ -498,11 +514,11 @@ def _test_list_get_union_key():
 
 def _test_list_get_compound_key():
     r = yang_foo_root()
-    r.li_union.create("a", u64(1), "hi".encode())
-    r.li_union.create("a", u64(2), "hi".encode())
-    r.li_union.create("b", u64(1), "hi".encode())
+    r.li_union.create(("a", u64(1), "hi".encode()))
+    r.li_union.create(("a", u64(2), "hi".encode()))
+    r.li_union.create(("b", u64(1), "hi".encode()))
 
-    found = r.li_union.get("a", u64(2), "hi".encode())
+    found = r.li_union.get(("a", u64(2), "hi".encode()))
     testing.assertNotNone(found)
     if found is not None:
         testing.assertEqual(found.k1, "a")
@@ -512,7 +528,7 @@ def _test_list_get_compound_key():
         else:
             testing.error("k2 in adata is not u64")
 
-    testing.assertNone(r.li_union.get("z", u64(1), "hi".encode()))
+    testing.assertNone(r.li_union.get(("z", u64(1), "hi".encode())))
 
 def _test_p_container_create_idempotency():
     r = yang_foo_root()

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -277,18 +277,12 @@ class filter_test__interfaces__interface_entry(yadata.MNode):
         return filter_test__interfaces__interface_entry.from_gdata(self.to_gdata())
 
 _breaker7: None = None
-class filter_test__interfaces__interface(yadata.MList[filter_test__interfaces__interface_entry]):
+class filter_test__interfaces__interface(yadata.MKeyedList[str, filter_test__interfaces__interface_entry]):
     mut def __init__(self, elements: list[filter_test__interfaces__interface_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?filter_test__interfaces__interface_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, description: ?str=None, type: ?str=None, enabled: ?bool=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None) -> filter_test__interfaces__interface_entry:
-        e = self.get(name)
+    mut def create(self, key: str, description: ?str=None, type: ?str=None, enabled: ?bool=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None) -> filter_test__interfaces__interface_entry:
+        e = self.get(key)
         if e is not None:
             if description is not None:
                 e.description = description
@@ -303,6 +297,7 @@ class filter_test__interfaces__interface(yadata.MList[filter_test__interfaces__i
             if last_change is not None:
                 e.last_change = last_change
             return e
+        name = key
         res = filter_test__interfaces__interface_entry(name=name, description=description, type=type, enabled=enabled, admin_status=admin_status, oper_status=oper_status, last_change=last_change)
         self.elements.append(res)
         return res
@@ -323,27 +318,6 @@ class filter_test__interfaces__interface(yadata.MList[filter_test__interfaces__i
                 copied_elements.append(ce)
         return filter_test__interfaces__interface(elements=copied_elements)
 
-
-extension filter_test__interfaces__interface(Indexed[str, filter_test__interfaces__interface_entry]):
-    def __getitem__(self, k: str) -> filter_test__interfaces__interface_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: filter_test__interfaces__interface_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker8: None = None
 class filter_test__interfaces(yadata.MNode):

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -613,22 +613,17 @@ class foo__c1__li_entry(yadata.MNode):
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__c1__li(yadata.MList[foo__c1__li_entry]):
+class foo__c1__li(yadata.MKeyedList[str, foo__c1__li_entry]):
     mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__c1__li_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
-        e = self.get(name)
+    mut def create(self, key: str, val: ?str=None) -> foo__c1__li_entry:
+        e = self.get(key)
         if e is not None:
             if val is not None:
                 e.val = val
             return e
+        name = key
         res = foo__c1__li_entry(name=name, val=val)
         self.elements.append(res)
         return res
@@ -649,27 +644,6 @@ class foo__c1__li(yadata.MList[foo__c1__li_entry]):
                 copied_elements.append(ce)
         return foo__c1__li(elements=copied_elements)
 
-
-extension foo__c1__li(Indexed[str, foo__c1__li_entry]):
-    def __getitem__(self, k: str) -> foo__c1__li_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__c1__li_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class foo__c1(yadata.MNode):
@@ -980,20 +954,15 @@ class foo__cc__death_entry(yadata.MNode):
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
 _breaker16: None = None
-class foo__cc__death(yadata.MList[foo__cc__death_entry]):
+class foo__cc__death(yadata.MKeyedList[str, foo__cc__death_entry]):
     mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__cc__death_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> foo__cc__death_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> foo__cc__death_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = foo__cc__death_entry(name=name)
         self.elements.append(res)
         return res
@@ -1014,27 +983,6 @@ class foo__cc__death(yadata.MList[foo__cc__death_entry]):
                 copied_elements.append(ce)
         return foo__cc__death(elements=copied_elements)
 
-
-extension foo__cc__death(Indexed[str, foo__cc__death_entry]):
-    def __getitem__(self, k: str) -> foo__cc__death_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__cc__death_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker17: None = None
 class foo__cc(yadata.MNode):
@@ -1167,20 +1115,15 @@ class foo__special_entry(yadata.MNode):
         return foo__special_entry.from_gdata(self.to_gdata())
 
 _breaker22: None = None
-class foo__special(yadata.MList[foo__special_entry]):
+class foo__special(yadata.MKeyedList[bool, foo__special_entry]):
     mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.yes, elements)
 
-    pure def get(self, yes: bool) -> ?foo__special_entry:
-        for e in self:
-            if e.yes != yes:
-                continue
-            return e
-
-    mut def create(self, yes: bool) -> foo__special_entry:
-        e = self.get(yes)
+    mut def create(self, key: bool) -> foo__special_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        yes = key
         res = foo__special_entry(yes=yes)
         self.elements.append(res)
         return res
@@ -1201,27 +1144,6 @@ class foo__special(yadata.MList[foo__special_entry]):
                 copied_elements.append(ce)
         return foo__special(elements=copied_elements)
 
-
-extension foo__special(Indexed[bool, foo__special_entry]):
-    def __getitem__(self, k: bool) -> foo__special_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: bool, n: foo__special_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.yes == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: bool) -> None:
-        for i, e in enumerate(self.elements):
-            if e.yes == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker23: None = None
 class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
@@ -1246,24 +1168,17 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
 _breaker24: None = None
-class foo__nested__f_inner__li1__li2(yadata.MList[foo__nested__f_inner__li1__li2_entry]):
+class foo__nested__f_inner__li1__li2(yadata.MKeyedList[(key1: str, key2: str), foo__nested__f_inner__li1__li2_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: (e.key1, e.key2), elements)
 
-    pure def get(self, key1: str, key2: str) -> ?foo__nested__f_inner__li1__li2_entry:
-        for e in self:
-            if e.key1 != key1:
-                continue
-            if e.key2 != key2:
-                continue
-            return e
-
-    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
-        e = self.get(key1, key2)
+    mut def create(self, key: (key1: str, key2: str), baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
+        e = self.get(key)
         if e is not None:
             if baz is not None:
                 e.baz = baz
             return e
+        (key1=key1, key2=key2) = key
         res = foo__nested__f_inner__li1__li2_entry(key1=key1, key2=key2, baz=baz)
         self.elements.append(res)
         return res
@@ -1310,24 +1225,19 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
 _breaker26: None = None
-class foo__nested__f_inner__li1(yadata.MList[foo__nested__f_inner__li1_entry]):
+class foo__nested__f_inner__li1(yadata.MKeyedList[str, foo__nested__f_inner__li1_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__nested__f_inner__li1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
-        e = self.get(name)
+    mut def create(self, key: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
+        e = self.get(key)
         if e is not None:
             if f_bar is not None:
                 e.f_bar = f_bar
             if bar_bar is not None:
                 e.bar_bar = bar_bar
             return e
+        name = key
         res = foo__nested__f_inner__li1_entry(name=name, f_bar=f_bar, bar_bar=bar_bar)
         self.elements.append(res)
         return res
@@ -1348,27 +1258,6 @@ class foo__nested__f_inner__li1(yadata.MList[foo__nested__f_inner__li1_entry]):
                 copied_elements.append(ce)
         return foo__nested__f_inner__li1(elements=copied_elements)
 
-
-extension foo__nested__f_inner__li1(Indexed[str, foo__nested__f_inner__li1_entry]):
-    def __getitem__(self, k: str) -> foo__nested__f_inner__li1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__nested__f_inner__li1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker27: None = None
 class foo__nested__f_inner(yadata.MNode):
@@ -1466,7 +1355,8 @@ class foo__li_union(yadata.MList[foo__li_union_entry]):
     mut def __init__(self, elements: list[foo__li_union_entry]=[]) -> None:
         self.elements = elements
 
-    pure def get(self, k1: str, k2: value, k3: bytes) -> ?foo__li_union_entry:
+    pure def get(self, key: (k1: str, k2: value, k3: bytes)) -> ?foo__li_union_entry:
+        (k1=k1, k2=k2, k3=k3) = key
         for e in self:
             if e.k1 != k1:
                 continue
@@ -1487,12 +1377,13 @@ class foo__li_union(yadata.MList[foo__li_union_entry]):
                 continue
             return e
 
-    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
-        e = self.get(k1, k2, k3)
+    mut def create(self, key: (k1: str, k2: value, k3: bytes), checker: ?value=None) -> foo__li_union_entry:
+        e = self.get(key)
         if e is not None:
             if checker is not None:
                 e.checker = checker
             return e
+        (k1=k1, k2=k2, k3=k3) = key
         res = foo__li_union_entry(k1=k1, k2=k2, k3=k3, checker=checker)
         self.elements.append(res)
         return res
@@ -1537,7 +1428,8 @@ class foo__li_union_one_base(yadata.MList[foo__li_union_one_base_entry]):
     mut def __init__(self, elements: list[foo__li_union_one_base_entry]=[]) -> None:
         self.elements = elements
 
-    pure def get(self, k1: value) -> ?foo__li_union_one_base_entry:
+    pure def get(self, key: value) -> ?foo__li_union_one_base_entry:
+        k1 = key
         for e in self:
             e_k1 = e.k1
             k1_match = False
@@ -1548,10 +1440,11 @@ class foo__li_union_one_base(yadata.MList[foo__li_union_one_base_entry]):
                 continue
             return e
 
-    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
-        e = self.get(k1)
+    mut def create(self, key: value) -> foo__li_union_one_base_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        k1 = key
         res = foo__li_union_one_base_entry(k1=k1)
         self.elements.append(res)
         return res

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -613,22 +613,17 @@ class foo__c1__li_entry(yadata.MNode):
         return foo__c1__li_entry.from_gdata(self.to_gdata())
 
 _breaker3: None = None
-class foo__c1__li(yadata.MList[foo__c1__li_entry]):
+class foo__c1__li(yadata.MKeyedList[str, foo__c1__li_entry]):
     mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__c1__li_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, val: ?str=None) -> foo__c1__li_entry:
-        e = self.get(name)
+    mut def create(self, key: str, val: ?str=None) -> foo__c1__li_entry:
+        e = self.get(key)
         if e is not None:
             if val is not None:
                 e.val = val
             return e
+        name = key
         res = foo__c1__li_entry(name=name, val=val)
         self.elements.append(res)
         return res
@@ -649,27 +644,6 @@ class foo__c1__li(yadata.MList[foo__c1__li_entry]):
                 copied_elements.append(ce)
         return foo__c1__li(elements=copied_elements)
 
-
-extension foo__c1__li(Indexed[str, foo__c1__li_entry]):
-    def __getitem__(self, k: str) -> foo__c1__li_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__c1__li_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class foo__c1(yadata.MNode):
@@ -980,20 +954,15 @@ class foo__cc__death_entry(yadata.MNode):
         return foo__cc__death_entry.from_gdata(self.to_gdata())
 
 _breaker16: None = None
-class foo__cc__death(yadata.MList[foo__cc__death_entry]):
+class foo__cc__death(yadata.MKeyedList[str, foo__cc__death_entry]):
     mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__cc__death_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str) -> foo__cc__death_entry:
-        e = self.get(name)
+    mut def create(self, key: str) -> foo__cc__death_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        name = key
         res = foo__cc__death_entry(name=name)
         self.elements.append(res)
         return res
@@ -1014,27 +983,6 @@ class foo__cc__death(yadata.MList[foo__cc__death_entry]):
                 copied_elements.append(ce)
         return foo__cc__death(elements=copied_elements)
 
-
-extension foo__cc__death(Indexed[str, foo__cc__death_entry]):
-    def __getitem__(self, k: str) -> foo__cc__death_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__cc__death_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker17: None = None
 class foo__cc(yadata.MNode):
@@ -1167,20 +1115,15 @@ class foo__special_entry(yadata.MNode):
         return foo__special_entry.from_gdata(self.to_gdata())
 
 _breaker22: None = None
-class foo__special(yadata.MList[foo__special_entry]):
+class foo__special(yadata.MKeyedList[bool, foo__special_entry]):
     mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.yes, elements)
 
-    pure def get(self, yes: bool) -> ?foo__special_entry:
-        for e in self:
-            if e.yes != yes:
-                continue
-            return e
-
-    mut def create(self, yes: bool) -> foo__special_entry:
-        e = self.get(yes)
+    mut def create(self, key: bool) -> foo__special_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        yes = key
         res = foo__special_entry(yes=yes)
         self.elements.append(res)
         return res
@@ -1201,27 +1144,6 @@ class foo__special(yadata.MList[foo__special_entry]):
                 copied_elements.append(ce)
         return foo__special(elements=copied_elements)
 
-
-extension foo__special(Indexed[bool, foo__special_entry]):
-    def __getitem__(self, k: bool) -> foo__special_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: bool, n: foo__special_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.yes == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: bool) -> None:
-        for i, e in enumerate(self.elements):
-            if e.yes == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker23: None = None
 class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
@@ -1246,24 +1168,17 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
         return foo__nested__f_inner__li1__li2_entry.from_gdata(self.to_gdata())
 
 _breaker24: None = None
-class foo__nested__f_inner__li1__li2(yadata.MList[foo__nested__f_inner__li1__li2_entry]):
+class foo__nested__f_inner__li1__li2(yadata.MKeyedList[(key1: str, key2: str), foo__nested__f_inner__li1__li2_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: (e.key1, e.key2), elements)
 
-    pure def get(self, key1: str, key2: str) -> ?foo__nested__f_inner__li1__li2_entry:
-        for e in self:
-            if e.key1 != key1:
-                continue
-            if e.key2 != key2:
-                continue
-            return e
-
-    mut def create(self, key1: str, key2: str, baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
-        e = self.get(key1, key2)
+    mut def create(self, key: (key1: str, key2: str), baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
+        e = self.get(key)
         if e is not None:
             if baz is not None:
                 e.baz = baz
             return e
+        (key1=key1, key2=key2) = key
         res = foo__nested__f_inner__li1__li2_entry(key1=key1, key2=key2, baz=baz)
         self.elements.append(res)
         return res
@@ -1310,24 +1225,19 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
         return foo__nested__f_inner__li1_entry.from_gdata(self.to_gdata())
 
 _breaker26: None = None
-class foo__nested__f_inner__li1(yadata.MList[foo__nested__f_inner__li1_entry]):
+class foo__nested__f_inner__li1(yadata.MKeyedList[str, foo__nested__f_inner__li1_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__nested__f_inner__li1_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
-        e = self.get(name)
+    mut def create(self, key: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
+        e = self.get(key)
         if e is not None:
             if f_bar is not None:
                 e.f_bar = f_bar
             if bar_bar is not None:
                 e.bar_bar = bar_bar
             return e
+        name = key
         res = foo__nested__f_inner__li1_entry(name=name, f_bar=f_bar, bar_bar=bar_bar)
         self.elements.append(res)
         return res
@@ -1348,27 +1258,6 @@ class foo__nested__f_inner__li1(yadata.MList[foo__nested__f_inner__li1_entry]):
                 copied_elements.append(ce)
         return foo__nested__f_inner__li1(elements=copied_elements)
 
-
-extension foo__nested__f_inner__li1(Indexed[str, foo__nested__f_inner__li1_entry]):
-    def __getitem__(self, k: str) -> foo__nested__f_inner__li1_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__nested__f_inner__li1_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker27: None = None
 class foo__nested__f_inner(yadata.MNode):
@@ -1466,7 +1355,8 @@ class foo__li_union(yadata.MList[foo__li_union_entry]):
     mut def __init__(self, elements: list[foo__li_union_entry]=[]) -> None:
         self.elements = elements
 
-    pure def get(self, k1: str, k2: value, k3: bytes) -> ?foo__li_union_entry:
+    pure def get(self, key: (k1: str, k2: value, k3: bytes)) -> ?foo__li_union_entry:
+        (k1=k1, k2=k2, k3=k3) = key
         for e in self:
             if e.k1 != k1:
                 continue
@@ -1487,12 +1377,13 @@ class foo__li_union(yadata.MList[foo__li_union_entry]):
                 continue
             return e
 
-    mut def create(self, k1: str, k2: value, k3: bytes, checker: ?value=None) -> foo__li_union_entry:
-        e = self.get(k1, k2, k3)
+    mut def create(self, key: (k1: str, k2: value, k3: bytes), checker: ?value=None) -> foo__li_union_entry:
+        e = self.get(key)
         if e is not None:
             if checker is not None:
                 e.checker = checker
             return e
+        (k1=k1, k2=k2, k3=k3) = key
         res = foo__li_union_entry(k1=k1, k2=k2, k3=k3, checker=checker)
         self.elements.append(res)
         return res
@@ -1537,7 +1428,8 @@ class foo__li_union_one_base(yadata.MList[foo__li_union_one_base_entry]):
     mut def __init__(self, elements: list[foo__li_union_one_base_entry]=[]) -> None:
         self.elements = elements
 
-    pure def get(self, k1: value) -> ?foo__li_union_one_base_entry:
+    pure def get(self, key: value) -> ?foo__li_union_one_base_entry:
+        k1 = key
         for e in self:
             e_k1 = e.k1
             k1_match = False
@@ -1548,10 +1440,11 @@ class foo__li_union_one_base(yadata.MList[foo__li_union_one_base_entry]):
                 continue
             return e
 
-    mut def create(self, k1: value) -> foo__li_union_one_base_entry:
-        e = self.get(k1)
+    mut def create(self, key: value) -> foo__li_union_one_base_entry:
+        e = self.get(key)
         if e is not None:
             return e
+        k1 = key
         res = foo__li_union_one_base_entry(k1=k1)
         self.elements.append(res)
         return res

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -183,21 +183,16 @@ class foo__li_entry(yadata.MNode):
         return foo__li_entry.from_gdata(self.to_gdata())
 
 _breaker4: None = None
-class foo__li(yadata.MList[foo__li_entry]):
+class foo__li(yadata.MKeyedList[str, foo__li_entry]):
     mut def __init__(self, elements: list[foo__li_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
 
-    pure def get(self, name: str) -> ?foo__li_entry:
-        for e in self:
-            if e.name != name:
-                continue
-            return e
-
-    mut def create(self, name: str, c1: foo__li__c1) -> foo__li_entry:
-        e = self.get(name)
+    mut def create(self, key: str, c1: foo__li__c1) -> foo__li_entry:
+        e = self.get(key)
         if e is not None:
             e.c1 = c1
             return e
+        name = key
         res = foo__li_entry(name=name, c1=c1)
         self.elements.append(res)
         return res
@@ -218,27 +213,6 @@ class foo__li(yadata.MList[foo__li_entry]):
                 copied_elements.append(ce)
         return foo__li(elements=copied_elements)
 
-
-extension foo__li(Indexed[str, foo__li_entry]):
-    def __getitem__(self, k: str) -> foo__li_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: foo__li_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.name == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker5: None = None
 class root(yadata.MNode):

--- a/test/test_data_source_roundtrip/src/xml_full_adata.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata.act
@@ -76,13 +76,13 @@ def adata():
     special_element = ad.special.create(True)
     
     # List /li-union element: first,4,b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('first', u64(4), b'Hello Acton \xf0\x9f\xab\xa1', checker=u64(47))
+    li_union_element = ad.li_union.create((k1='first', k2=u64(4), k3=b'Hello Acton \xf0\x9f\xab\xa1'), checker=u64(47))
     
     # List /li-union element: second,unlimited,b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('second', 'unlimited', b'Hello Acton \xf0\x9f\xab\xa1', checker=u64(1514))
+    li_union_element = ad.li_union.create((k1='second', k2='unlimited', k3=b'Hello Acton \xf0\x9f\xab\xa1'), checker=u64(1514))
     
     # List /li-union element: third,b'hi',b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('third', b'hi', b'Hello Acton \xf0\x9f\xab\xa1', checker='Frank')
+    li_union_element = ad.li_union.create((k1='third', k2=b'hi', k3=b'Hello Acton \xf0\x9f\xab\xa1'), checker='Frank')
     
     # Container: /c2
     ad.c2.l1 = 'foo-qux'

--- a/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
+++ b/test/test_data_source_roundtrip/src/xml_full_adata_loose.act
@@ -79,13 +79,13 @@ def adata():
     special_element = ad.special.create(True)
     
     # List /li-union element: first,4,b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('first', u64(4), b'Hello Acton \xf0\x9f\xab\xa1', checker=u64(47))
+    li_union_element = ad.li_union.create((k1='first', k2=u64(4), k3=b'Hello Acton \xf0\x9f\xab\xa1'), checker=u64(47))
     
     # List /li-union element: second,unlimited,b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('second', 'unlimited', b'Hello Acton \xf0\x9f\xab\xa1', checker=u64(1514))
+    li_union_element = ad.li_union.create((k1='second', k2='unlimited', k3=b'Hello Acton \xf0\x9f\xab\xa1'), checker=u64(1514))
     
     # List /li-union element: third,b'hi',b'Hello Acton \xf0\x9f\xab\xa1'
-    li_union_element = ad.li_union.create('third', b'hi', b'Hello Acton \xf0\x9f\xab\xa1', checker='Frank')
+    li_union_element = ad.li_union.create((k1='third', k2=b'hi', k3=b'Hello Acton \xf0\x9f\xab\xa1'), checker='Frank')
     
     # Container: /c2
     ad.c2.l1 = 'foo-qux'

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -49,47 +49,21 @@ class m__cfg__items_entry(yadata.MNode):
         self.val = val
 
 _breaker3: None = None
-class m__cfg__items(yadata.MList[m__cfg__items_entry]):
+class m__cfg__items(yadata.MKeyedList[str, m__cfg__items_entry]):
     mut def __init__(self, elements: list[m__cfg__items_entry]=[]) -> None:
-        self.elements = elements
+        yadata.MKeyedList.__init__(self, lambda e: e.id, elements)
 
-    pure def get(self, id: str) -> ?m__cfg__items_entry:
-        for e in self:
-            if e.id != id:
-                continue
-            return e
-
-    mut def create(self, id: str, val: ?u64=None) -> m__cfg__items_entry:
-        e = self.get(id)
+    mut def create(self, key: str, val: ?u64=None) -> m__cfg__items_entry:
+        e = self.get(key)
         if e is not None:
             if val is not None:
                 e.val = val
             return e
+        id = key
         res = m__cfg__items_entry(id=id, val=val)
         self.elements.append(res)
         return res
 
-
-extension m__cfg__items(Indexed[str, m__cfg__items_entry]):
-    def __getitem__(self, k: str) -> m__cfg__items_entry:
-        e = self.get(k)
-        if e is not None:
-            return e
-        raise KeyError(k)
-
-    mut def __setitem__(self, k: str, n: m__cfg__items_entry) -> None:
-        for i, e in enumerate(self.elements):
-            if e.id == k:
-                self.elements[i] = n
-                return
-        self.elements.append(n)
-
-    mut def __delitem__(self, k: str) -> None:
-        for i, e in enumerate(self.elements):
-            if e.id == k:
-                del self.elements[i]
-                return
-        raise KeyError(k)
 
 _breaker4: None = None
 class m__cfg(yadata.MNode):

--- a/test/test_device_mode/src/test_device_mode.act
+++ b/test/test_device_mode/src/test_device_mode.act
@@ -17,8 +17,8 @@ import m
 
 def _test_device_navigation():
     lst = m.m__cfg__items()
-    lst.create(id="i1", val=u64(7))
-    lst.create(id="i2")
+    lst.create("i1", val=u64(7))
+    lst.create("i2")
     testing.assertNotNone(lst.get("i1"), "list get failed")
     testing.assertNone(lst.get("nope"), "unexpected entry present")
     n = 0
@@ -29,6 +29,6 @@ def _test_device_navigation():
 def _test_device_construct():
     # config tree has no serialization methods; just structure + navigation
     r = m.root(cfg=m.m__cfg(name="dev1", enabled=True, sub=m.m__cfg__sub(detail="d")))
-    r.cfg.items.create(id="x", val=u64(1))
+    r.cfg.items.create("x", val=u64(1))
     testing.assertEqual(r.cfg.name, "dev1", "field roundtrip")
     testing.assertNotNone(r.cfg.items.get("x"), "nested list get")


### PR DESCRIPTION
Lists whose key leaves all map to concrete Acton types now subclass yang.adata.MKeyedList[K, entry], where K is the key leaf Acton type, or a tuple of the key leaf types for lists with compound keys. The generic type implements:
1. .get(self, key: K)
2. Indexed[K, entry] protocol Both of these optimizations result in less generated code (to chew on for the type checker).

Lists with a key leaf mapped to value still use the old MList base and keep the generated protocol extensions.