### PR TITLE
Descend into SchemaNode attributes for transforms

### DIFF
--- a/src/transform_explicit_cases.act
+++ b/src/transform_explicit_cases.act
@@ -1,4 +1,5 @@
 import schema as yschema
+import transform_utils
 
 
 mut def create_explicit_cases(node: yschema.SchemaNode) -> None:
@@ -21,31 +22,28 @@ mut def create_explicit_cases(node: yschema.SchemaNode) -> None:
     the same as the wrapped node's name.
     """
 
-    if isinstance(node, yschema.Choice):
-        new_children = []
-        for child in node.children:
-            if not isinstance(child, yschema.Case):
-                name = child._get_arg()
-                if name is not None:
-                    implicit_case = yschema.Case(
-                        name=name,
-                        children=[child],  # The data node becomes child of the case
-                        parent=node,
-                        mod=child.mod,
-                        ns=child.ns,
-                        pfx=child.pfx
-                    )
-                    # Update the child's parent to be the new Case node
-                    child.parent = implicit_case
-                    new_children.append(implicit_case)
+    for n in transform_utils.collect_snodes(node):
+        if isinstance(n, yschema.Choice):
+            new_children = []
+            for child in n.children:
+                if not isinstance(child, yschema.Case):
+                    name = child._get_arg()
+                    if name is not None:
+                        implicit_case = yschema.Case(
+                            name=name,
+                            children=[child],  # The data node becomes child of the case
+                            parent=n,
+                            mod=child.mod,
+                            ns=child.ns,
+                            pfx=child.pfx
+                        )
+                        # Update the child's parent to be the new Case node
+                        child.parent = implicit_case
+                        new_children.append(implicit_case)
+                    else:
+                        raise ValueError("Child {child} name is empty")
                 else:
-                    raise ValueError("Child {child} name is empty")
-            else:
-                new_children.append(child)
+                    new_children.append(child)
 
-        node.children = new_children
-
-    if isinstance(node, yschema.SchemaNodeInner):
-        for child in node.children:
-            create_explicit_cases(child)
+            n.children = new_children
 

--- a/src/transform_remove_empty_refines.act
+++ b/src/transform_remove_empty_refines.act
@@ -1,6 +1,7 @@
 import testing
 
 import schema as yschema
+import transform_utils
 
 mut def remove_empty_refines(node: yschema.SchemaNode) -> None:
     """Remove Refine instances where all attributes have default/empty values.
@@ -34,13 +35,8 @@ mut def remove_empty_refines(node: yschema.SchemaNode) -> None:
                 refine.presence is None and
                 refine.reference is None)
 
-    # Check if this node is a Uses node with refine statements
-    if isinstance(node, yschema.Uses):
-        # Filter out empty refines
-        node.refine = [r for r in node.refine if not is_empty(r)]
-
-    # Recursively process children if this is an inner node
-    if isinstance(node, yschema.SchemaNodeInner):
-        for child in node.children:
-            remove_empty_refines(child)
+    # Filter out empty refines from all Uses nodes
+    for n in transform_utils.collect_snodes(node):
+        if isinstance(n, yschema.Uses):
+            n.refine = [r for r in n.refine if not is_empty(r)]
 

--- a/src/transform_repair_patterns.act
+++ b/src/transform_repair_patterns.act
@@ -20,6 +20,7 @@ PATTERN_MAP = {
     r".*[a-zA-Z0-9-$_]{1,64}.*": r".*[a-zA-Z0-9\-$_]{1,64}.*", # Cisco NXOS 10.4-4 # Unescaped '-'
     r".*[a-zA-Z0-9-$_]{0,63}.*": r".*[a-zA-Z0-9\-$_]{0,63}.*", # Cisco NXOS 10.4-4 # Unescaped '-'
     r"[a-zA-Z0-9-_,]+": r"[a-zA-Z0-9\-_,]+", # Cisco IOS XE 17.18.02 # Unescaped '-'
+    r"[0-9a-zA-Z_.-/]+": r"[0-9a-zA-Z_\.\-/]+", # Adtran AOS # Assuming literal '.' and '-' rather than the '.-/' range (which excludes '-')
 }
 
 mut def repair_patterns(node: yschema.SchemaNode) -> None:

--- a/src/transform_repair_patterns.act
+++ b/src/transform_repair_patterns.act
@@ -1,4 +1,8 @@
+import testing
+
+import parser as yparser
 import schema as yschema
+import transform_utils
 
 PATTERN_MAP = {
     r"[a-zA-Z0-9_.-]+": r"[a-zA-Z0-9_\.-]+", # Cisco-XR 24.1.1 # Assuming literal '.' rather than wildcard that would make other group members redundant
@@ -37,14 +41,51 @@ mut def repair_patterns(node: yschema.SchemaNode) -> None:
             repair_type(alt_type)
 
     # For types, replace known broken pattern expressions
-    if isinstance(node, yschema.Leaf):
-        repair_type(node.type_)
-    elif isinstance(node, yschema.LeafList):
-        repair_type(node.type_)
-    elif isinstance(node, yschema.Typedef):
-        repair_type(node.type_)
+    for n in transform_utils.collect_snodes(node):
+        if isinstance(n, yschema.Leaf):
+            repair_type(n.type_)
+        elif isinstance(n, yschema.LeafList):
+            repair_type(n.type_)
+        elif isinstance(n, yschema.Typedef):
+            repair_type(n.type_)
 
-    # Recursively process children if this is an inner node
-    if isinstance(node, yschema.SchemaNodeInner):
-        for child in node.children:
-            repair_patterns(child)
+
+def _test_repair_patterns_augment_action_input():
+    test_yang = r"""module test_repair {
+  yang-version "1.1";
+  namespace "http://example.com/test_repair";
+  prefix "test_repair";
+
+  container top {
+  }
+
+  augment "/top" {
+    container fm {
+      action copy-from {
+        input {
+          leaf remote-file {
+            type string {
+              pattern "[0-9a-zA-Z_.-/]+";
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"""
+    n = yschema.stmt_to_snode(yparser.parse(test_yang))
+    repair_patterns(n)
+
+    repaired = ""
+    if isinstance(n, yschema.Module):
+        fm = n.augment[0].get("fm")
+        if isinstance(fm, yschema.SchemaNodeInner):
+            act = fm.get("copy-from")
+            if isinstance(act, yschema.Action):
+                act_input = act.input
+                if act_input is not None:
+                    leaf = act_input.get("remote-file")
+                    if isinstance(leaf, yschema.Leaf):
+                        repaired = leaf.type_.pattern[0].value
+    testing.assertEqual(repaired, r"[0-9a-zA-Z_\.\-/]+")

--- a/src/transform_unions.act
+++ b/src/transform_unions.act
@@ -3,6 +3,7 @@ import testing
 import lib as yang
 import schema as yschema
 import parser as yparser
+import transform_utils
 
 mut def rewrite_unions(node: yschema.SchemaNode) -> None:
     """Rewrite stupid union types to sane types
@@ -47,13 +48,11 @@ mut def rewrite_unions(node: yschema.SchemaNode) -> None:
         return tn
 
 
-    if isinstance(node, yschema.Leaf):
-        node.type_ = rewrite_type(node.type_)
-    elif isinstance(node, yschema.LeafList):
-        node.type_ = rewrite_type(node.type_)
-    elif isinstance(node, yschema.SchemaNodeInner):
-        for child in node.children:
-            rewrite_unions(child)
+    for n in transform_utils.collect_snodes(node):
+        if isinstance(n, yschema.Leaf):
+            n.type_ = rewrite_type(n.type_)
+        elif isinstance(n, yschema.LeafList):
+            n.type_ = rewrite_type(n.type_)
 
 test_yang = r"""module test_yang {
   yang-version "1.1";

--- a/src/transform_utils.act
+++ b/src/transform_utils.act
@@ -1,6 +1,41 @@
-import lib as yang
 import schema as yschema
 import xpath as xpath
+
+
+def collect_snodes(node: yschema.SchemaNode) -> list[yschema.SchemaNode]:
+    """Collect all schema nodes in the subtree rooted at node, in pre-order.
+
+    Descends into .children as well as schema nodes that are kept outside of
+    .children: augments on module/submodule/uses, input/output on action/rpc.
+    """
+    res = [node]
+    if isinstance(node, yschema.Module):
+        for augment in node.augment:
+            res.extend(collect_snodes(augment))
+    elif isinstance(node, yschema.Submodule):
+        for augment in node.augment:
+            res.extend(collect_snodes(augment))
+    elif isinstance(node, yschema.Uses):
+        for augment in node.augment:
+            res.extend(collect_snodes(augment))
+    elif isinstance(node, yschema.Action):
+        node_input = node.input
+        if node_input is not None:
+            res.extend(collect_snodes(node_input))
+        node_output = node.output
+        if node_output is not None:
+            res.extend(collect_snodes(node_output))
+    elif isinstance(node, yschema.Rpc):
+        node_input = node.input
+        if node_input is not None:
+            res.extend(collect_snodes(node_input))
+        node_output = node.output
+        if node_output is not None:
+            res.extend(collect_snodes(node_output))
+    if isinstance(node, yschema.SchemaNodeInner):
+        for child in node.children:
+            res.extend(collect_snodes(child))
+    return res
 
 
 def resolve_filter_paths(root: yschema.DNode, filter_paths: list[str]) -> list[str]:


### PR DESCRIPTION
Iterating over the children is not sufficient for SchemaNode as we may
not see nodes that are only accessible via attributes: augments,
rpc/action inputs and outputs.