### PR TITLE
Process Rpc/Action (SchemaNode) input/output as children

### DIFF
--- a/gen/src/rfcgen.act
+++ b/gen/src/rfcgen.act
@@ -23,10 +23,12 @@ child_stmts = {
     "container",
     "grouping",
     "identity",
+    "input",
     "leaf",
     "leaf-list",
     "list",
     "notification",
+    "output",
     "rpc",
     "typedef",
     "uses",
@@ -291,66 +293,19 @@ def _attr_defval(name, stmt, stms) -> str:
 
 snode_methods = {
     "action": {
-        "get": """    def get(self, name: str, ns: ?str=None) -> SchemaNode:
-        # TODO: support looking up qualified by namespace
-        #tns = ns if ns is not None else self.get_namespace()
-        if name == 'input':
-            _input = self.input
-            if _input is not None:
-                return _input
-        if name == 'output':
-            _output = self.output
-            if _output is not None:
-                return _output
-        return SchemaNode.get(self, name, ns)
-
-""",
-        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
-        self_input = self.input
-        self_output = self.output
-        # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
-        new_input = None
-        if self_input is not None:
-            new_input = self_input.compile(context, new_mod, new_ns, new_pfx)
-        # new_output = self_output.compile(context) if self_output is not None else None # actonc codegen pre-evaluates before None-check
-        new_output = None
-        if self_output is not None:
-            new_output = self_output.compile(context, new_mod, new_ns, new_pfx)
-        new = Action(self.name,
-                     description=self.description,
-                     if_feature=self.if_feature,
-                     input=new_input if new_input is not None and isinstance(new_input, Input) else Input(),
-                     output=new_output if new_output is not None and isinstance(new_output, Output) else Output(),
-                     reference=self.reference,
-                     status=self.status,
-                     exts=self.compile_exts(context),
-                     mod=new_mod if new_mod is not None else self.mod,
-                     ns=new_ns if new_ns is not None else self.ns,
-                     pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_mod, new_ns, new_pfx)
-        return new
-
-""",
-        "resolve_compiled_schema_path_dependencies": """    mut def resolve_compiled_schema_path_dependencies(self):
-        self_input = self.input
-        if self_input is not None:
-            self_input.resolve_compiled_schema_path_dependencies()
-        self_output = self.output
-        if self_output is not None:
-            self_output.resolve_compiled_schema_path_dependencies()
-        for child in self.children:
-            child.resolve_compiled_schema_path_dependencies()
-
-""",
         "to_dnode": """    def to_dnode(self, context: DTypeContext) -> DAction:
+        input_dnode = None
+        output_dnode = None
+        for child in self.children:
+            if isinstance(child, Input) and len(child.children) > 0:
+                input_dnode = child.to_dnode(context)
+            if isinstance(child, Output) and len(child.children) > 0:
+                output_dnode = child.to_dnode(context)
+
         dnode_children = []
-        self_input = self.input
-        if self_input is not None:
-            input_dnode = self_input.to_dnode(context)
+        if input_dnode is not None:
             dnode_children.append(input_dnode)
-        self_output = self.output
-        if self_output is not None:
-            output_dnode = self_output.to_dnode(context)
+        if output_dnode is not None:
             dnode_children.append(output_dnode)
 
         new_dnode = DAction(
@@ -831,74 +786,20 @@ snode_methods = {
 """
     },
     "rpc": {
-        "get": """    def get(self, name: str, ns: ?str=None) -> SchemaNode:
-        # TODO: support looking up qualified by namespace
-        #tns = ns if ns is not None else self.get_namespace()
-        if name == 'input':
-            _input = self.input
-            if _input is not None:
-                return _input
-        if name == 'output':
-            _output = self.output
-            if _output is not None:
-                return _output
-        return SchemaNode.get(self, name, ns)
-
-""",
-        "compile": """    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
-        self_input = self.input
-        self_output = self.output
-        # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
-        new_input = None
-        if self_input is not None:
-            new_input = self_input.compile(context, new_mod, new_ns, new_pfx)
-        # new_output = self_output.compile(context) if self_output is not None else None # actonc codegen pre-evaluates before None-check
-        new_output = None
-        if self_output is not None:
-            new_output = self_output.compile(context, new_mod, new_ns, new_pfx)
-        new = Rpc(self.name,
-                  description=self.description,
-                  if_feature=self.if_feature,
-                  input=new_input if new_input is not None and isinstance(new_input, Input) else Input(),
-                  output=new_output if new_output is not None and isinstance(new_output, Output) else Output(),
-                  reference=self.reference,
-                  status=self.status,
-                  exts=self.compile_exts(context),
-                  mod=new_mod if new_mod is not None else self.mod,
-                  ns=new_ns if new_ns is not None else self.ns,
-                  pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_mod, new_ns, new_pfx)
-        return new
-
-""",
-        "resolve_compiled_schema_path_dependencies": """    mut def resolve_compiled_schema_path_dependencies(self):
-        self_input = self.input
-        if self_input is not None:
-            self_input.resolve_compiled_schema_path_dependencies()
-        self_output = self.output
-        if self_output is not None:
-            self_output.resolve_compiled_schema_path_dependencies()
-        for child in self.children:
-            child.resolve_compiled_schema_path_dependencies()
-
-""",
         "to_dnode": """    def to_dnode(self, context: DTypeContext) -> DRpc:
-        # Convert SchemaNode Rpc.input/output to DRpc.input/output and add to
-        # its children, but only if Input and Output actually contain data
-        # nodes.
+        input_dnode = None
+        output_dnode = None
+        for child in self.children:
+            if isinstance(child, Input) and len(child.children) > 0:
+                input_dnode = child.to_dnode(context)
+            if isinstance(child, Output) and len(child.children) > 0:
+                output_dnode = child.to_dnode(context)
+
         dnode_children = []
-        self_input = self.input
-        if self_input is not None and len(self_input.children) > 0:
-            input_dnode = self_input.to_dnode(context)
+        if input_dnode is not None:
             dnode_children.append(input_dnode)
-        else:
-            input_dnode = None
-        self_output = self.output
-        if self_output is not None and len(self_output.children) > 0:
-            output_dnode = self_output.to_dnode(context)
+        if output_dnode is not None:
             dnode_children.append(output_dnode)
-        else:
-            output_dnode = None
 
         new_dnode = DRpc(
             module=self.get_module_name(),
@@ -1420,6 +1321,20 @@ def gen(stmts: dict[str, Stmt]) -> list[str]:
             res.append('        new = {_class_name(stmt_name)}({(",\n               " + " " * len(_class_name(stmt_name))).join(new_args)})')
             if have_children:
                 res.append("        self.expand_children(context, new, new_mod, new_ns, new_pfx)")
+            if stmt_name in {"rpc", "action"}:
+                # Always synthesize the input/output children so that augments
+                # may target them. Empty nodes are skipped in .to_dnode().
+                res.append("        has_input = False")
+                res.append("        has_output = False")
+                res.append("        for c in new.children:")
+                res.append("            if isinstance(c, Input):")
+                res.append("                has_input = True")
+                res.append("            if isinstance(c, Output):")
+                res.append("                has_output = True")
+                res.append("        if not has_input:")
+                res.append("            new.children.append(Input(parent=new))")
+                res.append("        if not has_output:")
+                res.append("            new.children.append(Output(parent=new))")
             for substmt in stmt.substmts.values():
                 if substmt.name == "augment":
                     res.append("        new.expand_augments(context)")

--- a/snapshots/expected/test_yang/prsrc
+++ b/snapshots/expected/test_yang/prsrc
@@ -58,11 +58,14 @@ Module('test_yang', yang_version=1.1, namespace='http://example.com/test_yang', 
             Leaf('k2', type_=Type('string'))
         ])
     ]),
-    Rpc('rpc1', description='rpc 1', input=Input(children=[
-    Leaf('rli1', type_=Type('string'), description='rpc input leaf 1')
-]), output=Output(children=[
-    Leaf('rlo1', type_=Type('string'), description='rpc output leaf 1')
-])),
+    Rpc('rpc1', description='rpc 1', children=[
+        Input(children=[
+            Leaf('rli1', type_=Type('string'), description='rpc input leaf 1')
+        ]),
+        Output(children=[
+            Leaf('rlo1', type_=Type('string'), description='rpc output leaf 1')
+        ])
+    ]),
     Notification('n1', description='notification 1', children=[
         Anydata('n1ad', description='notification anydata 1'),
         Anyxml('n1ax', description='notification anyxml 1')

--- a/snapshots/expected/test_yang/prsrc_action_1
+++ b/snapshots/expected/test_yang/prsrc_action_1
@@ -1,6 +1,9 @@
-Action('action1', description='action 1', input=Input(children=[
-    Leaf('rli1', type_=Type('string'), description='action input leaf 1')
-]), output=Output(children=[
-    Leaf('rlo1', type_=Type('string'), description='action output leaf 1'),
-    Leaf('rlo2', type_=Type('string'), description='action output leaf 2')
-]))
+Action('action1', description='action 1', children=[
+    Input(children=[
+        Leaf('rli1', type_=Type('string'), description='action input leaf 1')
+    ]),
+    Output(children=[
+        Leaf('rlo1', type_=Type('string'), description='action output leaf 1'),
+        Leaf('rlo2', type_=Type('string'), description='action output leaf 2')
+    ])
+])

--- a/snapshots/expected/test_yang/prsrc_rpc_1
+++ b/snapshots/expected/test_yang/prsrc_rpc_1
@@ -1,6 +1,9 @@
-Rpc('rpc1', description='rpc 1', input=Input(children=[
-    Leaf('rli1', type_=Type('string'), description='rpc input leaf 1')
-]), output=Output(children=[
-    Leaf('rlo1', type_=Type('string'), description='rpc output leaf 1'),
-    Leaf('rlo2', type_=Type('string'), description='rpc output leaf 2')
-]))
+Rpc('rpc1', description='rpc 1', children=[
+    Input(children=[
+        Leaf('rli1', type_=Type('string'), description='rpc input leaf 1')
+    ]),
+    Output(children=[
+        Leaf('rlo1', type_=Type('string'), description='rpc output leaf 1'),
+        Leaf('rlo2', type_=Type('string'), description='rpc output leaf 2')
+    ])
+])

--- a/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
+++ b/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
@@ -1,0 +1,198 @@
+import base64
+import json
+import std.xml as xml
+import yang.adata as yadata
+import yang.gdata as ygdata
+import yang.xml as yxml
+import yang.xpath as yxpath
+from yang.identityref import Identityref, PartialIdentityref
+from yang.pattern import YangPattern
+from yang.schema import *
+from yang.type import Decimal, Ranges
+
+# == This file is generated ==
+
+
+
+
+_identities: list[DIdentity] = []
+
+
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='svc', namespace='urn:example:svc', prefix='svc', name='mgmt', config=True, presence=False)
+
+SRC_DNODE_RPC_0: DRpc = DRpc(module='svc', namespace='urn:example:svc', prefix='svc', name='register', input=DInput(module='svc', namespace='urn:example:svc', prefix='svc', children=[
+    DList(module='svc', namespace='urn:example:svc', prefix='svc', name='servers', key=['id'], config=False, min_elements=0, ordered_by='system', children=[
+        DLeaf(module='svc', namespace='urn:example:svc', prefix='svc', name='id', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+        DLeaf(module='svc', namespace='urn:example:svc', prefix='svc', name='port', config=False, mandatory=False, type_=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])))
+    ])
+]), children=[
+    DInput(module='svc', namespace='urn:example:svc', prefix='svc', children=[
+        DList(module='svc', namespace='urn:example:svc', prefix='svc', name='servers', key=['id'], config=False, min_elements=0, ordered_by='system', children=[
+            DLeaf(module='svc', namespace='urn:example:svc', prefix='svc', name='id', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+            DLeaf(module='svc', namespace='urn:example:svc', prefix='svc', name='port', config=False, mandatory=False, type_=DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)])))
+        ])
+    ])
+])
+
+SRC_DNODE: DRoot = DRoot(
+    children=[SRC_DNODE_CHILD_0],
+    identities=[],
+    rpcs=[SRC_DNODE_RPC_0],
+    module_metadata={'urn:example:keygrp':('keygrp', None), 'urn:example:svc':('svc', None)},
+)
+
+NS_keygrp: str = 'urn:example:keygrp'
+NS_svc: str = 'urn:example:svc'
+
+
+_breaker1: None = None
+class svc__mgmt(yadata.MNode):
+
+    mut def __init__(self) -> None:
+        pass
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['svc:mgmt'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> svc__mgmt:
+        if n is not None:
+            return svc__mgmt()
+        return svc__mgmt()
+
+    mut def copy(self) -> svc__mgmt:
+        """Create a deep copy of this adata object"""
+        return svc__mgmt.from_gdata(self.to_gdata())
+
+
+_breaker2: None = None
+class root(yadata.MNode):
+    mgmt: svc__mgmt
+
+    mut def __init__(self, mgmt: ?svc__mgmt=None) -> None:
+        self.mgmt = mgmt if mgmt is not None else svc__mgmt()
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False)
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> root:
+        if n is not None:
+            return root(mgmt=svc__mgmt.from_gdata(n.get_opt_cnt(ygdata.Id(NS_svc, 'mgmt'))))
+        return root()
+
+    mut def copy(self) -> root:
+        """Create a deep copy of this adata object"""
+        return root.from_gdata(self.to_gdata())
+
+
+_breaker3: None = None
+class svc__register__input__servers_entry(yadata.MNode):
+    id: str
+    port: ?u64
+
+    mut def __init__(self, id: str, port: ?u64) -> None:
+        self.id = id
+        self.port = port
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['svc:register', 'input', 'servers'])
+
+    @staticmethod
+    mut def from_gdata(n: ygdata.Node) -> svc__register__input__servers_entry:
+        return svc__register__input__servers_entry(id=n.get_str(ygdata.Id(NS_svc, 'id')), port=n.get_opt_u64(ygdata.Id(NS_svc, 'port')))
+
+    mut def copy(self) -> svc__register__input__servers_entry:
+        """Create a deep copy of this adata object"""
+        return svc__register__input__servers_entry.from_gdata(self.to_gdata())
+
+_breaker4: None = None
+class svc__register__input__servers(yadata.MList[svc__register__input__servers_entry]):
+    mut def __init__(self, elements: list[svc__register__input__servers_entry]=[]) -> None:
+        self.elements = elements
+
+    pure def get(self, id: str) -> ?svc__register__input__servers_entry:
+        for e in self:
+            if e.id != id:
+                continue
+            return e
+
+    mut def create(self, id: str, port: ?u64=None) -> svc__register__input__servers_entry:
+        e = self.get(id)
+        if e is not None:
+            if port is not None:
+                e.port = port
+            return e
+        res = svc__register__input__servers_entry(id=id, port=port)
+        self.elements.append(res)
+        return res
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.List) -> list[svc__register__input__servers_entry]:
+        if n is not None:
+            return [svc__register__input__servers_entry.from_gdata(e) for e in n.elements]
+        return []
+
+    mut def copy(self) -> svc__register__input__servers:
+        """Create a deep copy of this list object"""
+        # Copy each element in the list
+        copied_elements = []
+        for e in self:
+            ce = e.copy()
+            if ce is not None:
+                copied_elements.append(ce)
+        return svc__register__input__servers(elements=copied_elements)
+
+
+extension svc__register__input__servers(Indexed[str, svc__register__input__servers_entry]):
+    def __getitem__(self, k: str) -> svc__register__input__servers_entry:
+        e = self.get(k)
+        if e is not None:
+            return e
+        raise KeyError(k)
+
+    mut def __setitem__(self, k: str, n: svc__register__input__servers_entry) -> None:
+        for i, e in enumerate(self.elements):
+            if e.id == k:
+                self.elements[i] = n
+                return
+        self.elements.append(n)
+
+    mut def __delitem__(self, k: str) -> None:
+        for i, e in enumerate(self.elements):
+            if e.id == k:
+                del self.elements[i]
+                return
+        raise KeyError(k)
+
+_breaker5: None = None
+class svc__register__input(yadata.MNode):
+    servers: svc__register__input__servers
+
+    mut def __init__(self, servers: list[svc__register__input__servers_entry]=[]) -> None:
+        self.servers = svc__register__input__servers(elements=servers)
+
+    mut def to_gdata(self) -> ygdata.Node:
+        return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['svc:register', 'input'])
+
+    @staticmethod
+    mut def from_gdata(n: ?ygdata.Node) -> svc__register__input:
+        if n is not None:
+            return svc__register__input(servers=svc__register__input__servers.from_gdata(n.get_opt_list(ygdata.Id(NS_svc, 'servers'))))
+        return svc__register__input()
+
+    mut def copy(self) -> svc__register__input:
+        """Create a deep copy of this adata object"""
+        return svc__register__input.from_gdata(self.to_gdata())
+
+
+actor rpc_root(tp: ygdata.TreeProvider):
+    register: action(cb: action(?Exception) -> None, inp: ?svc__register__input) -> None
+    def register(cb, inp):
+        rpc_xml = xml.Node('register', nsdefs=[(None, 'urn:example:svc')])
+        if inp is not None:
+            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["svc:register", "input"])
+            rpc_xml.children.extend(gdata_inp.to_xml())
+        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
+
+

--- a/src/schema.act
+++ b/src/schema.act
@@ -4547,7 +4547,7 @@ extension SchemaNode (Eq):
         if type(self) != type(other):
             return False
         elif isinstance(self, Action) and isinstance(other, Action):
-            return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.input == other.input and self.output == other.output and self.reference == other.reference and self.status == other.status
+            return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.reference == other.reference and self.status == other.status
         elif isinstance(self, Anydata) and isinstance(other, Anydata):
             return self.name == other.name and self.config == other.config and self.description == other.description and self.if_feature == other.if_feature and self.mandatory == other.mandatory and self.must == other.must and self.reference == other.reference and self.status == other.status and self.when == other.when
         elif isinstance(self, Anyxml) and isinstance(other, Anyxml):
@@ -4605,7 +4605,7 @@ extension SchemaNode (Eq):
         elif isinstance(self, Revision) and isinstance(other, Revision):
             return self.date == other.date and self.description == other.description and self.reference == other.reference
         elif isinstance(self, Rpc) and isinstance(other, Rpc):
-            return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.input == other.input and self.output == other.output and self.reference == other.reference and self.status == other.status
+            return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.reference == other.reference and self.status == other.status
         elif isinstance(self, Submodule) and isinstance(other, Submodule):
             return self.name == other.name and self.augment == other.augment and self.belongs_to == other.belongs_to and self.contact == other.contact and self.description == other.description and self.deviation == other.deviation and self.extension_ == other.extension_ and self.feature == other.feature and self.import_ == other.import_ and self.include == other.include and self.organization == other.organization and self.reference == other.reference and self.revision == other.revision and self.yang_version == other.yang_version
         elif isinstance(self, Type) and isinstance(other, Type):
@@ -4758,12 +4758,10 @@ class Action(SchemaNodeInner):
     name: str
     description: ?str
     if_feature: list[str]
-    input: ?Input
-    output: ?Output
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
         new_mod = mod
         new_ns = ns
@@ -4781,38 +4779,12 @@ class Action(SchemaNodeInner):
         self.name = name
         self.description = description
         self.if_feature = if_feature
-        self.input = input
-        self.output = output
         self.reference = reference
         self.status = status
         self.exts = exts
         self.children = children
         for n in self.exts:
             n.parent = self
-        self_input = self.input
-        if self_input is not None:
-            self_input.parent = self
-            n_mod = self_input.mod
-            if n_mod is None:
-                self_input.mod = self.mod
-            n_ns = self_input.ns
-            if n_ns is None:
-                self_input.ns = self.ns
-            n_pfx = self_input.pfx
-            if n_pfx is None:
-                self_input.pfx = self.pfx
-        self_output = self.output
-        if self_output is not None:
-            self_output.parent = self
-            n_mod = self_output.mod
-            if n_mod is None:
-                self_output.mod = self.mod
-            n_ns = self_output.ns
-            if n_ns is None:
-                self_output.ns = self.ns
-            n_pfx = self_output.pfx
-            if n_pfx is None:
-                self_output.pfx = self.pfx
         for n in self.children:
             n.parent = self
             n_mod = n.mod
@@ -4829,8 +4801,6 @@ class Action(SchemaNodeInner):
         return [
             ("description", self.description),
             ("if-feature", self.if_feature),
-            ("input", self.input),
-            ("output", self.output),
             ("reference", self.reference),
             ("status", self.status),
             ("exts", self.exts),
@@ -4848,63 +4818,19 @@ class Action(SchemaNodeInner):
             self.reference = ref_reference
         self.exts.extend(refine.compile_exts(context))
 
-    def get(self, name: str, ns: ?str=None) -> SchemaNode:
-        # TODO: support looking up qualified by namespace
-        #tns = ns if ns is not None else self.get_namespace()
-        if name == 'input':
-            _input = self.input
-            if _input is not None:
-                return _input
-        if name == 'output':
-            _output = self.output
-            if _output is not None:
-                return _output
-        return SchemaNode.get(self, name, ns)
-
-    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
-        self_input = self.input
-        self_output = self.output
-        # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
-        new_input = None
-        if self_input is not None:
-            new_input = self_input.compile(context, new_mod, new_ns, new_pfx)
-        # new_output = self_output.compile(context) if self_output is not None else None # actonc codegen pre-evaluates before None-check
-        new_output = None
-        if self_output is not None:
-            new_output = self_output.compile(context, new_mod, new_ns, new_pfx)
-        new = Action(self.name,
-                     description=self.description,
-                     if_feature=self.if_feature,
-                     input=new_input if new_input is not None and isinstance(new_input, Input) else Input(),
-                     output=new_output if new_output is not None and isinstance(new_output, Output) else Output(),
-                     reference=self.reference,
-                     status=self.status,
-                     exts=self.compile_exts(context),
-                     mod=new_mod if new_mod is not None else self.mod,
-                     ns=new_ns if new_ns is not None else self.ns,
-                     pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_mod, new_ns, new_pfx)
-        return new
-
-    mut def resolve_compiled_schema_path_dependencies(self):
-        self_input = self.input
-        if self_input is not None:
-            self_input.resolve_compiled_schema_path_dependencies()
-        self_output = self.output
-        if self_output is not None:
-            self_output.resolve_compiled_schema_path_dependencies()
-        for child in self.children:
-            child.resolve_compiled_schema_path_dependencies()
-
     def to_dnode(self, context: DTypeContext) -> DAction:
+        input_dnode = None
+        output_dnode = None
+        for child in self.children:
+            if isinstance(child, Input) and len(child.children) > 0:
+                input_dnode = child.to_dnode(context)
+            if isinstance(child, Output) and len(child.children) > 0:
+                output_dnode = child.to_dnode(context)
+
         dnode_children = []
-        self_input = self.input
-        if self_input is not None:
-            input_dnode = self_input.to_dnode(context)
+        if input_dnode is not None:
             dnode_children.append(input_dnode)
-        self_output = self.output
-        if self_output is not None:
-            output_dnode = self_output.to_dnode(context)
+        if output_dnode is not None:
             dnode_children.append(output_dnode)
 
         new_dnode = DAction(
@@ -4923,6 +4849,30 @@ class Action(SchemaNodeInner):
 
     def is_config(self) -> bool:
         return False
+
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
+        new = Action(self.name,
+                     description=self.description,
+                     if_feature=self.if_feature,
+                     reference=self.reference,
+                     status=self.status,
+                     exts=self.compile_exts(context),
+                     mod=new_mod if new_mod is not None else self.mod,
+                     ns=new_ns if new_ns is not None else self.ns,
+                     pfx=new_pfx if new_pfx is not None else self.pfx)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
+        has_input = False
+        has_output = False
+        for c in new.children:
+            if isinstance(c, Input):
+                has_input = True
+            if isinstance(c, Output):
+                has_output = True
+        if not has_input:
+            new.children.append(Input(parent=new))
+        if not has_output:
+            new.children.append(Output(parent=new))
+        return new
 
     def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
         """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
@@ -4961,7 +4911,7 @@ class Action(SchemaNodeInner):
 
 extension Action (Ord):
     def __eq__(self, other: Action):
-        return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.input == other.input and self.output == other.output and self.reference == other.reference and self.status == other.status
+        return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.reference == other.reference and self.status == other.status
 
     def __lt__(a, b):
         return a.name < b.name
@@ -8877,12 +8827,10 @@ class Rpc(SchemaNodeInner):
     name: str
     description: ?str
     if_feature: list[str]
-    input: ?Input
-    output: ?Output
     reference: ?str
     status: ?str
 
-    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], input: ?Input=None, output: ?Output=None, reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
+    def __init__(self, name: str, description: ?str=None, if_feature: list[str]=[], reference: ?str=None, status: ?str=None, exts=[], children=[], parent=None, mod=None, ns=None, pfx=None):
         self.parent = parent
         new_mod = mod
         new_ns = ns
@@ -8900,38 +8848,12 @@ class Rpc(SchemaNodeInner):
         self.name = name
         self.description = description
         self.if_feature = if_feature
-        self.input = input
-        self.output = output
         self.reference = reference
         self.status = status
         self.exts = exts
         self.children = children
         for n in self.exts:
             n.parent = self
-        self_input = self.input
-        if self_input is not None:
-            self_input.parent = self
-            n_mod = self_input.mod
-            if n_mod is None:
-                self_input.mod = self.mod
-            n_ns = self_input.ns
-            if n_ns is None:
-                self_input.ns = self.ns
-            n_pfx = self_input.pfx
-            if n_pfx is None:
-                self_input.pfx = self.pfx
-        self_output = self.output
-        if self_output is not None:
-            self_output.parent = self
-            n_mod = self_output.mod
-            if n_mod is None:
-                self_output.mod = self.mod
-            n_ns = self_output.ns
-            if n_ns is None:
-                self_output.ns = self.ns
-            n_pfx = self_output.pfx
-            if n_pfx is None:
-                self_output.pfx = self.pfx
         for n in self.children:
             n.parent = self
             n_mod = n.mod
@@ -8948,8 +8870,6 @@ class Rpc(SchemaNodeInner):
         return [
             ("description", self.description),
             ("if-feature", self.if_feature),
-            ("input", self.input),
-            ("output", self.output),
             ("reference", self.reference),
             ("status", self.status),
             ("exts", self.exts),
@@ -8967,71 +8887,20 @@ class Rpc(SchemaNodeInner):
             self.reference = ref_reference
         self.exts.extend(refine.compile_exts(context))
 
-    def get(self, name: str, ns: ?str=None) -> SchemaNode:
-        # TODO: support looking up qualified by namespace
-        #tns = ns if ns is not None else self.get_namespace()
-        if name == 'input':
-            _input = self.input
-            if _input is not None:
-                return _input
-        if name == 'output':
-            _output = self.output
-            if _output is not None:
-                return _output
-        return SchemaNode.get(self, name, ns)
-
-    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
-        self_input = self.input
-        self_output = self.output
-        # new_input = self_input.compile(context) if self_input is not None else None # actonc codegen pre-evaluates before None-check
-        new_input = None
-        if self_input is not None:
-            new_input = self_input.compile(context, new_mod, new_ns, new_pfx)
-        # new_output = self_output.compile(context) if self_output is not None else None # actonc codegen pre-evaluates before None-check
-        new_output = None
-        if self_output is not None:
-            new_output = self_output.compile(context, new_mod, new_ns, new_pfx)
-        new = Rpc(self.name,
-                  description=self.description,
-                  if_feature=self.if_feature,
-                  input=new_input if new_input is not None and isinstance(new_input, Input) else Input(),
-                  output=new_output if new_output is not None and isinstance(new_output, Output) else Output(),
-                  reference=self.reference,
-                  status=self.status,
-                  exts=self.compile_exts(context),
-                  mod=new_mod if new_mod is not None else self.mod,
-                  ns=new_ns if new_ns is not None else self.ns,
-                  pfx=new_pfx if new_pfx is not None else self.pfx)
-        self.expand_children(context, new, new_mod, new_ns, new_pfx)
-        return new
-
-    mut def resolve_compiled_schema_path_dependencies(self):
-        self_input = self.input
-        if self_input is not None:
-            self_input.resolve_compiled_schema_path_dependencies()
-        self_output = self.output
-        if self_output is not None:
-            self_output.resolve_compiled_schema_path_dependencies()
-        for child in self.children:
-            child.resolve_compiled_schema_path_dependencies()
-
     def to_dnode(self, context: DTypeContext) -> DRpc:
-        # Convert SchemaNode Rpc.input/output to DRpc.input/output and add to
-        # its children, but only if Input and Output actually contain data
-        # nodes.
+        input_dnode = None
+        output_dnode = None
+        for child in self.children:
+            if isinstance(child, Input) and len(child.children) > 0:
+                input_dnode = child.to_dnode(context)
+            if isinstance(child, Output) and len(child.children) > 0:
+                output_dnode = child.to_dnode(context)
+
         dnode_children = []
-        self_input = self.input
-        if self_input is not None and len(self_input.children) > 0:
-            input_dnode = self_input.to_dnode(context)
+        if input_dnode is not None:
             dnode_children.append(input_dnode)
-        else:
-            input_dnode = None
-        self_output = self.output
-        if self_output is not None and len(self_output.children) > 0:
-            output_dnode = self_output.to_dnode(context)
+        if output_dnode is not None:
             dnode_children.append(output_dnode)
-        else:
-            output_dnode = None
 
         new_dnode = DRpc(
             module=self.get_module_name(),
@@ -9051,6 +8920,30 @@ class Rpc(SchemaNodeInner):
 
     def is_config(self) -> bool:
         return False
+
+    def compile(self, context: Context, new_mod: ?str=None, new_ns: ?str=None, new_pfx: ?str=None):
+        new = Rpc(self.name,
+                  description=self.description,
+                  if_feature=self.if_feature,
+                  reference=self.reference,
+                  status=self.status,
+                  exts=self.compile_exts(context),
+                  mod=new_mod if new_mod is not None else self.mod,
+                  ns=new_ns if new_ns is not None else self.ns,
+                  pfx=new_pfx if new_pfx is not None else self.pfx)
+        self.expand_children(context, new, new_mod, new_ns, new_pfx)
+        has_input = False
+        has_output = False
+        for c in new.children:
+            if isinstance(c, Input):
+                has_input = True
+            if isinstance(c, Output):
+                has_output = True
+        if not has_input:
+            new.children.append(Input(parent=new))
+        if not has_output:
+            new.children.append(Output(parent=new))
+        return new
 
     def update_namespace_qualifiers(self, new_ns: str, new_pfx: str, new_mod: str) -> None:
         """Updates the ns (namespace), pfx (prefix), and mod (module) attributes.
@@ -9089,7 +8982,7 @@ class Rpc(SchemaNodeInner):
 
 extension Rpc (Ord):
     def __eq__(self, other: Rpc):
-        return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.input == other.input and self.output == other.output and self.reference == other.reference and self.status == other.status
+        return self.name == other.name and self.description == other.description and self.if_feature == other.if_feature and self.reference == other.reference and self.status == other.status
 
     def __lt__(a, b):
         return a.name < b.name
@@ -10524,14 +10417,12 @@ def stmt_to_snode(stmt: Statement, parent: ?SchemaNode=None) -> SchemaNode:
             n = Action(arg,
                        description=take_opt_str(ss, "description"),
                        if_feature=take_strlist(ss, "if-feature"),
-                       input=take_opt_input(ss),
-                       output=take_opt_output(ss),
                        reference=take_opt_str(ss, "reference"),
                        status=take_opt_str(ss, "status"),
                        exts=take_exts(ss),
                        parent=parent
                        )
-            n.children=take_nodes(ss, ["grouping", "typedef"], n)
+            n.children=take_nodes(ss, ["grouping", "input", "output", "typedef"], n)
             if len(ss) > 0:
                 name = ss[0].kw
                 prefix = ss[0].prefix
@@ -11020,14 +10911,12 @@ def stmt_to_snode(stmt: Statement, parent: ?SchemaNode=None) -> SchemaNode:
             n = Rpc(arg,
                     description=take_opt_str(ss, "description"),
                     if_feature=take_strlist(ss, "if-feature"),
-                    input=take_opt_input(ss),
-                    output=take_opt_output(ss),
                     reference=take_opt_str(ss, "reference"),
                     status=take_opt_str(ss, "status"),
                     exts=take_exts(ss),
                     parent=parent
                     )
-            n.children=take_nodes(ss, ["grouping", "typedef"], n)
+            n.children=take_nodes(ss, ["grouping", "input", "output", "typedef"], n)
             if len(ss) > 0:
                 name = ss[0].kw
                 prefix = ss[0].prefix

--- a/src/test_yang.act
+++ b/src/test_yang.act
@@ -1222,13 +1222,13 @@ def _test_compile_augment_action_rpc():
     }
   }
 
-  augment "/f:reset/input" {
+  augment "/f:reset/f:input" {
     leaf reset-at {
       type string;
     }
   }
 
-  augment "/f:reset/output" {
+  augment "/f:reset/f:output" {
     leaf reset-finished-at {
       type string;
     }
@@ -1301,6 +1301,169 @@ def _test_compile_augment_augmented_node():
     root = yang.compile([ys_base, ys_voice])
     src = root.prdaclass()
     return src
+
+def _test_rpc_action_input_cross_module_grouping_key():
+    """A cross-module grouping supplies a list key leaf under both an rpc input
+    and an action input.
+    """
+    ys_keygrp = r"""module keygrp {
+  yang-version 1.1;
+  namespace "urn:example:keygrp";
+  prefix kg;
+  grouping id-key {
+    leaf id {
+      type string;
+    }
+  }
+}"""
+    ys_svc = r"""module svc {
+  yang-version 1.1;
+  namespace "urn:example:svc";
+  prefix svc;
+  import keygrp {
+    prefix kg;
+  }
+  rpc register {
+    input {
+      list servers {
+        key id;
+        uses kg:id-key;
+        leaf port {
+          type uint16;
+        }
+      }
+    }
+  }
+  container mgmt {
+    action reset {
+      input {
+        list targets {
+          key id;
+          uses kg:id-key;
+          leaf force {
+            type boolean;
+          }
+        }
+      }
+    }
+  }
+}"""
+    root = yang.compile([ys_keygrp, ys_svc])
+    # TODO: remove this when we also print DAction / action "actions" in rpc_root
+    act = root.get("mgmt").get("reset")
+    if isinstance(act, yschema.DAction):
+        targets = act.get("input").get("targets")
+        if isinstance(targets, yschema.DList):
+            found_key = False
+            for child in targets.children:
+                if isinstance(child, yschema.DLeaf) and child.name == "id":
+                    found_key = True
+                    testing.assertEqual(child.module, "svc")
+                    testing.assertEqual(child.namespace, targets.namespace)
+                    testing.assertEqual(child.prefix, "svc")
+            testing.assertTrue(found_key, "action key leaf 'id' missing")
+        else:
+            testing.error("Expected DList targets")
+    else:
+        testing.error("Expected DAction reset")
+    return root.prdaclass()
+
+def _test_rpc_input_submodule_prefix_remap():
+    """A submodule imports a module under a different prefix than the parent
+    module. Prefix references under rpc input must be remapped when the
+    submodule is merged, like everywhere else in the tree.
+    """
+    ys_keygrp = r"""module keygrp {
+  yang-version 1.1;
+  namespace "urn:example:keygrp";
+  prefix kg;
+  grouping id-key {
+    leaf id {
+      type string;
+    }
+  }
+}"""
+    ys_main = r"""module main {
+  yang-version 1.1;
+  namespace "urn:example:main";
+  prefix m;
+  import keygrp {
+    prefix kg;
+  }
+  include sub;
+}"""
+    ys_sub = r"""submodule sub {
+  yang-version 1.1;
+  belongs-to main {
+    prefix m;
+  }
+  import keygrp {
+    prefix kgx;
+  }
+  rpc register {
+    input {
+      uses kgx:id-key;
+    }
+  }
+}"""
+    root = yang.compile([ys_keygrp, ys_main, ys_sub])
+    rpc = root.get("register")
+    if isinstance(rpc, yschema.DRpc):
+        rpc_input = rpc.input
+        if rpc_input is not None:
+            leaf = rpc_input.get("id")
+            if isinstance(leaf, yschema.DLeaf):
+                testing.assertEqual(leaf.module, "main")
+            else:
+                testing.error("Expected DLeaf id")
+        else:
+            testing.error("Expected DRpc input")
+    else:
+        testing.error("Expected DRpc register")
+
+def _test_rpc_input_import_prefix_leafref():
+    """A leafref under rpc input written with a non-canonical import prefix is
+    prefix-remapped like the rest of the tree, so its path resolves.
+    """
+    ys_b = r"""module b {
+  yang-version 1.1;
+  namespace "urn:example:b";
+  prefix b;
+  container targets {
+    leaf name {
+      type string;
+    }
+  }
+}"""
+    ys_a = r"""module a {
+  yang-version 1.1;
+  namespace "urn:example:a";
+  prefix a;
+  import b {
+    prefix bx;
+  }
+  rpc register {
+    input {
+      leaf ref {
+        type leafref {
+          path "/bx:targets/bx:name";
+        }
+      }
+    }
+  }
+}"""
+    root = yang.compile([ys_a, ys_b])
+    rpc = root.get("register", module="a")
+    if isinstance(rpc, yschema.DRpc):
+        rpc_input = rpc.input
+        if rpc_input is not None:
+            leaf = rpc_input.get("ref")
+            if not isinstance(leaf, yschema.DLeaf):
+                testing.error("Expected DLeaf ref")
+        else:
+            testing.error("Expected DRpc input")
+    else:
+        testing.error("Expected DRpc register")
 
 def _test_compile_refine():
     """Refining a grouping"""

--- a/src/transform_repair_patterns.act
+++ b/src/transform_repair_patterns.act
@@ -84,8 +84,8 @@ def _test_repair_patterns_augment_action_input():
         if isinstance(fm, yschema.SchemaNodeInner):
             act = fm.get("copy-from")
             if isinstance(act, yschema.Action):
-                act_input = act.input
-                if act_input is not None:
+                act_input = act.get("input")
+                if isinstance(act_input, yschema.Input):
                     leaf = act_input.get("remote-file")
                     if isinstance(leaf, yschema.Leaf):
                         repaired = leaf.type_.pattern[0].value

--- a/src/transform_utils.act
+++ b/src/transform_utils.act
@@ -6,7 +6,7 @@ def collect_snodes(node: yschema.SchemaNode) -> list[yschema.SchemaNode]:
     """Collect all schema nodes in the subtree rooted at node, in pre-order.
 
     Descends into .children as well as schema nodes that are kept outside of
-    .children: augments on module/submodule/uses, input/output on action/rpc.
+    .children: augments on module/submodule/uses.
     """
     res = [node]
     if isinstance(node, yschema.Module):
@@ -18,20 +18,6 @@ def collect_snodes(node: yschema.SchemaNode) -> list[yschema.SchemaNode]:
     elif isinstance(node, yschema.Uses):
         for augment in node.augment:
             res.extend(collect_snodes(augment))
-    elif isinstance(node, yschema.Action):
-        node_input = node.input
-        if node_input is not None:
-            res.extend(collect_snodes(node_input))
-        node_output = node.output
-        if node_output is not None:
-            res.extend(collect_snodes(node_output))
-    elif isinstance(node, yschema.Rpc):
-        node_input = node.input
-        if node_input is not None:
-            res.extend(collect_snodes(node_input))
-        node_output = node.output
-        if node_output is not None:
-            res.extend(collect_snodes(node_output))
     if isinstance(node, yschema.SchemaNodeInner):
         for child in node.children:
             res.extend(collect_snodes(child))

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -184,14 +184,17 @@ actor rpc_root(tp: ygdata.TreeProvider):
 mut def src_schema() -> dict[str, SchemaNode]:
     res = {}
     res["yangrpc"] = Module('yangrpc', yang_version=1.1, namespace='http://example.com/yangrpc', prefix='yrpc', children=[
-    Rpc('foo', input=Input(children=[
-    Leaf('a', type_=Type('string')),
-    Container('woo', children=[
-        Leaf('woo_b', type_=Type('int64'))
-    ])
-]), output=Output(children=[
-    Leaf('outoo', type_=Type('string'))
-])),
+    Rpc('foo', children=[
+        Input(children=[
+            Leaf('a', type_=Type('string')),
+            Container('woo', children=[
+                Leaf('woo_b', type_=Type('int64'))
+            ])
+        ]),
+        Output(children=[
+            Leaf('outoo', type_=Type('string'))
+        ])
+    ]),
     Rpc('silent')
 ])
     return res


### PR DESCRIPTION
Move Input and Output schema nodes into Rpc/Action node children list instead of exposing them as attributes. This removes the need for special handling in .compile(), submodule merging (and prefix remapping) and import prefix normalization -> less code! In the SchemaNode tree the Input/Output children are always present, which makes it easier to augment without extra checks.

The compiled schema nodes DRpc and DAction keep the attributes for convenience. If the Input/Output children from SchemaNode are empty, then the input/output attributes are None.