### PR TITLE
Support YANG bits in adata

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -2399,12 +2399,26 @@ class DTypeBits(DType):
         return DTypeBits(t.name, resolver.description, resolver.reference, resolver.units, [ext.to_dext() for ext in t.exts], resolver.builtin_type, resolver.default, resolver.bits)
 
     def validate_value(self, val: value) -> bool:
-        if isinstance(val, set):
+        if isinstance(val, list):
             for elem in val:
                 if elem not in self.name_to_pos:
                     return False
             return True
         return False
+
+    def canonical_bits(self, names: list[str]) -> list[str]:
+        """Bit names in RFC 7950 canonical order (ascending position), deduplicated
+        """
+        wanted = set()
+        for name in names:
+            if name == "":
+                continue
+            if name in self.name_to_pos:
+                wanted.add(name)
+            else:
+                raise ValueError("Invalid bit name '{name}', expected one of: {', '.join(self.name_to_pos.keys())}")
+        # name_to_pos was built in ascending position order so iteration is canonical order
+        return [name for name in self.name_to_pos.keys() if name in wanted]
 
     def prtyinst(self) -> str:
         return "DTypeBits({self.format_common_params()}, name_to_pos={repr(self.name_to_pos)})"
@@ -2872,7 +2886,8 @@ class DTypeResolver(object):
                 next_pos = 0
                 if self.bits:
                     raise ValueError("Invalid restriction of bits in type \"{t.name}\"")
-                positions = set(None)
+                positions = set()
+                bits = []
                 for b in _bit:
                     name = b.name
                     _position = b.position
@@ -2887,7 +2902,11 @@ class DTypeResolver(object):
                             raise ValueError("Bit \"{name}\" must be assigned an explicit position when automatic assignment would exceed maximum limit of {MAX_BIT_POSITION} in type \"{t.name}\"")
                         position = next_pos
                         next_pos += 1
-                    self.bits[name] = position
+                    positions.add(position)
+                    bits.append((pos=position, name=name))
+                # Acton dicts iterate in insertion order, so insert in ascending
+                # position order is preserved
+                self.bits.update([(b.name, b.pos) for b in sorted(bits)])
 
             # enum
             _enum = t.enum
@@ -4238,6 +4257,11 @@ def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, key_names: ?list[str], loose: b
     return optional_str + t
 
 def taker_name(n: DNode, key_names: ?list[str], loose: bool=False) -> str:
+    def set_to_bits(acton_type: str) -> str:
+        if acton_type == "set[str]":
+            return "bits"
+        return acton_type
+
     taker_prefix = "get_"
     if isinstance(n, DContainer):
         optional = loose or n.presence or optional_subtree(n)
@@ -4252,11 +4276,11 @@ def taker_name(n: DNode, key_names: ?list[str], loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         if n.type_.builtin_type == "empty":
             return taker_prefix + optional_str + "empty"
-        return taker_prefix + optional_str + yang_type_to_acton_type(n.type_)
+        return taker_prefix + optional_str + set_to_bits(yang_type_to_acton_type(n.type_))
     if isinstance(n, DLeafList):
         optional = loose or n.min_elements == 0
         optional_str = "opt_" if optional else ""
-        return taker_prefix + optional_str + yang_type_to_acton_type(n.type_) + "s"
+        return taker_prefix + optional_str + set_to_bits(yang_type_to_acton_type(n.type_)) + "s"
     raise ValueError("unreachable - unknown node type {type(n)}")
 
 def yang_leaflist_to_acton_type(leaf: DLeafList) -> str:
@@ -4268,7 +4292,7 @@ def yang_typename_to_acton_type(type_name: str) -> str:
     if type_name == "binary":
         return "bytes"
     elif type_name == "bits":
-        raise NotImplementedError('bits not supported')
+        return "set[str]"
     elif type_name == "boolean":
         return "bool"
     elif type_name == "decimal64":
@@ -4366,6 +4390,10 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return "False"
     elif ytype == "enumeration":
         return '"' + value + '"'
+    elif ytype == "bits":
+        names = set(value.split(" "))
+        names.discard("")
+        return repr(names)
     elif ytype == "identityref":
         return value
     elif ytype in SIGNED_INT_TYPES:

--- a/snapshots/expected/gdata/serialization_roundtrip_special_types
+++ b/snapshots/expected/gdata/serialization_roundtrip_special_types
@@ -69,6 +69,23 @@
                     "value": "3.14"
                 }
             }
+        },
+        {
+            "id": {
+                "q": "http://example.com/special",
+                "name": "flags"
+            },
+            "node": {
+                "type": "Leaf",
+                "value": {
+                    "type": "bits",
+                    "value": [
+                        "zulu",
+                        "alpha",
+                        "mike"
+                    ]
+                }
+            }
         }
     ]
 }

--- a/src/adata.act
+++ b/src/adata.act
@@ -84,6 +84,15 @@ def try_validate_mnode_value(val: value, schema_type: yschema.DType, path: list[
         intval = coerce_integer_value(val, schema_type, path)
         if intval is not None and schema_type.validate_value(intval):
             return (t=schema_type.builtin_type, val=intval)
+    elif isinstance(schema_type, yschema.DTypeBits):
+        if isinstance(val, set):
+            # TODO(acton#2969): drop the set[str] annotation once
+            # value-narrowing unboxes set elements.
+            sv: set[str] = val
+            try:
+                return (t=schema_type.builtin_type, val=schema_type.canonical_bits(list(sv)))
+            except ValueError:
+                return None
     else:
         if schema_type.validate_value(val):
             return (t=schema_type.builtin_type, val=val)

--- a/src/data.act
+++ b/src/data.act
@@ -10,7 +10,6 @@ import lib as yang
 import gdata as ygdata
 import schema as yschema
 from identityref import Identityref, PartialIdentityref
-from gdata import repr_adata
 from type import Decimal, Ranges
 from type import SIGNED_INT_TYPES, UNSIGNED_INT_TYPES
 
@@ -348,6 +347,14 @@ def from_data_recursive[A(YangData)](root: yschema.DRoot, s: yschema.DNodeInner,
         raise ValueError("Unknown schema node type at {format_schema_path(spath)}: {type(s)}")
 
 
+def repr_adata(v: value) -> str:
+    if ygdata.as_bits(v) is not None:
+        return "set({ygdata.repr_gdata(v)})"
+    if isinstance(v, ygdata.Present):
+        return "True"
+    return ygdata.repr_gdata(v)
+
+
 def pradata(root: yschema.DRoot, node: ygdata.Node, self_name: str="ad", loose: bool=False, root_path: list[str]=[]):
     return _pradata_recursive(root, node, self_name, loose, top=True, root_path=root_path, spath=[PathElement(root)], path_var_names={}, reserved_names=set([self_name]), create_consumed_leaves=set())
 
@@ -428,7 +435,7 @@ def _pradata_recursive(s: yschema.DNodeInner, node: ygdata.Node, self_name: str,
                 # come first in the correct order.
                 if not yschema.is_optional_arg_yang_leaf(cchild, yschema.list_keys(container), loose):
                     leaf = node.get_leaf(fqname(cchild))
-                    non_optional_args.append("{repr_adata(leaf.val)}")
+                    non_optional_args.append(repr_adata(leaf.val))
             elif isinstance(cchild, yschema.DContainer):
                 if not (cchild.presence or loose or yschema.optional_subtree(cchild)):
                     cchild_safe_name = unique_namer.unique_safe_name(cchild.name, cchild.prefix)
@@ -523,8 +530,8 @@ def _pradata_recursive(s: yschema.DNodeInner, node: ygdata.Node, self_name: str,
             leaflist = node.get_opt_leaflist(fqname(child))
             if leaflist is not None:
                 # DLeafList values are copied verbatim
-                vals = [e.val for e in leaflist.entries if isinstance(e, ygdata.LeafListEntryMerge)]
-                leaves.append("{self_name}.{usname(child)} = {repr_adata(vals)}")
+                vals = [repr_adata(e.val) for e in leaflist.entries if isinstance(e, ygdata.LeafListEntryMerge)]
+                leaves.append("{self_name}.{usname(child)} = [{", ".join(vals)}]")
         elif isinstance(child, yschema.DContainer):
             container = node.get_opt_cnt(fqname(child))
             if container is not None:

--- a/src/gdata.act
+++ b/src/gdata.act
@@ -277,6 +277,21 @@ def _nsq(node_ns, v: ?value=None):
     return r
 
 
+def as_bits(v: ?value) -> ?list[str]:
+    if isinstance(v, list):
+        # TODO(acton#2969): drop the list[str] annotation once value-narrowing
+        # unboxes list elements.
+        lv: list[str] = v
+        return lv
+
+
+def adata_val(v: value) -> value:
+    bits = as_bits(v)
+    if bits is not None:
+        return set(bits)
+    return v
+
+
 def yang_str(v) -> str:
     if isinstance(v, bytes):
         s = base64.encode(v).decode()
@@ -284,6 +299,9 @@ def yang_str(v) -> str:
     if isinstance(v, Identityref):
         s = "{v.mod}:{v.val}"
         return s
+    bits = as_bits(v)
+    if bits is not None:
+        return " ".join(bits)
     s = str(v)
     if isinstance(v, bool):
         s = s.lower()
@@ -310,6 +328,9 @@ def json_val(v: value) -> ?value:
         return "{v.mod}:{v.val}"
     if isinstance(v, Decimal):
         return str(v)
+    bits = as_bits(v)
+    if bits is not None:
+        return " ".join(bits)
     return v
 
 
@@ -326,12 +347,6 @@ def repr_gdata(v) -> str:
     elif isinstance(v, list):
         return "[" + ", ".join([repr_gdata(e) for e in v]) + "]"
     return repr(v)
-
-
-def repr_adata(v) -> str:
-    if isinstance(v, Present):
-        return "True"
-    return repr_gdata(v)
 
 
 class Id:
@@ -416,6 +431,9 @@ def value_to_json(v: value) -> dict[str, ?value]:
         return {"type": "float", "value": v}
     if isinstance(v, str):
         return {"type": "str", "value": v}
+    bits = as_bits(v)
+    if bits is not None:
+        return {"type": "bits", "value": bits}
     raise ValueError("Unsupported gdata value in serialization: {type(v)}")
 
 
@@ -464,6 +482,16 @@ def value_from_json(data: value) -> value:
                 raw = data.get("value")
                 if isinstance(raw, str):
                     return raw
+            if value_type == "bits":
+                raw = data.get("value")
+                if isinstance(raw, list):
+                    names = []
+                    for item in raw:
+                        if isinstance(item, str):
+                            names.append(item)
+                        else:
+                            raise ValueError("Invalid gdata value encoding: {data}")
+                    return names
     raise ValueError("Invalid gdata value encoding: {data}")
 
 
@@ -1169,19 +1197,18 @@ class Node(value):
             return []
 
     def get_value(self, name) -> value:
-        child = self.get_leaf(name)
-        return child.val
+        return adata_val(self.get_leaf(name).val)
 
     def get_opt_value(self, name) -> ?value:
         child = self.get_opt_leaf(name)
         if child is not None:
-            return child.val
+            return adata_val(child.val)
 
     def get_values(self, name) -> list[value]:
         if isinstance(self, Container):
             for nm,child in self.children.items():
                 if isinstance(child, LeafList) and nm == name:
-                    return [e.val for e in child.entries]
+                    return [adata_val(e.val) for e in child.entries]
         raise ValueError("Cannot find leaf-list child with name {name}")
 
     def get_opt_values(self, name) -> list[value]:
@@ -1219,6 +1246,35 @@ class Node(value):
     def get_opt_Identityrefs(self, name) -> list[Identityref]:
         try:
             return self.get_Identityrefs(name)
+        except ValueError:
+            return []
+
+    def get_bits(self, name) -> set[str]:
+        bits = as_bits(self.get_leaf(name).val)
+        if bits is not None:
+            return set(bits)
+        raise ValueError("Leaf {name} value is not type bits")
+
+    def get_opt_bits(self, name) -> ?set[str]:
+        bits = as_bits(self.get_opt_leaf(name)?.val)
+        if bits is not None:
+            return set(bits)
+
+    def get_bitss(self, name) -> list[set[str]]:
+        if isinstance(self, Container):
+            for nm,child in self.children.items():
+                if isinstance(child, LeafList) and nm == name:
+                    cvals: list[set[str]] = []
+                    for entry in child.entries:
+                        bits = as_bits(entry.val)
+                        if bits is not None:
+                            cvals.append(set(bits))
+                    return cvals
+        raise ValueError("Cannot find leaf-list child with name {name}")
+
+    def get_opt_bitss(self, name) -> list[set[str]]:
+        try:
+            return self.get_bitss(name)
         except ValueError:
             return []
 
@@ -1949,16 +2005,10 @@ def vals_equal(a: value, b: value) -> bool:
         return a == b
     if isinstance(a, Present) and isinstance(b, Present):
         return True
-    if isinstance(a, set) and isinstance(b, set):
-        # YANG bits values are decoded into a set of bit names. Assign to a
-        # correctly-typed local so set operations use the str element witness:
-        # isinstance-narrowing a `value` back to a parameterized type otherwise
-        # picks an arbitrary element type (actonlang/acton#2969).
-        # TODO(acton#2969): drop the set[str] annotation once value-narrowing
-        # unboxes set elements, leaving `return a == b`.
-        sa: set[str] = a
-        sb: set[str] = b
-        return sa == sb
+    la = as_bits(a)
+    lb = as_bits(b)
+    if la is not None and lb is not None:
+        return la == lb
     if type(a) != type(b):
         # It is valid to compare values of different type, which happens if
         # leaves are of type union and value a and b happen to be of different
@@ -1986,17 +2036,10 @@ def vals_less_than(a: value, b: value) -> bool:
         return a < b
     if isinstance(a, Present) and isinstance(b, Present):
         return False
-    if isinstance(a, set) and isinstance(b, set):
-        # YANG bits values are decoded into a set of bit names. Assign to a
-        # correctly-typed local (actonlang/acton#2969) so iteration unboxes the
-        # bit names, then order lexicographically by the sorted names. Equal sets
-        # have equal sorted lists, so they are never less-than each other
-        # (consistent with vals_equal).
-        # TODO(acton#2969): drop the set[str] annotation once value-narrowing
-        # unboxes set elements, leaving `return sorted(list(a)) < sorted(list(b))`.
-        sa: set[str] = a
-        sb: set[str] = b
-        return sorted(list(sa)) < sorted(list(sb))
+    la = as_bits(a)
+    lb = as_bits(b)
+    if la is not None and lb is not None:
+        return la < lb
     raise ValueError("Unsupported value type or mismatch in lt comparison: {type(a)}, {type(b)}")
 
 
@@ -5703,6 +5746,9 @@ def _test_serialization_roundtrip_special_types():
         Id(ns_special, "empty"): Leaf(Present()),
         Id(ns_special, "counter"): Leaf(u64(18446744073709551615)),
         Id(ns_special, "fraction"): Leaf(Decimal(314, -2)),
+        # YANG bits: canonical position-ordered list of bit names (position
+        # order deliberately contradicts name order)
+        Id(ns_special, "flags"): Leaf(["zulu", "alpha", "mike"]),
     }, ns=ns_special, module="special")
 
     return _serde_roundtrip_json(original)

--- a/src/json.act
+++ b/src/json.act
@@ -155,15 +155,12 @@ def try_parse_json_value(leaf_value: ?value, schema_node: yschema.DNodeLeaf, sch
             val = leaf_value
         elif isinstance(schema_type, yschema.DTypeBits):
             if isinstance(leaf_value, str):
-                bits_val = set(None)
-                for bit in leaf_value.split(" "):
-                    if bit in schema_type.name_to_pos:
-                        bits_val.add(bit)
-                    else:
-                        raise YangValidationError(path, schema_type, leaf_value)
-                val = bits_val
+                try:
+                    val = schema_type.canonical_bits(leaf_value.split(" "))
+                except ValueError:
+                    raise YangValidationError(path, schema_type, leaf_value)
             else:
-                val = leaf_value
+                raise YangValidationError(path, schema_type, leaf_value)
 
         if val is not None and schema_type.validate_value(val):
             return (t=type_name, val=val)

--- a/src/schema.act
+++ b/src/schema.act
@@ -2395,12 +2395,26 @@ class DTypeBits(DType):
         return DTypeBits(t.name, resolver.description, resolver.reference, resolver.units, [ext.to_dext() for ext in t.exts], resolver.builtin_type, resolver.default, resolver.bits)
 
     def validate_value(self, val: value) -> bool:
-        if isinstance(val, set):
+        if isinstance(val, list):
             for elem in val:
                 if elem not in self.name_to_pos:
                     return False
             return True
         return False
+
+    def canonical_bits(self, names: list[str]) -> list[str]:
+        """Bit names in RFC 7950 canonical order (ascending position), deduplicated
+        """
+        wanted = set()
+        for name in names:
+            if name == "":
+                continue
+            if name in self.name_to_pos:
+                wanted.add(name)
+            else:
+                raise ValueError("Invalid bit name '{name}', expected one of: {', '.join(self.name_to_pos.keys())}")
+        # name_to_pos was built in ascending position order so iteration is canonical order
+        return [name for name in self.name_to_pos.keys() if name in wanted]
 
     def prtyinst(self) -> str:
         return "DTypeBits({self.format_common_params()}, name_to_pos={repr(self.name_to_pos)})"
@@ -2868,7 +2882,8 @@ class DTypeResolver(object):
                 next_pos = 0
                 if self.bits:
                     raise ValueError("Invalid restriction of bits in type \"{t.name}\"")
-                positions = set(None)
+                positions = set()
+                bits = []
                 for b in _bit:
                     name = b.name
                     _position = b.position
@@ -2883,7 +2898,11 @@ class DTypeResolver(object):
                             raise ValueError("Bit \"{name}\" must be assigned an explicit position when automatic assignment would exceed maximum limit of {MAX_BIT_POSITION} in type \"{t.name}\"")
                         position = next_pos
                         next_pos += 1
-                    self.bits[name] = position
+                    positions.add(position)
+                    bits.append((pos=position, name=name))
+                # Acton dicts iterate in insertion order, so insert in ascending
+                # position order is preserved
+                self.bits.update([(b.name, b.pos) for b in sorted(bits)])
 
             # enum
             _enum = t.enum
@@ -4234,6 +4253,11 @@ def yang_leaf_to_acton_arg_type(leaf: DNodeLeaf, key_names: ?list[str], loose: b
     return optional_str + t
 
 def taker_name(n: DNode, key_names: ?list[str], loose: bool=False) -> str:
+    def set_to_bits(acton_type: str) -> str:
+        if acton_type == "set[str]":
+            return "bits"
+        return acton_type
+
     taker_prefix = "get_"
     if isinstance(n, DContainer):
         optional = loose or n.presence or optional_subtree(n)
@@ -4248,11 +4272,11 @@ def taker_name(n: DNode, key_names: ?list[str], loose: bool=False) -> str:
         optional_str = "opt_" if optional else ""
         if n.type_.builtin_type == "empty":
             return taker_prefix + optional_str + "empty"
-        return taker_prefix + optional_str + yang_type_to_acton_type(n.type_)
+        return taker_prefix + optional_str + set_to_bits(yang_type_to_acton_type(n.type_))
     if isinstance(n, DLeafList):
         optional = loose or n.min_elements == 0
         optional_str = "opt_" if optional else ""
-        return taker_prefix + optional_str + yang_type_to_acton_type(n.type_) + "s"
+        return taker_prefix + optional_str + set_to_bits(yang_type_to_acton_type(n.type_)) + "s"
     raise ValueError("unreachable - unknown node type {type(n)}")
 
 def yang_leaflist_to_acton_type(leaf: DLeafList) -> str:
@@ -4264,7 +4288,7 @@ def yang_typename_to_acton_type(type_name: str) -> str:
     if type_name == "binary":
         return "bytes"
     elif type_name == "bits":
-        raise NotImplementedError('bits not supported')
+        return "set[str]"
     elif type_name == "boolean":
         return "bool"
     elif type_name == "decimal64":
@@ -4362,6 +4386,10 @@ def prsrc_literal(ytype: str, value: str) -> str:
         return "False"
     elif ytype == "enumeration":
         return '"' + value + '"'
+    elif ytype == "bits":
+        names = set(value.split(" "))
+        names.discard("")
+        return repr(names)
     elif ytype == "identityref":
         return value
     elif ytype in SIGNED_INT_TYPES:

--- a/src/test_data.act
+++ b/src/test_data.act
@@ -4,6 +4,7 @@ import std.xml as xml
 import lib as yang
 import adata as yadata
 import gdata as ygdata
+import schema as yschema
 
 from data import YangValidationError, format_schema_path
 from xml import from_xml
@@ -1755,11 +1756,14 @@ def _test_json_path_rejects_wrong_top_key():
 def _test_bits_leaf_comparison():
     """Regression: comparing gdata trees containing a YANG bits leaf must not crash.
 
-    A YANG bits leaf decodes into a set of bit names. The value-comparison
-    helpers (vals_equal / vals_less_than), reached via Node.__eq__ and leaf-list
-    entry sorting, must handle set values instead of raising "Unsupported value
-    type". A downstream consumer that diffs subscription trees (merged !=
-    last_merged) hit this when a monitored subtree contained a bits leaf.
+    A YANG bits leaf decodes into a canonical position-ordered list of bit
+    names — the only representation gdata holds, since bits values are
+    constructed exclusively by schema-adjacent code (the XML/JSON parsers and
+    adata conversion). The value-comparison helpers (vals_equal /
+    vals_less_than), reached via Node.__eq__ and leaf-list entry sorting, must
+    handle it instead of raising "Unsupported value type". A downstream
+    consumer that diffs subscription trees (merged != last_merged) hit this
+    when a monitored subtree contained a bits leaf.
     """
     ybits = r"""module ybits {
   namespace "urn:example:ybits";
@@ -1801,32 +1805,51 @@ def _test_bits_leaf_comparison():
     testing.assertTrue(gd_ab1 != gd_ac, "different bits leaves should compare unequal")
     testing.assertFalse(gd_ab1 == gd_ac, "different bits leaves should not compare equal")
 
-    # vals_less_than over set values must be a deterministic total order and not
-    # raise: equal sets are never less-than, and unequal sets order in exactly
-    # one direction (consistent with vals_equal).
-    s_ab = set(["a", "b"])
-    s_ab2 = set(["a", "b"])
-    s_ac = set(["a", "c"])
-    testing.assertFalse(ygdata.vals_less_than(s_ab, s_ab2), "equal sets must not be less-than")
-    testing.assertFalse(ygdata.vals_less_than(s_ab2, s_ab), "equal sets must not be less-than")
-    testing.assertTrue(ygdata.vals_equal(s_ab, s_ab2), "equal sets must be vals_equal")
-    testing.assertFalse(ygdata.vals_equal(s_ab, s_ac), "different sets must not be vals_equal")
-    lt_fwd = ygdata.vals_less_than(s_ab, s_ac)
-    lt_rev = ygdata.vals_less_than(s_ac, s_ab)
+    # Wire form: bit name order in the input does not matter, and output is the
+    # RFC 7950 canonical form ordered by position (a=0, b=1, c=2)
+    gd_ba = from_xml(s, xml.decode(r"""<data>
+<c xmlns="urn:example:ybits"><flags>b a</flags></c>
+</data>"""))
+    testing.assertTrue(gd_ab1 == gd_ba, "bit name order in input must not matter")
+    testing.assertTrue("<flags>a b</flags>" in gd_ba.to_xmlstr(), "serialized bits must be in canonical position order")
+
+    # vals_less_than over canonical bits values must be a deterministic total
+    # order and not raise: equal values are never less-than, and unequal values
+    # order in exactly one direction (consistent with vals_equal).
+    l_ab = ["a", "b"]
+    l_ab2 = ["a", "b"]
+    l_ac = ["a", "c"]
+    testing.assertFalse(ygdata.vals_less_than(l_ab, l_ab2), "equal bits values must not be less-than")
+    testing.assertFalse(ygdata.vals_less_than(l_ab2, l_ab), "equal bits values must not be less-than")
+    testing.assertTrue(ygdata.vals_equal(l_ab, l_ab2), "equal bits values must be vals_equal")
+    testing.assertFalse(ygdata.vals_equal(l_ab, l_ac), "different bits values must not be vals_equal")
+    lt_fwd = ygdata.vals_less_than(l_ab, l_ac)
+    lt_rev = ygdata.vals_less_than(l_ac, l_ab)
     testing.assertTrue(
         lt_fwd != lt_rev,
-        "unequal sets must order in exactly one direction")
+        "unequal bits values must order in exactly one direction")
 
-    # The ordering must be canonical: sets with the same elements built in a
-    # different insertion order compare equal and are never less-than each other.
-    s_ba = set(["b", "a"])
-    testing.assertTrue(ygdata.vals_equal(s_ab, s_ba), "set order must not affect equality")
-    testing.assertFalse(ygdata.vals_less_than(s_ab, s_ba), "equal sets must not be less-than")
-    testing.assertFalse(ygdata.vals_less_than(s_ba, s_ab), "equal sets must not be less-than")
+    # gdata holds bits only in RFC 7950 canonical form, guaranteed by
+    # construction: every entry point (XML/JSON parsers, adata conversion)
+    # produces values via DTypeBits.canonical_bits. validate_value checks bit
+    # name membership and value shape only.
+    flags_leaf = s.get("c").get("flags")
+    if isinstance(flags_leaf, yschema.DLeaf):
+        flags_type = flags_leaf.type_
+        if isinstance(flags_type, yschema.DTypeBits):
+            empty_bits: list[str] = []
+            testing.assertTrue(flags_type.validate_value(["a", "b"]), "canonical bits value must validate")
+            testing.assertTrue(flags_type.validate_value(empty_bits), "empty bits value must validate")
+            testing.assertFalse(flags_type.validate_value(["a", "z"]), "unknown bit name must not validate")
+            testing.assertFalse(flags_type.validate_value(set(["a", "b"])), "set values must not validate")
+        else:
+            raise ValueError("Expected flags leaf type to be DTypeBits")
+    else:
+        raise ValueError("Expected flags to be a DLeaf")
 
     # Deterministically serialising a bits leaf-list sorts its entries, which
-    # exercises vals_less_than over set values; it must not raise and must be
-    # stable across calls.
+    # exercises vals_less_than over canonical list values; it must not raise
+    # and must be stable across calls.
     gd_list = from_xml(s, xml.decode(r"""<data>
 <c xmlns="urn:example:ybits">
   <flaglist>b c</flaglist>

--- a/src/xml.act
+++ b/src/xml.act
@@ -240,13 +240,10 @@ def try_parse_xml_value(text_value: ?str, schema_node: yschema.DNodeLeaf, schema
         elif isinstance(schema_type, yschema.DTypeInstanceIdentifier):
             val = text_value
         elif isinstance(schema_type, yschema.DTypeBits):
-            bits_val = set(None)
-            for bit in text_value.split(" "):
-                if bit in schema_type.name_to_pos:
-                    bits_val.add(bit)
-                else:
-                    raise YangValidationError(path, schema_type, text_value)
-            val = bits_val
+            try:
+                val = schema_type.canonical_bits(text_value.split(" "))
+            except ValueError:
+                raise YangValidationError(path, schema_type, text_value)
 
         if val is not None and schema_type.validate_value(val):
             return (t=type_name, val=val)

--- a/test/test_data_classes/snapshots/expected/test_data_classes/bits_from_xml
+++ b/test/test_data_classes/snapshots/expected/test_data_classes/bits_from_xml
@@ -1,0 +1,5 @@
+<c1 xmlns="http://example.com/foo">
+  <l_bits>zebra aardvark medved</l_bits>
+  <ll_bits>x y</ll_bits>
+  <ll_bits>x</ll_bits>
+</c1>

--- a/test/test_data_classes/src/test_data_classes.act
+++ b/test/test_data_classes/src/test_data_classes.act
@@ -582,6 +582,7 @@ def basics_leaf_defaults(r):
     testing.assertEqual(r.c.l_str_def_quoted, '"foo"')
     testing.assertEqual(r.c.l_binary_def, "Hello Acton 🫡".encode())
     testing.assertEqual(r.c.l_identityref_def, yang_basics.basics_id2)
+    testing.assertEqual(r.c.l_bits_def, set(["a", "c"]))
 
     # union types
     uds = r.c.l_union_def_str
@@ -642,6 +643,42 @@ def _test_union_default_other_type():
     c.l_union_def_int = "foo"
     c.l_union_def_float = "foo"
     c.l_union_def_enumeration = 42
+
+def _test_bits_from_xml():
+    # Bit name order in the input does not matter; adata exposes bits as a set
+    # of names and serialized output is the RFC 7950 canonical form ordered by
+    # bit position (zebra=0, aardvark=1, medved=2).
+    xml_text = """<data><c1 xmlns="http://example.com/foo"><l_bits>medved aardvark zebra</l_bits><ll_bits>y x</ll_bits><ll_bits>x</ll_bits></c1></data>"""
+    gd = yxml.from_xml(yang_foo.SRC_DNODE, xml.decode(xml_text))
+    r = yang_foo_root.from_gdata(gd)
+    l_bits = r.c1.l_bits
+    if l_bits is not None:
+        testing.assertEqual(l_bits, set(["aardvark", "medved", "zebra"]))
+    else:
+        raise ValueError("Expected l_bits to be set")
+    testing.assertEqual(r.c1.ll_bits, [set(["x", "y"]), set(["x"])])
+    xml_out = r.to_gdata().to_xmlstr()
+    testing.assertTrue("<l_bits>zebra aardvark medved</l_bits>" in xml_out, "bits must serialize in canonical position order, got: {xml_out}")
+    testing.assertTrue("<ll_bits>x y</ll_bits>" in xml_out, "bits leaf-list entries must serialize in canonical position order, got: {xml_out}")
+    return xml_out
+
+def _test_union_bits_roundtrip():
+    # A union with a bits member: adata presents bits as set[str] even in the
+    # value-typed union field (from_gdata converts the canonical gdata list),
+    # and to_gdata canonicalizes the set back to position order.
+    xml_text = """<data><c1 xmlns="http://example.com/foo"><l_union_bits>green red</l_union_bits></c1></data>"""
+    gd = yxml.from_xml(yang_foo.SRC_DNODE, xml.decode(xml_text))
+    r = yang_foo_root.from_gdata(gd)
+    v = r.c1.l_union_bits
+    if isinstance(v, set):
+        # TODO(acton#2969): drop the set[str] annotation once value-narrowing
+        # unboxes set elements.
+        sv: set[str] = v
+        testing.assertEqual(sv, set(["red", "green"]))
+    else:
+        raise ValueError("Expected l_union_bits to hold a set of bit names")
+    xml_out = r.to_gdata().to_xmlstr()
+    testing.assertTrue("<l_union_bits>red green</l_union_bits>" in xml_out, "union bits must round-trip in canonical position order, got: {xml_out}")
 
 def _test_empty_presence():
     xml_text = """<data><empty-presence xmlns="http://example.com/foo"/></data>"""

--- a/test/test_data_classes/src/yang_basics.act
+++ b/test/test_data_classes/src/yang_basics.act
@@ -39,7 +39,8 @@ SRC_DNODE_CHILD_0: DContainer = DContainer(module='basics', namespace='http://ex
     DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_union_def_bool', config=True, default='false', mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]), DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None)])),
     DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_union_def_enumeration', config=True, default='unlimited', mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'unlimited':0}), DTypeIntegerUnsigned(name='uint16', description=None, reference=None, exts=[], builtin_type='uint16', default=None, ranges=Ranges([(0, 65535)]))])),
     DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_binary_def', config=True, default='SGVsbG8gQWN0b24g8J+roQ==', mandatory=False, type_=DTypeBinary(name='binary', description=None, reference=None, exts=[], builtin_type='binary', default=None, length=None)),
-    DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_identityref_def', config=True, default='b:id2', mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_basics_id1], identities=_identities))
+    DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_identityref_def', config=True, default='b:id2', mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_basics_id1], identities=_identities)),
+    DLeaf(module='basics', namespace='http://example.com/basics', prefix='b', name='l_bits_def', config=True, default='c a', mandatory=False, type_=DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'a':0, 'b':1, 'c':2}))
 ])
 
 SRC_DNODE_IDENTITY_0: DIdentity = DIdentity(module='basics', namespace='http://example.com/basics', prefix='b', name='id1')
@@ -131,6 +132,14 @@ SRC_YANG_0: str = r"""module basics {
             }
             default id2;
         }
+        leaf l_bits_def {
+            type bits {
+                bit a;
+                bit b;
+                bit c;
+            }
+            default "c a";
+        }
     }
 }"""
 
@@ -156,8 +165,9 @@ class basics__c(yadata.MNode):
     l_union_def_enumeration: value
     l_binary_def: bytes
     l_identityref_def: Identityref
+    l_bits_def: set[str]
 
-    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?u64=None, l_decimal64_def: ?Decimal=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None) -> None:
+    mut def __init__(self, l_str_def: ?str=None, l_str_def_quoted: ?str=None, l_uint64_def: ?u64=None, l_decimal64_def: ?Decimal=None, l_union_def_str: ?value=None, l_union_def_int: ?value=None, l_union_def_float: ?value=None, l_union_def_bool: ?value=None, l_union_def_enumeration: ?value=None, l_binary_def: ?bytes=None, l_identityref_def: ?Identityref=None, l_bits_def: ?set[str]=None) -> None:
         self.l_str_def = l_str_def if l_str_def is not None else "foo"
         self.l_str_def_quoted = l_str_def_quoted if l_str_def_quoted is not None else "\"foo\""
         self.l_uint64_def = l_uint64_def if l_uint64_def is not None else u64(1234567890)
@@ -169,6 +179,7 @@ class basics__c(yadata.MNode):
         self.l_union_def_enumeration = l_union_def_enumeration if l_union_def_enumeration is not None else "unlimited"
         self.l_binary_def = l_binary_def if l_binary_def is not None else base64.decode('SGVsbG8gQWN0b24g8J+roQ=='.encode())
         self.l_identityref_def = l_identityref_def if l_identityref_def is not None else basics_id2
+        self.l_bits_def = l_bits_def if l_bits_def is not None else {'a', 'c'}
 
     mut def to_gdata(self) -> ygdata.Node:
         return yadata.from_adata(SRC_DNODE, self, loose=False, root_path=['basics:c'])
@@ -176,7 +187,7 @@ class basics__c(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> basics__c:
         if n is not None:
-            return basics__c(l_str_def=n.get_opt_str(ygdata.Id(NS_basics, 'l_str_def')), l_str_def_quoted=n.get_opt_str(ygdata.Id(NS_basics, 'l_str_def_quoted')), l_uint64_def=n.get_opt_u64(ygdata.Id(NS_basics, 'l_uint64_def')), l_decimal64_def=n.get_opt_Decimal(ygdata.Id(NS_basics, 'l_decimal64_def')), l_union_def_str=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_str')), l_union_def_int=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_int')), l_union_def_float=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_float')), l_union_def_bool=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_bool')), l_union_def_enumeration=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_enumeration')), l_binary_def=n.get_opt_bytes(ygdata.Id(NS_basics, 'l_binary_def')), l_identityref_def=n.get_opt_Identityref(ygdata.Id(NS_basics, 'l_identityref_def')))
+            return basics__c(l_str_def=n.get_opt_str(ygdata.Id(NS_basics, 'l_str_def')), l_str_def_quoted=n.get_opt_str(ygdata.Id(NS_basics, 'l_str_def_quoted')), l_uint64_def=n.get_opt_u64(ygdata.Id(NS_basics, 'l_uint64_def')), l_decimal64_def=n.get_opt_Decimal(ygdata.Id(NS_basics, 'l_decimal64_def')), l_union_def_str=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_str')), l_union_def_int=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_int')), l_union_def_float=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_float')), l_union_def_bool=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_bool')), l_union_def_enumeration=n.get_opt_value(ygdata.Id(NS_basics, 'l_union_def_enumeration')), l_binary_def=n.get_opt_bytes(ygdata.Id(NS_basics, 'l_binary_def')), l_identityref_def=n.get_opt_Identityref(ygdata.Id(NS_basics, 'l_identityref_def')), l_bits_def=n.get_opt_bits(ygdata.Id(NS_basics, 'l_bits_def')))
         return basics__c()
 
     mut def copy(self) -> basics__c:
@@ -241,7 +252,12 @@ mut def src_schema() -> dict[str, SchemaNode]:
         Type('uint16')
     ]), default='unlimited'),
         Leaf('l_binary_def', type_=Type('binary'), default='SGVsbG8gQWN0b24g8J+roQ=='),
-        Leaf('l_identityref_def', type_=Type('identityref', base=['id1']), default='id2')
+        Leaf('l_identityref_def', type_=Type('identityref', base=['id1']), default='id2'),
+        Leaf('l_bits_def', type_=Type('bits', bit=[
+        Bit('a'),
+        Bit('b'),
+        Bit('c')
+    ]), default='c a')
     ])
 ])
     return res

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -31,44 +31,64 @@ foo_basey: Identityref = Identityref('basey', ns='http://example.com/foo', mod='
 bar_bary: Identityref = Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')
 
 
-SRC_DNODE_CHILD_0: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=True, presence=False, children=[
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l3', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty_delete', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_decimal64', config=True, mandatory=False, type_=DTypeDecimal64(name='decimal64', description=None, reference=None, exts=[], builtin_type='decimal64', default=None, fraction_digits=2, ranges=Ranges([(Decimal(bigint("-9223372036854775808"), bigint("-2")), Decimal(bigint("9223372036854775807"), bigint("-2")))]))),
-    DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li', key=['name'], config=True, min_elements=0, ordered_by='user', children=[
-        DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-        DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='val', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-        DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c4', config=True, presence=False, children=[
-            DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l5', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-        ])
-    ]),
-    DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_uint64', config=True, min_elements=0, ordered_by='system', type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
-    DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_str', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities)),
-    DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_identityref', config=True, min_elements=0, ordered_by='system', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref_noval', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_fooy], identities=_identities)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l4', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l2', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l_leafref', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yxpath.AbsoluteLocationPath([yxpath.NodeTestStep('f', 'c1', []), yxpath.NodeTestStep('f', 'li', []), yxpath.NodeTestStep('f', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+SRC_DNODE_CHILD_1: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_2: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l3', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)])))
+
+SRC_DNODE_CHILD_3: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None))
+
+SRC_DNODE_CHILD_4: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty_delete', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None))
+
+SRC_DNODE_CHILD_5: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_decimal64', config=True, mandatory=False, type_=DTypeDecimal64(name='decimal64', description=None, reference=None, exts=[], builtin_type='decimal64', default=None, fraction_digits=2, ranges=Ranges([(Decimal(bigint("-9223372036854775808"), bigint("-2")), Decimal(bigint("9223372036854775807"), bigint("-2")))])))
+
+SRC_DNODE_CHILD_6: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li', key=['name'], config=True, min_elements=0, ordered_by='user', children=[
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='val', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c4', config=True, presence=False, children=[
+        DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l5', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ])
 ])
 
-SRC_DNODE_CHILD_1: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc1', config=True, presence=True, children=[
+SRC_DNODE_CHILD_7: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_uint64', config=True, min_elements=0, ordered_by='system', type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)])))
+
+SRC_DNODE_CHILD_8: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_str', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_9: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities))
+
+SRC_DNODE_CHILD_10: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_identityref', config=True, min_elements=0, ordered_by='system', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities))
+
+SRC_DNODE_CHILD_11: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref_noval', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_fooy], identities=_identities))
+
+SRC_DNODE_CHILD_12: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_bits', config=True, mandatory=False, type_=DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'zebra':0, 'aardvark':1, 'medved':2}))
+
+SRC_DNODE_CHILD_13: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_bits', config=True, min_elements=0, ordered_by='system', type_=DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'x':0, 'y':1}))
+
+SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_union_bits', config=True, mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'red':0, 'green':1}), DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 255)]))]))
+
+SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l4', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_16: DLeaf = DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_17: DLeaf = DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l2', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_18: DLeaf = DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l_leafref', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yxpath.AbsoluteLocationPath([yxpath.NodeTestStep('f', 'c1', []), yxpath.NodeTestStep('f', 'li', []), yxpath.NodeTestStep('f', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11, SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18])
+
+SRC_DNODE_CHILD_19: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc1', config=True, presence=True, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, presence=False, children=[
         DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, min_elements=0, ordered_by='system', type_=DTypeBinary(name='binary', description=None, reference=None, exts=[], builtin_type='binary', default=None, length=None))
     ])
 ])
 
-SRC_DNODE_CHILD_2: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc2', config=True, presence=True, children=[
+SRC_DNODE_CHILD_20: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc2', config=True, presence=True, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_mandatory', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty_mandatory', config=True, mandatory=True, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None))
     ])
 ])
 
-SRC_DNODE_CHILD_3: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc3', config=True, presence=True, children=[
+SRC_DNODE_CHILD_21: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc3', config=True, presence=True, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='level1', config=True, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1-optional', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -83,32 +103,32 @@ SRC_DNODE_CHILD_3: DContainer = DContainer(module='foo', namespace='http://examp
     ])
 ])
 
-SRC_DNODE_CHILD_4: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='empty-presence', config=True, presence=True)
+SRC_DNODE_CHILD_22: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='empty-presence', config=True, presence=True)
 
-SRC_DNODE_CHILD_5: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c.dot', config=True, presence=False, children=[
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c.dot', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l.dot1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l.dot2', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_6: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='cc', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='cc', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='cake', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DList(module='foo', namespace='http://example.com/foo', prefix='f', name='death', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
     ])
 ])
 
-SRC_DNODE_CHILD_7: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='conflict', config=True, presence=False, children=[
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='conflict', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='inner', config=True, presence=True),
     DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='inner', config=True, presence=True)
 ])
 
-SRC_DNODE_CHILD_8: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='special', key=['yes'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_26: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='special', key=['yes'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='yes', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_9: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='nested', config=True, presence=False, children=[
+SRC_DNODE_CHILD_27: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='nested', config=True, presence=False, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='inner', config=True, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li1', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
@@ -130,7 +150,7 @@ SRC_DNODE_CHILD_9: DContainer = DContainer(module='foo', namespace='http://examp
     ])
 ])
 
-SRC_DNODE_CHILD_10: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union', key=[
+SRC_DNODE_CHILD_28: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union', key=[
 'k1',
 'k2',
 'k3'
@@ -141,28 +161,28 @@ SRC_DNODE_CHILD_10: DList = DList(module='foo', namespace='http://example.com/fo
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='checker', config=True, mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1514, 1514)])), DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(47, 47)])), DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])]))
 ])
 
-SRC_DNODE_CHILD_11: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union-one-base', key=['k1'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_29: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union-one-base', key=['k1'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='k1', config=True, mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'foo':0}), DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])]))
 ])
 
-SRC_DNODE_CHILD_12: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='state', config=False, presence=False, children=[
+SRC_DNODE_CHILD_30: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='state', config=False, presence=False, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=False, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l2', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
     ])
 ])
 
-SRC_DNODE_CHILD_13: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll-empty', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_31: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll-empty', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_14: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c2', config=True, presence=False, children=[
+SRC_DNODE_CHILD_32: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c2', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_15: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='test-idref', config=True, presence=False, children=[
+SRC_DNODE_CHILD_33: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='test-idref', config=True, presence=False, children=[
     DLeafList(module='bar', namespace='http://example.com/bar', prefix='bar', name='idref', config=True, min_elements=0, ordered_by='system', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities))
 ])
 
-SRC_DNODE_CHILD_16: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='conflict', config=True, presence=False, children=[
+SRC_DNODE_CHILD_34: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='conflict', config=True, presence=False, children=[
     DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
@@ -177,7 +197,7 @@ SRC_DNODE_IDENTITY_2: DIdentity = DIdentity(module='bar', namespace='http://exam
     ])
 
 SRC_DNODE: DRoot = DRoot(
-    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11, SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16],
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28, SRC_DNODE_CHILD_29, SRC_DNODE_CHILD_30, SRC_DNODE_CHILD_31, SRC_DNODE_CHILD_32, SRC_DNODE_CHILD_33, SRC_DNODE_CHILD_34],
     identities=[SRC_DNODE_IDENTITY_0, SRC_DNODE_IDENTITY_1, SRC_DNODE_IDENTITY_2],
     rpcs=[],
     module_metadata={'http://example.com/foo':('foo', None), 'http://example.com/bar':('bar', None)},
@@ -252,6 +272,34 @@ SRC_YANG_0: str = r"""module foo {
             // There are no identities derived from base fooy, this leaf has no valid value!
             type identityref {
                 base fooy;
+            }
+        }
+        leaf l_bits {
+            // positions contradict both alphabetical and declaration order to
+            // prove canonical (position-ordered) serialization
+            type bits {
+                bit aardvark {
+                    position 1;
+                }
+                bit zebra {
+                    position 0;
+                }
+                bit medved;
+            }
+        }
+        leaf-list ll_bits {
+            type bits {
+                bit x;
+                bit y;
+            }
+        }
+        leaf l_union_bits {
+            type union {
+                type bits {
+                    bit red;
+                    bit green;
+                }
+                type uint8;
             }
         }
     }
@@ -636,12 +684,15 @@ class foo__c1(yadata.MNode):
     l_identityref: ?Identityref
     ll_identityref: list[Identityref]
     l_identityref_noval: ?Identityref
+    l_bits: ?set[str]
+    ll_bits: list[set[str]]
+    l_union_bits: ?value
     l4: ?str
     bar_l1: ?str
     l2: ?str
     l_leafref: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str) -> None:
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l_bits: ?set[str], ll_bits: ?list[set[str]]=None, l_union_bits: ?value, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str) -> None:
         self.f_l1 = f_l1
         self.l3 = l3
         self.l_empty = l_empty
@@ -653,6 +704,9 @@ class foo__c1(yadata.MNode):
         self.l_identityref = l_identityref
         self.ll_identityref = ll_identityref if ll_identityref is not None else []
         self.l_identityref_noval = l_identityref_noval
+        self.l_bits = l_bits
+        self.ll_bits = ll_bits if ll_bits is not None else []
+        self.l_union_bits = l_union_bits
         self.l4 = l4
         self.bar_l1 = bar_l1
         self.l2 = l2
@@ -664,7 +718,7 @@ class foo__c1(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> foo__c1:
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(ygdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(ygdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(ygdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(ygdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(ygdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(ygdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(ygdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(ygdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(ygdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(ygdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(ygdata.Id(NS_bar, 'l_leafref')))
+            return foo__c1(f_l1=n.get_opt_str(ygdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(ygdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(ygdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(ygdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(ygdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(ygdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(ygdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref_noval')), l_bits=n.get_opt_bits(ygdata.Id(NS_foo, 'l_bits')), ll_bits=n.get_opt_bitss(ygdata.Id(NS_foo, 'll_bits')), l_union_bits=n.get_opt_value(ygdata.Id(NS_foo, 'l_union_bits')), l4=n.get_opt_str(ygdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(ygdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(ygdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(ygdata.Id(NS_bar, 'l_leafref')))
         return foo__c1()
 
     mut def copy(self) -> foo__c1:
@@ -1743,7 +1797,23 @@ mut def src_schema() -> dict[str, SchemaNode]:
         LeafList('ll_str', type_=Type('string')),
         Leaf('l_identityref', type_=Type('identityref', base=['basey'])),
         LeafList('ll_identityref', type_=Type('identityref', base=['basey'])),
-        Leaf('l_identityref_noval', type_=Type('identityref', base=['fooy']))
+        Leaf('l_identityref_noval', type_=Type('identityref', base=['fooy'])),
+        Leaf('l_bits', type_=Type('bits', bit=[
+        Bit('aardvark', position=1),
+        Bit('zebra', position=0),
+        Bit('medved')
+    ])),
+        LeafList('ll_bits', type_=Type('bits', bit=[
+        Bit('x'),
+        Bit('y')
+    ])),
+        Leaf('l_union_bits', type_=Type('union', type_=[
+        Type('bits', bit=[
+                Bit('red'),
+                Bit('green')
+            ]),
+        Type('uint8')
+    ]))
     ]),
     Container('pc1', presence='p', children=[
         Container('foo', children=[

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -31,44 +31,64 @@ foo_basey: Identityref = Identityref('basey', ns='http://example.com/foo', mod='
 bar_bary: Identityref = Identityref('bary', ns='http://example.com/bar', mod='bar', pfx='bar')
 
 
-SRC_DNODE_CHILD_0: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=True, presence=False, children=[
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l3', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty_delete', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_decimal64', config=True, mandatory=False, type_=DTypeDecimal64(name='decimal64', description=None, reference=None, exts=[], builtin_type='decimal64', default=None, fraction_digits=2, ranges=Ranges([(Decimal(bigint("-9223372036854775808"), bigint("-2")), Decimal(bigint("9223372036854775807"), bigint("-2")))]))),
-    DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li', key=['name'], config=True, min_elements=0, ordered_by='user', children=[
-        DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-        DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='val', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-        DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c4', config=True, presence=False, children=[
-            DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l5', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
-        ])
-    ]),
-    DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_uint64', config=True, min_elements=0, ordered_by='system', type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)]))),
-    DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_str', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities)),
-    DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_identityref', config=True, min_elements=0, ordered_by='system', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref_noval', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_fooy], identities=_identities)),
-    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l4', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l2', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
-    DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l_leafref', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yxpath.AbsoluteLocationPath([yxpath.NodeTestStep('f', 'c1', []), yxpath.NodeTestStep('f', 'li', []), yxpath.NodeTestStep('f', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+SRC_DNODE_CHILD_1: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_2: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l3', config=True, mandatory=False, type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)])))
+
+SRC_DNODE_CHILD_3: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None))
+
+SRC_DNODE_CHILD_4: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty_delete', config=True, mandatory=False, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None))
+
+SRC_DNODE_CHILD_5: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_decimal64', config=True, mandatory=False, type_=DTypeDecimal64(name='decimal64', description=None, reference=None, exts=[], builtin_type='decimal64', default=None, fraction_digits=2, ranges=Ranges([(Decimal(bigint("-9223372036854775808"), bigint("-2")), Decimal(bigint("9223372036854775807"), bigint("-2")))])))
+
+SRC_DNODE_CHILD_6: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li', key=['name'], config=True, min_elements=0, ordered_by='user', children=[
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='val', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
+    DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c4', config=True, presence=False, children=[
+        DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l5', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+    ])
 ])
 
-SRC_DNODE_CHILD_1: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc1', config=True, presence=True, children=[
+SRC_DNODE_CHILD_7: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_uint64', config=True, min_elements=0, ordered_by='system', type_=DTypeIntegerUnsigned(name='uint64', description=None, reference=None, exts=[], builtin_type='uint64', default=None, ranges=Ranges([(0, 18446744073709551615)])))
+
+SRC_DNODE_CHILD_8: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_str', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_9: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities))
+
+SRC_DNODE_CHILD_10: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_identityref', config=True, min_elements=0, ordered_by='system', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities))
+
+SRC_DNODE_CHILD_11: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_identityref_noval', config=True, mandatory=False, type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_fooy], identities=_identities))
+
+SRC_DNODE_CHILD_12: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_bits', config=True, mandatory=False, type_=DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'zebra':0, 'aardvark':1, 'medved':2}))
+
+SRC_DNODE_CHILD_13: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll_bits', config=True, min_elements=0, ordered_by='system', type_=DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'x':0, 'y':1}))
+
+SRC_DNODE_CHILD_14: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_union_bits', config=True, mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeBits(name='bits', description=None, reference=None, exts=[], builtin_type='bits', default=None, name_to_pos={'red':0, 'green':1}), DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(0, 255)]))]))
+
+SRC_DNODE_CHILD_15: DLeaf = DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l4', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_16: DLeaf = DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_17: DLeaf = DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l2', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+
+SRC_DNODE_CHILD_18: DLeaf = DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l_leafref', config=True, mandatory=False, type_=DTypeLeafref(name='leafref', description=None, reference=None, exts=[], builtin_type='leafref', default=None, path=yxpath.AbsoluteLocationPath([yxpath.NodeTestStep('f', 'c1', []), yxpath.NodeTestStep('f', 'li', []), yxpath.NodeTestStep('f', 'name', [])]), require_instance=False, target_type=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])))
+
+SRC_DNODE_CHILD_0: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=True, presence=False, children=[SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11, SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16, SRC_DNODE_CHILD_17, SRC_DNODE_CHILD_18])
+
+SRC_DNODE_CHILD_19: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc1', config=True, presence=True, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, presence=False, children=[
         DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, min_elements=0, ordered_by='system', type_=DTypeBinary(name='binary', description=None, reference=None, exts=[], builtin_type='binary', default=None, length=None))
     ])
 ])
 
-SRC_DNODE_CHILD_2: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc2', config=True, presence=True, children=[
+SRC_DNODE_CHILD_20: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc2', config=True, presence=True, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_mandatory', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l_empty_mandatory', config=True, mandatory=True, type_=DTypeEmpty(name='empty', description=None, reference=None, exts=[], builtin_type='empty', default=None))
     ])
 ])
 
-SRC_DNODE_CHILD_3: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc3', config=True, presence=True, children=[
+SRC_DNODE_CHILD_21: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='pc3', config=True, presence=True, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='level1', config=True, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=True, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1-optional', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
@@ -83,32 +103,32 @@ SRC_DNODE_CHILD_3: DContainer = DContainer(module='foo', namespace='http://examp
     ])
 ])
 
-SRC_DNODE_CHILD_4: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='empty-presence', config=True, presence=True)
+SRC_DNODE_CHILD_22: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='empty-presence', config=True, presence=True)
 
-SRC_DNODE_CHILD_5: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c.dot', config=True, presence=False, children=[
+SRC_DNODE_CHILD_23: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c.dot', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l.dot1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='l.dot2', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_6: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='cc', config=True, presence=False, children=[
+SRC_DNODE_CHILD_24: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='cc', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='cake', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DList(module='foo', namespace='http://example.com/foo', prefix='f', name='death', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='name', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
     ])
 ])
 
-SRC_DNODE_CHILD_7: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='conflict', config=True, presence=False, children=[
+SRC_DNODE_CHILD_25: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='conflict', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='inner', config=True, presence=True),
     DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
     DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='inner', config=True, presence=True)
 ])
 
-SRC_DNODE_CHILD_8: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='special', key=['yes'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_26: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='special', key=['yes'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='yes', config=True, mandatory=False, type_=DTypeBoolean(name='boolean', description=None, reference=None, exts=[], builtin_type='boolean', default=None))
 ])
 
-SRC_DNODE_CHILD_9: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='nested', config=True, presence=False, children=[
+SRC_DNODE_CHILD_27: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='nested', config=True, presence=False, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='inner', config=True, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li1', key=['name'], config=True, min_elements=0, ordered_by='system', children=[
@@ -130,7 +150,7 @@ SRC_DNODE_CHILD_9: DContainer = DContainer(module='foo', namespace='http://examp
     ])
 ])
 
-SRC_DNODE_CHILD_10: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union', key=[
+SRC_DNODE_CHILD_28: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union', key=[
 'k1',
 'k2',
 'k3'
@@ -141,28 +161,28 @@ SRC_DNODE_CHILD_10: DList = DList(module='foo', namespace='http://example.com/fo
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='checker', config=True, mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeIntegerUnsigned(name='uint32', description=None, reference=None, exts=[], builtin_type='uint32', default=None, ranges=Ranges([(1514, 1514)])), DTypeIntegerUnsigned(name='uint8', description=None, reference=None, exts=[], builtin_type='uint8', default=None, ranges=Ranges([(47, 47)])), DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])]))
 ])
 
-SRC_DNODE_CHILD_11: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union-one-base', key=['k1'], config=True, min_elements=0, ordered_by='system', children=[
+SRC_DNODE_CHILD_29: DList = DList(module='foo', namespace='http://example.com/foo', prefix='f', name='li-union-one-base', key=['k1'], config=True, min_elements=0, ordered_by='system', children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='k1', config=True, mandatory=False, type_=DTypeUnion(name='union', description=None, reference=None, exts=[], builtin_type='union', default=None, types=[DTypeEnum(name='enumeration', description=None, reference=None, exts=[], builtin_type='enumeration', default=None, name_to_val={'foo':0}), DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])]))
 ])
 
-SRC_DNODE_CHILD_12: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='state', config=False, presence=False, children=[
+SRC_DNODE_CHILD_30: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='state', config=False, presence=False, children=[
     DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c1', config=False, presence=False, children=[
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[])),
         DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l2', config=False, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
     ])
 ])
 
-SRC_DNODE_CHILD_13: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll-empty', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
+SRC_DNODE_CHILD_31: DLeafList = DLeafList(module='foo', namespace='http://example.com/foo', prefix='f', name='ll-empty', config=True, min_elements=0, ordered_by='system', type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 
-SRC_DNODE_CHILD_14: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c2', config=True, presence=False, children=[
+SRC_DNODE_CHILD_32: DContainer = DContainer(module='foo', namespace='http://example.com/foo', prefix='f', name='c2', config=True, presence=False, children=[
     DLeaf(module='foo', namespace='http://example.com/foo', prefix='f', name='l1', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
-SRC_DNODE_CHILD_15: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='test-idref', config=True, presence=False, children=[
+SRC_DNODE_CHILD_33: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='test-idref', config=True, presence=False, children=[
     DLeafList(module='bar', namespace='http://example.com/bar', prefix='bar', name='idref', config=True, min_elements=0, ordered_by='system', type_=DTypeIdentityref(name='identityref', description=None, reference=None, exts=[], builtin_type='identityref', default=None, identity_bases=[_base_foo_basey], identities=_identities))
 ])
 
-SRC_DNODE_CHILD_16: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='conflict', config=True, presence=False, children=[
+SRC_DNODE_CHILD_34: DContainer = DContainer(module='bar', namespace='http://example.com/bar', prefix='bar', name='conflict', config=True, presence=False, children=[
     DLeaf(module='bar', namespace='http://example.com/bar', prefix='bar', name='foo', config=True, mandatory=False, type_=DTypeString(name='string', description=None, reference=None, exts=[], builtin_type='string', default=None, length=None, patterns=[]))
 ])
 
@@ -177,7 +197,7 @@ SRC_DNODE_IDENTITY_2: DIdentity = DIdentity(module='bar', namespace='http://exam
     ])
 
 SRC_DNODE: DRoot = DRoot(
-    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_1, SRC_DNODE_CHILD_2, SRC_DNODE_CHILD_3, SRC_DNODE_CHILD_4, SRC_DNODE_CHILD_5, SRC_DNODE_CHILD_6, SRC_DNODE_CHILD_7, SRC_DNODE_CHILD_8, SRC_DNODE_CHILD_9, SRC_DNODE_CHILD_10, SRC_DNODE_CHILD_11, SRC_DNODE_CHILD_12, SRC_DNODE_CHILD_13, SRC_DNODE_CHILD_14, SRC_DNODE_CHILD_15, SRC_DNODE_CHILD_16],
+    children=[SRC_DNODE_CHILD_0, SRC_DNODE_CHILD_19, SRC_DNODE_CHILD_20, SRC_DNODE_CHILD_21, SRC_DNODE_CHILD_22, SRC_DNODE_CHILD_23, SRC_DNODE_CHILD_24, SRC_DNODE_CHILD_25, SRC_DNODE_CHILD_26, SRC_DNODE_CHILD_27, SRC_DNODE_CHILD_28, SRC_DNODE_CHILD_29, SRC_DNODE_CHILD_30, SRC_DNODE_CHILD_31, SRC_DNODE_CHILD_32, SRC_DNODE_CHILD_33, SRC_DNODE_CHILD_34],
     identities=[SRC_DNODE_IDENTITY_0, SRC_DNODE_IDENTITY_1, SRC_DNODE_IDENTITY_2],
     rpcs=[],
     module_metadata={'http://example.com/foo':('foo', None), 'http://example.com/bar':('bar', None)},
@@ -252,6 +272,34 @@ SRC_YANG_0: str = r"""module foo {
             // There are no identities derived from base fooy, this leaf has no valid value!
             type identityref {
                 base fooy;
+            }
+        }
+        leaf l_bits {
+            // positions contradict both alphabetical and declaration order to
+            // prove canonical (position-ordered) serialization
+            type bits {
+                bit aardvark {
+                    position 1;
+                }
+                bit zebra {
+                    position 0;
+                }
+                bit medved;
+            }
+        }
+        leaf-list ll_bits {
+            type bits {
+                bit x;
+                bit y;
+            }
+        }
+        leaf l_union_bits {
+            type union {
+                type bits {
+                    bit red;
+                    bit green;
+                }
+                type uint8;
             }
         }
     }
@@ -636,12 +684,15 @@ class foo__c1(yadata.MNode):
     l_identityref: ?Identityref
     ll_identityref: list[Identityref]
     l_identityref_noval: ?Identityref
+    l_bits: ?set[str]
+    ll_bits: list[set[str]]
+    l_union_bits: ?value
     l4: ?str
     bar_l1: ?str
     l2: ?str
     l_leafref: ?str
 
-    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str) -> None:
+    mut def __init__(self, f_l1: ?str, l3: ?u64, l_empty: ?bool, l_empty_delete: ?bool, l_decimal64: ?Decimal, li: list[foo__c1__li_entry]=[], ll_uint64: ?list[u64]=None, ll_str: ?list[str]=None, l_identityref: ?Identityref, ll_identityref: ?list[Identityref]=None, l_identityref_noval: ?Identityref, l_bits: ?set[str], ll_bits: ?list[set[str]]=None, l_union_bits: ?value, l4: ?str, bar_l1: ?str, l2: ?str, l_leafref: ?str) -> None:
         self.f_l1 = f_l1
         self.l3 = l3
         self.l_empty = l_empty
@@ -653,6 +704,9 @@ class foo__c1(yadata.MNode):
         self.l_identityref = l_identityref
         self.ll_identityref = ll_identityref if ll_identityref is not None else []
         self.l_identityref_noval = l_identityref_noval
+        self.l_bits = l_bits
+        self.ll_bits = ll_bits if ll_bits is not None else []
+        self.l_union_bits = l_union_bits
         self.l4 = l4
         self.bar_l1 = bar_l1
         self.l2 = l2
@@ -664,7 +718,7 @@ class foo__c1(yadata.MNode):
     @staticmethod
     mut def from_gdata(n: ?ygdata.Node) -> foo__c1:
         if n is not None:
-            return foo__c1(f_l1=n.get_opt_str(ygdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(ygdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(ygdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(ygdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(ygdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(ygdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(ygdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref_noval')), l4=n.get_opt_str(ygdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(ygdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(ygdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(ygdata.Id(NS_bar, 'l_leafref')))
+            return foo__c1(f_l1=n.get_opt_str(ygdata.Id(NS_foo, 'l1')), l3=n.get_opt_u64(ygdata.Id(NS_foo, 'l3')), l_empty=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty')), l_empty_delete=n.get_opt_empty(ygdata.Id(NS_foo, 'l_empty_delete')), l_decimal64=n.get_opt_Decimal(ygdata.Id(NS_foo, 'l_decimal64')), li=foo__c1__li.from_gdata(n.get_opt_list(ygdata.Id(NS_foo, 'li'))), ll_uint64=n.get_opt_u64s(ygdata.Id(NS_foo, 'll_uint64')), ll_str=n.get_opt_strs(ygdata.Id(NS_foo, 'll_str')), l_identityref=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref')), ll_identityref=n.get_opt_Identityrefs(ygdata.Id(NS_foo, 'll_identityref')), l_identityref_noval=n.get_opt_Identityref(ygdata.Id(NS_foo, 'l_identityref_noval')), l_bits=n.get_opt_bits(ygdata.Id(NS_foo, 'l_bits')), ll_bits=n.get_opt_bitss(ygdata.Id(NS_foo, 'll_bits')), l_union_bits=n.get_opt_value(ygdata.Id(NS_foo, 'l_union_bits')), l4=n.get_opt_str(ygdata.Id(NS_foo, 'l4')), bar_l1=n.get_opt_str(ygdata.Id(NS_bar, 'l1')), l2=n.get_opt_str(ygdata.Id(NS_bar, 'l2')), l_leafref=n.get_opt_str(ygdata.Id(NS_bar, 'l_leafref')))
         return foo__c1()
 
     mut def copy(self) -> foo__c1:
@@ -1741,7 +1795,23 @@ mut def src_schema() -> dict[str, SchemaNode]:
         LeafList('ll_str', type_=Type('string')),
         Leaf('l_identityref', type_=Type('identityref', base=['basey'])),
         LeafList('ll_identityref', type_=Type('identityref', base=['basey'])),
-        Leaf('l_identityref_noval', type_=Type('identityref', base=['fooy']))
+        Leaf('l_identityref_noval', type_=Type('identityref', base=['fooy'])),
+        Leaf('l_bits', type_=Type('bits', bit=[
+        Bit('aardvark', position=1),
+        Bit('zebra', position=0),
+        Bit('medved')
+    ])),
+        LeafList('ll_bits', type_=Type('bits', bit=[
+        Bit('x'),
+        Bit('y')
+    ])),
+        Leaf('l_union_bits', type_=Type('union', type_=[
+        Type('bits', bit=[
+                Bit('red'),
+                Bit('green')
+            ]),
+        Type('uint8')
+    ]))
     ]),
     Container('pc1', presence='p', children=[
         Container('foo', children=[

--- a/test/test_data_classes_gen/src/gen.act
+++ b/test/test_data_classes_gen/src/gen.act
@@ -167,6 +167,34 @@ ys_foo = r"""module foo {
                 base fooy;
             }
         }
+        leaf l_bits {
+            // positions contradict both alphabetical and declaration order to
+            // prove canonical (position-ordered) serialization
+            type bits {
+                bit aardvark {
+                    position 1;
+                }
+                bit zebra {
+                    position 0;
+                }
+                bit medved;
+            }
+        }
+        leaf-list ll_bits {
+            type bits {
+                bit x;
+                bit y;
+            }
+        }
+        leaf l_union_bits {
+            type union {
+                type bits {
+                    bit red;
+                    bit green;
+                }
+                type uint8;
+            }
+        }
     }
     container pc1 {
         presence "p";
@@ -510,6 +538,14 @@ ys_basics = r"""module basics {
                 base id1;
             }
             default id2;
+        }
+        leaf l_bits_def {
+            type bits {
+                bit a;
+                bit b;
+                bit c;
+            }
+            default "c a";
         }
     }
 }"""


### PR DESCRIPTION
Expose a set[str] attribute for YANG bits. The natural way of working with YANG bits in adata would be some type so we also build-time validation. This is likely possible, but this intermediate solution works.

The canonical form for bits (like in XML, JSON) is a string of names that is sorted in ascending position order. To make it possible to convert gdata to XML, JSON, ... without schema information, we store the bits value in gdata as a list[str] in canonical order.