### PR TITLE
Compare list keys in place instead of extracting per element

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -866,10 +866,10 @@ class DNodeInner(DNode):
             breaker_name, breaker_idx = next_breaker_name(breaker_idx)
             res.append("{breaker_name}: None = None")
             if key_impl_eq:
-                key_expr = "e.{list_key_args[0]}" if single_key else as_tuple(["e.{k}" for k in list_key_args])
+                match_expr = "e.{list_key_args[0]} == k" if single_key else " and ".join(["e.{k} == k.{k}" for k in list_key_args])
                 res.append("class {pname()}(yadata.MKeyedList[{key_type}, {pname()}_entry]):")
                 res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")
-                res.append("        yadata.MKeyedList.__init__(self, lambda e: {key_expr}, elements)")
+                res.append("        yadata.MKeyedList.__init__(self, lambda e, k: {match_expr}, elements)")
             else:
                 res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
                 res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")

--- a/snapshots/expected/test_yang/compile_extension
+++ b/snapshots/expected/test_yang/compile_extension
@@ -63,7 +63,7 @@ class foo__c1__things_entry(yadata.MNode):
 _breaker2: None = None
 class foo__c1__things(yadata.MKeyedList[str, foo__c1__things_entry]):
     mut def __init__(self, elements: list[foo__c1__things_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, id: ?str=None) -> foo__c1__things_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/compile_imported_grouping
+++ b/snapshots/expected/test_yang/compile_imported_grouping
@@ -75,7 +75,7 @@ class bar__c1__li1_entry(yadata.MNode):
 _breaker2: None = None
 class bar__c1__li1(yadata.MKeyedList[str, bar__c1__li1_entry]):
     mut def __init__(self, elements: list[bar__c1__li1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.l1 == k, elements)
 
     mut def create(self, key: str, l2: ?Identityref=None) -> bar__c1__li1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/compile_submodule_different_prefix
+++ b/snapshots/expected/test_yang/compile_submodule_different_prefix
@@ -95,7 +95,7 @@ class main_module__main_container__sub_list_entry(yadata.MNode):
 _breaker3: None = None
 class main_module__main_container__sub_list(yadata.MKeyedList[str, main_module__main_container__sub_list_entry]):
     mut def __init__(self, elements: list[main_module__main_container__sub_list_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, sub_value: ?str=None, ref_to_main: ?str=None) -> main_module__main_container__sub_list_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/compile_uses
+++ b/snapshots/expected/test_yang/compile_uses
@@ -55,7 +55,7 @@ class foo__c1__li1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__c1__li1(yadata.MKeyedList[str, foo__c1__li1_entry]):
     mut def __init__(self, elements: list[foo__c1__li1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.l1 == k, elements)
 
     mut def create(self, key: str) -> foo__c1__li1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/leafref_augment_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_augment_prefix_alias
@@ -85,7 +85,7 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
 _breaker3: None = None
 class base_module__network_instances__network_instance(yadata.MKeyedList[str, base_module__network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, ref: ?str=None) -> base_module__network_instances__network_instance_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/leafref_resolve_defining_module
+++ b/snapshots/expected/test_yang/leafref_resolve_defining_module
@@ -69,7 +69,7 @@ class other_module__other_network_instances__network_instance_entry(yadata.MNode
 _breaker2: None = None
 class other_module__other_network_instances__network_instance(yadata.MKeyedList[str, other_module__other_network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[other_module__other_network_instances__network_instance_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> other_module__other_network_instances__network_instance_entry:
         e = self.get(key)
@@ -162,7 +162,7 @@ class base_module__base_network_instances__network_instance_entry(yadata.MNode):
 _breaker6: None = None
 class base_module__base_network_instances__network_instance(yadata.MKeyedList[str, base_module__base_network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__base_network_instances__network_instance_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> base_module__base_network_instances__network_instance_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/leafref_typedef_prefix_alias
+++ b/snapshots/expected/test_yang/leafref_typedef_prefix_alias
@@ -86,7 +86,7 @@ class base_module__network_instances__network_instance_entry(yadata.MNode):
 _breaker3: None = None
 class base_module__network_instances__network_instance(yadata.MKeyedList[str, base_module__network_instances__network_instance_entry]):
     mut def __init__(self, elements: list[base_module__network_instances__network_instance_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> base_module__network_instances__network_instance_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/mixed_req_args
+++ b/snapshots/expected/test_yang/mixed_req_args
@@ -84,7 +84,7 @@ class foo__c__li_entry(yadata.MNode):
 _breaker3: None = None
 class foo__c__li(yadata.MKeyedList[str, foo__c__li_entry]):
     mut def __init__(self, elements: list[foo__c__li_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, bar: foo__c__li__bar, foo: ?str=None) -> foo__c__li_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
+++ b/snapshots/expected/test_yang/prdaclass_augment_inner_list_conflict
@@ -62,7 +62,7 @@ class base__c1__base_l1_entry(yadata.MNode):
 _breaker2: None = None
 class base__c1__base_l1(yadata.MKeyedList[str, base__c1__base_l1_entry]):
     mut def __init__(self, elements: list[base__c1__base_l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.base_k1, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.base_k1 == k, elements)
 
     mut def create(self, key: str, foo_k1: str) -> base__c1__base_l1_entry:
         e = self.get(key)
@@ -112,7 +112,7 @@ class base__c1__foo_l1_entry(yadata.MNode):
 _breaker4: None = None
 class base__c1__foo_l1(yadata.MKeyedList[str, base__c1__foo_l1_entry]):
     mut def __init__(self, elements: list[base__c1__foo_l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.k2, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.k2 == k, elements)
 
     mut def create(self, key: str) -> base__c1__foo_l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_identityref_list_key
+++ b/snapshots/expected/test_yang/prdaclass_identityref_list_key
@@ -77,7 +77,7 @@ class foo__c1__l1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__c1__l1(yadata.MKeyedList[(k1: str, k2: Identityref), foo__c1__l1_entry]):
     mut def __init__(self, elements: list[foo__c1__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: (e.k1, e.k2), elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.k1 == k.k1 and e.k2 == k.k2, elements)
 
     mut def create(self, key: (k1: str, k2: Identityref)) -> foo__c1__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_list_key_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_list_key_mandatory
@@ -53,7 +53,7 @@ class foo__l1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> foo__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_list_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_key_reorder
@@ -56,7 +56,7 @@ class foo__l1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, id: ?str=None) -> foo__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
+++ b/snapshots/expected/test_yang/prdaclass_list_multi_key_reorder
@@ -62,7 +62,7 @@ class foo__l1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__l1(yadata.MKeyedList[(name: str, id: str), foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: (e.name, e.id), elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k.name and e.id == k.id, elements)
 
     mut def create(self, key: (name: str, id: str), other: ?str=None) -> foo__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
+++ b/snapshots/expected/test_yang/prdaclass_max_elements_unbounded
@@ -55,7 +55,7 @@ class foo__li1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__li1(yadata.MKeyedList[str, foo__li1_entry]):
     mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.l1 == k, elements)
 
     mut def create(self, key: str) -> foo__li1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_min_elements
+++ b/snapshots/expected/test_yang/prdaclass_min_elements
@@ -55,7 +55,7 @@ class foo__li1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__li1(yadata.MKeyedList[str, foo__li1_entry]):
     mut def __init__(self, elements: list[foo__li1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.l1, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.l1 == k, elements)
 
     mut def create(self, key: str) -> foo__li1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_req_arg
+++ b/snapshots/expected/test_yang/prdaclass_req_arg
@@ -82,7 +82,7 @@ class foo__l1_entry(yadata.MNode):
 _breaker3: None = None
 class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, id: ?str=None) -> foo__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_mandatory
@@ -56,7 +56,7 @@ class foo__l1_entry(yadata.MNode):
 _breaker2: None = None
 class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, id: str) -> foo__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
+++ b/snapshots/expected/test_yang/prdaclass_strict_list_p_container_with_mandatory_leaf
@@ -91,7 +91,7 @@ class foo__l1_entry(yadata.MNode):
 _breaker3: None = None
 class foo__l1(yadata.MKeyedList[str, foo__l1_entry]):
     mut def __init__(self, elements: list[foo__l1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> foo__l1_entry:
         e = self.get(key)

--- a/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
+++ b/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
@@ -109,7 +109,7 @@ class svc__register__input__servers_entry(yadata.MNode):
 _breaker4: None = None
 class svc__register__input__servers(yadata.MKeyedList[str, svc__register__input__servers_entry]):
     mut def __init__(self, elements: list[svc__register__input__servers_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.id, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.id == k, elements)
 
     mut def create(self, key: str, port: ?u64=None) -> svc__register__input__servers_entry:
         e = self.get(key)

--- a/src/adata.act
+++ b/src/adata.act
@@ -35,15 +35,15 @@ class MKeyedList[K(Eq), T(MNode)](MList[T]):
     that are not Acton "value".
     """
     @property
-    _key_of: pure(T) -> K
+    _key_matches: pure(T, K) -> bool
 
-    mut def __init__(self, key_of: pure(T) -> K, elements: list[T]) -> None:
+    mut def __init__(self, key_matches: pure(T, K) -> bool, elements: list[T]) -> None:
         MList.__init__(self, elements)
-        self._key_of = key_of
+        self._key_matches = key_matches
 
     pure def get(self, key: K) -> ?T:
         for e in self.elements:
-            if self._key_of(e) == key:
+            if self._key_matches(e, key):
                 return e
 
 
@@ -56,14 +56,14 @@ extension MKeyedList[K(Eq), T(MNode)](Indexed[K, T]):
 
     mut def __setitem__(self, key: K, n: T) -> None:
         for i, e in enumerate(self.elements):
-            if self._key_of(e) == key:
+            if self._key_matches(e, key):
                 self.elements[i] = n
                 return
         self.elements.append(n)
 
     mut def __delitem__(self, key: K) -> None:
         for i, e in enumerate(self.elements):
-            if self._key_of(e) == key:
+            if self._key_matches(e, key):
                 del self.elements[i]
                 return
         raise KeyError(key)

--- a/src/schema.act
+++ b/src/schema.act
@@ -862,10 +862,10 @@ class DNodeInner(DNode):
             breaker_name, breaker_idx = next_breaker_name(breaker_idx)
             res.append("{breaker_name}: None = None")
             if key_impl_eq:
-                key_expr = "e.{list_key_args[0]}" if single_key else as_tuple(["e.{k}" for k in list_key_args])
+                match_expr = "e.{list_key_args[0]} == k" if single_key else " and ".join(["e.{k} == k.{k}" for k in list_key_args])
                 res.append("class {pname()}(yadata.MKeyedList[{key_type}, {pname()}_entry]):")
                 res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")
-                res.append("        yadata.MKeyedList.__init__(self, lambda e: {key_expr}, elements)")
+                res.append("        yadata.MKeyedList.__init__(self, lambda e, k: {match_expr}, elements)")
             else:
                 res.append("class {pname()}(yadata.MList[{pname()}_entry]):")
                 res.append("    mut def __init__(self, elements: list[{pname()}_entry]=[]) -> None:")

--- a/test/test_data_classes/src/yang_filter_test_oper.act
+++ b/test/test_data_classes/src/yang_filter_test_oper.act
@@ -279,7 +279,7 @@ class filter_test__interfaces__interface_entry(yadata.MNode):
 _breaker7: None = None
 class filter_test__interfaces__interface(yadata.MKeyedList[str, filter_test__interfaces__interface_entry]):
     mut def __init__(self, elements: list[filter_test__interfaces__interface_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, description: ?str=None, type: ?str=None, enabled: ?bool=None, admin_status: ?str=None, oper_status: ?str=None, last_change: ?str=None) -> filter_test__interfaces__interface_entry:
         e = self.get(key)

--- a/test/test_data_classes/src/yang_foo.act
+++ b/test/test_data_classes/src/yang_foo.act
@@ -615,7 +615,7 @@ class foo__c1__li_entry(yadata.MNode):
 _breaker3: None = None
 class foo__c1__li(yadata.MKeyedList[str, foo__c1__li_entry]):
     mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, val: ?str=None) -> foo__c1__li_entry:
         e = self.get(key)
@@ -956,7 +956,7 @@ class foo__cc__death_entry(yadata.MNode):
 _breaker16: None = None
 class foo__cc__death(yadata.MKeyedList[str, foo__cc__death_entry]):
     mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> foo__cc__death_entry:
         e = self.get(key)
@@ -1117,7 +1117,7 @@ class foo__special_entry(yadata.MNode):
 _breaker22: None = None
 class foo__special(yadata.MKeyedList[bool, foo__special_entry]):
     mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.yes, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.yes == k, elements)
 
     mut def create(self, key: bool) -> foo__special_entry:
         e = self.get(key)
@@ -1170,7 +1170,7 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
 _breaker24: None = None
 class foo__nested__f_inner__li1__li2(yadata.MKeyedList[(key1: str, key2: str), foo__nested__f_inner__li1__li2_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: (e.key1, e.key2), elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.key1 == k.key1 and e.key2 == k.key2, elements)
 
     mut def create(self, key: (key1: str, key2: str), baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
         e = self.get(key)
@@ -1227,7 +1227,7 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
 _breaker26: None = None
 class foo__nested__f_inner__li1(yadata.MKeyedList[str, foo__nested__f_inner__li1_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
         e = self.get(key)

--- a/test/test_data_classes/src/yang_foo_loose.act
+++ b/test/test_data_classes/src/yang_foo_loose.act
@@ -615,7 +615,7 @@ class foo__c1__li_entry(yadata.MNode):
 _breaker3: None = None
 class foo__c1__li(yadata.MKeyedList[str, foo__c1__li_entry]):
     mut def __init__(self, elements: list[foo__c1__li_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, val: ?str=None) -> foo__c1__li_entry:
         e = self.get(key)
@@ -956,7 +956,7 @@ class foo__cc__death_entry(yadata.MNode):
 _breaker16: None = None
 class foo__cc__death(yadata.MKeyedList[str, foo__cc__death_entry]):
     mut def __init__(self, elements: list[foo__cc__death_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str) -> foo__cc__death_entry:
         e = self.get(key)
@@ -1117,7 +1117,7 @@ class foo__special_entry(yadata.MNode):
 _breaker22: None = None
 class foo__special(yadata.MKeyedList[bool, foo__special_entry]):
     mut def __init__(self, elements: list[foo__special_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.yes, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.yes == k, elements)
 
     mut def create(self, key: bool) -> foo__special_entry:
         e = self.get(key)
@@ -1170,7 +1170,7 @@ class foo__nested__f_inner__li1__li2_entry(yadata.MNode):
 _breaker24: None = None
 class foo__nested__f_inner__li1__li2(yadata.MKeyedList[(key1: str, key2: str), foo__nested__f_inner__li1__li2_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1__li2_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: (e.key1, e.key2), elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.key1 == k.key1 and e.key2 == k.key2, elements)
 
     mut def create(self, key: (key1: str, key2: str), baz: ?str=None) -> foo__nested__f_inner__li1__li2_entry:
         e = self.get(key)
@@ -1227,7 +1227,7 @@ class foo__nested__f_inner__li1_entry(yadata.MNode):
 _breaker26: None = None
 class foo__nested__f_inner__li1(yadata.MKeyedList[str, foo__nested__f_inner__li1_entry]):
     mut def __init__(self, elements: list[foo__nested__f_inner__li1_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, f_bar: ?str=None, bar_bar: ?str=None) -> foo__nested__f_inner__li1_entry:
         e = self.get(key)

--- a/test/test_data_classes/src/yang_keywords.act
+++ b/test/test_data_classes/src/yang_keywords.act
@@ -146,7 +146,7 @@ class keywords__import_entry(yadata.MNode):
 _breaker3: None = None
 class keywords__import(yadata.MKeyedList[(from: str, type: str), keywords__import_entry]):
     mut def __init__(self, elements: list[keywords__import_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: (e.from, e.type), elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.from == k.from and e.type == k.type, elements)
 
     mut def create(self, key: (from: str, type: str), class: ?str=None) -> keywords__import_entry:
         e = self.get(key)

--- a/test/test_data_classes/src/yang_one.act
+++ b/test/test_data_classes/src/yang_one.act
@@ -185,7 +185,7 @@ class foo__li_entry(yadata.MNode):
 _breaker4: None = None
 class foo__li(yadata.MKeyedList[str, foo__li_entry]):
     mut def __init__(self, elements: list[foo__li_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.name, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.name == k, elements)
 
     mut def create(self, key: str, c1: foo__li__c1) -> foo__li_entry:
         e = self.get(key)

--- a/test/test_device_mode/src/m.act
+++ b/test/test_device_mode/src/m.act
@@ -51,7 +51,7 @@ class m__cfg__items_entry(yadata.MNode):
 _breaker3: None = None
 class m__cfg__items(yadata.MKeyedList[str, m__cfg__items_entry]):
     mut def __init__(self, elements: list[m__cfg__items_entry]=[]) -> None:
-        yadata.MKeyedList.__init__(self, lambda e: e.id, elements)
+        yadata.MKeyedList.__init__(self, lambda e, k: e.id == k, elements)
 
     mut def create(self, key: str, val: ?u64=None) -> m__cfg__items_entry:
         e = self.get(key)


### PR DESCRIPTION
Avoid recreating the key named tuple for lists with compound keys for element lookup (called from .get() -> create() / Indexed protocol). Instead of the MKeyedList._key_of, use a comparator (_key_matches: pure(T, K) -> bool). The new method compares element key leaves against the provided key values in place individually, so it avoids allocating a new tuple and can also short-circuit earlier.

But this also means we're not using the auto-generated Eq extension for tuples at all, except to satisfy the constraint that in `Indexed[K, T]`, `K` must implement `Eq`.
@nordlander are you planning on doing some clever optimizations regarding tuples (like to avoid allocation), or is this The Right Way? It has a measurable effect on performance for example for list insertion in a list with with 1000 elements (µs scale, but still 10x).