### PR TITLE
Use gdata for RPCs in rpc_root and TreeProvider

### DIFF
--- a/gen/schema-header.act
+++ b/gen/schema-header.act
@@ -1034,29 +1034,28 @@ class DNodeInner(DNode):
                 res.append("    {name}: action({params}) -> None")
                 res.append("    def {name}({argnames}):")
 
-                # Generate callback wrapper for parsing RPC output XML -> gdata -> adata
+                # Generate callback wrapper converting RPC output gdata -> adata
                 if output_node is not None:
-                    res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
+                    res.append("        def cb_wrap(res: ?ygdata.Node, err: ?Exception):")
                     res.append("            if res is not None:")
-                    res.append('                gdata_res = yxml.from_xml(SRC_DNODE, res, {loose}, ["{rpc.module}:{rpc.name}", "output"])')
-                    res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(gdata_res)")
+                    res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(res)")
                     res.append("                cb(adata_res, err)")
                     res.append("            else:")
                     res.append("                cb(None, err)")
                     res.append("")
 
-                # Generate RPC XML, add input
-                res.append("        rpc_xml = xml.Node({repr(rpc.name)}, nsdefs=[(None, {repr(rpc.namespace)})])")
+                # Build the RPC gdata root container, rpc_input is empty for no input
+                res.append("        rpc_input = ygdata.Container()")
                 if input_node is not None:
                     res.append("        if inp is not None:")
-                    res.append('            gdata_inp = yadata.from_adata(SRC_DNODE, inp, {loose}, ["{rpc.module}:{rpc.name}", "input"])')
-                    res.append('            rpc_xml.children.extend(gdata_inp.to_xml())')
+                    res.append('            rpc_input = yadata.from_adata(SRC_DNODE, inp, {loose}, ["{rpc.module}:{rpc.name}", "input"])')
+                res.append("        rpc_gdata = ygdata.Container({{ygdata.Id({repr(rpc.namespace)}, {repr(rpc.name)}): rpc_input}})")
 
-                # Call tp.rpc_xml with appropriate callback
+                # Call tp.rpc with appropriate callback
                 if output_node is not None:
-                    res.append("        tp.rpc_xml(cb_wrap, rpc_xml)")
+                    res.append("        tp.rpc(cb_wrap, rpc_gdata)")
                 else:
-                    res.append("        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)")
+                    res.append("        tp.rpc(lambda _, err: cb(err), rpc_gdata)")
                 res.append("")
 
             res.append("")

--- a/snapshots/expected/test_yang/compile_augment_action_rpc
+++ b/snapshots/expected/test_yang/compile_augment_action_rpc
@@ -187,18 +187,17 @@ class foo__reset__output(yadata.MNode):
 actor rpc_root(tp: ygdata.TreeProvider):
     reset: action(cb: action(?foo__reset__output, ?Exception) -> None, inp: ?foo__reset__input) -> None
     def reset(cb, inp):
-        def cb_wrap(res: ?xml.Node, err: ?Exception):
+        def cb_wrap(res: ?ygdata.Node, err: ?Exception):
             if res is not None:
-                gdata_res = yxml.from_xml(SRC_DNODE, res, False, ["foo:reset", "output"])
-                adata_res = foo__reset__output.from_gdata(gdata_res)
+                adata_res = foo__reset__output.from_gdata(res)
                 cb(adata_res, err)
             else:
                 cb(None, err)
 
-        rpc_xml = xml.Node('reset', nsdefs=[(None, 'http://example.com/foo')])
+        rpc_input = ygdata.Container()
         if inp is not None:
-            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["foo:reset", "input"])
-            rpc_xml.children.extend(gdata_inp.to_xml())
-        tp.rpc_xml(cb_wrap, rpc_xml)
+            rpc_input = yadata.from_adata(SRC_DNODE, inp, False, ["foo:reset", "input"])
+        rpc_gdata = ygdata.Container({ygdata.Id('http://example.com/foo', 'reset'): rpc_input})
+        tp.rpc(cb_wrap, rpc_gdata)
 
 

--- a/snapshots/expected/test_yang/compile_augment_implicit_input_output
+++ b/snapshots/expected/test_yang/compile_augment_implicit_input_output
@@ -154,18 +154,17 @@ class foo__r1__output(yadata.MNode):
 actor rpc_root(tp: ygdata.TreeProvider):
     r1: action(cb: action(?foo__r1__output, ?Exception) -> None, inp: ?foo__r1__input) -> None
     def r1(cb, inp):
-        def cb_wrap(res: ?xml.Node, err: ?Exception):
+        def cb_wrap(res: ?ygdata.Node, err: ?Exception):
             if res is not None:
-                gdata_res = yxml.from_xml(SRC_DNODE, res, False, ["foo:r1", "output"])
-                adata_res = foo__r1__output.from_gdata(gdata_res)
+                adata_res = foo__r1__output.from_gdata(res)
                 cb(adata_res, err)
             else:
                 cb(None, err)
 
-        rpc_xml = xml.Node('r1', nsdefs=[(None, 'http://example.com/foo')])
+        rpc_input = ygdata.Container()
         if inp is not None:
-            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["foo:r1", "input"])
-            rpc_xml.children.extend(gdata_inp.to_xml())
-        tp.rpc_xml(cb_wrap, rpc_xml)
+            rpc_input = yadata.from_adata(SRC_DNODE, inp, False, ["foo:r1", "input"])
+        rpc_gdata = ygdata.Container({ygdata.Id('http://example.com/foo', 'r1'): rpc_input})
+        tp.rpc(cb_wrap, rpc_gdata)
 
 

--- a/snapshots/expected/test_yang/prdaclass_rpc
+++ b/snapshots/expected/test_yang/prdaclass_rpc
@@ -137,23 +137,23 @@ class yangrpc__foo__output(yadata.MNode):
 actor rpc_root(tp: ygdata.TreeProvider):
     foo: action(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input) -> None
     def foo(cb, inp):
-        def cb_wrap(res: ?xml.Node, err: ?Exception):
+        def cb_wrap(res: ?ygdata.Node, err: ?Exception):
             if res is not None:
-                gdata_res = yxml.from_xml(SRC_DNODE, res, False, ["yangrpc:foo", "output"])
-                adata_res = yangrpc__foo__output.from_gdata(gdata_res)
+                adata_res = yangrpc__foo__output.from_gdata(res)
                 cb(adata_res, err)
             else:
                 cb(None, err)
 
-        rpc_xml = xml.Node('foo', nsdefs=[(None, 'http://example.com/yangrpc')])
+        rpc_input = ygdata.Container()
         if inp is not None:
-            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["yangrpc:foo", "input"])
-            rpc_xml.children.extend(gdata_inp.to_xml())
-        tp.rpc_xml(cb_wrap, rpc_xml)
+            rpc_input = yadata.from_adata(SRC_DNODE, inp, False, ["yangrpc:foo", "input"])
+        rpc_gdata = ygdata.Container({ygdata.Id('http://example.com/yangrpc', 'foo'): rpc_input})
+        tp.rpc(cb_wrap, rpc_gdata)
 
     silent: action(cb: action(?Exception) -> None) -> None
     def silent(cb):
-        rpc_xml = xml.Node('silent', nsdefs=[(None, 'http://example.com/yangrpc')])
-        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
+        rpc_input = ygdata.Container()
+        rpc_gdata = ygdata.Container({ygdata.Id('http://example.com/yangrpc', 'silent'): rpc_input})
+        tp.rpc(lambda _, err: cb(err), rpc_gdata)
 
 

--- a/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
+++ b/snapshots/expected/test_yang/rpc_action_input_cross_module_grouping_key
@@ -163,10 +163,10 @@ class svc__register__input(yadata.MNode):
 actor rpc_root(tp: ygdata.TreeProvider):
     register: action(cb: action(?Exception) -> None, inp: ?svc__register__input) -> None
     def register(cb, inp):
-        rpc_xml = xml.Node('register', nsdefs=[(None, 'urn:example:svc')])
+        rpc_input = ygdata.Container()
         if inp is not None:
-            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["svc:register", "input"])
-            rpc_xml.children.extend(gdata_inp.to_xml())
-        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
+            rpc_input = yadata.from_adata(SRC_DNODE, inp, False, ["svc:register", "input"])
+        rpc_gdata = ygdata.Container({ygdata.Id('urn:example:svc', 'register'): rpc_input})
+        tp.rpc(lambda _, err: cb(err), rpc_gdata)
 
 

--- a/src/gdata.act
+++ b/src/gdata.act
@@ -3330,7 +3330,6 @@ extension Delivery(Hashable):
 class TreeProvider(object):
     """Imperative transport interface for RPCs and owner-scoped subscriptions."""
     rpc: proc(action(?Node, ?Exception) -> None, Node) -> None
-    rpc_xml: proc(action(?xml.Node, ?Exception) -> None, xml.Node) -> None
     declare_subscriptions: proc(str, action(?Node, ?Exception) -> None, set[SubscriptionSpec]) -> None
     remove_subscriptions: proc(str) -> None
 

--- a/src/schema.act
+++ b/src/schema.act
@@ -1030,29 +1030,28 @@ class DNodeInner(DNode):
                 res.append("    {name}: action({params}) -> None")
                 res.append("    def {name}({argnames}):")
 
-                # Generate callback wrapper for parsing RPC output XML -> gdata -> adata
+                # Generate callback wrapper converting RPC output gdata -> adata
                 if output_node is not None:
-                    res.append("        def cb_wrap(res: ?xml.Node, err: ?Exception):")
+                    res.append("        def cb_wrap(res: ?ygdata.Node, err: ?Exception):")
                     res.append("            if res is not None:")
-                    res.append('                gdata_res = yxml.from_xml(SRC_DNODE, res, {loose}, ["{rpc.module}:{rpc.name}", "output"])')
-                    res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(gdata_res)")
+                    res.append("                adata_res = {get_path_name(spath + [rpc, output_node])}.from_gdata(res)")
                     res.append("                cb(adata_res, err)")
                     res.append("            else:")
                     res.append("                cb(None, err)")
                     res.append("")
 
-                # Generate RPC XML, add input
-                res.append("        rpc_xml = xml.Node({repr(rpc.name)}, nsdefs=[(None, {repr(rpc.namespace)})])")
+                # Build the RPC gdata root container, rpc_input is empty for no input
+                res.append("        rpc_input = ygdata.Container()")
                 if input_node is not None:
                     res.append("        if inp is not None:")
-                    res.append('            gdata_inp = yadata.from_adata(SRC_DNODE, inp, {loose}, ["{rpc.module}:{rpc.name}", "input"])')
-                    res.append('            rpc_xml.children.extend(gdata_inp.to_xml())')
+                    res.append('            rpc_input = yadata.from_adata(SRC_DNODE, inp, {loose}, ["{rpc.module}:{rpc.name}", "input"])')
+                res.append("        rpc_gdata = ygdata.Container({{ygdata.Id({repr(rpc.namespace)}, {repr(rpc.name)}): rpc_input}})")
 
-                # Call tp.rpc_xml with appropriate callback
+                # Call tp.rpc with appropriate callback
                 if output_node is not None:
-                    res.append("        tp.rpc_xml(cb_wrap, rpc_xml)")
+                    res.append("        tp.rpc(cb_wrap, rpc_gdata)")
                 else:
-                    res.append("        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)")
+                    res.append("        tp.rpc(lambda _, err: cb(err), rpc_gdata)")
                 res.append("")
 
             res.append("")

--- a/test/test_data_classes/src/test_rpc_exec.act
+++ b/test/test_data_classes/src/test_rpc_exec.act
@@ -10,16 +10,9 @@ class MockTreeProviderSuccess(ygdata.TreeProvider):
     def __init__(self):
         pass
 
-    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
-        # Return a successful response with output data
-        xml_response = xml.Node("rpc-reply", [(None, "urn:ietf:params:xml:ns:netconf:base:1.0")], children=[
-            xml.Node("outoo", [(None, "http://example.com/yangrpc")], text="Hello from RPC!")
-        ])
-        cb(xml_response, None)
-
     proc def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, rpc: ygdata.Node):
         output_gdata = ygdata.Container({
-            ygdata.Id("http://example.com/yangrpc", "outoo"): ygdata.Leaf("string", "Hello from RPC!")
+            ygdata.Id("http://example.com/yangrpc", "outoo"): ygdata.Leaf("Hello from RPC!")
         }, ns="http://example.com/yangrpc", module="yangrpc")
         cb(output_gdata, None)
 
@@ -35,10 +28,6 @@ class MockTreeProviderError(ygdata.TreeProvider):
     def __init__(self):
         pass
 
-    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
-        # Return an error
-        cb(None, ValueError("RPC execution failed"))
-
     proc def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, rpc: ygdata.Node):
         cb(None, ValueError("RPC execution failed"))
 
@@ -53,13 +42,6 @@ class MockTreeProviderEmpty(ygdata.TreeProvider):
     """Mock TreeProvider that returns empty output"""
     def __init__(self):
         pass
-
-    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
-        # Return a response with no output data
-        xml_response = xml.Node("rpc-reply", [(None, "urn:ietf:params:xml:ns:netconf:base:1.0")], children=[
-            xml.Node("ok")
-        ])
-        cb(xml_response, None)
 
     proc def rpc(self, cb: action(?ygdata.Node, ?Exception) -> None, rpc: ygdata.Node):
         output_gdata = ygdata.Container({}, ns="http://example.com/yangrpc", module="yangrpc")

--- a/test/test_data_classes/src/test_subs_dst.act
+++ b/test/test_data_classes/src/test_subs_dst.act
@@ -71,9 +71,6 @@ class MockSubscriptionTreeProvider(gdata.TreeProvider):
         self.declared = {}
         self.callbacks = {}
 
-    proc def rpc_xml(self, cb: action(?xml.Node, ?Exception) -> None, xml_rpc: xml.Node):
-        cb(None, ValueError("rpc_xml is not used in this test"))
-
     proc def rpc(self, cb: action(?gdata.Node, ?Exception) -> None, rpc: gdata.Node):
         cb(None, ValueError("rpc is not used in this test"))
 

--- a/test/test_data_classes/src/yangrpc.act
+++ b/test/test_data_classes/src/yangrpc.act
@@ -161,24 +161,24 @@ class yangrpc__foo__output(yadata.MNode):
 actor rpc_root(tp: ygdata.TreeProvider):
     foo: action(cb: action(?yangrpc__foo__output, ?Exception) -> None, inp: ?yangrpc__foo__input) -> None
     def foo(cb, inp):
-        def cb_wrap(res: ?xml.Node, err: ?Exception):
+        def cb_wrap(res: ?ygdata.Node, err: ?Exception):
             if res is not None:
-                gdata_res = yxml.from_xml(SRC_DNODE, res, False, ["yangrpc:foo", "output"])
-                adata_res = yangrpc__foo__output.from_gdata(gdata_res)
+                adata_res = yangrpc__foo__output.from_gdata(res)
                 cb(adata_res, err)
             else:
                 cb(None, err)
 
-        rpc_xml = xml.Node('foo', nsdefs=[(None, 'http://example.com/yangrpc')])
+        rpc_input = ygdata.Container()
         if inp is not None:
-            gdata_inp = yadata.from_adata(SRC_DNODE, inp, False, ["yangrpc:foo", "input"])
-            rpc_xml.children.extend(gdata_inp.to_xml())
-        tp.rpc_xml(cb_wrap, rpc_xml)
+            rpc_input = yadata.from_adata(SRC_DNODE, inp, False, ["yangrpc:foo", "input"])
+        rpc_gdata = ygdata.Container({ygdata.Id('http://example.com/yangrpc', 'foo'): rpc_input})
+        tp.rpc(cb_wrap, rpc_gdata)
 
     silent: action(cb: action(?Exception) -> None) -> None
     def silent(cb):
-        rpc_xml = xml.Node('silent', nsdefs=[(None, 'http://example.com/yangrpc')])
-        tp.rpc_xml(lambda _, err: cb(err), rpc_xml)
+        rpc_input = ygdata.Container()
+        rpc_gdata = ygdata.Container({ygdata.Id('http://example.com/yangrpc', 'silent'): rpc_input})
+        tp.rpc(lambda _, err: cb(err), rpc_gdata)
 
 
 mut def src_schema() -> dict[str, SchemaNode]:


### PR DESCRIPTION
The generated rpc_root actor builds each RPC wrapper to work with gdata instead of XML. This will be aligned with stratoweave.device.TreeProvider.